### PR TITLE
Add undo button to remove initiated projects

### DIFF
--- a/client/src/core/contexts/sample-data-context.tsx
+++ b/client/src/core/contexts/sample-data-context.tsx
@@ -13,6 +13,7 @@ interface SampleDataContextType {
   sampleActions: SampleAction[];
   initiatedProjects: string[];
   initiateProject: (actionId: string) => void;
+  uninitateProject: (actionId: string) => void;
   sampleProjectId: string;
   sampleCityId: string;
   sampleUserId: string;
@@ -192,6 +193,10 @@ export function SampleDataProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const uninitateProject = (actionId: string) => {
+    setInitiatedProjects(prev => prev.filter(id => id !== actionId));
+  };
+
   return (
     <SampleDataContext.Provider
       value={{
@@ -202,6 +207,7 @@ export function SampleDataProvider({ children }: { children: ReactNode }) {
         sampleActions: SAMPLE_ACTIONS,
         initiatedProjects,
         initiateProject,
+        uninitateProject,
         sampleProjectId: SAMPLE_PROJECT_ID,
         sampleCityId: SAMPLE_CITY_ID,
         sampleUserId: SAMPLE_USER_ID,

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -83,6 +83,7 @@
     "noSelectedActions": "No selected actions",
     "emptySelectedActionsHint": "Go to the High Impact Action Prioritizer to identify actions that are relevant for your city",
     "noInitiatedProjects": "No initiated projects yet",
+    "removeProject": "Remove project",
     "mitigation": "Mitigation",
     "adaptation": "Adaptation"
   },

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -83,6 +83,7 @@
     "noSelectedActions": "Nenhuma ação selecionada",
     "emptySelectedActionsHint": "Acesse o Priorizador de Ações de Alto Impacto para identificar ações relevantes para sua cidade",
     "noInitiatedProjects": "Nenhum projeto iniciado ainda",
+    "removeProject": "Remover projeto",
     "mitigation": "Mitigação",
     "adaptation": "Adaptação"
   },

--- a/client/src/modules/city-information/pages/city-information.tsx
+++ b/client/src/modules/city-information/pages/city-information.tsx
@@ -19,6 +19,7 @@ import {
   AlertCircle,
   ArrowRight,
   FolderOpen,
+  Undo2,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useSampleData } from '@/core/contexts/sample-data-context';
@@ -42,7 +43,7 @@ export default function CityInformation() {
   const { t } = useTranslation();
   const [, setLocation] = useLocation();
   const queryClient = useQueryClient();
-  const { isSampleMode, sampleCity, sampleActions, initiatedProjects, initiateProject } = useSampleData();
+  const { isSampleMode, sampleCity, sampleActions, initiatedProjects, initiateProject, uninitateProject } = useSampleData();
   const { isSampleRoute, routePrefix } = useSampleRoute();
 
   const shouldFetchFromApi = !isSampleMode && !isSampleRoute;
@@ -63,6 +64,15 @@ export default function CityInformation() {
         actionType: action.type,
         cityId: action.cityId,
       });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', cityId] });
+    },
+  });
+
+  const deleteProjectMutation = useMutation({
+    mutationFn: async (projectId: string) => {
+      return apiRequest('DELETE', `/api/projects/${projectId}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/projects', cityId] });
@@ -124,6 +134,20 @@ export default function CityInformation() {
     }
   };
 
+  const handleRemoveProject = (actionId: string, projectId?: string) => {
+    track('Climate Action - Remove Project', {
+      actionId,
+      projectId,
+      isSampleMode,
+    });
+
+    if (isSampleMode || isSampleRoute) {
+      uninitateProject(actionId);
+    } else if (projectId) {
+      deleteProjectMutation.mutate(projectId);
+    }
+  };
+
   if (isLoading && !useSampleContent) {
     return (
       <div className='min-h-screen bg-background'>
@@ -172,13 +196,24 @@ export default function CityInformation() {
         <CardContent>
           <p className='text-sm text-muted-foreground mb-4'>{action.description}</p>
           {isInitiated ? (
-            <Button 
-              onClick={() => handleGoToProject(action.id, project?.id)}
-              className='w-full'
-            >
-              {t('cityInfo.goToProject')}
-              <ArrowRight className='h-4 w-4 ml-2' />
-            </Button>
+            <div className='flex gap-2'>
+              <Button
+                onClick={() => handleGoToProject(action.id, project?.id)}
+                className='flex-1'
+              >
+                {t('cityInfo.goToProject')}
+                <ArrowRight className='h-4 w-4 ml-2' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => handleRemoveProject(action.id, project?.id)}
+                disabled={deleteProjectMutation.isPending}
+                title={t('cityInfo.removeProject')}
+              >
+                <Undo2 className='h-4 w-4' />
+              </Button>
+            </div>
           ) : (
             <Button 
               onClick={() => handleStartProject(action)}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -769,6 +769,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete('/api/projects/:projectId', requireAuth, async (req: any, res) => {
+    try {
+      const { projectId } = req.params;
+      const project = await storage.getProject(projectId);
+      if (!project) {
+        return res.status(404).json({ message: 'Project not found' });
+      }
+      await storage.deleteProject(projectId);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Delete project error:', error);
+      res.status(500).json({ message: 'Failed to delete project' });
+    }
+  });
+
   // Geospatial API routes (for Site Explorer)
   app.post('/api/geospatial/boundary', async (req: any, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -71,6 +71,7 @@ export interface IStorage {
   getProject(id: string): Promise<Project | undefined>;
   createProject(project: InsertProject): Promise<Project>;
   createProjectWithId(id: string, project: InsertProject): Promise<Project>;
+  deleteProject(id: string): Promise<void>;
 
   getCityBoundaryCache(cityLocode: string): Promise<CityBoundaryCache | undefined>;
   setCityBoundaryCache(data: InsertCityBoundaryCache): Promise<CityBoundaryCache>;
@@ -227,6 +228,10 @@ export class DatabaseStorage implements IStorage {
   async createProjectWithId(id: string, insertProject: InsertProject): Promise<Project> {
     const [project] = await db.insert(projects).values({ ...insertProject, id } as typeof projects.$inferInsert).returning();
     return project;
+  }
+
+  async deleteProject(id: string): Promise<void> {
+    await db.delete(projects).where(eq(projects.id, id));
   }
 
   async getCityBoundaryCache(cityLocode: string): Promise<CityBoundaryCache | undefined> {


### PR DESCRIPTION
## Summary
- Add an undo button on initiated project cards in the city info page
- Clicking it moves the project back from "Initiated Projects" to "Selected Actions"
- Works in both sample mode (localStorage) and API mode (new `DELETE /api/projects/:projectId` endpoint)

## Changes
- `server/storage.ts` — Add `deleteProject()` to storage interface and implementation
- `server/routes.ts` — Add `DELETE /api/projects/:projectId` endpoint
- `sample-data-context.tsx` — Add `uninitateProject()` to remove from localStorage state
- `city-information.tsx` — Add delete mutation, handler, and undo button UI
- `en.json` / `pt.json` — Add `removeProject` i18n key

## Test plan
- [ ] In sample mode: initiate a project, then click undo — it moves back to Selected Actions
- [ ] In API mode: same flow, verify the DELETE endpoint is called
- [ ] Verify the undo button tooltip shows "Remove project" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)