### PR TITLE
Add Prepare/Output layout, Data Readiness checklist, and Concept Note export

### DIFF
--- a/client/src/core/contexts/sample-data-context.tsx
+++ b/client/src/core/contexts/sample-data-context.tsx
@@ -234,6 +234,21 @@ export const SAMPLE_HIAP_ADAPTATION_DATA = {
   },
 };
 
+// Data readiness checklist - describes which upstream datasets are available for this city.
+// In sample mode these are hardcoded; in API mode, replace with a fetch to the project's data status endpoint.
+export interface DataReadinessItem {
+  key: string;
+  i18nKey: string; // maps to project.dataReadiness.[key]
+  available: boolean;
+}
+
+export const SAMPLE_DATA_READINESS: DataReadinessItem[] = [
+  { key: 'ghgInventory', i18nKey: 'ghgInventory', available: true },
+  { key: 'ccra', i18nKey: 'ccra', available: true },
+  { key: 'hiap', i18nKey: 'hiap', available: true },
+  { key: 'localDataEnhancement', i18nKey: 'localDataEnhancement', available: false },
+];
+
 export async function loadSampleBoundaryData(): Promise<any> {
   const response = await fetch('/sample-data/porto-alegre-boundary.json');
   if (!response.ok) {

--- a/client/src/core/pages/project.tsx
+++ b/client/src/core/pages/project.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'wouter';
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
-import { ArrowLeft, Map, ArrowRight, DollarSign, Settings, Landmark, Database, ChevronRight, ChevronDown, Lightbulb } from 'lucide-react';
+import { ArrowLeft, Map, ArrowRight, DollarSign, Settings, Landmark, Database, ChevronRight, ChevronDown, Lightbulb, FileText, CheckCircle2, Circle, Download } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
 import { Header } from '@/core/components/layout/header';
 import { DisplayLarge } from '@oef/components';
@@ -12,9 +12,10 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Di
 import { ScrollArea } from '@/core/components/ui/scroll-area';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/core/components/ui/collapsible';
 import { useTranslation } from 'react-i18next';
-import { useSampleData } from '@/core/contexts/sample-data-context';
+import { useSampleData, SAMPLE_DATA_READINESS, DataReadinessItem } from '@/core/contexts/sample-data-context';
 import { useSampleRoute } from '@/core/hooks/useSampleRoute';
 import { useProjectContext, ProjectContextData } from '@/core/contexts/project-context';
+import { assembleConceptNote, ConceptNote } from '@/core/types/concept-note';
 
 interface Project {
   id: string;
@@ -1012,6 +1013,142 @@ function ContextViewer({ context }: { context: ProjectContextData | null }) {
   );
 }
 
+function DataReadinessChecklist({ items }: { items: DataReadinessItem[] }) {
+  const { t } = useTranslation();
+  const available = items.filter(i => i.available).length;
+
+  return (
+    <div className="border rounded-lg p-3 bg-muted/30">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium">{t('project.dataReadiness.title')}</span>
+        <Badge variant="outline" className="text-xs">
+          {t('project.dataReadiness.loaded', { count: available, total: items.length })}
+        </Badge>
+      </div>
+      <div className="space-y-1">
+        {items.map(item => (
+          <div key={item.key} className="flex items-center gap-2 text-xs">
+            {item.available ? (
+              <CheckCircle2 className="h-3.5 w-3.5 text-green-600 shrink-0" />
+            ) : (
+              <Circle className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />
+            )}
+            <span className={item.available ? 'text-foreground' : 'text-muted-foreground'}>
+              {t(`project.dataReadiness.${item.i18nKey}`)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ConceptNotePanel({ context }: { context: ProjectContextData | null }) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [note, setNote] = useState<ConceptNote | null>(null);
+
+  const handleGenerate = () => {
+    const assembled = assembleConceptNote(context);
+    setNote(assembled);
+    setIsOpen(true);
+  };
+
+  const sectionKeys = [
+    'summary', 'contextBaseline', 'projectDescription',
+    'expectedResults', 'implementation', 'financing',
+  ] as const;
+
+  const sectionColors: Record<string, string> = {
+    summary: 'border-l-blue-500',
+    contextBaseline: 'border-l-amber-500',
+    projectDescription: 'border-l-green-500',
+    expectedResults: 'border-l-purple-500',
+    implementation: 'border-l-orange-500',
+    financing: 'border-l-emerald-500',
+  };
+
+  return (
+    <>
+      <Card
+        className="cursor-pointer hover:shadow-lg transition-shadow border-2 border-dashed border-primary/30 bg-primary/5"
+        onClick={handleGenerate}
+      >
+        <CardContent className="flex items-center justify-between p-6">
+          <div className="flex items-center gap-4">
+            <div className="p-3 bg-primary/10 rounded-lg">
+              <FileText className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">{t('project.conceptNote.exportBanner')}</h3>
+              <p className="text-sm text-muted-foreground">{t('project.conceptNote.exportBannerDescription')}</p>
+            </div>
+          </div>
+          <Button size="lg">
+            {t('project.conceptNote.exportButton')}
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="max-w-3xl max-h-[85vh]">
+          <DialogHeader>
+            <DialogTitle>{t('project.conceptNote.viewerTitle')}</DialogTitle>
+            <DialogDescription>{t('project.conceptNote.viewerDescription')}</DialogDescription>
+          </DialogHeader>
+          {note && (
+            <ScrollArea className="h-[60vh] pr-4">
+              <div className="space-y-6">
+                <div className="text-xs text-muted-foreground text-right">
+                  {t('project.conceptNote.generatedFrom', {
+                    date: new Date(note.generatedAt).toLocaleDateString(),
+                  })}
+                </div>
+
+                <div className="text-center pb-4 border-b">
+                  <h2 className="text-xl font-bold">{note.projectName}</h2>
+                  <p className="text-sm text-muted-foreground">{note.cityName}</p>
+                </div>
+
+                {sectionKeys.map(key => {
+                  const section = note.sections[key];
+                  return (
+                    <div key={key} className={`border-l-4 ${sectionColors[key]} pl-4 space-y-2`}>
+                      <h3 className="font-semibold text-sm">
+                        {t(`project.conceptNote.${section.title}`)}
+                      </h3>
+                      {section.hasData ? (
+                        <div className="space-y-1">
+                          {section.content.map((line, i) => (
+                            <p key={i} className={`text-sm ${line.startsWith('  -') ? 'ml-4 text-muted-foreground' : ''}`}>
+                              {line}
+                            </p>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground italic">
+                          {t('project.conceptNote.noData')}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          )}
+          <div className="flex justify-end pt-2 border-t">
+            <Button variant="outline" onClick={() => window.print()}>
+              <Download className="h-4 w-4 mr-2" />
+              {t('project.conceptNote.downloadPdf')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const { t } = useTranslation();
@@ -1081,7 +1218,7 @@ export default function ProjectPage() {
               <DisplayLarge>{action.name}</DisplayLarge>
               <Badge variant="secondary">{t('cityInfo.sampleDataBadge')}</Badge>
             </div>
-            <div className="flex items-center gap-3 mt-2">
+            <div className="flex items-center gap-4 mt-2">
               <Badge variant={action.type === 'mitigation' ? 'default' : 'secondary'}>
                 {action.type === 'mitigation' ? t('cityInfo.mitigation') : t('cityInfo.adaptation')}
               </Badge>
@@ -1100,124 +1237,141 @@ export default function ProjectPage() {
                   <ContextViewer context={context} />
                 </DialogContent>
               </Dialog>
+              <DataReadinessChecklist items={SAMPLE_DATA_READINESS} />
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <Link href={`${routePrefix}/funder-selection/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-green-500/10 rounded-lg">
-                      <DollarSign className="h-6 w-6 text-green-600" />
+          {/* PREPARE Section */}
+          <div className="mb-10">
+            <div className="flex items-center gap-2 mb-4">
+              <h2 className="text-lg font-semibold tracking-tight">{t('project.sections.prepare')}</h2>
+              <span className="text-sm text-muted-foreground">{t('project.sections.prepareDescription')}</span>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href={`${routePrefix}/funder-selection/${projectId}`}>
+                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-green-500/10 rounded-lg">
+                        <DollarSign className="h-6 w-6 text-green-600" />
+                      </div>
+                      <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
                     </div>
-                    <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>
-                    {t('project.funderSelectionDescription')}
-                  </CardDescription>
-                  <FunderHighlight data={context?.funderSelection} />
-                  <div className="flex items-center text-green-600 text-sm font-medium mt-3">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>
+                      {t('project.funderSelectionDescription')}
+                    </CardDescription>
+                    <FunderHighlight data={context?.funderSelection} />
+                    <div className="flex items-center text-green-600 text-sm font-medium mt-3">
+                      {t('common.view')}
+                      <ArrowRight className="h-4 w-4 ml-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
 
-            <Link href={`${routePrefix}/site-explorer/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <Map className="h-6 w-6 text-primary" />
+              <Link href={`${routePrefix}/site-explorer/${projectId}`}>
+                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-primary/10 rounded-lg">
+                        <Map className="h-6 w-6 text-primary" />
+                      </div>
+                      <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
                     </div>
-                    <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>
-                    {t('project.siteExplorerDescription')}
-                  </CardDescription>
-                  <SiteExplorerHighlight data={context?.siteExplorer} />
-                  <div className="flex items-center text-primary text-sm font-medium mt-3">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>
+                      {t('project.siteExplorerDescription')}
+                    </CardDescription>
+                    <SiteExplorerHighlight data={context?.siteExplorer} />
+                    <div className="flex items-center text-primary text-sm font-medium mt-3">
+                      {t('common.view')}
+                      <ArrowRight className="h-4 w-4 ml-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
 
-            <Link href={`${routePrefix}/impact-model/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-amber-500/10 rounded-lg">
-                      <Lightbulb className="h-6 w-6 text-amber-600" />
+              <Link href={`${routePrefix}/impact-model/${projectId}`}>
+                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-amber-500/10 rounded-lg">
+                        <Lightbulb className="h-6 w-6 text-amber-600" />
+                      </div>
+                      <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
                     </div>
-                    <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>
-                    {t('project.impactModelDescription')}
-                  </CardDescription>
-                  <ImpactModelHighlight data={context?.impactModel} />
-                  <div className="flex items-center text-amber-600 text-sm font-medium mt-3">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>
+                      {t('project.impactModelDescription')}
+                    </CardDescription>
+                    <ImpactModelHighlight data={context?.impactModel} />
+                    <div className="flex items-center text-amber-600 text-sm font-medium mt-3">
+                      {t('common.view')}
+                      <ArrowRight className="h-4 w-4 ml-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
 
-            <Link href={`${routePrefix}/project-operations/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-orange-500/10 rounded-lg">
-                      <Settings className="h-6 w-6 text-orange-600" />
+              <Link href={`${routePrefix}/project-operations/${projectId}`}>
+                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-orange-500/10 rounded-lg">
+                        <Settings className="h-6 w-6 text-orange-600" />
+                      </div>
+                      <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
                     </div>
-                    <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>
-                    {t('project.projectOperationsDescription')}
-                  </CardDescription>
-                  <OperationsHighlight data={context?.operations} />
-                  <div className="flex items-center text-orange-600 text-sm font-medium mt-3">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>
+                      {t('project.projectOperationsDescription')}
+                    </CardDescription>
+                    <OperationsHighlight data={context?.operations} />
+                    <div className="flex items-center text-orange-600 text-sm font-medium mt-3">
+                      {t('common.view')}
+                      <ArrowRight className="h-4 w-4 ml-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
 
-            <Link href={`${routePrefix}/business-model/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-purple-500/10 rounded-lg">
-                      <Landmark className="h-6 w-6 text-purple-600" />
+              <Link href={`${routePrefix}/business-model/${projectId}`}>
+                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                  <CardHeader>
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-purple-500/10 rounded-lg">
+                        <Landmark className="h-6 w-6 text-purple-600" />
+                      </div>
+                      <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
                     </div>
-                    <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>
-                    {t('project.businessModelDescription')}
-                  </CardDescription>
-                  <BusinessModelHighlight data={context?.businessModel} />
-                  <div className="flex items-center text-purple-600 text-sm font-medium mt-3">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription>
+                      {t('project.businessModelDescription')}
+                    </CardDescription>
+                    <BusinessModelHighlight data={context?.businessModel} />
+                    <div className="flex items-center text-purple-600 text-sm font-medium mt-3">
+                      {t('common.view')}
+                      <ArrowRight className="h-4 w-4 ml-1" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            </div>
+          </div>
+
+          {/* OUTPUT Section */}
+          <div>
+            <div className="flex items-center gap-2 mb-4">
+              <h2 className="text-lg font-semibold tracking-tight">{t('project.sections.output')}</h2>
+              <span className="text-sm text-muted-foreground">{t('project.sections.outputDescription')}</span>
+            </div>
+            <ConceptNotePanel context={context} />
           </div>
         </div>
       </div>
@@ -1291,116 +1445,132 @@ export default function ProjectPage() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <Link href={`/funder-selection/${projectId}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-green-500/10 rounded-lg">
-                    <DollarSign className="h-6 w-6 text-green-600" />
+        {/* PREPARE Section */}
+        <div className="mb-10">
+          <div className="flex items-center gap-2 mb-4">
+            <h2 className="text-lg font-semibold tracking-tight">{t('project.sections.prepare')}</h2>
+            <span className="text-sm text-muted-foreground">{t('project.sections.prepareDescription')}</span>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <Link href={`/funder-selection/${projectId}`}>
+              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-green-500/10 rounded-lg">
+                      <DollarSign className="h-6 w-6 text-green-600" />
+                    </div>
+                    <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
                   </div>
-                  <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="mb-4">
-                  {t('project.funderSelectionDescription')}
-                </CardDescription>
-                <div className="flex items-center text-green-600 text-sm font-medium">
-                  {t('common.view')}
-                  <ArrowRight className="h-4 w-4 ml-1" />
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="mb-4">
+                    {t('project.funderSelectionDescription')}
+                  </CardDescription>
+                  <div className="flex items-center text-green-600 text-sm font-medium">
+                    {t('common.view')}
+                    <ArrowRight className="h-4 w-4 ml-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
 
-          <Link href={`/site-explorer/${projectId}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-primary/10 rounded-lg">
-                    <Map className="h-6 w-6 text-primary" />
+            <Link href={`/site-explorer/${projectId}`}>
+              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-primary/10 rounded-lg">
+                      <Map className="h-6 w-6 text-primary" />
+                    </div>
+                    <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
                   </div>
-                  <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="mb-4">
-                  {t('project.siteExplorerDescription')}
-                </CardDescription>
-                <div className="flex items-center text-primary text-sm font-medium">
-                  {t('common.view')}
-                  <ArrowRight className="h-4 w-4 ml-1" />
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="mb-4">
+                    {t('project.siteExplorerDescription')}
+                  </CardDescription>
+                  <div className="flex items-center text-primary text-sm font-medium">
+                    {t('common.view')}
+                    <ArrowRight className="h-4 w-4 ml-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
 
-          <Link href={`/impact-model/${projectId}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-amber-500/10 rounded-lg">
-                    <Lightbulb className="h-6 w-6 text-amber-600" />
+            <Link href={`/impact-model/${projectId}`}>
+              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-amber-500/10 rounded-lg">
+                      <Lightbulb className="h-6 w-6 text-amber-600" />
+                    </div>
+                    <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
                   </div>
-                  <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="mb-4">
-                  {t('project.impactModelDescription')}
-                </CardDescription>
-                <div className="flex items-center text-amber-600 text-sm font-medium">
-                  {t('common.view')}
-                  <ArrowRight className="h-4 w-4 ml-1" />
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="mb-4">
+                    {t('project.impactModelDescription')}
+                  </CardDescription>
+                  <div className="flex items-center text-amber-600 text-sm font-medium">
+                    {t('common.view')}
+                    <ArrowRight className="h-4 w-4 ml-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
 
-          <Link href={`/project-operations/${projectId}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-orange-500/10 rounded-lg">
-                    <Settings className="h-6 w-6 text-orange-600" />
+            <Link href={`/project-operations/${projectId}`}>
+              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-orange-500/10 rounded-lg">
+                      <Settings className="h-6 w-6 text-orange-600" />
+                    </div>
+                    <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
                   </div>
-                  <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="mb-4">
-                  {t('project.projectOperationsDescription')}
-                </CardDescription>
-                <div className="flex items-center text-orange-600 text-sm font-medium">
-                  {t('common.view')}
-                  <ArrowRight className="h-4 w-4 ml-1" />
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="mb-4">
+                    {t('project.projectOperationsDescription')}
+                  </CardDescription>
+                  <div className="flex items-center text-orange-600 text-sm font-medium">
+                    {t('common.view')}
+                    <ArrowRight className="h-4 w-4 ml-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
 
-          <Link href={`/business-model/${projectId}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-purple-500/10 rounded-lg">
-                    <Landmark className="h-6 w-6 text-purple-600" />
+            <Link href={`/business-model/${projectId}`}>
+              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-purple-500/10 rounded-lg">
+                      <Landmark className="h-6 w-6 text-purple-600" />
+                    </div>
+                    <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
                   </div>
-                  <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="mb-4">
-                  {t('project.businessModelDescription')}
-                </CardDescription>
-                <div className="flex items-center text-purple-600 text-sm font-medium">
-                  {t('common.view')}
-                  <ArrowRight className="h-4 w-4 ml-1" />
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="mb-4">
+                    {t('project.businessModelDescription')}
+                  </CardDescription>
+                  <div className="flex items-center text-purple-600 text-sm font-medium">
+                    {t('common.view')}
+                    <ArrowRight className="h-4 w-4 ml-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        </div>
+
+        {/* OUTPUT Section */}
+        <div>
+          <div className="flex items-center gap-2 mb-4">
+            <h2 className="text-lg font-semibold tracking-tight">{t('project.sections.output')}</h2>
+            <span className="text-sm text-muted-foreground">{t('project.sections.outputDescription')}</span>
+          </div>
+          <ConceptNotePanel context={context} />
         </div>
       </div>
     </div>

--- a/client/src/core/types/concept-note.ts
+++ b/client/src/core/types/concept-note.ts
@@ -1,0 +1,245 @@
+import { ProjectContextData } from '@/core/contexts/project-context';
+
+/**
+ * GCF-style concept note structure.
+ * Each section maps to a standard GCF concept note section.
+ * Content is assembled from ProjectContextData across all modules.
+ */
+export interface ConceptNote {
+  generatedAt: string;
+  projectName: string;
+  cityName: string;
+  sections: {
+    summary: ConceptNoteSection;
+    contextBaseline: ConceptNoteSection;
+    projectDescription: ConceptNoteSection;
+    expectedResults: ConceptNoteSection;
+    implementation: ConceptNoteSection;
+    financing: ConceptNoteSection;
+  };
+}
+
+export interface ConceptNoteSection {
+  title: string; // i18n key
+  content: string[];
+  hasData: boolean;
+}
+
+/**
+ * Assembles a concept note from project context data.
+ * Each section pulls from the relevant module outputs.
+ */
+export function assembleConceptNote(context: ProjectContextData | null): ConceptNote {
+  const now = new Date().toISOString();
+  const projectName = context?.projectName || 'Untitled Project';
+  const cityName = context?.cityName || 'Unknown City';
+
+  return {
+    generatedAt: now,
+    projectName,
+    cityName,
+    sections: {
+      summary: buildSummary(context),
+      contextBaseline: buildContextBaseline(context),
+      projectDescription: buildProjectDescription(context),
+      expectedResults: buildExpectedResults(context),
+      implementation: buildImplementation(context),
+      financing: buildFinancing(context),
+    },
+  };
+}
+
+function buildSummary(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionA', content, hasData: false };
+
+  if (ctx.projectName) content.push(`Project: ${ctx.projectName}`);
+  if (ctx.cityName) content.push(`Location: ${ctx.cityName} (${ctx.cityLocode})`);
+  if (ctx.actionType) content.push(`Type: ${ctx.actionType}`);
+  if (ctx.hazardFocus?.length) content.push(`Hazard Focus: ${ctx.hazardFocus.join(', ')}`);
+  if (ctx.projectDescription) content.push(ctx.projectDescription);
+
+  // Funder pathway info
+  if (ctx.funderSelection?.pathway?.primary) {
+    content.push(`Financing Pathway: ${ctx.funderSelection.pathway.primary.replace(/_/g, ' ')}`);
+  }
+  if (ctx.funderSelection?.fundingPlan?.selectedFunderNowName) {
+    content.push(`Preparation Fund: ${ctx.funderSelection.fundingPlan.selectedFunderNowName}`);
+  }
+  if (ctx.funderSelection?.fundingPlan?.selectedFunderNextName) {
+    content.push(`Target Funder: ${ctx.funderSelection.fundingPlan.selectedFunderNextName}`);
+  }
+
+  return { title: 'sectionA', content, hasData: content.length > 0 };
+}
+
+function buildContextBaseline(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionB', content, hasData: false };
+
+  // Climate risk data from site explorer
+  if (ctx.siteExplorer?.hazardSummary) {
+    const hs = ctx.siteExplorer.hazardSummary;
+    const hazards: string[] = [];
+    if (hs.floodCells > 0) hazards.push(`Flood (${hs.floodCells} cells)`);
+    if (hs.heatCells > 0) hazards.push(`Heat (${hs.heatCells} cells)`);
+    if (hs.landslideCells > 0) hazards.push(`Landslide (${hs.landslideCells} cells)`);
+    if (hazards.length) content.push(`Climate Hazards Identified: ${hazards.join(', ')}`);
+    content.push(`Total Analysis Area: ${hs.totalCells} grid cells`);
+  }
+
+  // Selected zones
+  if (ctx.siteExplorer?.selectedZones?.length) {
+    content.push(`Intervention Zones: ${ctx.siteExplorer.selectedZones.length} zones selected for NBS deployment`);
+    ctx.siteExplorer.selectedZones.forEach(zone => {
+      if (typeof zone !== 'string' && zone.zoneId) {
+        const riskPct = zone.riskScore !== undefined ? ` (risk: ${(zone.riskScore * 100).toFixed(0)}%)` : '';
+        const area = zone.area ? `, ${zone.area.toFixed(2)} km²` : '';
+        content.push(`  - Zone ${zone.zoneId}: ${zone.hazardType}${riskPct}${area}`);
+      }
+    });
+  }
+
+  // Stakeholder context
+  if (ctx.stakeholders?.length) {
+    content.push(`Stakeholders: ${ctx.stakeholders.map(s => `${s.name} (${s.type})`).join(', ')}`);
+  }
+
+  return { title: 'sectionB', content, hasData: content.length > 0 };
+}
+
+function buildProjectDescription(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionC', content, hasData: false };
+
+  if (ctx.projectDescription) {
+    content.push(ctx.projectDescription);
+  }
+
+  // Intervention types from zones
+  if (ctx.siteExplorer?.selectedZones?.length) {
+    const interventionTypes = new Set<string>();
+    ctx.siteExplorer.selectedZones.forEach(zone => {
+      if (typeof zone !== 'string' && zone.interventionType) {
+        interventionTypes.add(zone.interventionType.replace(/_/g, ' '));
+      }
+    });
+    if (interventionTypes.size > 0) {
+      content.push(`NBS Interventions: ${Array.from(interventionTypes).join(', ')}`);
+    }
+  }
+
+  // Sites
+  if (ctx.sites?.length) {
+    content.push('Project Sites:');
+    ctx.sites.forEach(s => {
+      content.push(`  - ${s.name}: ${s.hazardType} / ${s.interventionType}`);
+    });
+  }
+
+  return { title: 'sectionC', content, hasData: content.length > 0 };
+}
+
+function buildExpectedResults(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionD', content, hasData: false };
+
+  // Impact model data
+  if (ctx.impactModel) {
+    if (ctx.impactModel.selectedLens && ctx.impactModel.selectedLens !== 'neutral') {
+      content.push(`Impact Lens: ${ctx.impactModel.selectedLens}`);
+    }
+    if (ctx.impactModel.narrativeCache?.base?.length) {
+      content.push(`Impact Narratives: ${ctx.impactModel.narrativeCache.base.length} narrative blocks generated`);
+    }
+    const coBenefits = ctx.impactModel.coBenefits?.filter(cb => cb.included);
+    if (coBenefits?.length) {
+      content.push(`Co-benefits: ${coBenefits.map(cb => cb.title || cb.id).join(', ')}`);
+    }
+    const signals = ctx.impactModel.downstreamSignals;
+    if (signals) {
+      const totalSignals = Object.values(signals).flat().length;
+      if (totalSignals > 0) {
+        content.push(`Downstream Signals: ${totalSignals} signals identified for operations and business model`);
+      }
+    }
+  }
+
+  return { title: 'sectionD', content, hasData: content.length > 0 };
+}
+
+function buildImplementation(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionE', content, hasData: false };
+
+  if (ctx.operations) {
+    if (ctx.operations.operatingModel) {
+      content.push(`Operating Model: ${ctx.operations.operatingModel.replace(/_/g, ' ')}`);
+    }
+    if (ctx.operations.roles) {
+      const roles: string[] = [];
+      if (ctx.operations.roles.assetOwnerEntityId) roles.push(`Asset Owner: ${ctx.operations.roles.assetOwnerEntityId}`);
+      if (ctx.operations.roles.operatorEntityId) roles.push(`Operator: ${ctx.operations.roles.operatorEntityId}`);
+      if (ctx.operations.roles.maintainerEntityId) roles.push(`Maintainer: ${ctx.operations.roles.maintainerEntityId}`);
+      if (roles.length) content.push(`Key Roles: ${roles.join(' | ')}`);
+    }
+    if (ctx.operations.taskPlan?.length) {
+      content.push(`Task Plan: ${ctx.operations.taskPlan.length} operational tasks defined`);
+    }
+    if (ctx.operations.nbsExtensions) {
+      const ext = ctx.operations.nbsExtensions;
+      content.push(`NBS Parameters: ${ext.establishmentPeriodMonths}mo establishment, ${ext.maintenanceIntensity} maintenance, ${ext.survivalTargetPercent}% survival target`);
+    }
+    if (ctx.operations.omCostBand?.low && ctx.operations.omCostBand?.high) {
+      content.push(`O&M Cost Range: ${ctx.operations.omCostBand.currency} ${ctx.operations.omCostBand.low.toLocaleString()} - ${ctx.operations.omCostBand.high.toLocaleString()}`);
+    }
+  }
+
+  return { title: 'sectionE', content, hasData: content.length > 0 };
+}
+
+function buildFinancing(ctx: ProjectContextData | null): ConceptNoteSection {
+  const content: string[] = [];
+  if (!ctx) return { title: 'sectionF', content, hasData: false };
+
+  if (ctx.businessModel) {
+    if (ctx.businessModel.primaryArchetype) {
+      content.push(`Business Archetype: ${ctx.businessModel.primaryArchetype.replace(/_/g, ' ')}`);
+    }
+    if (ctx.businessModel.revenueStack?.length) {
+      content.push('Revenue Stack:');
+      ctx.businessModel.revenueStack.forEach(rev => {
+        const dur = rev.durationYears ? ` (${rev.durationYears}y)` : '';
+        content.push(`  - ${rev.revenueType.replace(/_/g, ' ')} [${rev.confidence}]${dur}`);
+      });
+    }
+    if (ctx.businessModel.sourcesAndUsesRom) {
+      const rom = ctx.businessModel.sourcesAndUsesRom;
+      if (rom.capexBand?.low && rom.capexBand?.high) {
+        content.push(`CAPEX: ${rom.capexBand.currency || 'USD'} ${rom.capexBand.low.toLocaleString()} - ${rom.capexBand.high.toLocaleString()}`);
+      }
+      if (rom.opexBand?.low && rom.opexBand?.high) {
+        content.push(`OPEX: ${rom.opexBand.currency || 'USD'} ${rom.opexBand.low.toLocaleString()} - ${rom.opexBand.high.toLocaleString()}`);
+      }
+    }
+    if (ctx.businessModel.financingPathway?.pathway) {
+      content.push(`Financing Pathway: ${ctx.businessModel.financingPathway.pathway.replace(/_/g, ' ')}`);
+      if (ctx.businessModel.financingPathway.rationale) {
+        content.push(`Rationale: ${ctx.businessModel.financingPathway.rationale}`);
+      }
+    }
+  }
+
+  // Funder selection data
+  if (ctx.funderSelection?.fundingPlan) {
+    const plan = ctx.funderSelection.fundingPlan;
+    if (plan.selectedFunderNowName) {
+      content.push(`Project Preparation Facility: ${plan.selectedFunderNowName}`);
+    }
+    if (plan.selectedFunderNextName) {
+      content.push(`Target Investment Funder: ${plan.selectedFunderNextName}`);
+    }
+  }
+
+  return { title: 'sectionF', content, hasData: content.length > 0 };
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -161,7 +161,37 @@
       "signals": "downstream signals"
     },
     "impactModel": "Impact Model",
-    "impactModelDescription": "Generate AI-powered impact narratives, co-benefits, and downstream signals to communicate your project's value"
+    "impactModelDescription": "Generate AI-powered impact narratives, co-benefits, and downstream signals to communicate your project's value",
+    "sections": {
+      "prepare": "Prepare",
+      "prepareDescription": "Build your project through guided modules",
+      "output": "Output",
+      "outputDescription": "Generate funding-ready deliverables from your project data"
+    },
+    "dataReadiness": {
+      "title": "Data Readiness",
+      "loaded": "{{count}} of {{total}} datasets loaded",
+      "ghgInventory": "GHG Inventory",
+      "ccra": "Climate Risk Assessment",
+      "hiap": "High-Impact Action Plan",
+      "localDataEnhancement": "Local Data Enhancement"
+    },
+    "conceptNote": {
+      "exportBanner": "Export as Concept Note",
+      "exportBannerDescription": "Generate a GCF-style concept note from your project data across all modules",
+      "exportButton": "Generate Concept Note",
+      "viewerTitle": "Concept Note",
+      "viewerDescription": "GCF-style project concept note generated from your project data",
+      "downloadPdf": "Download PDF",
+      "sectionA": "Project Summary",
+      "sectionB": "Project Context & Baseline",
+      "sectionC": "Project Description",
+      "sectionD": "Expected Results",
+      "sectionE": "Implementation Arrangements",
+      "sectionF": "Financing",
+      "noData": "Complete more modules to populate this section",
+      "generatedFrom": "Generated from project data on {{date}}"
+    }
   },
   "funderSelection": {
     "title": "Funder Selection",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -161,7 +161,37 @@
       "signals": "sinais downstream"
     },
     "impactModel": "Modelo de Impacto",
-    "impactModelDescription": "Gere narrativas de impacto com IA, co-benefícios e sinais downstream para comunicar o valor do seu projeto"
+    "impactModelDescription": "Gere narrativas de impacto com IA, co-benefícios e sinais downstream para comunicar o valor do seu projeto",
+    "sections": {
+      "prepare": "Preparar",
+      "prepareDescription": "Construa seu projeto através de módulos guiados",
+      "output": "Resultado",
+      "outputDescription": "Gere entregas prontas para financiamento a partir dos dados do projeto"
+    },
+    "dataReadiness": {
+      "title": "Prontidão dos Dados",
+      "loaded": "{{count}} de {{total}} conjuntos de dados carregados",
+      "ghgInventory": "Inventário de GEE",
+      "ccra": "Avaliação de Risco Climático",
+      "hiap": "Plano de Ação de Alto Impacto",
+      "localDataEnhancement": "Aprimoramento de Dados Locais"
+    },
+    "conceptNote": {
+      "exportBanner": "Exportar como Nota Conceitual",
+      "exportBannerDescription": "Gere uma nota conceitual no estilo GCF a partir dos dados do projeto em todos os módulos",
+      "exportButton": "Gerar Nota Conceitual",
+      "viewerTitle": "Nota Conceitual",
+      "viewerDescription": "Nota conceitual do projeto no estilo GCF gerada a partir dos dados do projeto",
+      "downloadPdf": "Baixar PDF",
+      "sectionA": "Resumo do Projeto",
+      "sectionB": "Contexto e Linha de Base",
+      "sectionC": "Descrição do Projeto",
+      "sectionD": "Resultados Esperados",
+      "sectionE": "Arranjos de Implementação",
+      "sectionF": "Financiamento",
+      "noData": "Complete mais módulos para preencher esta seção",
+      "generatedFrom": "Gerado a partir dos dados do projeto em {{date}}"
+    }
   },
   "funderSelection": {
     "title": "Seleção de Financiador",


### PR DESCRIPTION
## Summary

- Restructure project page into **Prepare** (module cards) and **Output** (concept note export) sections
- Add **Data Readiness Checklist** beside "Show project context" button (GHG Inventory, CCRA, HIAP checked; Local Data Enhancement unchecked)
- Add **Export as Concept Note** banner + viewer that assembles all module data into a GCF-style document with 6 sections

## Files Changed

| File | Change |
|------|--------|
| `client/src/locales/en.json` | Added `project.sections`, `project.dataReadiness`, `project.conceptNote` i18n keys |
| `client/src/locales/pt.json` | Same keys in Portuguese |
| `client/src/core/contexts/sample-data-context.tsx` | Added `DataReadinessItem` interface + `SAMPLE_DATA_READINESS` array |
| `client/src/core/types/concept-note.ts` | **New** — types + `assembleConceptNote()` mapping all module data to GCF sections |
| `client/src/core/pages/project.tsx` | Added `DataReadinessChecklist` + `ConceptNotePanel` components; restructured both sample and API render paths |

## Test plan

- [ ] Navigate to a sample project page — verify Prepare/Output section headers appear
- [ ] Verify Data Readiness Checklist shows beside project context button (3/4 checked)
- [ ] Click "Export as Concept Note" — verify dialog opens with 6 GCF sections
- [ ] Complete some modules, re-export — verify sections populate with module data
- [ ] Switch to Portuguese — verify all new strings translate

🤖 Generated with [Claude Code](https://claude.com/claude-code)