### PR TITLE
feat: CBO UX — Portuguese i18n, language picker → agent, simpler prompts

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/core/components/ui/button';
 import { Badge } from '@/core/components/ui/badge';
 import { Check, X, MapPin, Pencil, Loader2, Trash2, Eye, EyeOff, ChevronRight } from 'lucide-react';
@@ -27,6 +28,7 @@ interface Props {
 type CompositeStep = 'zone' | 'assets';
 
 export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation();
   const mapRef = useRef<L.Map | null>(null);
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const tileLayerRefs = useRef<Record<string, L.TileLayer>>({});
@@ -40,7 +42,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const [sampledPoints, setSampledPoints] = useState<SampledPoint[]>([]);
   const [drawMode, setDrawMode] = useState<'off' | 'point' | 'polygon'>('off');
   const [loading, setLoading] = useState(true);
-  const [loadingStatus, setLoadingStatus] = useState('Initializing...');
+  const [loadingStatus, setLoadingStatus] = useState('');
   const [enabledTiles, setEnabledTiles] = useState<Set<string>>(new Set());
   // Composite stepper: step 1 = pick zone, step 2 = pick assets
   const [compositeStep, setCompositeStep] = useState<CompositeStep>('zone');
@@ -50,7 +52,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const isComposite = selectionMode === 'composite';
   const showZones = !isComposite || compositeStep === 'zone';
   const showAssets = !isComposite || compositeStep === 'assets';
-  const polygonHelp = drawMode === 'polygon' ? 'Click vertices, double-click to close' : '';
+  const polygonHelp = drawMode === 'polygon' ? t('mapMicroapp.polygonHelp') : '';
 
   const enabledTileLayerDefs = Array.from(enabledTiles)
     .map(id => TILE_LAYERS.find(l => l.id === id))
@@ -467,11 +469,11 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   // Step instructions
   const stepInstruction = isComposite
     ? compositeStep === 'zone'
-      ? 'Step 1: Click the zone where your intervention is located'
-      : `Step 2: Select sites within ${selectedZone?.name || 'zone'} — click features or draw custom areas`
-    : selectionMode === 'assets' ? 'Click features to select'
-    : selectionMode === 'sample' ? 'Click anywhere to sample values'
-    : 'Click zone boundaries to select';
+      ? t('mapMicroapp.step1Zone')
+      : t('mapMicroapp.step2Sites', { zone: selectedZone?.name || 'zone' })
+    : selectionMode === 'assets' ? t('mapMicroapp.clickFeatures')
+    : selectionMode === 'sample' ? t('mapMicroapp.clickSample')
+    : t('mapMicroapp.clickZones');
 
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
@@ -491,7 +493,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
             className={`flex items-center gap-1 text-[10px] px-2 py-0.5 rounded ${compositeStep === 'zone' ? 'bg-primary text-primary-foreground font-medium' : 'text-muted-foreground hover:bg-muted/50'}`}
           >
             <span className="w-4 h-4 rounded-full bg-current/20 flex items-center justify-center text-[9px] font-bold">1</span>
-            Zone
+            {t('mapMicroapp.zone')}
             {selectedZone && <Check className="w-3 h-3 text-emerald-500" />}
           </button>
           <ChevronRight className="w-3 h-3 text-muted-foreground" />
@@ -500,11 +502,11 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
             className={`flex items-center gap-1 text-[10px] px-2 py-0.5 rounded ${compositeStep === 'assets' ? 'bg-primary text-primary-foreground font-medium' : selectedZone ? 'text-foreground hover:bg-muted/50' : 'text-muted-foreground/50 cursor-not-allowed'}`}
           >
             <span className="w-4 h-4 rounded-full bg-current/20 flex items-center justify-center text-[9px] font-bold">2</span>
-            Sites
+            {t('mapMicroapp.sites')}
           </button>
           {isComposite && compositeStep === 'zone' && selectedZone && (
             <Button size="sm" className="h-6 text-[10px] gap-1 ml-auto" onClick={advanceToAssets}>
-              Next: Select sites <ChevronRight className="w-3 h-3" />
+              {t('mapMicroapp.nextSites')} <ChevronRight className="w-3 h-3" />
             </Button>
           )}
         </div>
@@ -515,7 +517,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         {/* Tile layer toggles */}
         {availableTileLayers.length > 0 && (
           <>
-            <span className="text-[9px] text-muted-foreground shrink-0">Layers:</span>
+            <span className="text-[9px] text-muted-foreground shrink-0">{t('mapMicroapp.layers')}:</span>
             {availableTileLayers.map(layer => {
               const isOn = enabledTiles.has(layer.id);
               return (
@@ -534,11 +536,11 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
           <>
             <Button variant={drawMode === 'point' ? 'default' : 'outline'} size="sm" className="h-5 text-[9px] gap-1 px-1.5"
               onClick={() => setDrawMode(drawMode === 'point' ? 'off' : 'point')}>
-              <MapPin className="w-2.5 h-2.5" /> Point
+              <MapPin className="w-2.5 h-2.5" /> {t('mapMicroapp.point')}
             </Button>
             <Button variant={drawMode === 'polygon' ? 'default' : 'outline'} size="sm" className="h-5 text-[9px] gap-1 px-1.5"
               onClick={() => setDrawMode(drawMode === 'polygon' ? 'off' : 'polygon')}>
-              <Pencil className="w-2.5 h-2.5" /> Area
+              <Pencil className="w-2.5 h-2.5" /> {t('mapMicroapp.area')}
             </Button>
           </>
         )}
@@ -584,9 +586,9 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
 
       {/* Action bar */}
       <div className="flex items-center gap-2 px-3 py-2 border-t bg-background shrink-0">
-        <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onCancel}>Cancel</Button>
+        <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onCancel}>{t('mapMicroapp.cancel')}</Button>
         <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={handleConfirm} disabled={totalSelections === 0}>
-          <Check className="w-3 h-3" /> Confirm {totalSelections} selection{totalSelections !== 1 ? 's' : ''}
+          <Check className="w-3 h-3" /> {t('mapMicroapp.confirm', { count: totalSelections })}
         </Button>
       </div>
     </div>

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo, lazy, Suspense } fro
 import { Link } from 'wouter';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useTranslation } from 'react-i18next';
 import { Header } from '@/core/components/layout/header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -70,6 +71,8 @@ function saveMapParams(p: OpenMapParams | null) { try { if (p) sessionStorage.se
 // ============================================================================
 
 export default function CboProfilePage() {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.resolvedLanguage || 'en';
   const [cboId, setCboId] = useState<string | null>(null);
   const [state, setState] = useState<CboState | null>(null);
   const [messages, setMessages] = useState<CboChatMessage[]>([]);
@@ -232,7 +235,7 @@ export default function CboProfilePage() {
     setMessages(prev => [...prev, { role: 'user', content: text, messageType: 'content', timestamp: new Date().toISOString() }]);
     setIsStreaming(true);
     try {
-      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text }) });
+      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang }) });
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
@@ -309,7 +312,7 @@ export default function CboProfilePage() {
             <div className="flex items-center gap-2">
               <Link href="/sample/project/sample-ada-1"><Button variant="ghost" size="sm" className="h-7 px-2"><ArrowLeft className="w-4 h-4" /></Button></Link>
               <div>
-                <h2 className="text-sm font-semibold flex items-center gap-1.5"><Leaf className="w-4 h-4 text-green-600" /> CBO Intervention Profile</h2>
+                <h2 className="text-sm font-semibold flex items-center gap-1.5"><Leaf className="w-4 h-4 text-green-600" /> {t('cbo.title')}</h2>
                 <div className="flex items-center gap-1.5 mt-0.5">
                   {[1,2,3,4,5].map(p => (
                     <button key={p} onClick={() => !isStreaming && sendMessage(`Jump to Phase ${p}`)}
@@ -322,8 +325,8 @@ export default function CboProfilePage() {
               </div>
             </div>
             <div className="flex gap-1">
-              <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>Export profile</TooltipContent></Tooltip>
-              <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>Start over</TooltipContent></Tooltip>
+              <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.export')}</TooltipContent></Tooltip>
+              <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.startOver')}</TooltipContent></Tooltip>
             </div>
           </div>
 
@@ -331,10 +334,10 @@ export default function CboProfilePage() {
             {messages.length === 0 && state.phase === 0 && (
               <div className="text-center text-muted-foreground py-8">
                 <Leaf className="w-12 h-12 mx-auto mb-3 text-green-500" />
-                <p className="text-lg mb-2">Document Your Community Intervention</p>
-                <p className="text-sm mb-4">We'll help you create a structured profile of your NBS project</p>
+                <p className="text-lg mb-2">{t('cbo.welcomeTitle')}</p>
+                <p className="text-sm mb-4">{t('cbo.welcomeSubtitle')}</p>
                 <Button className="bg-green-600 hover:bg-green-700" onClick={() => sendMessage("Start the CBO intervention profile for Porto Alegre. Use the /cbo-intervention skill flow. Always use the ask_user tool for multiple-choice questions. In your first message, mention that the user can drop existing documents (proposals, reports, plans, photos) into the chat at any time — you'll extract info and auto-fill sections.")}>
-                  Start Profile
+                  {t('cbo.startProfile')}
                 </Button>
               </div>
             )}
@@ -342,7 +345,7 @@ export default function CboProfilePage() {
             {messages.map((msg, i) => (
               <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div className={`max-w-[90%] rounded-lg px-4 py-2.5 ${msg.role === 'user' ? 'bg-green-600 text-white' : msg.messageType === 'thinking' ? 'bg-muted/50 border border-dashed border-muted-foreground/20' : 'bg-muted'}`}>
-                  {msg.messageType === 'thinking' && <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Working</p>}
+                  {msg.messageType === 'thinking' && <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('cbo.working')}</p>}
                   {msg.role === 'user' ? <p className="text-sm">{msg.content}</p> : (
                     <div className={`text-sm prose prose-sm max-w-none ${msg.messageType === 'thinking' ? 'text-muted-foreground italic text-xs' : ''}`}>
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{fixMarkdownTables(msg.content)}</ReactMarkdown>
@@ -386,14 +389,14 @@ export default function CboProfilePage() {
               </div>
             )}
 
-            {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">Working...</span></div>}
+            {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
 
             {/* Resume */}
             {!isStreaming && state.phase > 0 && !currentQuestion && messages.length > 0 && (
               <div className="text-center py-4">
                 <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-dashed border-green-300 bg-green-50">
-                  <p className="text-sm text-muted-foreground">Phase {state.phase}/5, {filledCount} sections filled</p>
-                  <Button variant="outline" onClick={() => sendMessage(`Continue from Phase ${state.phase}.`)}>Continue</Button>
+                  <p className="text-sm text-muted-foreground">{t('cbo.phase', { num: state.phase, count: filledCount })}</p>
+                  <Button variant="outline" onClick={() => sendMessage(`Continue from Phase ${state.phase}.`)}>{t('cbo.continue')}</Button>
                 </div>
               </div>
             )}
@@ -402,7 +405,7 @@ export default function CboProfilePage() {
           </div>
 
           <div className={`p-3 border-t transition-colors ${isStreaming ? 'bg-muted/50' : currentQuestion ? 'bg-green-50 border-t-green-200' : ''}`}>
-            {!isStreaming && currentQuestion && <p className="text-[10px] text-green-700 mb-1 font-medium">Your turn — arrows + Enter to select, or type below</p>}
+            {!isStreaming && currentQuestion && <p className="text-[10px] text-green-700 mb-1 font-medium">{t('cbo.yourTurn')}</p>}
             <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input); }} className="flex gap-2">
               <input ref={fileInputRef} type="file" className="hidden" accept=".pdf,.docx,.xlsx,.txt,.md,.csv,.png,.jpg,.jpeg"
                 onChange={(e) => {
@@ -420,8 +423,8 @@ export default function CboProfilePage() {
               />
               <Tooltip><TooltipTrigger asChild>
                 <Button type="button" variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isStreaming} className="shrink-0"><Paperclip className="w-4 h-4" /></Button>
-              </TooltipTrigger><TooltipContent>Upload a document</TooltipContent></Tooltip>
-              <Input ref={inputRef} value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? "Working..." : currentQuestion ? "Type a custom answer..." : "Type your response..."} disabled={isStreaming} className="flex-1" />
+              </TooltipTrigger><TooltipContent>{t('cbo.uploadDoc')}</TooltipContent></Tooltip>
+              <Input ref={inputRef} value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
           </div>
@@ -431,7 +434,7 @@ export default function CboProfilePage() {
         <div className="w-1/2 flex flex-col bg-muted/30">
           <div className="border-b bg-background">
             <div className="px-4 pt-3 pb-0">
-              <h2 className="text-base font-semibold">{state.orgName || 'Intervention Profile'}</h2>
+              <h2 className="text-base font-semibold">{state.orgName || t('cbo.interventionProfile')}</h2>
               <div className="flex items-center gap-3 mt-1.5 mb-2">
                 <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden"><div className="h-full bg-green-500 rounded-full transition-all duration-500" style={{ width: `${(filledCount / 5) * 100}%` }} /></div>
                 <span className="text-xs text-muted-foreground shrink-0">{filledCount}/5</span>
@@ -440,8 +443,8 @@ export default function CboProfilePage() {
             <div className="flex px-4 gap-0 border-t">
               {(['document', 'map', 'scorecard'] as const).map(tab => (
                 <button key={tab} onClick={() => setRightTab(tab)}
-                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors capitalize ${rightTab === tab ? 'border-green-600 text-green-700' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
-                  {tab}{tab === 'map' && mapRelevant && rightTab !== 'map' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${rightTab === tab ? 'border-green-600 text-green-700' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
+                  {t(`cbo.tabs.${tab}`)}{tab === 'map' && mapRelevant && rightTab !== 'map' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
                   {tab === 'scorecard' && state.totalMaturityScore > 0 && <span className="ml-1 text-xs text-muted-foreground">{state.totalMaturityScore}/27</span>}
                 </button>
               ))}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1564,5 +1564,46 @@
     },
     "selectLensToExport": "Select which lens version to export",
     "lensToExport": "Lens to Export"
+  },
+  "cbo": {
+    "title": "CBO Intervention Profile",
+    "welcomeTitle": "Document Your Community Intervention",
+    "welcomeSubtitle": "We'll help you create a structured profile of your NBS project",
+    "startProfile": "Start Profile",
+    "tabs": {
+      "document": "Document",
+      "map": "Map",
+      "scorecard": "Scorecard"
+    },
+    "export": "Export profile",
+    "startOver": "Start over",
+    "working": "Working...",
+    "phase": "Phase {{num}}/5, {{count}} sections filled",
+    "continue": "Continue",
+    "yourTurn": "Your turn — arrows + Enter to select, or type below",
+    "typePlaceholder": "Type your response...",
+    "typeCustom": "Type a custom answer...",
+    "uploadDoc": "Upload a document",
+    "interventionProfile": "Intervention Profile"
+  },
+  "mapMicroapp": {
+    "layers": "Layers",
+    "point": "Point",
+    "area": "Area",
+    "cancel": "Cancel",
+    "confirm": "Confirm {{count}} selection",
+    "confirm_plural": "Confirm {{count}} selections",
+    "step1Zone": "Step 1: Click the zone where your intervention is located",
+    "step2Sites": "Step 2: Select sites within {{zone}} — click features or draw",
+    "clickFeatures": "Click features to select",
+    "clickSample": "Click anywhere to sample values",
+    "selectZonesAssets": "Select zones + click assets",
+    "clickZones": "Click zone boundaries",
+    "polygonHelp": "Click vertices, double-click to close",
+    "zone": "Zone",
+    "sites": "Sites",
+    "nextSites": "Next: Select sites",
+    "loading": "Loading...",
+    "clickToSelect": "click to select"
   }
 }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1543,5 +1543,46 @@
     },
     "selectLensToExport": "Selecione qual versão da lente exportar",
     "lensToExport": "Lente para Exportar"
+  },
+  "cbo": {
+    "title": "Perfil de Intervenção Comunitária",
+    "welcomeTitle": "Documente sua Intervenção Comunitária",
+    "welcomeSubtitle": "Vamos criar um perfil estruturado do seu projeto de soluções baseadas na natureza",
+    "startProfile": "Iniciar Perfil",
+    "tabs": {
+      "document": "Documento",
+      "map": "Mapa",
+      "scorecard": "Placar"
+    },
+    "export": "Exportar perfil",
+    "startOver": "Recomeçar",
+    "working": "Processando...",
+    "phase": "Fase {{num}}/5, {{count}} seções preenchidas",
+    "continue": "Continuar",
+    "yourTurn": "Sua vez — setas + Enter para selecionar, ou digite abaixo",
+    "typePlaceholder": "Digite sua resposta...",
+    "typeCustom": "Digite uma resposta personalizada...",
+    "uploadDoc": "Enviar documento",
+    "interventionProfile": "Perfil de Intervenção"
+  },
+  "mapMicroapp": {
+    "layers": "Camadas",
+    "point": "Ponto",
+    "area": "Área",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar {{count}} seleção",
+    "confirm_plural": "Confirmar {{count}} seleções",
+    "step1Zone": "Passo 1: Clique na zona onde fica sua intervenção",
+    "step2Sites": "Passo 2: Selecione os locais em {{zone}} — clique ou desenhe",
+    "clickFeatures": "Clique nos locais para selecionar",
+    "clickSample": "Clique em qualquer lugar para ver valores",
+    "selectZonesAssets": "Selecione zona + clique nos locais",
+    "clickZones": "Clique nos limites das zonas",
+    "polygonHelp": "Clique nos vértices, duplo clique para fechar",
+    "zone": "Zona",
+    "sites": "Locais",
+    "nextSites": "Próximo: Selecionar locais",
+    "loading": "Carregando...",
+    "clickToSelect": "clique para selecionar"
   }
 }

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -82,7 +82,7 @@ export function registerCboRoutes(app: Express): void {
 
   // Chat (SSE)
   app.post("/api/cbo/:id/chat", async (req: Request, res: Response) => {
-    const { message } = req.body;
+    const { message, lang } = req.body;
     if (!message) return res.status(400).json({ error: "message required" });
 
     let state = getCboState(req.params.id);
@@ -92,11 +92,13 @@ export function registerCboRoutes(app: Express): void {
     }
     if (!state) return res.status(404).json({ error: "Not found" });
 
-    // Language detection
-    const isPt = /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
-      /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message);
+    // Language: prefer explicit lang from UI picker, fall back to auto-detection
+    const isPt = lang === 'pt' || (!lang && (
+      /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
+      /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message)
+    ));
     const langDirective = isPt
-      ? '\n[LANGUAGE: Respond in Portuguese.]'
+      ? '\n[LANGUAGE: Respond in Portuguese. ask_user option labels in Portuguese. update_section content in Portuguese.]'
       : '\n[LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian orgs.]';
 
     addCboMessage(req.params.id, { role: 'user', content: message, messageType: 'content', timestamp: new Date().toISOString() });

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -456,6 +456,20 @@ ${MATURITY_METRICS.join(', ')}
 ## PRIORITY FLAGS (set as you discover them)
 ${PRIORITY_FLAG_DEFINITIONS.join(', ')}
 
+## LANGUAGE
+- Each user message ends with [LANGUAGE: ...]. Follow it strictly.
+- ALL ask_user option labels and descriptions MUST be in the same language as your response.
+- update_section content: always in Portuguese for Brazilian organizations.
+- If Portuguese: use simple, accessible language. Avoid jargon. Write as if explaining to a community leader, not a scientist.
+
+## QUESTION STYLE
+- Use simple words: "Que tipo de solução?" not "Qual o tipo de SbN?"
+- Add example hints in descriptions: "(ex: plantio de árvores, restauração de áreas úmidas)"
+- Break complex questions into small steps: ask team size, THEN ask about paid vs volunteer
+- For financial questions: ask "Quanto custa o projeto todo?" then "Quanto vocês já têm?" then "Quanto falta?"
+- Avoid technical terms: "Alguém do governo sabe do projeto?" not "Status regulatório"
+- Offer encouragement: "Ótimo! Isso mostra que vocês já têm experiência."
+
 ## BEHAVIOR
 - Be warm and encouraging — many CBOs have limited formal documentation experience
 - Start IMMEDIATELY with set_phase(1) and ask_user questions
@@ -464,8 +478,6 @@ ${PRIORITY_FLAG_DEFINITIONS.join(', ')}
 - Phase 2: ALWAYS use open_map with "composite" mode
 - Phase 3: use open_map with "assets" mode if asking about specific intervention sites
 - The tool description has recipes — follow them
-- Each user message has a [LANGUAGE: ...] directive — follow it
-- update_section content in Portuguese if the org is Brazilian
 - After Phase 5: generate the full maturity scorecard using score_maturity for remaining metrics + set_priority_flag for all 6 flags
 - In your FIRST message: mention that the user can drop existing documents into the chat
 


### PR DESCRIPTION
## Summary

UX improvements for CBO flow targeting community orgs like Associação Vila Flores.

- **Language picker → agent**: UI language (en/pt) sent with every message. Agent responds + ask_user options match the UI language.
- **Portuguese UI**: All CBO page strings translated (tabs, buttons, placeholders, map stepper)
- **Simpler agent prompts**: LANGUAGE + QUESTION STYLE sections added. Accessible phrasing, example hints, jargon removal.
- **Map i18n**: Step labels, draw buttons, confirm/cancel all localized.

## Test plan

- [ ] Switch to PT in header → CBO page shows "Documento/Mapa/Placar" tabs
- [ ] Start profile in PT → agent responds in Portuguese with PT option labels
- [ ] Map stepper shows "Passo 1" / "Passo 2" in PT mode
- [ ] Switch to EN → everything reverts to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)