### PR TITLE
feat: Phase 4 spatial queries + zones toggle fix (#42)

### DIFF
--- a/client/src/core/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/core/components/concept-note/ConceptNoteMap.tsx
@@ -3,9 +3,10 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { Button } from '@/core/components/ui/button';
 import { Badge } from '@/core/components/ui/badge';
-import { Check, MapPin, Layers, X, BarChart3, ChevronDown, ChevronRight } from 'lucide-react';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, type TileLayerDef } from '@shared/geospatial-layers';
+import { Check, MapPin, Layers, X, BarChart3, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, type TileLayerDef } from '@shared/geospatial-layers';
 import ValueTooltip from './ValueTooltip';
+import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
 
 // ============================================================================
 // TYPES
@@ -116,10 +117,13 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
   const [showZones, setShowZones] = useState(true);
   const [enabledTileLayers, setEnabledTileLayers] = useState<Set<string>>(new Set());
   const [enabledOsmLayers, setEnabledOsmLayers] = useState<Set<string>>(new Set());
+  const [enabledSpatialQueries, setEnabledSpatialQueries] = useState<Set<string>>(new Set());
+  const [loadingSpatialQueries, setLoadingSpatialQueries] = useState<Set<string>>(new Set());
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [mapReady, setMapReady] = useState(false);
   const tileLayerRefs = useRef<Record<string, L.TileLayer>>({});
   const osmLayerRefs = useRef<Record<string, L.GeoJSON>>({});
+  const spatialQueryRefs = useRef<Record<string, L.GeoJSON>>({});
 
   // Enabled tile layer defs for ValueTooltip
   const enabledTileLayerDefs = useMemo(
@@ -372,6 +376,36 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
     }
   };
 
+  const toggleSpatialQuery = async (query: typeof SPATIAL_QUERIES[0]) => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const isEnabled = enabledSpatialQueries.has(query.id);
+
+    if (isEnabled) {
+      const existing = spatialQueryRefs.current[query.id];
+      if (existing) {
+        map.removeLayer(existing);
+        delete spatialQueryRefs.current[query.id];
+      }
+      setEnabledSpatialQueries(prev => { const next = new Set(prev); next.delete(query.id); return next; });
+    } else {
+      setLoadingSpatialQueries(prev => { const next = new Set(prev); next.add(query.id); return next; });
+      try {
+        const result = await buildSpatialQueryLayer(query);
+        if (result) {
+          result.layer.addTo(map);
+          spatialQueryRefs.current[query.id] = result.layer;
+          setEnabledSpatialQueries(prev => { const next = new Set(prev); next.add(query.id); return next; });
+        }
+      } catch {
+        // silently skip
+      } finally {
+        setLoadingSpatialQueries(prev => { const next = new Set(prev); next.delete(query.id); return next; });
+      }
+    }
+  };
+
   const toggleGroup = (groupId: string) => {
     setExpandedGroups(prev => {
       const next = new Set(prev);
@@ -574,6 +608,44 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
                     >
                       <span className="w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: isOn ? layer.color : '#d1d5db' }} />
                       <span className="truncate">{layer.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          {/* Spatial Queries */}
+          <div className="border-b">
+            <button
+              onClick={() => toggleGroup('spatial_queries')}
+              className="w-full flex items-center justify-between px-2 py-1.5 hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-[10px] font-medium">Spatial Queries</span>
+              <div className="flex items-center gap-1">
+                {enabledSpatialQueries.size > 0 && <span className="text-[9px] bg-primary/10 text-primary px-1 rounded">{enabledSpatialQueries.size}</span>}
+                {expandedGroups.has('spatial_queries') ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+              </div>
+            </button>
+            {expandedGroups.has('spatial_queries') && (
+              <div className="px-1 pb-1 space-y-0.5">
+                {SPATIAL_QUERIES.map(query => {
+                  const isOn = enabledSpatialQueries.has(query.id);
+                  const isLoading = loadingSpatialQueries.has(query.id);
+                  return (
+                    <button
+                      key={query.id}
+                      onClick={() => toggleSpatialQuery(query)}
+                      disabled={isLoading}
+                      className={`w-full text-left px-1.5 py-1 rounded text-[10px] flex items-center gap-1.5 transition-all ${
+                        isOn ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted/50'
+                      } ${isLoading ? 'opacity-60' : ''}`}
+                    >
+                      {isLoading ? (
+                        <Loader2 className="w-2 h-2 animate-spin shrink-0" />
+                      ) : (
+                        <span className="w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: isOn ? query.color : '#d1d5db' }} />
+                      )}
+                      <span className="truncate">{query.name}</span>
                     </button>
                   );
                 })}

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -36,7 +36,8 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS } from '@shared/geospatial-layers';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES } from '@shared/geospatial-layers';
+import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
 import ValueTooltip from '@/core/components/concept-note/ValueTooltip';
 
 interface BoundaryData {
@@ -77,7 +78,7 @@ interface CityInfo {
 }
 
 type LayerSource = 'geojson' | 'tiles';
-type LayerGroupId = 'analysis' | 'environment' | 'osm_reference' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
+type LayerGroupId = 'analysis' | 'environment' | 'osm_reference' | 'spatial_queries' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
 
 interface LayerState {
   id: string;
@@ -120,6 +121,16 @@ const LAYER_CONFIGS: LayerConfig[] = [
     group: 'osm_reference' as LayerGroupId,
     available: true,
   })),
+  // Spatial query layers (vector × raster intersection)
+  ...SPATIAL_QUERIES.map(q => ({
+    id: q.id,
+    name: q.name,
+    icon: AlertTriangle,
+    color: q.color,
+    source: 'geojson' as LayerSource,
+    group: 'spatial_queries' as LayerGroupId,
+    available: true,
+  })),
   // OEF tile layers — generated from shared catalog (48 layers)
   ...TILE_LAYERS.filter(l => l.available).map(l => ({
     id: l.id,
@@ -139,6 +150,7 @@ const LAYER_GROUPS: readonly { id: LayerGroupId; label: string }[] = [
   { id: 'analysis', label: 'Risk Analysis' },
   { id: 'environment', label: 'Environment' },
   { id: 'osm_reference', label: 'OSM Reference' },
+  { id: 'spatial_queries', label: 'Spatial Queries' },
   ...TILE_LAYER_GROUPS.map(g => ({ id: g.id as LayerGroupId, label: g.label })),
 ];
 
@@ -1673,6 +1685,29 @@ export default function SiteExplorerPage() {
         if (existingLayer && mapRef.current) {
           mapRef.current.removeLayer(existingLayer);
           layerRefs.current.delete(layerId);
+        }
+
+        // Spatial query layers — use buildSpatialQueryLayer
+        if (layerId.startsWith('sq_')) {
+          const queryDef = SPATIAL_QUERIES.find(q => q.id === layerId);
+          if (queryDef && mapRef.current) {
+            setLoadingLayers(prev => new Set(prev).add(layerId));
+            buildSpatialQueryLayer(queryDef).then(result => {
+              setLoadingLayers(prev => { const next = new Set(prev); next.delete(layerId); return next; });
+              if (result && mapRef.current) {
+                result.layer.addTo(mapRef.current);
+                layerRefs.current.set(layerId, result.layer);
+                setLayers(cur => cur.map(l => l.id === layerId ? { ...l, enabled: true, loaded: true } : l));
+              } else {
+                setLayers(cur => cur.map(l => l.id === layerId ? { ...l, enabled: false } : l));
+              }
+            }).catch(() => {
+              setLoadingLayers(prev => { const next = new Set(prev); next.delete(layerId); return next; });
+              setLayers(cur => cur.map(l => l.id === layerId ? { ...l, enabled: false } : l));
+            });
+            return prev.map(l => l.id === layerId ? { ...l, enabled: true } : l);
+          }
+          return prev;
         }
 
         if (layer.source === 'tiles') {

--- a/client/src/lib/spatialQueryBuilder.ts
+++ b/client/src/lib/spatialQueryBuilder.ts
@@ -1,0 +1,102 @@
+// Builds postprocessed Leaflet layers by filtering vector features against
+// raster tile values. Runs entirely client-side: fetches GeoJSON, samples
+// value tiles at each feature's centroid, keeps features that pass the threshold.
+
+import L from "leaflet";
+import { TILE_LAYERS, type SpatialQueryDef } from "@shared/geospatial-layers";
+import { sampleRasterAtPoint, geometryCentroid } from "./valueTileUtils";
+
+function compareValue(value: number, threshold: number, comparator: string): boolean {
+  switch (comparator) {
+    case '>': return value > threshold;
+    case '>=': return value >= threshold;
+    case '<': return value < threshold;
+    case '<=': return value <= threshold;
+    default: return value > threshold;
+  }
+}
+
+export interface SpatialQueryResult {
+  layer: L.GeoJSON;
+  featureCount: number;
+  totalSampled: number;
+}
+
+export async function buildSpatialQueryLayer(
+  query: SpatialQueryDef,
+  onProgress?: (sampled: number, total: number) => void,
+): Promise<SpatialQueryResult | null> {
+  // Fetch vector data
+  const res = await fetch(query.vectorSource);
+  if (!res.ok) return null;
+  const geojson = await res.json();
+  const features = geojson?.features;
+  if (!features || features.length === 0) return null;
+
+  // Find raster encoding
+  const rasterLayer = TILE_LAYERS.find(l => l.id === query.rasterLayerId);
+  const enc = rasterLayer?.valueEncoding;
+  if (!enc?.urlTemplate) return null;
+
+  // Sample raster at each feature's centroid
+  const passed: any[] = [];
+  const total = features.length;
+
+  for (let i = 0; i < total; i++) {
+    const feature = features[i];
+    const centroid = geometryCentroid(feature.geometry);
+    if (!centroid) continue;
+
+    const value = await sampleRasterAtPoint(centroid[0], centroid[1], enc, 11);
+    if (value !== null && compareValue(value, query.threshold, query.comparator)) {
+      passed.push({
+        ...feature,
+        properties: { ...feature.properties, [query.valueKey]: value },
+      });
+    }
+
+    if (onProgress && (i % 10 === 0 || i === total - 1)) {
+      onProgress(i + 1, total);
+    }
+  }
+
+  if (passed.length === 0) return null;
+
+  // Build styled layer
+  const unit = enc.unit || '';
+  const layer = L.geoJSON(
+    { type: "FeatureCollection", features: passed } as any,
+    {
+      style: {
+        color: query.color,
+        fillColor: query.color,
+        fillOpacity: 0.6,
+        weight: 2,
+        opacity: 1,
+      },
+      pointToLayer: (_feature, latlng) => L.circleMarker(latlng, {
+        radius: 7,
+        color: query.color,
+        fillColor: query.color,
+        fillOpacity: 0.7,
+        weight: 2,
+      }),
+      onEachFeature: (feature: any, layer: L.Layer) => {
+        const p = feature.properties || {};
+        const name = p.name || p.amenity || p.leisure || p.natural || 'Feature';
+        const val = p[query.valueKey]?.toFixed(enc.unit === 'index 0–1' ? 3 : 1) ?? '?';
+        (layer as any).bindTooltip(
+          `<div style="font-family:system-ui;font-size:11px;">
+            <strong style="color:${query.color}">${query.tooltipIcon} ${query.tooltipLabel}</strong><br/>
+            <strong>${name}</strong><br/>
+            ${rasterLayer?.name}: <strong>${val} ${unit}</strong>
+            <span style="color:#94a3b8">(threshold: ${query.threshold})</span>
+           </div>`,
+          { sticky: true }
+        );
+      },
+    }
+  );
+
+  return { layer, featureCount: passed.length, totalSampled: total };
+}

--- a/client/src/lib/valueTileUtils.ts
+++ b/client/src/lib/valueTileUtils.ts
@@ -137,3 +137,41 @@ export async function sampleRasterAtPoint(
     return null;
   }
 }
+
+// ── Geometry centroid helpers ─────────────────────────────────────────────────
+// Returns [lat, lng] centroid of a GeoJSON geometry (coordinates are [lng, lat]).
+export function geometryCentroid(geometry: any): [number, number] | null {
+  if (!geometry) return null;
+
+  let coords: [number, number][] = [];
+
+  const collect = (geom: any): void => {
+    switch (geom.type) {
+      case "Point":
+        coords.push(geom.coordinates);
+        break;
+      case "MultiPoint":
+      case "LineString":
+        coords.push(...geom.coordinates);
+        break;
+      case "MultiLineString":
+      case "Polygon":
+        for (const ring of geom.coordinates) coords.push(...ring);
+        break;
+      case "MultiPolygon":
+        for (const poly of geom.coordinates)
+          for (const ring of poly) coords.push(...ring);
+        break;
+      case "GeometryCollection":
+        for (const g of geom.geometries) collect(g);
+        break;
+    }
+  };
+
+  collect(geometry);
+  if (coords.length === 0) return null;
+
+  const sumLng = coords.reduce((s, c) => s + c[0], 0);
+  const sumLat = coords.reduce((s, c) => s + c[1], 0);
+  return [sumLat / coords.length, sumLng / coords.length]; // [lat, lng]
+}

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -169,3 +169,93 @@ export const OSM_LAYERS: OsmLayerDef[] = [
   { id: 'osm_hospitals', name: 'Hospitals & Health',    color: '#ef4444', endpoint: '/api/osm/hospitals' },
   { id: 'osm_wetlands',  name: 'Wetlands',             color: '#3b82f6', endpoint: '/api/osm/wetlands' },
 ];
+
+// ── Spatial Queries (vector × raster intersection) ────────────────────────────
+
+export interface SpatialQueryDef {
+  id: string;
+  name: string;
+  color: string;
+  vectorSource: string;  // OSM layer endpoint or static GeoJSON path
+  rasterLayerId: string; // TILE_LAYERS id to sample
+  threshold: number;
+  comparator: '>' | '>=' | '<' | '<=';
+  valueKey: string;      // property name for the sampled value
+  tooltipLabel: string;  // e.g. "High flood risk"
+  tooltipIcon: string;   // emoji for tooltip
+}
+
+export const SPATIAL_QUERIES: SpatialQueryDef[] = [
+  {
+    id: 'sq_parks_flood',
+    name: 'Parks in Flood Risk > 0.4',
+    color: '#ef4444',
+    vectorSource: '/api/osm/parks',
+    rasterLayerId: 'oef_fri_2024',
+    threshold: 0.4,
+    comparator: '>',
+    valueKey: 'fri_value',
+    tooltipLabel: 'High flood risk',
+    tooltipIcon: '⚠',
+  },
+  {
+    id: 'sq_schools_flood',
+    name: 'Schools in Flood Risk > 0.4',
+    color: '#dc2626',
+    vectorSource: '/api/osm/schools',
+    rasterLayerId: 'oef_fri_2024',
+    threshold: 0.4,
+    comparator: '>',
+    valueKey: 'fri_value',
+    tooltipLabel: 'High flood risk',
+    tooltipIcon: '⚠',
+  },
+  {
+    id: 'sq_hospitals_flood',
+    name: 'Hospitals in Flood Risk > 0.4',
+    color: '#b91c1c',
+    vectorSource: '/api/osm/hospitals',
+    rasterLayerId: 'oef_fri_2024',
+    threshold: 0.4,
+    comparator: '>',
+    valueKey: 'fri_value',
+    tooltipLabel: 'High flood risk',
+    tooltipIcon: '⚠',
+  },
+  {
+    id: 'sq_parks_heatwave',
+    name: 'Parks in Heatwave >= 10 °C·d',
+    color: '#fb923c',
+    vectorSource: '/api/osm/parks',
+    rasterLayerId: 'oef_hwm_2024',
+    threshold: 10,
+    comparator: '>=',
+    valueKey: 'hwm_value',
+    tooltipLabel: 'Heatwave zone',
+    tooltipIcon: '🌡',
+  },
+  {
+    id: 'sq_schools_heatwave',
+    name: 'Schools in Heatwave >= 10 °C·d',
+    color: '#ea580c',
+    vectorSource: '/api/osm/schools',
+    rasterLayerId: 'oef_hwm_2024',
+    threshold: 10,
+    comparator: '>=',
+    valueKey: 'hwm_value',
+    tooltipLabel: 'Heatwave zone',
+    tooltipIcon: '🌡',
+  },
+  {
+    id: 'sq_wetlands_flood',
+    name: 'Wetlands in Flood Risk > 0.4',
+    color: '#7c3aed',
+    vectorSource: '/api/osm/wetlands',
+    rasterLayerId: 'oef_fri_2024',
+    threshold: 0.4,
+    comparator: '>',
+    valueKey: 'fri_value',
+    tooltipLabel: 'High flood risk',
+    tooltipIcon: '⚠',
+  },
+];


### PR DESCRIPTION
## Summary

- **Phase 4 spatial queries**: 6 vector × raster intersection layers (parks/schools/hospitals/wetlands filtered by FRI > 0.4 or HWM >= 10°C·d). New Spatial Queries group in both ConceptNoteMap and site-explorer.
- **Zones toggle fix**: Uses `map.removeLayer/addTo` instead of opacity:0 so zones fully disappear when toggled off.

## Test plan

- [ ] Toggle "Parks in Flood Risk > 0.4" — should show loading spinner, then render only parks where FRI exceeds threshold
- [ ] Hover on a highlighted park — tooltip shows name + FRI value
- [ ] Toggle Zones off — zones fully disappear (no ghost borders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)