### PR TITLE
Only NBS action opens modules; others show Coming Soon

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -84,6 +84,7 @@
     "emptySelectedActionsHint": "Go to the High Impact Action Prioritizer to identify actions that are relevant for your city",
     "noInitiatedProjects": "No initiated projects yet",
     "removeProject": "Remove project",
+    "moduleComingSoon": "Module Coming Soon",
     "mitigation": "Mitigation",
     "adaptation": "Adaptation"
   },

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -84,6 +84,7 @@
     "emptySelectedActionsHint": "Acesse o Priorizador de Ações de Alto Impacto para identificar ações relevantes para sua cidade",
     "noInitiatedProjects": "Nenhum projeto iniciado ainda",
     "removeProject": "Remover projeto",
+    "moduleComingSoon": "Módulo Em Breve",
     "mitigation": "Mitigação",
     "adaptation": "Adaptação"
   },

--- a/client/src/modules/city-information/pages/city-information.tsx
+++ b/client/src/modules/city-information/pages/city-information.tsx
@@ -125,7 +125,9 @@ export default function CityInformation() {
 
     if (isSampleMode || isSampleRoute) {
       initiateProject(action.id);
-      setLocation(`${routePrefix}/project/${action.id}`);
+      if (action.id === 'sample-ada-1') {
+        setLocation(`${routePrefix}/project/${action.id}`);
+      }
     } else {
       createProjectMutation.mutate(action, {
         onSuccess: (response: any) => {
@@ -223,13 +225,23 @@ export default function CityInformation() {
           <p className='text-sm text-muted-foreground mb-4'>{action.description}</p>
           {isInitiated ? (
             <div className='flex gap-2'>
-              <Button
-                onClick={() => handleGoToProject(action.id, project?.id)}
-                className='flex-1'
-              >
-                {t('cityInfo.goToProject')}
-                <ArrowRight className='h-4 w-4 ml-2' />
-              </Button>
+              {useSampleContent && action.id !== 'sample-ada-1' ? (
+                <Button
+                  disabled
+                  variant='outline'
+                  className='flex-1'
+                >
+                  {t('cityInfo.moduleComingSoon')}
+                </Button>
+              ) : (
+                <Button
+                  onClick={() => handleGoToProject(action.id, project?.id)}
+                  className='flex-1'
+                >
+                  {t('cityInfo.goToProject')}
+                  <ArrowRight className='h-4 w-4 ml-2' />
+                </Button>
+              )}
               <Button
                 variant='ghost'
                 size='icon'


### PR DESCRIPTION
## Summary
- In sample mode, clicking "Start Project" on non-NBS actions moves them to Initiated Projects without navigating
- Initiated non-NBS cards show a disabled "Module Coming Soon" button
- Only "Nature Based Solutions for Climate Resilience" gets the active "Go to Project" button

## Test plan
- [ ] Click Start Project on any non-NBS action — card moves to Initiated Projects, no navigation
- [ ] Non-NBS initiated cards show disabled "Module Coming Soon" button
- [ ] Click Start Project on NBS action — navigates to project modules
- [ ] NBS initiated card shows active "Go to Project" button
- [ ] Undo button still works on all initiated cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)