### PR TITLE
fix: hide chat widget on concept-note and CBO pages

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -97,6 +97,14 @@ export default function CboProfilePage() {
   const [highlightedSections, setHighlightedSections] = useState<string[]>([]);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
+  // Hide Replit chat widget on this page
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.textContent = '[class*="chat-button"], [class*="intercom"], iframe[title*="chat"], #fc_frame, .replit-ui-theme-root .chat-button { display: none !important; }';
+    document.head.appendChild(style);
+    return () => { document.head.removeChild(style); };
+  }, []);
+
   // Auto-scroll to related sections when question changes
   useEffect(() => {
     // Check if current question has relatedSections (from ask_user event)

--- a/client/src/core/pages/concept-note.tsx
+++ b/client/src/core/pages/concept-note.tsx
@@ -189,6 +189,14 @@ export default function ConceptNotePage() {
     init();
   }, []);
 
+  // Hide Replit chat widget on this page
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.textContent = '[class*="chat-button"], [class*="intercom"], iframe[title*="chat"], #fc_frame, .replit-ui-theme-root .chat-button { display: none !important; }';
+    document.head.appendChild(style);
+    return () => { document.head.removeChild(style); };
+  }, []);
+
   // Auto-scroll chat
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
Hides Replit's chat button on agent pages where it overlaps with the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)