### PR TITLE
feat: open_map MCP tool — agent-invokable map microapp

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -1,0 +1,437 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Button } from '@/core/components/ui/button';
+import { Badge } from '@/core/components/ui/badge';
+import { Check, X, MapPin, Pencil, Crosshair, Loader2, Trash2 } from 'lucide-react';
+import { TILE_LAYERS, OSM_LAYERS, SPATIAL_QUERIES } from '@shared/geospatial-layers';
+import type { OpenMapParams, SelectedAsset, SampledPoint, MapSelectionResult, MapSelectionMode } from '@shared/concept-note-schema';
+import { sampleRasterAtPoint, geometryCentroid, latLngToTilePixel, fetchTilePixels, samplePixel, decodePixelNumeric } from '@/lib/valueTileUtils';
+import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
+import ValueTooltip from './ValueTooltip';
+
+interface Props {
+  params: OpenMapParams;
+  onConfirm: (result: MapSelectionResult) => void;
+  onCancel: () => void;
+}
+
+export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
+  const mapRef = useRef<L.Map | null>(null);
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const tileLayerRefs = useRef<Record<string, L.TileLayer>>({});
+  const osmLayerRefs = useRef<Record<string, L.GeoJSON>>({});
+  const spatialQueryRefs = useRef<Record<string, L.GeoJSON>>({});
+  const zonesLayerRef = useRef<L.GeoJSON | null>(null);
+  const customMarkersRef = useRef<L.Layer[]>([]);
+
+  const [mapReady, setMapReady] = useState(false);
+  const [selectedAssets, setSelectedAssets] = useState<SelectedAsset[]>([]);
+  const [sampledPoints, setSampledPoints] = useState<SampledPoint[]>([]);
+  const [drawMode, setDrawMode] = useState<'off' | 'point' | 'polygon'>('off');
+  const [loading, setLoading] = useState(true);
+  const [loadingStatus, setLoadingStatus] = useState('Initializing map...');
+
+  const selectionMode = params.selectionMode;
+
+  // Get enabled tile layer defs for ValueTooltip
+  const enabledTileLayerDefs = (params.tileLayers || [])
+    .map(id => TILE_LAYERS.find(l => l.id === id))
+    .filter(Boolean) as typeof TILE_LAYERS;
+
+  // ── Initialize map ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapContainerRef.current || mapRef.current) return;
+
+    const map = L.map(mapContainerRef.current, {
+      zoomControl: false,
+      attributionControl: false,
+      center: [-30.03, -51.22], // Porto Alegre
+      zoom: 11,
+    });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', { maxZoom: 17 }).addTo(map);
+    L.control.zoom({ position: 'bottomright' }).addTo(map);
+    mapRef.current = map;
+    setMapReady(true);
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  // ── Load boundary + fit bounds ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+
+    (async () => {
+      try {
+        const res = await fetch('/sample-data/porto-alegre-boundary.json');
+        const data = await res.json();
+        if (data.boundaryGeoJson) {
+          const bl = L.geoJSON(data.boundaryGeoJson, {
+            style: { color: '#94a3b8', weight: 2, fillOpacity: 0.02, dashArray: '6 3' },
+          }).addTo(map);
+          map.fitBounds(bl.getBounds(), { padding: [20, 20] });
+        }
+      } catch {}
+    })();
+  }, [mapReady]);
+
+  // ── Load requested layers ───────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+
+    (async () => {
+      // Tile layers
+      for (const tileId of params.tileLayers || []) {
+        const layerDef = TILE_LAYERS.find(l => l.id === tileId);
+        if (!layerDef) continue;
+        setLoadingStatus(`Loading ${layerDef.name}...`);
+        const tl = L.tileLayer(`/api/geospatial/tiles/${layerDef.tileLayerId}/{z}/{x}/{y}.png`, {
+          opacity: 0.7, maxNativeZoom: 15, maxZoom: 19, minZoom: 8, errorTileUrl: '',
+        });
+        tl.addTo(map);
+        tileLayerRefs.current[tileId] = tl;
+      }
+
+      // OSM layers
+      for (const osmId of params.layers || []) {
+        const osmDef = OSM_LAYERS.find(l => l.id === osmId);
+        if (!osmDef) continue;
+        setLoadingStatus(`Fetching ${osmDef.name}...`);
+        try {
+          const res = await fetch(osmDef.endpoint);
+          if (!res.ok) continue;
+          const geojson = await res.json();
+
+          const layer = L.geoJSON(geojson, {
+            style: { color: osmDef.color, weight: 1.5, fillColor: osmDef.color, fillOpacity: 0.3, opacity: 0.7 },
+            pointToLayer: (_f, latlng) => L.circleMarker(latlng, {
+              radius: 6, color: osmDef.color, fillColor: osmDef.color, fillOpacity: 0.6, weight: 1.5,
+            }),
+            onEachFeature: (feature, layer) => {
+              const p = feature.properties || {};
+              const name = p.name || p.amenity || p.leisure || p.natural || 'Feature';
+
+              // Make OSM features clickable for selection
+              if (selectionMode === 'assets' || selectionMode === 'composite') {
+                (layer as any).on('click', async () => {
+                  const centroid = geometryCentroid(feature.geometry);
+                  if (!centroid) return;
+
+                  // Sample raster values at centroid
+                  const rasterValues: Record<string, number> = {};
+                  for (const tileId of params.tileLayers || []) {
+                    const tileDef = TILE_LAYERS.find(l => l.id === tileId);
+                    if (!tileDef?.valueEncoding?.urlTemplate) continue;
+                    const val = await sampleRasterAtPoint(centroid[0], centroid[1], tileDef.valueEncoding, 11);
+                    if (val !== null) rasterValues[tileDef.name] = val;
+                  }
+
+                  const asset: SelectedAsset = {
+                    type: 'osm',
+                    source: osmId,
+                    name: typeof name === 'string' ? name : String(name),
+                    geometry: feature.geometry,
+                    coordinates: centroid,
+                    properties: p,
+                    rasterValues,
+                  };
+
+                  setSelectedAssets(prev => {
+                    // Toggle — remove if already selected
+                    const existing = prev.findIndex(a => a.type === 'osm' && a.name === asset.name && a.source === asset.source);
+                    if (existing >= 0) return prev.filter((_, i) => i !== existing);
+                    return [...prev, asset];
+                  });
+                });
+
+                // Hover cursor
+                (layer as any).on('mouseover', () => { map.getContainer().style.cursor = 'pointer'; });
+                (layer as any).on('mouseout', () => { map.getContainer().style.cursor = ''; });
+              }
+
+              // Tooltip
+              const type = p.amenity || p.leisure || p.natural || p.landuse || '';
+              const label = [name, type].filter(Boolean).join('<br/>');
+              layer.bindTooltip(label || 'OSM Feature', { sticky: true });
+            },
+          });
+          layer.addTo(map);
+          osmLayerRefs.current[osmId] = layer;
+        } catch {}
+      }
+
+      // Zones (for zones/composite mode)
+      if (selectionMode === 'zones' || selectionMode === 'composite') {
+        setLoadingStatus('Loading intervention zones...');
+        try {
+          const res = await fetch('/sample-data/porto-alegre-zones.json');
+          const data = await res.json();
+          if (data.geoJson) {
+            const zonesLayer = L.geoJSON(data.geoJson, {
+              style: { color: '#1e293b', weight: 2, fillOpacity: 0, dashArray: '4 2' },
+              onEachFeature: (feature, layer) => {
+                const p = feature.properties || {};
+                layer.bindTooltip(`<strong>${p.zoneId}</strong><br/>${p.typologyLabel} — ${p.interventionType?.replace(/_/g, ' ')}`, { sticky: true });
+
+                (layer as any).on('click', () => {
+                  const centroid = geometryCentroid(feature.geometry);
+                  if (!centroid) return;
+
+                  const asset: SelectedAsset = {
+                    type: 'zone',
+                    source: 'intervention_zones',
+                    name: p.zoneId,
+                    geometry: feature.geometry,
+                    coordinates: centroid,
+                    properties: p,
+                  };
+
+                  setSelectedAssets(prev => {
+                    const existing = prev.findIndex(a => a.type === 'zone' && a.name === asset.name);
+                    if (existing >= 0) return prev.filter((_, i) => i !== existing);
+                    return [...prev, asset];
+                  });
+                });
+
+                (layer as any).on('mouseover', () => {
+                  (layer as any).setStyle({ weight: 3, color: '#1d4ed8', fillColor: '#3b82f6', fillOpacity: 0.15 });
+                });
+                (layer as any).on('mouseout', () => {
+                  zonesLayerRef.current?.resetStyle(layer as any);
+                });
+              },
+            });
+            zonesLayer.addTo(map);
+            zonesLayerRef.current = zonesLayer;
+          }
+        } catch {}
+      }
+
+      // Spatial queries
+      for (const sqId of params.spatialQueries || []) {
+        const queryDef = SPATIAL_QUERIES.find(q => q.id === sqId);
+        if (!queryDef) continue;
+        setLoadingStatus(`Running ${queryDef.name}...`);
+        try {
+          const result = await buildSpatialQueryLayer(queryDef);
+          if (result) {
+            result.layer.addTo(map);
+            spatialQueryRefs.current[sqId] = result.layer;
+          }
+        } catch {}
+      }
+
+      setLoading(false);
+    })();
+  }, [mapReady]);
+
+  // ── Click-to-sample mode ────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    if (selectionMode !== 'sample') return;
+    const map = mapRef.current;
+
+    const handleClick = async (e: L.LeafletMouseEvent) => {
+      const { lat, lng } = e.latlng;
+      const values: Record<string, number> = {};
+
+      const layersToSample = params.sampleLayers || params.tileLayers || [];
+      for (const tileId of layersToSample) {
+        const tileDef = TILE_LAYERS.find(l => l.id === tileId);
+        if (!tileDef?.valueEncoding?.urlTemplate) continue;
+        const val = await sampleRasterAtPoint(lat, lng, tileDef.valueEncoding, 11);
+        if (val !== null) values[tileDef.name] = val;
+      }
+
+      if (Object.keys(values).length > 0) {
+        // Add marker
+        const marker = L.circleMarker([lat, lng], {
+          radius: 6, color: '#ef4444', fillColor: '#ef4444', fillOpacity: 0.8, weight: 2,
+        });
+        const tooltipLines = Object.entries(values).map(([k, v]) => `${k}: <strong>${v.toFixed(3)}</strong>`);
+        marker.bindTooltip(tooltipLines.join('<br/>'), { permanent: true, direction: 'top' });
+        marker.addTo(map);
+        customMarkersRef.current.push(marker);
+
+        setSampledPoints(prev => [...prev, { lat, lng, values }]);
+      }
+    };
+
+    map.on('click', handleClick);
+    map.getContainer().style.cursor = 'crosshair';
+
+    return () => {
+      map.off('click', handleClick);
+      map.getContainer().style.cursor = '';
+    };
+  }, [mapReady, selectionMode]);
+
+  // ── Custom draw (point) mode ────────────────────────────────────────────────
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || drawMode !== 'point') return;
+    const map = mapRef.current;
+
+    const handleClick = async (e: L.LeafletMouseEvent) => {
+      const { lat, lng } = e.latlng;
+
+      // Sample raster values
+      const rasterValues: Record<string, number> = {};
+      for (const tileId of params.tileLayers || []) {
+        const tileDef = TILE_LAYERS.find(l => l.id === tileId);
+        if (!tileDef?.valueEncoding?.urlTemplate) continue;
+        const val = await sampleRasterAtPoint(lat, lng, tileDef.valueEncoding, 11);
+        if (val !== null) rasterValues[tileDef.name] = val;
+      }
+
+      const marker = L.circleMarker([lat, lng], {
+        radius: 8, color: '#8b5cf6', fillColor: '#8b5cf6', fillOpacity: 0.8, weight: 2,
+      });
+      marker.bindTooltip('Custom site', { permanent: false });
+      marker.addTo(map);
+      customMarkersRef.current.push(marker);
+
+      const asset: SelectedAsset = {
+        type: 'custom',
+        name: `Custom point (${lat.toFixed(4)}, ${lng.toFixed(4)})`,
+        coordinates: [lat, lng],
+        properties: {},
+        rasterValues,
+      };
+      setSelectedAssets(prev => [...prev, asset]);
+      setDrawMode('off');
+    };
+
+    map.on('click', handleClick);
+    map.getContainer().style.cursor = 'crosshair';
+
+    return () => {
+      map.off('click', handleClick);
+      map.getContainer().style.cursor = '';
+    };
+  }, [mapReady, drawMode]);
+
+  // ── Confirm handler ─────────────────────────────────────────────────────────
+  const handleConfirm = useCallback(() => {
+    const enabledLayers = [
+      ...(params.layers || []),
+      ...(params.tileLayers || []),
+      ...(params.spatialQueries || []),
+    ];
+
+    onConfirm({
+      selectionMode,
+      selectedAssets,
+      sampledPoints,
+      enabledLayers,
+    });
+  }, [selectedAssets, sampledPoints, selectionMode, params, onConfirm]);
+
+  const removeAsset = (index: number) => {
+    setSelectedAssets(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const clearAll = () => {
+    setSelectedAssets([]);
+    setSampledPoints([]);
+    for (const marker of customMarkersRef.current) {
+      mapRef.current?.removeLayer(marker);
+    }
+    customMarkersRef.current = [];
+  };
+
+  const totalSelections = selectedAssets.length + sampledPoints.length;
+
+  return (
+    <div className="flex flex-col h-full bg-background border rounded-lg overflow-hidden">
+      {/* Header with prompt */}
+      <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs font-medium truncate">{params.prompt}</p>
+          <p className="text-[10px] text-muted-foreground">
+            Mode: {selectionMode} — {selectionMode === 'assets' ? 'Click features to select' : selectionMode === 'sample' ? 'Click to sample values' : selectionMode === 'composite' ? 'Select zones + assets' : 'Click zone boundaries'}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 ml-2">
+          {(selectionMode === 'assets' || selectionMode === 'composite') && (
+            <Button
+              variant={drawMode === 'point' ? 'default' : 'outline'}
+              size="sm"
+              className="h-6 text-[10px] gap-1"
+              onClick={() => setDrawMode(drawMode === 'point' ? 'off' : 'point')}
+            >
+              <Pencil className="w-3 h-3" />
+              {drawMode === 'point' ? 'Drawing...' : 'Draw'}
+            </Button>
+          )}
+          {totalSelections > 0 && (
+            <Button variant="ghost" size="sm" className="h-6 text-[10px]" onClick={clearAll}>
+              <Trash2 className="w-3 h-3" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Map */}
+      <div className="flex-1 relative min-h-0">
+        <div ref={mapContainerRef} className="absolute inset-0">
+          <ValueTooltip mapRef={mapRef} enabledLayers={enabledTileLayerDefs} mapReady={mapReady} />
+        </div>
+        {loading && (
+          <div className="absolute inset-0 bg-background/60 flex items-center justify-center z-[1000]">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              {loadingStatus}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Selection list */}
+      {totalSelections > 0 && (
+        <div className="border-t px-3 py-1.5 max-h-24 overflow-y-auto">
+          <div className="flex flex-wrap gap-1">
+            {selectedAssets.map((asset, i) => (
+              <Badge key={i} variant="secondary" className="text-[9px] h-5 gap-1">
+                <span className={`w-1.5 h-1.5 rounded-full ${asset.type === 'zone' ? 'bg-blue-500' : asset.type === 'custom' ? 'bg-purple-500' : 'bg-emerald-500'}`} />
+                {asset.name.length > 25 ? asset.name.slice(0, 23) + '...' : asset.name}
+                {asset.rasterValues && Object.keys(asset.rasterValues).length > 0 && (
+                  <span className="text-emerald-500 text-[8px]">
+                    {Object.entries(asset.rasterValues).map(([, v]) => v.toFixed(2)).join(', ')}
+                  </span>
+                )}
+                <button onClick={() => removeAsset(i)}><X className="w-2.5 h-2.5" /></button>
+              </Badge>
+            ))}
+            {sampledPoints.map((pt, i) => (
+              <Badge key={`sp-${i}`} variant="secondary" className="text-[9px] h-5 gap-1">
+                <Crosshair className="w-2.5 h-2.5 text-red-500" />
+                ({pt.lat.toFixed(3)}, {pt.lng.toFixed(3)})
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Action bar */}
+      <div className="flex items-center gap-2 p-2.5 border-t bg-background">
+        <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-xs gap-1 flex-1"
+          onClick={handleConfirm}
+          disabled={totalSelections === 0}
+        >
+          <Check className="w-3 h-3" />
+          Confirm {totalSelections} selection{totalSelections !== 1 ? 's' : ''}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -20,6 +20,7 @@ import {
   type MaturityScore,
   type PriorityFlag,
 } from '@shared/cbo-schema';
+import type { OpenMapParams, MapSelectionResult } from '@shared/concept-note-schema';
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
   FileText, Loader2, RotateCcw, Star, Leaf,
@@ -27,6 +28,7 @@ import {
 } from 'lucide-react';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
+const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
 
 function fixMarkdownTables(text: string): string {
   if (!text.includes('|')) return text;
@@ -54,6 +56,7 @@ export default function CboProfilePage() {
   const [selectedOptionIdx, setSelectedOptionIdx] = useState(0);
   const [rightTab, setRightTab] = useState<'document' | 'map' | 'scorecard'>('document');
   const [mapRelevant, setMapRelevant] = useState(false);
+  const [openMapParams, setOpenMapParams] = useState<OpenMapParams | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -184,6 +187,12 @@ export default function CboProfilePage() {
         if (hasMap) { setMapRelevant(true); setRightTab('map'); }
         break;
       }
+      case 'open_map':
+        setOpenMapParams(event.params);
+        setRightTab('map');
+        setMapRelevant(true);
+        setIsStreaming(false);
+        break;
       case 'done': setIsStreaming(false); break;
       case 'error': setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
     }
@@ -462,10 +471,38 @@ export default function CboProfilePage() {
           {rightTab === 'map' && (
             <div className="flex-1 min-h-0 relative">
               <Suspense fallback={<div className="flex items-center justify-center h-full"><Loader2 className="w-6 h-6 animate-spin" /></div>}>
-                <ConceptNoteMap isActive={rightTab === 'map'} onConfirm={(_summary, description) => {
-                  if (currentQuestion) handleSelectOption(description); else sendMessage(description);
-                  setRightTab('document'); setMapRelevant(false);
-                }} />
+                {openMapParams ? (
+                  <MapMicroapp
+                    params={openMapParams}
+                    onConfirm={(result: MapSelectionResult) => {
+                      const lines: string[] = [`Map selection (${result.selectionMode} mode):`];
+                      for (const asset of result.selectedAssets) {
+                        const rasterInfo = asset.rasterValues
+                          ? Object.entries(asset.rasterValues).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ')
+                          : '';
+                        lines.push(`- [${asset.type}] ${asset.name} at (${asset.coordinates[0].toFixed(4)}, ${asset.coordinates[1].toFixed(4)})${rasterInfo ? ` | ${rasterInfo}` : ''}`);
+                      }
+                      for (const pt of result.sampledPoints) {
+                        const vals = Object.entries(pt.values).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ');
+                        lines.push(`- [sample] (${pt.lat.toFixed(4)}, ${pt.lng.toFixed(4)}) | ${vals}`);
+                      }
+                      lines.push(`Total: ${result.selectedAssets.length} assets, ${result.sampledPoints.length} sampled points`);
+                      const message = lines.join('\n');
+                      if (currentQuestion) handleSelectOption(message); else sendMessage(message);
+                      setOpenMapParams(null);
+                      setRightTab('document'); setMapRelevant(false);
+                    }}
+                    onCancel={() => {
+                      setOpenMapParams(null);
+                      setRightTab('document'); setMapRelevant(false);
+                    }}
+                  />
+                ) : (
+                  <ConceptNoteMap isActive={rightTab === 'map'} onConfirm={(_summary, description) => {
+                    if (currentQuestion) handleSelectOption(description); else sendMessage(description);
+                    setRightTab('document'); setMapRelevant(false);
+                  }} />
+                )}
               </Suspense>
             </div>
           )}

--- a/client/src/core/pages/concept-note.tsx
+++ b/client/src/core/pages/concept-note.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/core/components/ui/to
 import { useFileDrop } from '@/core/hooks/useFileDrop';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
+const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
 
 // Fix inline markdown tables
 function fixMarkdownTables(text: string): string {
@@ -28,6 +29,8 @@ import {
   type ThinkingStep,
   type SectionId,
   type Confidence,
+  type OpenMapParams,
+  type MapSelectionResult,
 } from '@shared/concept-note-schema';
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
@@ -112,6 +115,7 @@ export default function ConceptNotePage() {
   const [highlightedSections, setHighlightedSections] = useState<string[]>([]);
   const [rightPanelTab, setRightPanelTab] = useState<'document' | 'map'>('document');
   const [mapRelevant, setMapRelevant] = useState(false);
+  const [openMapParams, setOpenMapParams] = useState<OpenMapParams | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -424,6 +428,13 @@ export default function ConceptNotePage() {
         }
         break;
       }
+
+      case 'open_map':
+        setOpenMapParams(event.params);
+        setRightPanelTab('map');
+        setMapRelevant(true);
+        setIsStreaming(false);
+        break;
 
       case 'done':
         setIsStreaming(false);
@@ -1008,19 +1019,54 @@ export default function ConceptNotePage() {
                 <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
               </div>
             }>
-              <ConceptNoteMap
-                isActive={rightPanelTab === 'map'}
-                onConfirm={(_summary, description) => {
-                  // Send rich zone data as answer to current question
-                  if (currentQuestion) {
-                    handleSelectOption(description);
-                  } else {
-                    sendMessage(description);
-                  }
-                  setRightPanelTab('document');
-                  setMapRelevant(false);
-                }}
-              />
+              {openMapParams ? (
+                <MapMicroapp
+                  params={openMapParams}
+                  onConfirm={(result: MapSelectionResult) => {
+                    // Format structured selection as message for the agent
+                    const lines: string[] = [`Map selection (${result.selectionMode} mode):`];
+                    for (const asset of result.selectedAssets) {
+                      const rasterInfo = asset.rasterValues
+                        ? Object.entries(asset.rasterValues).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ')
+                        : '';
+                      lines.push(`- [${asset.type}] ${asset.name} at (${asset.coordinates[0].toFixed(4)}, ${asset.coordinates[1].toFixed(4)})${rasterInfo ? ` | ${rasterInfo}` : ''}`);
+                    }
+                    for (const pt of result.sampledPoints) {
+                      const vals = Object.entries(pt.values).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ');
+                      lines.push(`- [sample] (${pt.lat.toFixed(4)}, ${pt.lng.toFixed(4)}) | ${vals}`);
+                    }
+                    lines.push(`Total: ${result.selectedAssets.length} assets, ${result.sampledPoints.length} sampled points`);
+
+                    const message = lines.join('\n');
+                    if (currentQuestion) {
+                      handleSelectOption(message);
+                    } else {
+                      sendMessage(message);
+                    }
+                    setOpenMapParams(null);
+                    setRightPanelTab('document');
+                    setMapRelevant(false);
+                  }}
+                  onCancel={() => {
+                    setOpenMapParams(null);
+                    setRightPanelTab('document');
+                    setMapRelevant(false);
+                  }}
+                />
+              ) : (
+                <ConceptNoteMap
+                  isActive={rightPanelTab === 'map'}
+                  onConfirm={(_summary, description) => {
+                    if (currentQuestion) {
+                      handleSelectOption(description);
+                    } else {
+                      sendMessage(description);
+                    }
+                    setRightPanelTab('document');
+                    setMapRelevant(false);
+                  }}
+                />
+              )}
             </Suspense>
           </div>
         )}

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -155,6 +155,42 @@ function createCboMcpTools(cboId: string) {
     { annotations: { readOnlyHint: true } }
   );
 
+  const openMap = sdkTool(
+    "open_map",
+    `Open an interactive map microapp. The user can select assets (parks, schools, hospitals, custom sites), zones, or sample raster values.
+
+Selection modes:
+- "zones": User clicks intervention zone boundaries
+- "assets": User clicks individual OSM features or draws custom sites
+- "sample": User clicks anywhere to sample raster tile values
+- "composite": User selects zones AND picks specific assets within them
+
+STOP and wait for the user's map selection after calling this tool.`,
+    {
+      layers: z.array(z.string()).optional().describe("OSM layer IDs to enable"),
+      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs to enable"),
+      spatialQueries: z.array(z.string()).optional().describe("Spatial query IDs to run"),
+      selectionMode: z.enum(["zones", "assets", "sample", "composite"]),
+      prompt: z.string().describe("Instruction shown on the map"),
+      sampleLayers: z.array(z.string()).optional(),
+    },
+    async (args: any) => {
+      pushEvent({
+        type: 'open_map',
+        params: {
+          layers: args.layers,
+          tileLayers: args.tileLayers,
+          spatialQueries: args.spatialQueries,
+          selectionMode: args.selectionMode,
+          prompt: args.prompt,
+          sampleLayers: args.sampleLayers,
+        },
+      });
+      return { content: [{ type: "text" as const, text: `Map opened in "${args.selectionMode}" mode. STOP and wait for selection.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const scoreMaturity = sdkTool(
     "score_maturity",
     "Score a maturity metric (0-3) based on the COUGAR NBS Mapping Criteria. Call this after gathering enough information for each metric.",
@@ -217,7 +253,7 @@ function createCboMcpTools(cboId: string) {
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, askUser, scoreMaturity, setPriorityFlag, readKnowledge],
+    tools: [updateSection, flagGap, setPhase, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge],
   });
 }
 
@@ -284,6 +320,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__flag_gap",
           "mcp__cbo__set_phase",
           "mcp__cbo__ask_user",
+          "mcp__cbo__open_map",
           "mcp__cbo__score_maturity",
           "mcp__cbo__set_priority_flag",
           "mcp__cbo__read_knowledge",
@@ -391,12 +428,18 @@ Phase: ${state.phase}. Organization: ${state.orgName || '(not set)'}.
 
 ## YOUR TOOLS
 1. **update_section** — fill document fields (org_profile, intervention_site, intervention_plan, needs_assessment, results_evidence)
-2. **ask_user** — present multiple-choice questions. Use showMap: true for site selection.
-3. **set_phase** — advance phases (1-6)
-4. **flag_gap** — mark missing info
-5. **score_maturity** — score COUGAR maturity metrics (0-3) as you gather info
-6. **set_priority_flag** — mark priority flags (met/not met)
-7. **read_knowledge** — read detailed knowledge files
+2. **ask_user** — present multiple-choice questions for non-spatial decisions
+3. **open_map** — open interactive map microapp for spatial selection. Use instead of ask_user for site/zone/asset questions.
+   - selectionMode: "zones" | "assets" | "sample" | "composite"
+   - layers: ["osm_parks", "osm_schools", "osm_hospitals", "osm_wetlands"]
+   - tileLayers: ["oef_fri_2024", "oef_hwm_2024"] for evidence overlays
+   - spatialQueries: ["sq_parks_flood"] to highlight at-risk features
+   - For CBO Phase 2 (Where We Work): use "composite" mode with OSM layers + risk tiles
+4. **set_phase** — advance phases (1-6)
+5. **flag_gap** — mark missing info
+6. **score_maturity** — score COUGAR maturity metrics (0-3) as you gather info
+7. **set_priority_flag** — mark priority flags (met/not met)
+8. **read_knowledge** — read detailed knowledge files
 
 ## MATURITY METRICS (score each 0-3 as you go)
 ${MATURITY_METRICS.join(', ')}

--- a/server/services/conceptNoteAgent.ts
+++ b/server/services/conceptNoteAgent.ts
@@ -212,6 +212,42 @@ function createConceptNoteToolsForSdk(noteId: string) {
     { annotations: { readOnlyHint: true } }
   );
 
+  const openMap = sdkTool(
+    "open_map",
+    `Open an interactive map microapp. The user can select assets (parks, schools, hospitals, custom sites), zones, or sample raster values. The map opens with specified layers pre-enabled and returns structured data about what the user selected.
+
+Selection modes:
+- "zones": User clicks intervention zone boundaries (existing flow)
+- "assets": User clicks individual OSM features (parks, schools, etc.) or draws custom sites
+- "sample": User clicks anywhere to sample raster tile values at that point
+- "composite": User selects zones AND picks specific assets within them
+
+STOP and wait for the user's map selection after calling this tool.`,
+    {
+      layers: z.array(z.string()).optional().describe("OSM layer IDs to enable, e.g. ['osm_parks', 'osm_schools']"),
+      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs to enable, e.g. ['oef_fri_2024', 'oef_hwm_2024']"),
+      spatialQueries: z.array(z.string()).optional().describe("Spatial query IDs to run, e.g. ['sq_parks_flood']"),
+      selectionMode: z.enum(["zones", "assets", "sample", "composite"]).describe("What the user can select"),
+      prompt: z.string().describe("Instruction shown on the map, e.g. 'Select the parks you want to target'"),
+      sampleLayers: z.array(z.string()).optional().describe("For sample mode: which tile layers to sample on click"),
+    },
+    async (args: any) => {
+      pushEvent({
+        type: 'open_map',
+        params: {
+          layers: args.layers,
+          tileLayers: args.tileLayers,
+          spatialQueries: args.spatialQueries,
+          selectionMode: args.selectionMode,
+          prompt: args.prompt,
+          sampleLayers: args.sampleLayers,
+        },
+      });
+      return { content: [{ type: "text" as const, text: `Map opened in "${args.selectionMode}" mode. STOP and wait for the user's selection.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const readKnowledge = sdkTool(
     "read_knowledge",
     "Read a knowledge file for detailed data. Use when you need more information than what's in the city context. ONLY reads from the knowledge/ folder.",
@@ -237,7 +273,7 @@ function createConceptNoteToolsForSdk(noteId: string) {
   return sdkCreateMcpServer({
     name: "concept_note",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, askUser, readKnowledge],
+    tools: [updateSection, flagGap, setPhase, askUser, openMap, readKnowledge],
   });
 }
 
@@ -331,6 +367,7 @@ async function streamWithV2Session(
               "mcp__concept_note__flag_gap",
               "mcp__concept_note__set_phase",
               "mcp__concept_note__ask_user",
+              "mcp__concept_note__open_map",
               "mcp__concept_note__read_knowledge",
             ],
             mcpServers: mcpServer ? { concept_note: mcpServer } : {},
@@ -420,6 +457,7 @@ User message: ${userMessage}`;
           "mcp__concept_note__flag_gap",
           "mcp__concept_note__set_phase",
           "mcp__concept_note__ask_user",
+          "mcp__concept_note__open_map",
           "mcp__concept_note__read_knowledge",
         ],
         mcpServers: mcpServer ? { concept_note: mcpServer } : {},
@@ -591,6 +629,21 @@ function handleToolCall(noteId: string, toolName: string, input: any, pushEvent:
     return `${questions.length} question(s) shown. STOP and wait for ALL answers.`;
   }
 
+  if (toolName === "open_map") {
+    pushEvent({
+      type: 'open_map',
+      params: {
+        layers: input.layers,
+        tileLayers: input.tileLayers,
+        spatialQueries: input.spatialQueries,
+        selectionMode: input.selectionMode,
+        prompt: input.prompt,
+        sampleLayers: input.sampleLayers,
+      },
+    });
+    return `Map opened in "${input.selectionMode}" mode. STOP and wait for selection.`;
+  }
+
   return `Unknown tool: ${toolName}`;
 }
 
@@ -741,9 +794,15 @@ The user may be:
 
 1. **update_section(sectionId, field, value, confidence, source)** — fill a document field. The right panel updates in real-time. ALWAYS use this to save data.
 2. **ask_user({questions: [...]})** — present multiple-choice questions. The UI renders clickable buttons. Use for key decisions.
-3. **set_phase(phase)** — advance to next phase (0-10).
-4. **flag_gap(sectionId, field, reason)** — mark missing data.
-5. **read_knowledge(folder, file)** — read a knowledge file for detailed data. Use when the user asks about something not in the pre-loaded context, or when you need specific numbers for a later phase.
+3. **open_map({selectionMode, layers, tileLayers, prompt, ...})** — open an interactive map microapp. The user can select OSM features (parks, schools, hospitals), draw custom sites, or sample raster values. Use for spatial questions instead of ask_user with showMap.
+   - selectionMode: "zones" (zone boundaries), "assets" (individual features), "sample" (click-to-sample), "composite" (zones + assets)
+   - layers: OSM layer IDs like ["osm_parks", "osm_schools", "osm_hospitals", "osm_wetlands"]
+   - tileLayers: tile layer IDs like ["oef_fri_2024", "oef_hwm_2024"] for evidence overlays
+   - spatialQueries: spatial query IDs like ["sq_parks_flood"] to pre-filter features
+   - prompt: instruction for the user, e.g. "Select the parks you want to target for NBS interventions"
+4. **set_phase(phase)** — advance to next phase (0-10).
+5. **flag_gap(sectionId, field, reason)** — mark missing data.
+6. **read_knowledge(folder, file)** — read a knowledge file for detailed data. Use when the user asks about something not in the pre-loaded context, or when you need specific numbers for a later phase.
 
 ## HOW TO BEHAVE
 

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { OpenMapParams } from './concept-note-schema';
 
 // ============================================================================
 // CBO INTERVENTION PROFILE — 5 sections aligned to COUGAR NBS Mapping Criteria
@@ -83,6 +84,7 @@ export type CboEvent =
   | { type: 'phase_change'; phase: number }
   | { type: 'maturity_update'; scores: MaturityScore[]; total: number; flags: PriorityFlag[] }
   | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  | { type: 'open_map'; params: OpenMapParams }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 

--- a/shared/concept-note-schema.ts
+++ b/shared/concept-note-schema.ts
@@ -159,6 +159,42 @@ export interface ThinkingStep {
   status: 'pending' | 'active' | 'complete' | 'error';
 }
 
+// ── Map Microapp types ────────────────────────────────────────────────────────
+
+export type MapSelectionMode = 'zones' | 'assets' | 'sample' | 'composite';
+
+export interface OpenMapParams {
+  layers?: string[];          // OSM layer IDs to enable (e.g., 'osm_parks')
+  tileLayers?: string[];      // Tile layer IDs to enable (e.g., 'oef_fri_2024')
+  spatialQueries?: string[];  // Spatial query IDs to run (e.g., 'sq_parks_flood')
+  selectionMode: MapSelectionMode;
+  prompt: string;             // Instruction shown on the map
+  sampleLayers?: string[];    // For 'sample' mode: which tile layers to sample on click
+}
+
+export interface SelectedAsset {
+  type: 'osm' | 'custom' | 'zone';
+  source?: string;            // e.g., 'osm_parks', 'intervention_zones'
+  name: string;
+  geometry?: any;             // GeoJSON geometry
+  coordinates: [number, number]; // [lat, lng] centroid
+  properties: Record<string, any>;
+  rasterValues?: Record<string, number>; // sampled values from active tile layers
+}
+
+export interface SampledPoint {
+  lat: number;
+  lng: number;
+  values: Record<string, number>; // layerName → decoded value
+}
+
+export interface MapSelectionResult {
+  selectionMode: MapSelectionMode;
+  selectedAssets: SelectedAsset[];
+  sampledPoints: SampledPoint[];
+  enabledLayers: string[];
+}
+
 // SSE event types pushed to the browser
 export type ConceptNoteEvent =
   | { type: 'chat'; content: string; role: 'assistant'; messageType?: ChatMessageType }
@@ -169,6 +205,7 @@ export type ConceptNoteEvent =
   | { type: 'phase_change'; phase: number }
   | { type: 'cascade'; edits: Array<{ sectionId: string; field: string; value: string }> }
   | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  | { type: 'open_map'; params: OpenMapParams }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 


### PR DESCRIPTION
## Summary

New `open_map` MCP tool that the AI agent can call to open an interactive map with pre-configured layers and selection modes. Returns structured data about what the user selected.

**4 selection modes:**
- **zones**: Click intervention zone boundaries
- **assets**: Click OSM features (parks, schools, hospitals) — auto-samples raster values at centroid
- **sample**: Click anywhere to sample tile layer values
- **composite**: Select zones AND pick individual assets within them

**Agent usage example:**
```
open_map({
  layers: ["osm_parks", "osm_schools"],
  tileLayers: ["oef_fri_2024"],
  spatialQueries: ["sq_parks_flood"],
  selectionMode: "assets",
  prompt: "Select the parks you want to target for NBS interventions"
})
```

**Files:** 7 changed, 689 insertions — MapMicroapp.tsx (437 lines), both agents, both pages, shared schemas.

## Test plan

- [ ] In CBO flow, verify agent uses `open_map` for spatial questions (Phase 2)
- [ ] Click OSM parks — they appear in selection list with FRI values
- [ ] Draw a custom point — it appears with sampled raster values
- [ ] Switch to sample mode — click anywhere to read tile values
- [ ] Confirm sends structured data back to agent
- [ ] Cancel returns to chat without sending data
- [ ] Legacy `ask_user showMap:true` still works (fallback to ConceptNoteMap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)