### PR TITLE
fix: hide ChatDrawer button on concept-note and CBO pages

### DIFF
--- a/client/src/core/components/agent/ChatDrawer.tsx
+++ b/client/src/core/components/agent/ChatDrawer.tsx
@@ -797,7 +797,7 @@ export function ChatDrawer() {
 
   return (
     <>
-      {!isOpen && (
+      {!isOpen && !location.includes('/concept-note') && !location.includes('/cbo') && (
         <Button
           variant="outline"
           size="icon"


### PR DESCRIPTION
Hides the global chat button on pages that have their own built-in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)