### PR TITLE
feat: raster-enhanced risk scores v2 (FRI/HWM/CHIRPS)

### DIFF
--- a/client/public/sample-data/porto-alegre-grid.json
+++ b/client/public/sample-data/porto-alegre-grid.json
@@ -53,11 +53,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -130,11 +133,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -207,11 +213,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -284,11 +293,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -361,11 +373,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -438,11 +453,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.51,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.05,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -515,11 +533,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.52,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.09,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -592,11 +613,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.53,
-            "heat_score": 0.28,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.14,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -669,11 +693,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.54,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -746,11 +773,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.55,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.24,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -823,11 +853,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.56,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -899,12 +932,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.57,
-            "heat_score": 0.27,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.33,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -976,12 +1012,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.58,
-            "heat_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -1053,12 +1092,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.59,
-            "heat_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -1130,12 +1172,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.6,
-            "heat_score": 0.27,
+            "flood_score": 0.47,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -1207,12 +1252,15 @@
             "built_pct": null,
             "pop_density": 0.0917486187951624,
             "pop_density_raw": 2188.2799999999997,
-            "flood_score": 0.62,
-            "heat_score": 0.29,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -1284,12 +1332,15 @@
             "built_pct": null,
             "pop_density": 0.09903044321470507,
             "pop_density_raw": 2361.9575,
-            "flood_score": 0.67,
-            "heat_score": 0.43,
+            "flood_score": 0.43,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.56,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.24,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -1361,12 +1412,15 @@
             "built_pct": null,
             "pop_density": 0.13214156580850323,
             "pop_density_raw": 3151.685,
-            "flood_score": 0.63,
-            "heat_score": 0.44,
+            "flood_score": 0.41,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.6,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -1438,12 +1492,15 @@
             "built_pct": null,
             "pop_density": 0.13511724938073333,
             "pop_density_raw": 3222.6575000000003,
-            "flood_score": 0.66,
-            "heat_score": 0.59,
+            "flood_score": 0.36,
+            "heat_score": 0.75,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.64,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -1515,12 +1572,15 @@
             "built_pct": null,
             "pop_density": 0.11226363477870792,
             "pop_density_raw": 2677.58,
-            "flood_score": 0.66,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -1592,12 +1652,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.66,
-            "heat_score": 0.23,
+            "flood_score": 0.42,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.71,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -1669,12 +1732,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.66,
-            "heat_score": 0.24,
+            "flood_score": 0.42,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.74,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -1746,12 +1812,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.67,
-            "heat_score": 0.25,
+            "flood_score": 0.37,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.76,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -1823,12 +1892,15 @@
             "built_pct": null,
             "pop_density": 0.0005412811288525905,
             "pop_density_raw": 12.91,
-            "flood_score": 0.68,
-            "heat_score": 0.24,
+            "flood_score": 0.38,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.77,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -1900,12 +1972,15 @@
             "built_pct": null,
             "pop_density": 0.0006943156850347713,
             "pop_density_raw": 16.56,
-            "flood_score": 0.71,
-            "heat_score": 0.23,
+            "flood_score": 0.36,
+            "heat_score": 0.31,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.77,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -1977,12 +2052,15 @@
             "built_pct": null,
             "pop_density": 0.01072772238837088,
             "pop_density_raw": 255.86499999999998,
-            "flood_score": 0.7,
-            "heat_score": 0.22,
+            "flood_score": 0.4,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.76,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -2054,12 +2132,15 @@
             "built_pct": null,
             "pop_density": 0.03162165612575104,
             "pop_density_raw": 754.2025000000001,
-            "flood_score": 0.69,
-            "heat_score": 0.22,
+            "flood_score": 0.35,
+            "heat_score": 0.31,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.74,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -2131,12 +2212,15 @@
             "built_pct": null,
             "pop_density": 0.04139196917428079,
             "pop_density_raw": 987.2325,
-            "flood_score": 0.69,
-            "heat_score": 0.38,
+            "flood_score": 0.35,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.71,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2208,12 +2292,15 @@
             "built_pct": null,
             "pop_density": 0.024711726641368906,
             "pop_density_raw": 589.395,
-            "flood_score": 0.7,
-            "heat_score": 0.28,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2285,12 +2372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.008091020839903235,
             "pop_density_raw": 192.97749999999996,
-            "flood_score": 0.68,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.64,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2362,12 +2452,15 @@
             "built_pct": null,
             "pop_density": 0.009431121388388978,
             "pop_density_raw": 224.94,
-            "flood_score": 0.66,
-            "heat_score": 0.28,
+            "flood_score": 0.47,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.6,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2439,12 +2532,15 @@
             "built_pct": null,
             "pop_density": 0.006187417706461738,
             "pop_density_raw": 147.575,
-            "flood_score": 0.63,
-            "heat_score": 0.25,
+            "flood_score": 0.45,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.56,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2516,12 +2612,15 @@
             "built_pct": null,
             "pop_density": 0.000264875564022172,
             "pop_density_raw": 6.3175,
-            "flood_score": 0.61,
-            "heat_score": 0.25,
+            "flood_score": 0.44,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -2593,12 +2692,15 @@
             "built_pct": null,
             "pop_density": 0.0000406694573963604,
             "pop_density_raw": 0.97,
-            "flood_score": 0.61,
-            "heat_score": 0.27,
+            "flood_score": 0.39,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.24,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -2670,12 +2772,15 @@
             "built_pct": null,
             "pop_density": 0.00008961955173682512,
             "pop_density_raw": 2.1375,
-            "flood_score": 0.62,
-            "heat_score": 0.3,
+            "flood_score": 0.43,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.25,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -2747,12 +2852,15 @@
             "built_pct": null,
             "pop_density": 0.00008899064260182985,
             "pop_density_raw": 2.1225,
-            "flood_score": 0.59,
-            "heat_score": 0.3,
+            "flood_score": 0.39,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.25,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -2824,12 +2932,15 @@
             "built_pct": null,
             "pop_density": 0.000036057457073061797,
             "pop_density_raw": 0.86,
-            "flood_score": 0.59,
-            "heat_score": 0.31,
+            "flood_score": 0.39,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.24,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -2902,11 +3013,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -2979,11 +3093,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3056,11 +3173,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3133,11 +3253,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3210,11 +3333,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3287,11 +3413,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.51,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.06,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3364,11 +3493,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.52,
-            "heat_score": 0.29,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.11,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3441,11 +3573,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.53,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.15,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3518,11 +3653,14 @@
             "pop_density": 0.00099283788777919,
             "pop_density_raw": 23.68,
             "flood_score": 0.55,
-            "heat_score": 0.26,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.2,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3595,11 +3733,14 @@
             "pop_density": 0.0009534262486528202,
             "pop_density_raw": 22.740000000000002,
             "flood_score": 0.56,
-            "heat_score": 0.25,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3672,11 +3813,14 @@
             "pop_density": 0.0009140146095264502,
             "pop_density_raw": 21.8,
             "flood_score": 0.57,
-            "heat_score": 0.25,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3748,12 +3892,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.58,
-            "heat_score": 0.25,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.35,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -3825,12 +3972,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.59,
-            "heat_score": 0.26,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.4,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -3902,12 +4052,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.6,
-            "heat_score": 0.27,
+            "flood_score": 0.47,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.44,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -3979,12 +4132,15 @@
             "built_pct": null,
             "pop_density": 0.015118975605286146,
             "pop_density_raw": 360.6,
-            "flood_score": 0.61,
-            "heat_score": 0.26,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.49,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -4056,12 +4212,15 @@
             "built_pct": null,
             "pop_density": 0.06450553288543757,
             "pop_density_raw": 1538.5100000000002,
-            "flood_score": 0.74,
-            "heat_score": 0.28,
+            "flood_score": 0.53,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.54,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -4133,12 +4292,15 @@
             "built_pct": null,
             "pop_density": 0.16946795187960714,
             "pop_density_raw": 4041.95,
-            "flood_score": 0.49,
-            "heat_score": 0.55,
+            "flood_score": 0.37,
+            "heat_score": 0.68,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.58,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.21,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -4210,12 +4372,15 @@
             "built_pct": null,
             "pop_density": 0.28457205476652114,
             "pop_density_raw": 6787.277499999999,
-            "flood_score": 0.74,
-            "heat_score": 0.7,
+            "flood_score": 0.38,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.63,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -4287,12 +4452,15 @@
             "built_pct": null,
             "pop_density": 0.2528408636330918,
             "pop_density_raw": 6030.4625,
-            "flood_score": 0.68,
-            "heat_score": 0.62,
+            "flood_score": 0.37,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.67,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -4364,12 +4532,15 @@
             "built_pct": null,
             "pop_density": 0.12830962244897706,
             "pop_density_raw": 3060.2899999999995,
-            "flood_score": 0.69,
-            "heat_score": 0.28,
+            "flood_score": 0.45,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.71,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -4441,12 +4612,15 @@
             "built_pct": null,
             "pop_density": 0.06415564977000186,
             "pop_density_raw": 1530.165,
-            "flood_score": 0.69,
-            "heat_score": 0.24,
+            "flood_score": 0.45,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.75,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -4518,12 +4692,15 @@
             "built_pct": null,
             "pop_density": 0.06165280104909905,
             "pop_density_raw": 1470.47,
-            "flood_score": 0.68,
-            "heat_score": 0.25,
+            "flood_score": 0.43,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -4595,12 +4772,15 @@
             "built_pct": null,
             "pop_density": 0.007373749971441138,
             "pop_density_raw": 175.87,
-            "flood_score": 0.68,
-            "heat_score": 0.23,
+            "flood_score": 0.38,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.8,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -4672,12 +4852,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.69,
-            "heat_score": 0.23,
+            "flood_score": 0.38,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.82,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -4749,12 +4932,15 @@
             "built_pct": null,
             "pop_density": 0.0015492128358716667,
             "pop_density_raw": 36.949999999999996,
-            "flood_score": 0.71,
-            "heat_score": 0.23,
+            "flood_score": 0.4,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.82,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -4826,12 +5012,15 @@
             "built_pct": null,
             "pop_density": 0.013349749390355303,
             "pop_density_raw": 318.40250000000003,
-            "flood_score": 0.7,
-            "heat_score": 0.24,
+            "flood_score": 0.34,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.81,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -4903,12 +5092,15 @@
             "built_pct": null,
             "pop_density": 0.03163360539931595,
             "pop_density_raw": 754.4875000000001,
-            "flood_score": 0.7,
-            "heat_score": 0.31,
+            "flood_score": 0.35,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -4980,12 +5172,15 @@
             "built_pct": null,
             "pop_density": 0.023713123753185593,
             "pop_density_raw": 565.5775,
-            "flood_score": 0.7,
-            "heat_score": 0.28,
+            "flood_score": 0.35,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.75,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5057,12 +5252,15 @@
             "built_pct": null,
             "pop_density": 0.006600925462721124,
             "pop_density_raw": 157.4375,
-            "flood_score": 0.67,
-            "heat_score": 0.24,
+            "flood_score": 0.47,
+            "heat_score": 0.32,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.71,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5134,12 +5332,15 @@
             "built_pct": null,
             "pop_density": 0.003181127222995211,
             "pop_density_raw": 75.8725,
-            "flood_score": 0.66,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.67,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5211,12 +5412,15 @@
             "built_pct": null,
             "pop_density": 0.009047591634231033,
             "pop_density_raw": 215.7925,
-            "flood_score": 0.65,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.63,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5288,12 +5492,15 @@
             "built_pct": null,
             "pop_density": 0.00859383369333195,
             "pop_density_raw": 204.97,
-            "flood_score": 0.63,
-            "heat_score": 0.28,
+            "flood_score": 0.45,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.59,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5365,12 +5572,15 @@
             "built_pct": null,
             "pop_density": 0.0005961010417863443,
             "pop_density_raw": 14.2175,
-            "flood_score": 0.62,
-            "heat_score": 0.26,
+            "flood_score": 0.44,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.54,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -5442,12 +5652,15 @@
             "built_pct": null,
             "pop_density": 0.00004087909377469216,
             "pop_density_raw": 0.9750000000000001,
-            "flood_score": 0.62,
-            "heat_score": 0.08,
+            "flood_score": 0.41,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.5,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.25,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -5519,12 +5732,15 @@
             "built_pct": null,
             "pop_density": 0.00006320536806702403,
             "pop_density_raw": 1.5075,
-            "flood_score": 0.63,
-            "heat_score": 0.3,
+            "flood_score": 0.42,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.45,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.24,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -5596,12 +5812,15 @@
             "built_pct": null,
             "pop_density": 0.00006393909539118516,
             "pop_density_raw": 1.525,
-            "flood_score": 0.59,
-            "heat_score": 0.3,
+            "flood_score": 0.4,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.4,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.25,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -5673,12 +5892,15 @@
             "built_pct": null,
             "pop_density": 0.00003825863904554522,
             "pop_density_raw": 0.9125,
-            "flood_score": 0.59,
-            "heat_score": 0.29,
+            "flood_score": 0.39,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.35,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.24,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -5751,11 +5973,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -5828,11 +6053,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -5905,11 +6133,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -5982,11 +6213,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6059,11 +6293,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6135,12 +6372,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.51,
-            "heat_score": 0.29,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.06,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6212,12 +6452,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.52,
-            "heat_score": 0.28,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.11,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6289,12 +6532,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.54,
-            "heat_score": 0.26,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6366,12 +6612,15 @@
             "built_pct": null,
             "pop_density": 0.003247057863980548,
             "pop_density_raw": 77.44500000000001,
-            "flood_score": 0.39,
-            "heat_score": 0.25,
-            "landslide_score": 0.32,
+            "flood_score": 0.55,
+            "heat_score": 0,
+            "landslide_score": 0.28,
             "lakeside_risk": 1,
             "delta_risk": 0.21,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -6443,12 +6692,15 @@
             "built_pct": null,
             "pop_density": 0.0022713053410353956,
             "pop_density_raw": 54.1725,
-            "flood_score": 0.41,
-            "heat_score": 0.23,
-            "landslide_score": 0.21,
+            "flood_score": 0.57,
+            "heat_score": 0,
+            "landslide_score": 0.18,
             "lakeside_risk": 1,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -6520,12 +6772,15 @@
             "built_pct": null,
             "pop_density": 0.0012955528180902437,
             "pop_density_raw": 30.9,
-            "flood_score": 0.58,
-            "heat_score": 0.23,
+            "flood_score": 0.6,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.31,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6597,12 +6852,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.58,
-            "heat_score": 0.24,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -6674,12 +6932,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.59,
-            "heat_score": 0.24,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.41,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -6751,12 +7012,15 @@
             "built_pct": null,
             "pop_density": 0.07576510276563611,
             "pop_density_raw": 1807.06,
-            "flood_score": 0.6,
-            "heat_score": 0.27,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.46,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -6828,12 +7092,15 @@
             "built_pct": null,
             "pop_density": 0.07054054494485212,
             "pop_density_raw": 1682.45,
-            "flood_score": 0.63,
-            "heat_score": 0.27,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -6905,12 +7172,15 @@
             "built_pct": null,
             "pop_density": 0.049952889956214656,
             "pop_density_raw": 1191.4175,
-            "flood_score": 0.72,
-            "heat_score": 0.37,
+            "flood_score": 0.51,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.55,
-            "low_elev_risk": 0.69
+            "low_elev_risk": 0.69,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -6982,12 +7252,15 @@
             "built_pct": null,
             "pop_density": 0.1580360608964199,
             "pop_density_raw": 3769.29,
-            "flood_score": 0.5,
-            "heat_score": 0.37,
+            "flood_score": 0.41,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.6,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.25,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -7059,12 +7332,15 @@
             "built_pct": null,
             "pop_density": 0.34943658994985183,
             "pop_density_raw": 8334.349999999999,
-            "flood_score": 0.5,
-            "heat_score": 0.73,
+            "flood_score": 0.33,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.65,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -7136,12 +7412,15 @@
             "built_pct": null,
             "pop_density": 0.40845887372364403,
             "pop_density_raw": 9742.08,
-            "flood_score": 0.64,
-            "heat_score": 0.73,
+            "flood_score": 0.38,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.69,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.18,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -7213,12 +7492,15 @@
             "built_pct": null,
             "pop_density": 0.29697236099941193,
             "pop_density_raw": 7083.035,
-            "flood_score": 0.81,
-            "heat_score": 0.51,
+            "flood_score": 0.43,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.74,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.18,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -7290,12 +7572,15 @@
             "built_pct": null,
             "pop_density": 0.20925934730532497,
             "pop_density_raw": 4991.0075,
-            "flood_score": 0.77,
-            "heat_score": 0.45,
+            "flood_score": 0.44,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.18,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -7367,12 +7652,15 @@
             "built_pct": null,
             "pop_density": 0.13803381549427388,
             "pop_density_raw": 3292.2200000000003,
-            "flood_score": 0.68,
-            "heat_score": 0.33,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.82,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.26,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -7444,12 +7732,15 @@
             "built_pct": null,
             "pop_density": 0.03755509935986385,
             "pop_density_raw": 895.7199999999999,
-            "flood_score": 0.71,
-            "heat_score": 0.23,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.85,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": false,
@@ -7521,12 +7812,15 @@
             "built_pct": null,
             "pop_density": 0.013956332251058233,
             "pop_density_raw": 332.87,
-            "flood_score": 0.7,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.87,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -7598,12 +7892,15 @@
             "built_pct": null,
             "pop_density": 0.12693999811054296,
             "pop_density_raw": 3027.6233333333334,
-            "flood_score": 0.71,
-            "heat_score": 0.25,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.87,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -7675,12 +7972,15 @@
             "built_pct": null,
             "pop_density": 0.17581951487030267,
             "pop_density_raw": 4193.4400000000005,
-            "flood_score": 0.71,
-            "heat_score": 0.3,
+            "flood_score": 0.47,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.85,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -7752,12 +8052,15 @@
             "built_pct": null,
             "pop_density": 0.08251036287483865,
             "pop_density_raw": 1967.94,
-            "flood_score": 0.72,
-            "heat_score": 0.25,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.82,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -7829,12 +8132,15 @@
             "built_pct": null,
             "pop_density": 0.001162014445092916,
             "pop_density_raw": 27.715,
-            "flood_score": 0.68,
-            "heat_score": 0.24,
+            "flood_score": 0.38,
+            "heat_score": 0.32,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -7906,12 +8212,15 @@
             "built_pct": null,
             "pop_density": 0.0010882224399201385,
             "pop_density_raw": 25.955000000000002,
-            "flood_score": 0.67,
-            "heat_score": 0.24,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.74,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -7983,12 +8292,15 @@
             "built_pct": null,
             "pop_density": 0.0011331894430722997,
             "pop_density_raw": 27.0275,
-            "flood_score": 0.67,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.7,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -8060,12 +8372,15 @@
             "built_pct": null,
             "pop_density": 0.008668149789450557,
             "pop_density_raw": 206.7425,
-            "flood_score": 0.66,
-            "heat_score": 0.26,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.65,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -8137,12 +8452,15 @@
             "built_pct": null,
             "pop_density": 0.00883816489227761,
             "pop_density_raw": 210.7975,
-            "flood_score": 0.75,
-            "heat_score": 0.28,
+            "flood_score": 0.51,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.61,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": true,
@@ -8214,12 +8532,15 @@
             "built_pct": null,
             "pop_density": 0.000750917507184345,
             "pop_density_raw": 17.909999999999997,
-            "flood_score": 0.63,
-            "heat_score": 0.27,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.56,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -8291,12 +8612,15 @@
             "built_pct": null,
             "pop_density": 0.000057021094906237256,
             "pop_density_raw": 1.3599999999999999,
-            "flood_score": 0.63,
-            "heat_score": 0.08,
+            "flood_score": 0.43,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -8368,12 +8692,15 @@
             "built_pct": null,
             "pop_density": 0.00004874045796213296,
             "pop_density_raw": 1.1625,
-            "flood_score": 0.64,
-            "heat_score": 0.29,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.46,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.38,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -8445,12 +8772,15 @@
             "built_pct": null,
             "pop_density": 0.00004150800290968742,
             "pop_density_raw": 0.99,
-            "flood_score": 0.6,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.41,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -8522,12 +8852,15 @@
             "built_pct": null,
             "pop_density": 0.00023814692578487328,
             "pop_density_raw": 5.68,
-            "flood_score": 0.6,
-            "heat_score": 0.27,
+            "flood_score": 0.42,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -8600,11 +8933,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -8677,11 +9013,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -8754,11 +9093,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -8831,11 +9173,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -8908,11 +9253,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.5,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -8984,12 +9332,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.51,
-            "heat_score": 0.29,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -9061,12 +9412,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.53,
-            "heat_score": 0.27,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -9138,12 +9492,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.54,
-            "heat_score": 0.25,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -9215,12 +9572,15 @@
             "built_pct": null,
             "pop_density": 0.007236647780012172,
             "pop_density_raw": 172.60000000000002,
-            "flood_score": 0.39,
-            "heat_score": 0.25,
-            "landslide_score": 0.32,
+            "flood_score": 0.56,
+            "heat_score": 0,
+            "landslide_score": 0.28,
             "lakeside_risk": 1,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -9292,12 +9652,15 @@
             "built_pct": null,
             "pop_density": 0.005397927105664351,
             "pop_density_raw": 128.745,
-            "flood_score": 0.42,
-            "heat_score": 0.24,
-            "landslide_score": 0.21,
+            "flood_score": 0.59,
+            "heat_score": 0,
+            "landslide_score": 0.18,
             "lakeside_risk": 1,
             "delta_risk": 0.27,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -9369,12 +9732,15 @@
             "built_pct": null,
             "pop_density": 0.026324599057460648,
             "pop_density_raw": 627.8633333333333,
-            "flood_score": 0.59,
-            "heat_score": 0.23,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -9446,12 +9812,15 @@
             "built_pct": null,
             "pop_density": 0.1918662013284996,
             "pop_density_raw": 4576.166666666667,
-            "flood_score": 0.7,
-            "heat_score": 0.35,
+            "flood_score": 0.6,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -9523,12 +9892,15 @@
             "built_pct": null,
             "pop_density": 0.17536292683829607,
             "pop_density_raw": 4182.55,
-            "flood_score": 0.61,
-            "heat_score": 0.28,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.42,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -9600,12 +9972,15 @@
             "built_pct": null,
             "pop_density": 0.12371928455143943,
             "pop_density_raw": 2950.806666666667,
-            "flood_score": 0.61,
-            "heat_score": 0.27,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -9677,12 +10052,15 @@
             "built_pct": null,
             "pop_density": 0.11463902458158504,
             "pop_density_raw": 2734.235,
-            "flood_score": 0.64,
-            "heat_score": 0.38,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": false,
@@ -9754,12 +10132,15 @@
             "built_pct": null,
             "pop_density": 0.09416635514646254,
             "pop_density_raw": 2245.945,
-            "flood_score": 0.49,
-            "heat_score": 0.55,
+            "flood_score": 0.44,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.57,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -9831,12 +10212,15 @@
             "built_pct": null,
             "pop_density": 0.17815968576162003,
             "pop_density_raw": 4249.255,
-            "flood_score": 0.51,
-            "heat_score": 0.14,
+            "flood_score": 0.44,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -9908,12 +10292,15 @@
             "built_pct": null,
             "pop_density": 0.32484844395350954,
             "pop_density_raw": 7747.9025,
-            "flood_score": 0.51,
-            "heat_score": 0.66,
+            "flood_score": 0.34,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.66,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.36
           },
           "coverage": {
             "elevation": true,
@@ -9985,12 +10372,15 @@
             "built_pct": null,
             "pop_density": 0.4061235244690283,
             "pop_density_raw": 9686.38,
-            "flood_score": 0.79,
-            "heat_score": 0.73,
+            "flood_score": 0.41,
+            "heat_score": 0.86,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.71,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.18,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -10062,12 +10452,15 @@
             "built_pct": null,
             "pop_density": 0.46650970252024687,
             "pop_density_raw": 11126.64,
-            "flood_score": 0.82,
-            "heat_score": 0.74,
+            "flood_score": 0.43,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.76,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -10139,12 +10532,15 @@
             "built_pct": null,
             "pop_density": 0.4266029022682574,
             "pop_density_raw": 10174.83,
-            "flood_score": 0.55,
-            "heat_score": 0.71,
+            "flood_score": 0.36,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.81,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -10216,12 +10612,15 @@
             "built_pct": null,
             "pop_density": 0.2838271118961193,
             "pop_density_raw": 6769.51,
-            "flood_score": 0.56,
-            "heat_score": 0.52,
-            "landslide_score": 0.21,
+            "flood_score": 0.33,
+            "heat_score": 0.64,
+            "landslide_score": 0.18,
             "lakeside_risk": 1,
             "delta_risk": 0.85,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.14,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -10293,12 +10692,15 @@
             "built_pct": null,
             "pop_density": 0.17512498954888953,
             "pop_density_raw": 4176.875,
-            "flood_score": 0.57,
-            "heat_score": 0.38,
+            "flood_score": 0.39,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.89,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 67.92
           },
           "coverage": {
             "elevation": true,
@@ -10370,12 +10772,15 @@
             "built_pct": null,
             "pop_density": 0.18061082417586766,
             "pop_density_raw": 4307.716666666666,
-            "flood_score": 0.74,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.92,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -10447,12 +10852,15 @@
             "built_pct": null,
             "pop_density": 0.2917580753611662,
             "pop_density_raw": 6958.67,
-            "flood_score": 0.75,
-            "heat_score": 0.32,
+            "flood_score": 0.42,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.92,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -10524,12 +10932,15 @@
             "built_pct": null,
             "pop_density": 0.49428306364896196,
             "pop_density_raw": 11789.0575,
-            "flood_score": 0.83,
-            "heat_score": 0.53,
+            "flood_score": 0.44,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.89,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -10601,12 +11012,15 @@
             "built_pct": null,
             "pop_density": 0.2257554242798724,
             "pop_density_raw": 5384.452499999999,
-            "flood_score": 0.83,
-            "heat_score": 0.37,
+            "flood_score": 0.52,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.85,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -10678,12 +11092,15 @@
             "built_pct": null,
             "pop_density": 0.005067854627981002,
             "pop_density_raw": 120.8725,
-            "flood_score": 0.72,
-            "heat_score": 0.23,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.81,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -10755,12 +11172,15 @@
             "built_pct": null,
             "pop_density": 0.004677721327905607,
             "pop_density_raw": 111.5675,
-            "flood_score": 0.69,
-            "heat_score": 0.24,
+            "flood_score": 0.49,
+            "heat_score": 0.32,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.76,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": null,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -10832,12 +11252,15 @@
             "built_pct": null,
             "pop_density": 0.006767271928927372,
             "pop_density_raw": 161.405,
-            "flood_score": 0.7,
-            "heat_score": 0.26,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.72,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -10909,12 +11332,15 @@
             "built_pct": null,
             "pop_density": 0.013178266832879926,
             "pop_density_raw": 314.3125,
-            "flood_score": 0.67,
-            "heat_score": 0.13,
+            "flood_score": 0.47,
+            "heat_score": 0.07,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.67,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -10986,12 +11412,15 @@
             "built_pct": null,
             "pop_density": 0.007942807920422686,
             "pop_density_raw": 189.4425,
-            "flood_score": 0.66,
-            "heat_score": 0.27,
+            "flood_score": 0.47,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.62,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -11063,12 +11492,15 @@
             "built_pct": null,
             "pop_density": 0.0009514347030586684,
             "pop_density_raw": 22.6925,
-            "flood_score": 0.65,
-            "heat_score": 0.28,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 77.23
           },
           "coverage": {
             "elevation": false,
@@ -11140,12 +11572,15 @@
             "built_pct": null,
             "pop_density": 0.0006223055890778137,
             "pop_density_raw": 14.842500000000001,
-            "flood_score": 0.64,
-            "heat_score": 0.3,
+            "flood_score": 0.44,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -11217,12 +11652,15 @@
             "built_pct": null,
             "pop_density": 0.0001400371007256121,
             "pop_density_raw": 3.34,
-            "flood_score": 0.66,
-            "heat_score": 0.28,
+            "flood_score": 0.48,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -11294,12 +11732,15 @@
             "built_pct": null,
             "pop_density": 0.00003647672982972531,
             "pop_density_raw": 0.87,
-            "flood_score": 0.61,
-            "heat_score": 0.27,
+            "flood_score": 0.43,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.42,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -11371,12 +11812,15 @@
             "built_pct": null,
             "pop_density": 0.00046120003232986013,
             "pop_density_raw": 10.999999999999998,
-            "flood_score": 0.62,
-            "heat_score": 0.27,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 1,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.38,
+            "hwm_raw": 11,
+            "precip_trigger": 72.84
           },
           "coverage": {
             "elevation": false,
@@ -11449,11 +11893,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.48,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11526,11 +11973,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.48,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11603,11 +12053,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.48,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11680,11 +12133,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.48,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11757,11 +12213,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.49,
-            "heat_score": 0.28,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11833,12 +12292,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.5,
-            "heat_score": 0.28,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11910,12 +12372,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.51,
-            "heat_score": 0.27,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -11987,12 +12452,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.53,
-            "heat_score": 0.25,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -12064,12 +12532,15 @@
             "built_pct": null,
             "pop_density": 0.010725835660965894,
             "pop_density_raw": 255.82,
-            "flood_score": 0.65,
-            "heat_score": 0.26,
+            "flood_score": 0.63,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.49,
+            "hwm_raw": null,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -12141,12 +12612,15 @@
             "built_pct": null,
             "pop_density": 0.009647256494449016,
             "pop_density_raw": 230.095,
-            "flood_score": 0.42,
-            "heat_score": 0.06,
+            "flood_score": 0.44,
+            "heat_score": 0.04,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.27,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -12218,12 +12692,15 @@
             "built_pct": null,
             "pop_density": 0.025067269939019563,
             "pop_density_raw": 597.875,
-            "flood_score": 0.59,
-            "heat_score": 0.22,
+            "flood_score": 0.5,
+            "heat_score": 0.32,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": null,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -12295,12 +12772,15 @@
             "built_pct": null,
             "pop_density": 0.1469081426618137,
             "pop_density_raw": 3503.8800000000006,
-            "flood_score": 0.7,
-            "heat_score": 0.48,
+            "flood_score": 0.5,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -12372,12 +12852,15 @@
             "built_pct": null,
             "pop_density": 0.15774036878478295,
             "pop_density_raw": 3762.2375,
-            "flood_score": 0.85,
-            "heat_score": 0.48,
+            "flood_score": 0.56,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.42,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -12449,12 +12932,15 @@
             "built_pct": null,
             "pop_density": 0.13909992129628,
             "pop_density_raw": 3317.6475,
-            "flood_score": 0.6,
-            "heat_score": 0.41,
+            "flood_score": 0.49,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -12526,12 +13012,15 @@
             "built_pct": null,
             "pop_density": 0.15353946539939292,
             "pop_density_raw": 3662.0425,
-            "flood_score": 0.64,
-            "heat_score": 0.62,
+            "flood_score": 0.48,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": false,
@@ -12603,12 +13092,15 @@
             "built_pct": null,
             "pop_density": 0.17639004027393254,
             "pop_density_raw": 4207.047500000001,
-            "flood_score": 0.47,
-            "heat_score": 0.51,
+            "flood_score": 0.42,
+            "heat_score": 0.68,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.57,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -12680,12 +13172,15 @@
             "built_pct": 0.7,
             "pop_density": 0.2371811309898989,
             "pop_density_raw": 5656.965,
-            "flood_score": 0.49,
-            "heat_score": 0.45,
+            "flood_score": 0.44,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.62,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -12757,12 +13252,15 @@
             "built_pct": null,
             "pop_density": 0.2727567388473651,
             "pop_density_raw": 6505.4725,
-            "flood_score": 0.75,
-            "heat_score": 0.57,
+            "flood_score": 0.42,
+            "heat_score": 0.71,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.67,
-            "low_elev_risk": 0.71
+            "low_elev_risk": 0.71,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -12834,12 +13332,15 @@
             "built_pct": null,
             "pop_density": 0.2714458825736567,
             "pop_density_raw": 6474.2075,
-            "flood_score": 0.51,
-            "heat_score": 0.66,
-            "landslide_score": 0.21,
+            "flood_score": 0.34,
+            "heat_score": 0.82,
+            "landslide_score": 0.18,
             "lakeside_risk": 0.95,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -12911,12 +13412,15 @@
             "built_pct": null,
             "pop_density": 0.39700172155686786,
             "pop_density_raw": 9468.817500000001,
-            "flood_score": 0.52,
-            "heat_score": 0.69,
+            "flood_score": 0.34,
+            "heat_score": 0.83,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.77,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": null,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -12988,12 +13492,15 @@
             "built_pct": 0.7,
             "pop_density": 0.5064587445024702,
             "pop_density_raw": 12079.4575,
-            "flood_score": 0.53,
-            "heat_score": 0.75,
+            "flood_score": 0.33,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.82,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": null,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -13065,12 +13572,15 @@
             "built_pct": null,
             "pop_density": 0.46762067050721606,
             "pop_density_raw": 11153.1375,
-            "flood_score": 0.54,
-            "heat_score": 0.72,
+            "flood_score": 0.34,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.87,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": null,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -13142,12 +13652,15 @@
             "built_pct": null,
             "pop_density": 0.3733904810835515,
             "pop_density_raw": 8905.67,
-            "flood_score": 0.56,
-            "heat_score": 0.63,
+            "flood_score": 0.37,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.92,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": null,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -13219,12 +13732,15 @@
             "built_pct": null,
             "pop_density": 0.3886246518787309,
             "pop_density_raw": 9269.0175,
-            "flood_score": 0.74,
-            "heat_score": 0.65,
+            "flood_score": 0.42,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.96,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": false,
@@ -13296,12 +13812,15 @@
             "built_pct": null,
             "pop_density": 0.5319503534106297,
             "pop_density_raw": 12687.453333333333,
-            "flood_score": 0.74,
-            "heat_score": 0.67,
+            "flood_score": 0.42,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.96,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": null,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": false,
@@ -13373,12 +13892,15 @@
             "built_pct": null,
             "pop_density": 0.6545547917021008,
             "pop_density_raw": 15611.67,
-            "flood_score": 0.82,
-            "heat_score": 0.7,
+            "flood_score": 0.43,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.92,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.19,
+            "hwm_raw": null,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -13450,12 +13972,15 @@
             "built_pct": null,
             "pop_density": 0.2850176368886653,
             "pop_density_raw": 6797.905,
-            "flood_score": 0.81,
-            "heat_score": 0.51,
+            "flood_score": 0.43,
+            "heat_score": 0.66,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.87,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.19,
+            "hwm_raw": null,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -13527,12 +14052,15 @@
             "built_pct": null,
             "pop_density": 0.006289825077276801,
             "pop_density_raw": 150.0175,
-            "flood_score": 0.71,
-            "heat_score": 0.23,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.83,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.28,
+            "hwm_raw": null,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13604,12 +14132,15 @@
             "built_pct": null,
             "pop_density": 0.006509838456335976,
             "pop_density_raw": 155.265,
-            "flood_score": 0.69,
-            "heat_score": 0.25,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": null,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13681,12 +14212,15 @@
             "built_pct": null,
             "pop_density": 0.020622664263818865,
             "pop_density_raw": 491.86749999999995,
-            "flood_score": 0.66,
-            "heat_score": 0.32,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.73,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13758,12 +14292,15 @@
             "built_pct": null,
             "pop_density": 0.03811011167149718,
             "pop_density_raw": 908.9575000000001,
-            "flood_score": 0.7,
-            "heat_score": 0.36,
+            "flood_score": 0.52,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13835,12 +14372,15 @@
             "built_pct": null,
             "pop_density": 0.027401885466311147,
             "pop_density_raw": 653.5575,
-            "flood_score": 0.64,
-            "heat_score": 0.32,
+            "flood_score": 0.46,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.63,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13912,12 +14452,15 @@
             "built_pct": null,
             "pop_density": 0.0076829636294804765,
             "pop_density_raw": 183.245,
-            "flood_score": 0.64,
-            "heat_score": 0.32,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.58,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -13989,12 +14532,15 @@
             "built_pct": null,
             "pop_density": 0.0006307958624002498,
             "pop_density_raw": 15.045000000000002,
-            "flood_score": 0.62,
-            "heat_score": 0.29,
+            "flood_score": 0.53,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.53,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.38,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -14066,12 +14612,15 @@
             "built_pct": null,
             "pop_density": 0.00015359358652439892,
             "pop_density_raw": 3.6633333333333336,
-            "flood_score": 0.61,
-            "heat_score": 0.27,
+            "flood_score": 0.43,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.26,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -14143,12 +14692,15 @@
             "built_pct": null,
             "pop_density": 0.00005702109490623727,
             "pop_density_raw": 1.36,
-            "flood_score": 0.6,
-            "heat_score": 0.25,
+            "flood_score": 0.43,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -14220,12 +14772,15 @@
             "built_pct": null,
             "pop_density": 0.0012679506949432292,
             "pop_density_raw": 30.241666666666664,
-            "flood_score": 0.58,
-            "heat_score": 0.24,
+            "flood_score": 0.42,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.95,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -14298,11 +14853,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.45,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14375,11 +14933,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.45,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14452,11 +15013,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.45,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14529,11 +15093,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.45,
-            "heat_score": 0.28,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14606,11 +15173,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.46,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14682,12 +15252,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.47,
-            "heat_score": 0.26,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14759,12 +15332,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.48,
-            "heat_score": 0.26,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -14836,12 +15412,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.5,
-            "heat_score": 0.24,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -14913,12 +15492,15 @@
             "built_pct": null,
             "pop_density": 0.010826670758943469,
             "pop_density_raw": 258.225,
-            "flood_score": 0.36,
-            "heat_score": 0.25,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -14990,12 +15572,15 @@
             "built_pct": null,
             "pop_density": 0.010677619293949591,
             "pop_density_raw": 254.67000000000002,
-            "flood_score": 0.55,
-            "heat_score": 0.28,
+            "flood_score": 0.49,
+            "heat_score": 0.44,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.27,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -15067,12 +15652,15 @@
             "built_pct": null,
             "pop_density": 0.011364912160310249,
             "pop_density_raw": 271.0625,
-            "flood_score": 0.67,
-            "heat_score": 0.21,
+            "flood_score": 0.54,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -15144,12 +15732,15 @@
             "built_pct": null,
             "pop_density": 0.08422896190440238,
             "pop_density_raw": 2008.93,
-            "flood_score": 0.48,
-            "heat_score": 0.37,
+            "flood_score": 0.45,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -15221,12 +15812,15 @@
             "built_pct": null,
             "pop_density": 0.14302085529840797,
             "pop_density_raw": 3411.165,
-            "flood_score": 0.42,
-            "heat_score": 0.52,
+            "flood_score": 0.43,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.42,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15298,12 +15892,15 @@
             "built_pct": null,
             "pop_density": 0.14863921505588815,
             "pop_density_raw": 3545.1675,
-            "flood_score": 0.54,
-            "heat_score": 0.56,
+            "flood_score": 0.45,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15375,12 +15972,15 @@
             "built_pct": null,
             "pop_density": 0.24931215929482253,
             "pop_density_raw": 5946.3,
-            "flood_score": 0.63,
-            "heat_score": 0.6,
+            "flood_score": 0.5,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15452,12 +16052,15 @@
             "built_pct": null,
             "pop_density": 0.29243572495412357,
             "pop_density_raw": 6974.832499999999,
-            "flood_score": 0.57,
-            "heat_score": 0.6,
+            "flood_score": 0.45,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15529,12 +16132,15 @@
             "built_pct": null,
             "pop_density": 0.22124404941817308,
             "pop_density_raw": 5276.8525,
-            "flood_score": 0.45,
-            "heat_score": 0.52,
+            "flood_score": 0.42,
+            "heat_score": 0.72,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.62,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15606,12 +16212,15 @@
             "built_pct": null,
             "pop_density": 0.17368615026620954,
             "pop_density_raw": 4142.5575,
-            "flood_score": 0.47,
-            "heat_score": 0.54,
+            "flood_score": 0.32,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.67,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -15683,12 +16292,15 @@
             "built_pct": null,
             "pop_density": 0.14092553969698207,
             "pop_density_raw": 3361.19,
-            "flood_score": 0.47,
-            "heat_score": 0.17,
-            "landslide_score": 0.28,
+            "flood_score": 0.31,
+            "heat_score": 0.09,
+            "landslide_score": 0.22,
             "lakeside_risk": 0.86,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -15760,12 +16372,15 @@
             "built_pct": null,
             "pop_density": 0.2492205481974916,
             "pop_density_raw": 5944.115000000001,
-            "flood_score": 0.47,
-            "heat_score": 0.54,
-            "landslide_score": 0.45,
+            "flood_score": 0.29,
+            "heat_score": 0.75,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.86,
             "delta_risk": 0.77,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -15837,12 +16452,15 @@
             "built_pct": null,
             "pop_density": 0.4119165113296589,
             "pop_density_raw": 9824.5475,
-            "flood_score": 0.5,
-            "heat_score": 0.7,
+            "flood_score": 0.33,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.82,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -15914,12 +16532,15 @@
             "built_pct": null,
             "pop_density": 0.46851655157001676,
             "pop_density_raw": 11174.505,
-            "flood_score": 0.5,
-            "heat_score": 0.71,
+            "flood_score": 0.33,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.87,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -15991,12 +16612,15 @@
             "built_pct": null,
             "pop_density": 0.4000111565860094,
             "pop_density_raw": 9540.595000000001,
-            "flood_score": 0.52,
-            "heat_score": 0.6,
+            "flood_score": 0.35,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.92,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -16068,12 +16692,15 @@
             "built_pct": null,
             "pop_density": 0.42254612389297047,
             "pop_density_raw": 10078.0725,
-            "flood_score": 0.79,
-            "heat_score": 0.66,
+            "flood_score": 0.42,
+            "heat_score": 0.86,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.97,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -16145,12 +16772,15 @@
             "built_pct": null,
             "pop_density": 0.5659150105188054,
             "pop_density_raw": 13497.538333333332,
-            "flood_score": 0.7,
-            "heat_score": 0.68,
+            "flood_score": 0.41,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.97,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": false,
@@ -16222,12 +16852,15 @@
             "built_pct": null,
             "pop_density": 0.6529275941334898,
             "pop_density_raw": 15572.86,
-            "flood_score": 0.79,
-            "heat_score": 0.6,
+            "flood_score": 0.42,
+            "heat_score": 0.71,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.93,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -16299,12 +16932,15 @@
             "built_pct": null,
             "pop_density": 0.39274033807632913,
             "pop_density_raw": 9367.18,
-            "flood_score": 0.7,
-            "heat_score": 0.62,
+            "flood_score": 0.4,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.88,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -16376,12 +17012,15 @@
             "built_pct": null,
             "pop_density": 0.06487522663862562,
             "pop_density_raw": 1547.3275,
-            "flood_score": 0.66,
-            "heat_score": 0.38,
+            "flood_score": 0.39,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.83,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16453,12 +17092,15 @@
             "built_pct": null,
             "pop_density": 0.02454286453862268,
             "pop_density_raw": 585.3675000000001,
-            "flood_score": 0.66,
-            "heat_score": 0.28,
+            "flood_score": 0.49,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16530,12 +17172,15 @@
             "built_pct": null,
             "pop_density": 0.015381545169146665,
             "pop_density_raw": 366.86249999999995,
-            "flood_score": 0.67,
-            "heat_score": 0.25,
+            "flood_score": 0.51,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.73,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16607,12 +17252,15 @@
             "built_pct": null,
             "pop_density": 0.02990651609642979,
             "pop_density_raw": 713.2950000000001,
-            "flood_score": 0.62,
-            "heat_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16684,12 +17332,15 @@
             "built_pct": null,
             "pop_density": 0.0236233993832596,
             "pop_density_raw": 563.4375,
-            "flood_score": 0.62,
-            "heat_score": 0.27,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.63,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16761,12 +17412,15 @@
             "built_pct": null,
             "pop_density": 0.007167362956973525,
             "pop_density_raw": 170.9475,
-            "flood_score": 0.59,
-            "heat_score": 0.27,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.58,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -16838,12 +17492,15 @@
             "built_pct": null,
             "pop_density": 0.00008102446022522318,
             "pop_density_raw": 1.9325,
-            "flood_score": 0.6,
-            "heat_score": 0.28,
+            "flood_score": 0.44,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.53,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -16915,12 +17572,15 @@
             "built_pct": null,
             "pop_density": 0.00004807660943074907,
             "pop_density_raw": 1.1466666666666667,
-            "flood_score": 0.57,
-            "heat_score": 0.26,
+            "flood_score": 0.41,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -16992,12 +17652,15 @@
             "built_pct": null,
             "pop_density": 0.0002396842592259728,
             "pop_density_raw": 5.716666666666666,
-            "flood_score": 0.55,
-            "heat_score": 0.24,
+            "flood_score": 0.4,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -17069,12 +17732,15 @@
             "built_pct": null,
             "pop_density": 0.0074887704643524945,
             "pop_density_raw": 178.61333333333334,
-            "flood_score": 0.55,
-            "heat_score": 0.23,
+            "flood_score": 0.41,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.86,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -17147,11 +17813,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.42,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17224,11 +17893,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.42,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17301,11 +17973,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.42,
-            "heat_score": 0.28,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17378,11 +18053,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.42,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17455,11 +18133,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.43,
-            "heat_score": 0.26,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17531,12 +18212,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17608,12 +18292,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.46,
-            "heat_score": 0.24,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -17685,12 +18372,15 @@
             "built_pct": null,
             "pop_density": 0.001823417218729602,
             "pop_density_raw": 43.49,
-            "flood_score": 0.47,
-            "heat_score": 0.24,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -17762,12 +18452,15 @@
             "built_pct": null,
             "pop_density": 0.005848715197870401,
             "pop_density_raw": 139.49666666666667,
-            "flood_score": 0.51,
-            "heat_score": 0.03,
+            "flood_score": 0.48,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -17839,12 +18532,15 @@
             "built_pct": null,
             "pop_density": 0.007440414339750638,
             "pop_density_raw": 177.46000000000004,
-            "flood_score": 0.51,
-            "heat_score": 0.25,
+            "flood_score": 0.48,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.27,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -17916,12 +18612,15 @@
             "built_pct": null,
             "pop_density": 0.007555295075076437,
             "pop_density_raw": 180.2,
-            "flood_score": 0.71,
-            "heat_score": 0.07,
+            "flood_score": 0.55,
+            "heat_score": 0.05,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -17993,12 +18692,15 @@
             "built_pct": null,
             "pop_density": 0.06683473280628892,
             "pop_density_raw": 1594.0633333333333,
-            "flood_score": 0.43,
-            "heat_score": 0.08,
-            "landslide_score": 0.28,
+            "flood_score": 0.4,
+            "heat_score": 0.04,
+            "landslide_score": 0.22,
             "lakeside_risk": 0.77,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -18070,12 +18772,15 @@
             "built_pct": null,
             "pop_density": 0.15114604686797928,
             "pop_density_raw": 3604.9575,
-            "flood_score": 0.36,
-            "heat_score": 0.37,
-            "landslide_score": 0.22,
+            "flood_score": 0.37,
+            "heat_score": 0.52,
+            "landslide_score": 0.18,
             "lakeside_risk": 0.77,
             "delta_risk": 0.42,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18147,12 +18852,15 @@
             "built_pct": null,
             "pop_density": 0.13384035420031462,
             "pop_density_raw": 3192.2025000000003,
-            "flood_score": 0.38,
-            "heat_score": 0.5,
+            "flood_score": 0.4,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18224,12 +18932,15 @@
             "built_pct": null,
             "pop_density": 0.2743226177753142,
             "pop_density_raw": 6542.82,
-            "flood_score": 0.5,
-            "heat_score": 0.42,
+            "flood_score": 0.44,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.52,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18301,12 +19012,15 @@
             "built_pct": null,
             "pop_density": 0.3198206298737899,
             "pop_density_raw": 7627.985000000001,
-            "flood_score": 0.59,
-            "heat_score": 0.54,
+            "flood_score": 0.47,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18379,11 +19093,14 @@
             "pop_density": 0.16724350026912888,
             "pop_density_raw": 3988.895,
             "flood_score": 0.41,
-            "heat_score": 0.53,
+            "heat_score": 0.75,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.62,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18455,12 +19172,15 @@
             "built_pct": 0.7,
             "pop_density": 0.09724004372556273,
             "pop_density_raw": 2319.255,
-            "flood_score": 0.42,
-            "heat_score": 0.47,
-            "landslide_score": 0.33,
+            "flood_score": 0.29,
+            "heat_score": 0.71,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.77,
             "delta_risk": 0.67,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.14,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -18532,12 +19252,15 @@
             "built_pct": null,
             "pop_density": 0.048199700924226194,
             "pop_density_raw": 1149.6025,
-            "flood_score": 0.43,
-            "heat_score": 0.13,
-            "landslide_score": 0.39,
+            "flood_score": 0.27,
+            "heat_score": 0.08,
+            "landslide_score": 0.3,
             "lakeside_risk": 0.77,
             "delta_risk": 0.71,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.12,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -18609,12 +19332,15 @@
             "built_pct": null,
             "pop_density": 0.12176257353548724,
             "pop_density_raw": 2904.1375000000003,
-            "flood_score": 0.44,
-            "heat_score": 0.39,
-            "landslide_score": 0.46,
+            "flood_score": 0.27,
+            "heat_score": 0.54,
+            "landslide_score": 0.37,
             "lakeside_risk": 0.77,
             "delta_risk": 0.76,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.12,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -18686,12 +19412,15 @@
             "built_pct": null,
             "pop_density": 0.2804992392082919,
             "pop_density_raw": 6690.137500000001,
-            "flood_score": 0.47,
-            "heat_score": 0.64,
+            "flood_score": 0.33,
+            "heat_score": 0.88,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.81,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -18763,12 +19492,15 @@
             "built_pct": null,
             "pop_density": 0.34593817806825156,
             "pop_density_raw": 8250.91,
-            "flood_score": 0.72,
-            "heat_score": 0.69,
+            "flood_score": 0.4,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.85,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -18840,12 +19572,15 @@
             "built_pct": null,
             "pop_density": 0.3526176123546579,
             "pop_density_raw": 8410.22,
-            "flood_score": 0.47,
-            "heat_score": 0.71,
+            "flood_score": 0.33,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.9,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -18917,12 +19652,15 @@
             "built_pct": null,
             "pop_density": 0.39531781734791804,
             "pop_density_raw": 9428.655,
-            "flood_score": 0.65,
-            "heat_score": 0.63,
+            "flood_score": 0.37,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.92,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -18994,12 +19732,15 @@
             "built_pct": null,
             "pop_density": 0.4557199976426826,
             "pop_density_raw": 10869.296666666667,
-            "flood_score": 0.66,
-            "heat_score": 0.66,
+            "flood_score": 0.4,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.93,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": false,
@@ -19071,12 +19812,15 @@
             "built_pct": null,
             "pop_density": 0.5726834005084174,
             "pop_density_raw": 13658.97,
-            "flood_score": 0.8,
-            "heat_score": 0.7,
+            "flood_score": 0.46,
+            "heat_score": 0.88,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.9,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -19148,12 +19892,15 @@
             "built_pct": null,
             "pop_density": 0.48276941447822525,
             "pop_density_raw": 11514.447499999998,
-            "flood_score": 0.6,
-            "heat_score": 0.7,
+            "flood_score": 0.36,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.86,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -19225,12 +19972,15 @@
             "built_pct": null,
             "pop_density": 0.2349052136485402,
             "pop_density_raw": 5602.6825,
-            "flood_score": 0.59,
-            "heat_score": 0.65,
+            "flood_score": 0.37,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.81,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -19302,12 +20052,15 @@
             "built_pct": null,
             "pop_density": 0.1065246292854978,
             "pop_density_raw": 2540.7,
-            "flood_score": 0.6,
-            "heat_score": 0.54,
+            "flood_score": 0.45,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.77,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -19379,12 +20132,15 @@
             "built_pct": null,
             "pop_density": 0.03185959341515758,
             "pop_density_raw": 759.8775,
-            "flood_score": 0.61,
-            "heat_score": 0.37,
+            "flood_score": 0.46,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.72,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -19456,12 +20212,15 @@
             "built_pct": null,
             "pop_density": 0.02244429957333265,
             "pop_density_raw": 535.315,
-            "flood_score": 0.61,
-            "heat_score": 0.27,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.67,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -19534,11 +20293,14 @@
             "pop_density": 0.016731917900170666,
             "pop_density_raw": 399.07,
             "flood_score": 0.58,
-            "heat_score": 0.26,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.62,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -19610,12 +20372,15 @@
             "built_pct": null,
             "pop_density": 0.0029122685677847354,
             "pop_density_raw": 69.46,
-            "flood_score": 0.56,
-            "heat_score": 0.27,
+            "flood_score": 0.45,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -19687,12 +20452,15 @@
             "built_pct": null,
             "pop_density": 0.014531679291389736,
             "pop_density_raw": 346.59250000000003,
-            "flood_score": 0.57,
-            "heat_score": 0.28,
+            "flood_score": 0.44,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.52,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -19764,12 +20532,15 @@
             "built_pct": null,
             "pop_density": 0.018611308031914846,
             "pop_density_raw": 443.895,
-            "flood_score": 0.55,
-            "heat_score": 0.26,
+            "flood_score": 0.42,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -19841,12 +20612,15 @@
             "built_pct": null,
             "pop_density": 0.01020017244229902,
             "pop_density_raw": 243.2825,
-            "flood_score": 0.53,
-            "heat_score": 0.24,
+            "flood_score": 0.4,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.42,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -19918,12 +20692,15 @@
             "built_pct": null,
             "pop_density": 0.016551141463255918,
             "pop_density_raw": 394.7583333333334,
-            "flood_score": 0.52,
-            "heat_score": 0.23,
+            "flood_score": 0.41,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.77,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -19996,11 +20773,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.39,
-            "heat_score": 0.3,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -20073,11 +20853,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.39,
-            "heat_score": 0.29,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -20150,11 +20933,14 @@
             "pop_density": 0.0003282905684675278,
             "pop_density_raw": 7.83,
             "flood_score": 0.39,
-            "heat_score": 0.27,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -20227,11 +21013,14 @@
             "pop_density": 0.0003282905684675278,
             "pop_density_raw": 7.83,
             "flood_score": 0.4,
-            "heat_score": 0.26,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -20304,11 +21093,14 @@
             "pop_density": null,
             "pop_density_raw": null,
             "flood_score": 0.4,
-            "heat_score": 0.25,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -20380,12 +21172,15 @@
             "built_pct": null,
             "pop_density": 0.031541889483795806,
             "pop_density_raw": 752.3,
-            "flood_score": 0.51,
-            "heat_score": 0.24,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -20457,12 +21252,15 @@
             "built_pct": null,
             "pop_density": 0.020525497802462097,
             "pop_density_raw": 489.54999999999995,
-            "flood_score": 0.42,
-            "heat_score": 0.28,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.5
+            "low_elev_risk": 0.5,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -20534,12 +21332,15 @@
             "built_pct": null,
             "pop_density": 0.0054114137126703606,
             "pop_density_raw": 129.0666666666667,
-            "flood_score": 0.45,
-            "heat_score": 0.23,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.49,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -20611,12 +21412,15 @@
             "built_pct": null,
             "pop_density": 0.014279486728256635,
             "pop_density_raw": 340.57750000000004,
-            "flood_score": 0.46,
-            "heat_score": 0.25,
+            "flood_score": 0.47,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.21,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -20689,11 +21493,14 @@
             "pop_density": 0.015436469900269588,
             "pop_density_raw": 368.1725,
             "flood_score": 0.49,
-            "heat_score": 0.25,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -20766,11 +21573,14 @@
             "pop_density": 0.0075999476236611,
             "pop_density_raw": 181.265,
             "flood_score": 0.5,
-            "heat_score": 0.23,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.31,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -20842,12 +21652,15 @@
             "built_pct": null,
             "pop_density": 0.07508308574813012,
             "pop_density_raw": 1790.793333333333,
-            "flood_score": 0.47,
-            "heat_score": 0.47,
+            "flood_score": 0.45,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -20920,11 +21733,14 @@
             "pop_density": 0.1123389990567182,
             "pop_density_raw": 2679.3775,
             "flood_score": 0.41,
-            "heat_score": 0.46,
-            "landslide_score": 0.21,
+            "heat_score": 0.65,
+            "landslide_score": 0.18,
             "lakeside_risk": 0.68,
             "delta_risk": 0.41,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -20996,12 +21812,15 @@
             "built_pct": null,
             "pop_density": 0.07765644217094521,
             "pop_density_raw": 1852.17,
-            "flood_score": 0.34,
-            "heat_score": 0.38,
-            "landslide_score": 0.22,
+            "flood_score": 0.38,
+            "heat_score": 0.61,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.68,
             "delta_risk": 0.46,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -21074,11 +21893,14 @@
             "pop_density": 0.15519538315183545,
             "pop_density_raw": 3701.5375,
             "flood_score": 0.41,
-            "heat_score": 0.43,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.51,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -21150,12 +21972,15 @@
             "built_pct": null,
             "pop_density": 0.20425291613619517,
             "pop_density_raw": 4871.599999999999,
-            "flood_score": 0.55,
-            "heat_score": 0.47,
+            "flood_score": 0.47,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.56,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -21228,11 +22053,14 @@
             "pop_density": 0.11359115714449375,
             "pop_density_raw": 2709.2425,
             "flood_score": 0.4,
-            "heat_score": 0.4,
-            "landslide_score": 0.22,
+            "heat_score": 0.57,
+            "landslide_score": 0.18,
             "lakeside_risk": 0.68,
             "delta_risk": 0.6,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -21304,12 +22132,15 @@
             "built_pct": null,
             "pop_density": 0.044218496463327844,
             "pop_density_raw": 1054.6475,
-            "flood_score": 0.39,
-            "heat_score": 0.34,
-            "landslide_score": 0.34,
+            "flood_score": 0.3,
+            "heat_score": 0.5,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.68,
             "delta_risk": 0.65,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -21381,12 +22212,15 @@
             "built_pct": null,
             "pop_density": 0.019197556163919598,
             "pop_density_raw": 457.8775,
-            "flood_score": 0.41,
-            "heat_score": 0.06,
-            "landslide_score": 0.29,
+            "flood_score": 0.28,
+            "heat_score": 0.04,
+            "landslide_score": 0.23,
             "lakeside_risk": 0.68,
             "delta_risk": 0.7,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.12,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -21458,12 +22292,15 @@
             "built_pct": null,
             "pop_density": 0.07146587991880848,
             "pop_density_raw": 1704.52,
-            "flood_score": 0.4,
-            "heat_score": 0.15,
-            "landslide_score": 0.29,
+            "flood_score": 0.24,
+            "heat_score": 0.09,
+            "landslide_score": 0.23,
             "lakeside_risk": 0.68,
             "delta_risk": 0.74,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.1,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -21535,12 +22372,15 @@
             "built_pct": null,
             "pop_density": 0.22990108847957202,
             "pop_density_raw": 5483.33,
-            "flood_score": 0.42,
-            "heat_score": 0.65,
-            "landslide_score": 0.22,
+            "flood_score": 0.31,
+            "heat_score": 0.88,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.68,
             "delta_risk": 0.79,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -21612,12 +22452,15 @@
             "built_pct": null,
             "pop_density": 0.33992150919194103,
             "pop_density_raw": 8107.4075,
-            "flood_score": 0.42,
-            "heat_score": 0.73,
+            "flood_score": 0.3,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.83,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -21689,12 +22532,15 @@
             "built_pct": 0.7,
             "pop_density": 0.40535342523322665,
             "pop_density_raw": 9668.0125,
-            "flood_score": 0.42,
-            "heat_score": 0.77,
+            "flood_score": 0.29,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.86,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -21766,12 +22612,15 @@
             "built_pct": null,
             "pop_density": 0.4589185596244757,
             "pop_density_raw": 10945.585,
-            "flood_score": 0.44,
-            "heat_score": 0.72,
+            "flood_score": 0.34,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.88,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -21843,12 +22692,15 @@
             "built_pct": null,
             "pop_density": 0.5013578372055056,
             "pop_density_raw": 11957.796666666667,
-            "flood_score": 0.73,
-            "heat_score": 0.73,
+            "flood_score": 0.43,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.88,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -21920,12 +22772,15 @@
             "built_pct": null,
             "pop_density": 0.5062403033962485,
             "pop_density_raw": 12074.2475,
-            "flood_score": 0.44,
-            "heat_score": 0.7,
+            "flood_score": 0.34,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.86,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -21997,12 +22852,15 @@
             "built_pct": null,
             "pop_density": 0.45536092546599677,
             "pop_density_raw": 10860.732500000002,
-            "flood_score": 0.43,
-            "heat_score": 0.66,
+            "flood_score": 0.33,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.83,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -22074,12 +22932,15 @@
             "built_pct": null,
             "pop_density": 0.3936790897784987,
             "pop_density_raw": 9389.57,
-            "flood_score": 0.55,
-            "heat_score": 0.7,
+            "flood_score": 0.36,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.79,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -22151,12 +23012,15 @@
             "built_pct": null,
             "pop_density": 0.22372761159226934,
             "pop_density_raw": 5336.0875,
-            "flood_score": 0.56,
-            "heat_score": 0.68,
+            "flood_score": 0.43,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.75,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -22228,12 +23092,15 @@
             "built_pct": null,
             "pop_density": 0.09365861583814303,
             "pop_density_raw": 2233.835,
-            "flood_score": 0.61,
-            "heat_score": 0.54,
+            "flood_score": 0.5,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.7,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -22305,12 +23172,15 @@
             "built_pct": null,
             "pop_density": 0.1532301469231644,
             "pop_density_raw": 3654.6649999999995,
-            "flood_score": 0.55,
-            "heat_score": 0.5,
+            "flood_score": 0.44,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.66,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -22382,12 +23252,15 @@
             "built_pct": null,
             "pop_density": 0.2804579408417605,
             "pop_density_raw": 6689.1525,
-            "flood_score": 0.54,
-            "heat_score": 0.61,
+            "flood_score": 0.44,
+            "heat_score": 0.82,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.61,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -22459,12 +23332,15 @@
             "built_pct": null,
             "pop_density": 0.1691449022205979,
             "pop_density_raw": 4034.245,
-            "flood_score": 0.53,
-            "heat_score": 0.42,
+            "flood_score": 0.44,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.56,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -22536,12 +23412,15 @@
             "built_pct": null,
             "pop_density": 0.1594195561752203,
             "pop_density_raw": 3802.2875,
-            "flood_score": 0.52,
-            "heat_score": 0.36,
+            "flood_score": 0.41,
+            "heat_score": 0.56,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -22613,12 +23492,15 @@
             "built_pct": null,
             "pop_density": 0.17025366902559455,
             "pop_density_raw": 4060.69,
-            "flood_score": 0.51,
-            "heat_score": 0.31,
+            "flood_score": 0.4,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -22690,12 +23572,15 @@
             "built_pct": null,
             "pop_density": 0.05194516927769049,
             "pop_density_raw": 1238.935,
-            "flood_score": 0.49,
-            "heat_score": 0.25,
+            "flood_score": 0.39,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.42,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -22767,12 +23652,15 @@
             "built_pct": null,
             "pop_density": 0.06021001361462714,
             "pop_density_raw": 1436.0583333333334,
-            "flood_score": 0.56,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.68,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.27,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -22844,12 +23732,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.36,
-            "heat_score": 0.28,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -22921,12 +23812,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.36,
-            "heat_score": 0.28,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -22998,12 +23892,15 @@
             "built_pct": null,
             "pop_density": 0.00034757711527404916,
             "pop_density_raw": 8.29,
-            "flood_score": 0.37,
-            "heat_score": 0.26,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -23075,12 +23972,15 @@
             "built_pct": null,
             "pop_density": 0.00036127335865839054,
             "pop_density_raw": 8.616666666666667,
-            "flood_score": 0.37,
-            "heat_score": 0.24,
+            "flood_score": 0.42,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -23152,12 +24052,15 @@
             "built_pct": null,
             "pop_density": 0.0003886658454270731,
             "pop_density_raw": 9.27,
-            "flood_score": 0.37,
-            "heat_score": 0.23,
+            "flood_score": 0.57,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -23229,12 +24132,15 @@
             "built_pct": null,
             "pop_density": 0.04998108604910029,
             "pop_density_raw": 1192.0900000000001,
-            "flood_score": 0.48,
-            "heat_score": 0.24,
+            "flood_score": 0.67,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.06,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -23306,12 +24212,15 @@
             "built_pct": null,
             "pop_density": 0.02962801416781605,
             "pop_density_raw": 706.6525,
-            "flood_score": 0.41,
-            "heat_score": 0.35,
+            "flood_score": 0.52,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.11,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -23383,12 +24292,15 @@
             "built_pct": null,
             "pop_density": 0.006196851343486668,
             "pop_density_raw": 147.8,
-            "flood_score": 0.41,
-            "heat_score": 0.22,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -23460,12 +24372,15 @@
             "built_pct": null,
             "pop_density": 0.037470825535774493,
             "pop_density_raw": 893.71,
-            "flood_score": 0.44,
-            "heat_score": 0.31,
+            "flood_score": 0.53,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.21,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -23537,12 +24452,15 @@
             "built_pct": null,
             "pop_density": 0.06924562103589688,
             "pop_density_raw": 1651.565,
-            "flood_score": 0.45,
-            "heat_score": 0.43,
+            "flood_score": 0.54,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -23614,12 +24532,15 @@
             "built_pct": null,
             "pop_density": 0.04560870010623488,
             "pop_density_raw": 1087.805,
-            "flood_score": 0.48,
-            "heat_score": 0.29,
+            "flood_score": 0.55,
+            "heat_score": 0.45,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -23691,12 +24612,15 @@
             "built_pct": null,
             "pop_density": 0.06412315613136044,
             "pop_density_raw": 1529.3899999999996,
-            "flood_score": 0.56,
-            "heat_score": 0.41,
+            "flood_score": 0.5,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.35,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -23768,12 +24692,15 @@
             "built_pct": null,
             "pop_density": 0.04536856163485584,
             "pop_density_raw": 1082.0774999999999,
-            "flood_score": 0.39,
-            "heat_score": 0.34,
-            "landslide_score": 0.21,
+            "flood_score": 0.43,
+            "heat_score": 0.57,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.59,
             "delta_risk": 0.4,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -23845,12 +24772,15 @@
             "built_pct": null,
             "pop_density": 0.03081916806949708,
             "pop_density_raw": 735.0625,
-            "flood_score": 0.36,
-            "heat_score": 0.26,
-            "landslide_score": 0.57,
+            "flood_score": 0.37,
+            "heat_score": 0.39,
+            "landslide_score": 0.48,
             "lakeside_risk": 0.59,
             "delta_risk": 0.45,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.26,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -23922,12 +24852,15 @@
             "built_pct": null,
             "pop_density": 0.05039333598708968,
             "pop_density_raw": 1201.9225000000001,
-            "flood_score": 0.34,
-            "heat_score": 0.28,
-            "landslide_score": 0.46,
+            "flood_score": 0.38,
+            "heat_score": 0.42,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.59,
             "delta_risk": 0.49,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -24000,11 +24933,14 @@
             "pop_density": 0.07195674349867229,
             "pop_density_raw": 1716.2275,
             "flood_score": 0.44,
-            "heat_score": 0.06,
-            "landslide_score": 0.18,
+            "heat_score": 0.03,
+            "landslide_score": 0.15,
             "lakeside_risk": 0.59,
             "delta_risk": 0.54,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -24076,12 +25012,15 @@
             "built_pct": null,
             "pop_density": 0.05178762753937417,
             "pop_density_raw": 1235.1775,
-            "flood_score": 0.44,
-            "heat_score": 0.3,
+            "flood_score": 0.41,
+            "heat_score": 0.45,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.59,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -24153,12 +25092,15 @@
             "built_pct": null,
             "pop_density": 0.021399367045538017,
             "pop_density_raw": 510.3925,
-            "flood_score": 0.39,
-            "heat_score": 0.27,
-            "landslide_score": 0.46,
+            "flood_score": 0.34,
+            "heat_score": 0.42,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.59,
             "delta_risk": 0.63,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -24230,12 +25172,15 @@
             "built_pct": 0.7,
             "pop_density": 0.03632663018283976,
             "pop_density_raw": 866.4199999999998,
-            "flood_score": 0.43,
-            "heat_score": 0.32,
-            "landslide_score": 0.23,
+            "flood_score": 0.3,
+            "heat_score": 0.58,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.59,
             "delta_risk": 0.67,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -24307,12 +25252,15 @@
             "built_pct": null,
             "pop_density": 0.09245194884446546,
             "pop_density_raw": 2205.0550000000003,
-            "flood_score": 0.36,
-            "heat_score": 0.32,
-            "landslide_score": 0.34,
+            "flood_score": 0.27,
+            "heat_score": 0.46,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.59,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -24384,12 +25332,15 @@
             "built_pct": null,
             "pop_density": 0.2111515252561474,
             "pop_density_raw": 5036.1375,
-            "flood_score": 0.38,
-            "heat_score": 0.33,
-            "landslide_score": 0.39,
+            "flood_score": 0.31,
+            "heat_score": 0.19,
+            "landslide_score": 0.3,
             "lakeside_risk": 0.59,
             "delta_risk": 0.75,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -24461,12 +25412,15 @@
             "built_pct": null,
             "pop_density": 0.31034632339146456,
             "pop_density_raw": 7402.014999999999,
-            "flood_score": 0.38,
-            "heat_score": 0.67,
-            "landslide_score": 0.45,
+            "flood_score": 0.34,
+            "heat_score": 0.89,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.59,
             "delta_risk": 0.79,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -24538,12 +25492,15 @@
             "built_pct": null,
             "pop_density": 0.39454048565706384,
             "pop_density_raw": 9410.115,
-            "flood_score": 0.39,
-            "heat_score": 0.67,
+            "flood_score": 0.32,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.81,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -24615,12 +25572,15 @@
             "built_pct": null,
             "pop_density": 0.44840110252357157,
             "pop_density_raw": 10694.734999999999,
-            "flood_score": 0.69,
-            "heat_score": 0.69,
+            "flood_score": 0.44,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.83,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -24692,12 +25652,15 @@
             "built_pct": null,
             "pop_density": 0.5340560809521794,
             "pop_density_raw": 12737.676666666666,
-            "flood_score": 0.4,
-            "heat_score": 0.76,
+            "flood_score": 0.33,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.83,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -24769,12 +25732,15 @@
             "built_pct": null,
             "pop_density": 0.5470738012586536,
             "pop_density_raw": 13048.16,
-            "flood_score": 0.39,
-            "heat_score": 0.71,
+            "flood_score": 0.32,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.82,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -24846,12 +25812,15 @@
             "built_pct": null,
             "pop_density": 0.48408152857020376,
             "pop_density_raw": 11545.7425,
-            "flood_score": 0.38,
-            "heat_score": 0.72,
+            "flood_score": 0.31,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.79,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -24923,12 +25892,15 @@
             "built_pct": null,
             "pop_density": 0.4467151019508384,
             "pop_density_raw": 10654.5225,
-            "flood_score": 0.51,
-            "heat_score": 0.71,
+            "flood_score": 0.35,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.76,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -25000,12 +25972,15 @@
             "built_pct": null,
             "pop_density": 0.30913682630667955,
             "pop_density_raw": 7373.1675000000005,
-            "flood_score": 0.54,
-            "heat_score": 0.64,
+            "flood_score": 0.44,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.72,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -25077,12 +26052,15 @@
             "built_pct": null,
             "pop_density": 0.12747086729927173,
             "pop_density_raw": 3040.285,
-            "flood_score": 0.52,
-            "heat_score": 0.48,
+            "flood_score": 0.44,
+            "heat_score": 0.71,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -25154,12 +26132,15 @@
             "built_pct": null,
             "pop_density": 0.17215087824949693,
             "pop_density_raw": 4105.94,
-            "flood_score": 0.52,
-            "heat_score": 0.36,
+            "flood_score": 0.44,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.64,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -25231,12 +26212,15 @@
             "built_pct": null,
             "pop_density": 0.38760120707971524,
             "pop_density_raw": 9244.607499999998,
-            "flood_score": 0.5,
-            "heat_score": 0.46,
+            "flood_score": 0.43,
+            "heat_score": 0.56,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.59,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -25308,12 +26292,15 @@
             "built_pct": null,
             "pop_density": 0.2598282537592675,
             "pop_density_raw": 6197.1175,
-            "flood_score": 0.5,
-            "heat_score": 0.25,
+            "flood_score": 0.44,
+            "heat_score": 0.14,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.55,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -25385,12 +26372,15 @@
             "built_pct": null,
             "pop_density": 0.22836696946294024,
             "pop_density_raw": 5446.74,
-            "flood_score": 0.49,
-            "heat_score": 0.34,
+            "flood_score": 0.48,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.5,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -25462,12 +26452,15 @@
             "built_pct": null,
             "pop_density": 0.2896364503942597,
             "pop_density_raw": 6908.0675,
-            "flood_score": 0.47,
-            "heat_score": 0.34,
+            "flood_score": 0.45,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.45,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -25539,12 +26532,15 @@
             "built_pct": null,
             "pop_density": 0.14749784979406091,
             "pop_density_raw": 3517.9449999999997,
-            "flood_score": 0.49,
-            "heat_score": 0.3,
+            "flood_score": 0.5,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.4,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -25616,12 +26612,15 @@
             "built_pct": null,
             "pop_density": 0.09920769077258457,
             "pop_density_raw": 2366.185,
-            "flood_score": 0.45,
-            "heat_score": 0.08,
+            "flood_score": 0.46,
+            "heat_score": 0.03,
             "landslide_score": 0,
             "lakeside_risk": 0.59,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -25693,12 +26692,15 @@
             "built_pct": null,
             "pop_density": 0.0002926523841511295,
             "pop_density_raw": 6.98,
-            "flood_score": 0.33,
-            "heat_score": 0.27,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -25770,12 +26772,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.34,
-            "heat_score": 0.26,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -25847,12 +26852,15 @@
             "built_pct": null,
             "pop_density": 0.0008638416363123836,
             "pop_density_raw": 20.60333333333333,
-            "flood_score": 0.34,
-            "heat_score": 0.25,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -25924,12 +26932,15 @@
             "built_pct": null,
             "pop_density": 0.0008418298165875494,
             "pop_density_raw": 20.078333333333333,
-            "flood_score": 0.35,
-            "heat_score": 0.24,
+            "flood_score": 0.45,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -26001,12 +27012,15 @@
             "built_pct": null,
             "pop_density": 0.0027728184489184517,
             "pop_density_raw": 66.13399999999999,
-            "flood_score": 0.35,
-            "heat_score": 0.22,
+            "flood_score": 0.45,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -26078,12 +27092,15 @@
             "built_pct": null,
             "pop_density": 0.06657045121200535,
             "pop_density_raw": 1587.76,
-            "flood_score": 0.36,
-            "heat_score": 0.29,
+            "flood_score": 0.65,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.05,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -26155,12 +27172,15 @@
             "built_pct": null,
             "pop_density": 0.07469693553924305,
             "pop_density_raw": 1781.5833333333333,
-            "flood_score": 0.46,
-            "heat_score": 0.48,
+            "flood_score": 0.52,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.1,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -26232,12 +27252,15 @@
             "built_pct": null,
             "pop_density": 0.02647840228036338,
             "pop_density_raw": 631.5316666666666,
-            "flood_score": 0.48,
-            "heat_score": 0.12,
+            "flood_score": 0.54,
+            "heat_score": 0.08,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.14,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -26309,12 +27332,15 @@
             "built_pct": null,
             "pop_density": 0.03095721362462854,
             "pop_density_raw": 738.355,
-            "flood_score": 0.39,
-            "heat_score": 0.23,
+            "flood_score": 0.5,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -26386,12 +27412,15 @@
             "built_pct": null,
             "pop_density": 0.084499812105207,
             "pop_density_raw": 2015.39,
-            "flood_score": 0.4,
-            "heat_score": 0.42,
+            "flood_score": 0.5,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.24,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -26463,12 +27492,15 @@
             "built_pct": null,
             "pop_density": 0.07568907463909447,
             "pop_density_raw": 1805.2466666666667,
-            "flood_score": 0.52,
-            "heat_score": 0.39,
+            "flood_score": 0.56,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": true,
@@ -26540,12 +27572,15 @@
             "built_pct": null,
             "pop_density": 0.09043065817752159,
             "pop_density_raw": 2156.8455555555556,
-            "flood_score": 0.44,
-            "heat_score": 0.42,
+            "flood_score": 0.47,
+            "heat_score": 0.66,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 72.87
           },
           "coverage": {
             "elevation": false,
@@ -26617,12 +27652,15 @@
             "built_pct": null,
             "pop_density": 0.055280064784192035,
             "pop_density_raw": 1318.475,
-            "flood_score": 0.54,
-            "heat_score": 0.45,
+            "flood_score": 0.49,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -26694,12 +27732,15 @@
             "built_pct": null,
             "pop_density": 0.013096683342312485,
             "pop_density_raw": 312.3666666666667,
-            "flood_score": 0.47,
-            "heat_score": 0.25,
+            "flood_score": 0.45,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -26771,12 +27812,15 @@
             "built_pct": null,
             "pop_density": 0.012913041874893866,
             "pop_density_raw": 307.9866666666666,
-            "flood_score": 0.35,
-            "heat_score": 0.26,
-            "landslide_score": 0.34,
+            "flood_score": 0.41,
+            "heat_score": 0.4,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.5,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -26848,12 +27892,15 @@
             "built_pct": null,
             "pop_density": 0.01667000528977002,
             "pop_density_raw": 397.5933333333333,
-            "flood_score": 0.4,
-            "heat_score": 0.24,
+            "flood_score": 0.42,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.52,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -26925,12 +27972,15 @@
             "built_pct": null,
             "pop_density": 0.036522779954165516,
             "pop_density_raw": 871.0983333333334,
-            "flood_score": 0.31,
-            "heat_score": 0.35,
+            "flood_score": 0.38,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.56,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -27002,12 +28052,15 @@
             "built_pct": null,
             "pop_density": 0.04024270760886973,
             "pop_density_raw": 959.8216666666667,
-            "flood_score": 0.39,
-            "heat_score": 0.3,
-            "landslide_score": 0.22,
+            "flood_score": 0.32,
+            "heat_score": 0.46,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.5,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.7
           },
           "coverage": {
             "elevation": true,
@@ -27079,12 +28132,15 @@
             "built_pct": null,
             "pop_density": 0.07225725724701085,
             "pop_density_raw": 1723.3949999999998,
-            "flood_score": 0.42,
-            "heat_score": 0.26,
+            "flood_score": 0.29,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.65,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -27156,12 +28212,15 @@
             "built_pct": 0.7,
             "pop_density": 0.12963983514828484,
             "pop_density_raw": 3092.0166666666664,
-            "flood_score": 0.35,
-            "heat_score": 0.45,
-            "landslide_score": 0.34,
+            "flood_score": 0.3,
+            "heat_score": 0.7,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.5,
             "delta_risk": 0.68,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -27233,12 +28292,15 @@
             "built_pct": null,
             "pop_density": 0.2139933210614163,
             "pop_density_raw": 5103.916666666667,
-            "flood_score": 0.34,
-            "heat_score": 0.41,
-            "landslide_score": 0.46,
+            "flood_score": 0.28,
+            "heat_score": 0.54,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.5,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -27310,12 +28372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.37737441081736817,
             "pop_density_raw": 9000.69,
-            "flood_score": 0.34,
-            "heat_score": 0.7,
-            "landslide_score": 0.45,
+            "flood_score": 0.32,
+            "heat_score": 0.9,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.5,
             "delta_risk": 0.75,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -27387,12 +28452,15 @@
             "built_pct": null,
             "pop_density": 0.371887947281255,
             "pop_density_raw": 8869.833333333334,
-            "flood_score": 0.54,
-            "heat_score": 0.64,
+            "flood_score": 0.38,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.77,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 66.01
           },
           "coverage": {
             "elevation": true,
@@ -27464,12 +28532,15 @@
             "built_pct": null,
             "pop_density": 0.2750967350417006,
             "pop_density_raw": 6561.283333333334,
-            "flood_score": 0.56,
-            "heat_score": 0.49,
+            "flood_score": 0.39,
+            "heat_score": 0.7,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.78,
-            "low_elev_risk": 0.6
+            "low_elev_risk": 0.6,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -27541,12 +28612,15 @@
             "built_pct": null,
             "pop_density": 0.35292251682047593,
             "pop_density_raw": 8417.492222222221,
-            "flood_score": 0.45,
-            "heat_score": 0.55,
+            "flood_score": 0.35,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.78,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -27618,12 +28692,15 @@
             "built_pct": null,
             "pop_density": 0.3628921008930755,
             "pop_density_raw": 8655.275,
-            "flood_score": 0.35,
-            "heat_score": 0.65,
+            "flood_score": 0.3,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.77,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -27695,12 +28772,15 @@
             "built_pct": null,
             "pop_density": 0.36647527575031463,
             "pop_density_raw": 8740.736666666666,
-            "flood_score": 0.34,
-            "heat_score": 0.57,
+            "flood_score": 0.3,
+            "heat_score": 0.75,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.75,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.58
           },
           "coverage": {
             "elevation": true,
@@ -27772,12 +28852,15 @@
             "built_pct": null,
             "pop_density": 0.4106977902442271,
             "pop_density_raw": 9795.479999999998,
-            "flood_score": 0.35,
-            "heat_score": 0.62,
+            "flood_score": 0.32,
+            "heat_score": 0.82,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -27849,12 +28932,15 @@
             "built_pct": 0.7,
             "pop_density": 0.2891628468762119,
             "pop_density_raw": 6896.771666666667,
-            "flood_score": 0.59,
-            "heat_score": 0.66,
+            "flood_score": 0.47,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.69,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": true,
@@ -27926,12 +29012,15 @@
             "built_pct": null,
             "pop_density": 0.08762059899063905,
             "pop_density_raw": 2089.8233333333333,
-            "flood_score": 0.48,
-            "heat_score": 0.2,
+            "flood_score": 0.43,
+            "heat_score": 0.13,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.65,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -28003,12 +29092,15 @@
             "built_pct": null,
             "pop_density": 0.02942505121419452,
             "pop_density_raw": 701.8116666666666,
-            "flood_score": 0.48,
-            "heat_score": 0.24,
+            "flood_score": 0.55,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.61,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -28080,12 +29172,15 @@
             "built_pct": null,
             "pop_density": 0.09271301601428124,
             "pop_density_raw": 2211.2816666666663,
-            "flood_score": 0.47,
-            "heat_score": 0.29,
+            "flood_score": 0.43,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -28157,12 +29252,15 @@
             "built_pct": null,
             "pop_density": 0.078362357735581,
             "pop_density_raw": 1869.006666666667,
-            "flood_score": 0.58,
-            "heat_score": 0.33,
+            "flood_score": 0.49,
+            "heat_score": 0.57,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.53,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11,
+            "precip_trigger": 78.74
           },
           "coverage": {
             "elevation": false,
@@ -28234,12 +29332,15 @@
             "built_pct": null,
             "pop_density": 0.1466636367658861,
             "pop_density_raw": 3498.0483333333336,
-            "flood_score": 0.46,
-            "heat_score": 0.3,
+            "flood_score": 0.47,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -28311,12 +29412,15 @@
             "built_pct": null,
             "pop_density": 0.2591613655003978,
             "pop_density_raw": 6181.211666666667,
-            "flood_score": 0.43,
-            "heat_score": 0.33,
+            "flood_score": 0.44,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -28388,12 +29492,15 @@
             "built_pct": null,
             "pop_density": 0.21973959394907525,
             "pop_density_raw": 5240.97,
-            "flood_score": 0.42,
-            "heat_score": 0.43,
+            "flood_score": 0.43,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.39,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -28465,12 +29572,15 @@
             "built_pct": null,
             "pop_density": 0.15030164318252442,
             "pop_density_raw": 3584.8177777777773,
-            "flood_score": 0.41,
-            "heat_score": 0.34,
+            "flood_score": 0.44,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0.5,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 11,
+            "precip_trigger": 79.63
           },
           "coverage": {
             "elevation": false,
@@ -28542,12 +29652,15 @@
             "built_pct": null,
             "pop_density": 0.00030166674841939495,
             "pop_density_raw": 7.195,
-            "flood_score": 0.4,
-            "heat_score": 0.26,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -28619,12 +29732,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.31,
-            "heat_score": 0.24,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -28696,12 +29812,15 @@
             "built_pct": null,
             "pop_density": 0.0023929992586569793,
             "pop_density_raw": 57.075,
-            "flood_score": 0.31,
-            "heat_score": 0.24,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -28773,12 +29892,15 @@
             "built_pct": null,
             "pop_density": 0.0019443774090270244,
             "pop_density_raw": 46.375,
-            "flood_score": 0.39,
-            "heat_score": 0.04,
+            "flood_score": 0.46,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.35,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -28850,12 +29972,15 @@
             "built_pct": null,
             "pop_density": 0.002627267911442715,
             "pop_density_raw": 62.6625,
-            "flood_score": 0.32,
-            "heat_score": 0.22,
+            "flood_score": 0.44,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -28927,12 +30052,15 @@
             "built_pct": null,
             "pop_density": 0.0410638882421916,
             "pop_density_raw": 979.4075,
-            "flood_score": 0.4,
-            "heat_score": 0.27,
+            "flood_score": 0.65,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.04,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -29004,12 +30132,15 @@
             "built_pct": null,
             "pop_density": 0.06983144989514496,
             "pop_density_raw": 1665.5375000000001,
-            "flood_score": 0.39,
-            "heat_score": 0.44,
+            "flood_score": 0.49,
+            "heat_score": 0.68,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.08,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -29081,12 +30212,15 @@
             "built_pct": null,
             "pop_density": 0.03754566572283893,
             "pop_density_raw": 895.4950000000001,
-            "flood_score": 0.41,
-            "heat_score": 0.25,
+            "flood_score": 0.52,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.13,
-            "low_elev_risk": 0.67
+            "low_elev_risk": 0.67,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -29158,12 +30292,15 @@
             "built_pct": null,
             "pop_density": 0.016272499777056627,
             "pop_density_raw": 388.1125,
-            "flood_score": 0.54,
-            "heat_score": 0.25,
+            "flood_score": 0.69,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.18,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -29235,12 +30372,15 @@
             "built_pct": null,
             "pop_density": 0.044476454026865064,
             "pop_density_raw": 1060.8,
-            "flood_score": 0.37,
-            "heat_score": 0.36,
+            "flood_score": 0.49,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -29312,12 +30452,15 @@
             "built_pct": null,
             "pop_density": 0.03851177497238082,
             "pop_density_raw": 918.5375,
-            "flood_score": 0.45,
-            "heat_score": 0.29,
+            "flood_score": 0.53,
+            "heat_score": 0.44,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.27,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -29389,12 +30532,15 @@
             "built_pct": 0.7,
             "pop_density": 0.09202862311782087,
             "pop_density_raw": 2194.9583333333335,
-            "flood_score": 0.4,
-            "heat_score": 0.37,
+            "flood_score": 0.46,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -29466,12 +30612,15 @@
             "built_pct": null,
             "pop_density": 0.09696971761570392,
             "pop_density_raw": 2312.8075,
-            "flood_score": 0.5,
-            "heat_score": 0.49,
+            "flood_score": 0.48,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29543,12 +30692,15 @@
             "built_pct": null,
             "pop_density": 0.029489444521738763,
             "pop_density_raw": 703.3475000000001,
-            "flood_score": 0.37,
-            "heat_score": 0.35,
+            "flood_score": 0.39,
+            "heat_score": 0.59,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.41,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29620,12 +30772,15 @@
             "built_pct": null,
             "pop_density": 0.006930578667647808,
             "pop_density_raw": 165.29999999999998,
-            "flood_score": 0.46,
-            "heat_score": 0.09,
+            "flood_score": 0.43,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.45,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29697,12 +30852,15 @@
             "built_pct": null,
             "pop_density": 0.013442618305956269,
             "pop_density_raw": 320.6175,
-            "flood_score": 0.34,
-            "heat_score": 0.08,
+            "flood_score": 0.38,
+            "heat_score": 0.04,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.49,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29774,12 +30932,15 @@
             "built_pct": null,
             "pop_density": 0.046740841367415506,
             "pop_density_raw": 1114.8075,
-            "flood_score": 0.39,
-            "heat_score": 0.11,
+            "flood_score": 0.41,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.54,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29851,12 +31012,15 @@
             "built_pct": null,
             "pop_density": 0.053593644938702244,
             "pop_density_raw": 1278.2525,
-            "flood_score": 0.32,
-            "heat_score": 0.3,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.44,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.41,
             "delta_risk": 0.58,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -29928,12 +31092,15 @@
             "built_pct": 0.7,
             "pop_density": 0.06024414940489883,
             "pop_density_raw": 1436.8725,
-            "flood_score": 0.35,
-            "heat_score": 0.39,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.64,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.41,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -30005,12 +31172,15 @@
             "built_pct": null,
             "pop_density": 0.05959071281363875,
             "pop_density_raw": 1421.2875000000001,
-            "flood_score": 0.35,
-            "heat_score": 0.36,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.53,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.41,
             "delta_risk": 0.65,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -30082,12 +31252,15 @@
             "built_pct": 0.7,
             "pop_density": 0.2297850547441654,
             "pop_density_raw": 5480.5625,
-            "flood_score": 0.39,
-            "heat_score": 0.57,
-            "landslide_score": 0.46,
+            "flood_score": 0.33,
+            "heat_score": 0.79,
+            "landslide_score": 0.39,
             "lakeside_risk": 0.41,
             "delta_risk": 0.68,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -30159,12 +31332,15 @@
             "built_pct": null,
             "pop_density": 0.49210819104195913,
             "pop_density_raw": 11737.185,
-            "flood_score": 0.41,
-            "heat_score": 0.78,
-            "landslide_score": 0.22,
+            "flood_score": 0.36,
+            "heat_score": 0.9,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.41,
             "delta_risk": 0.7,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.23,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -30236,12 +31412,15 @@
             "built_pct": null,
             "pop_density": 0.43827587508652616,
             "pop_density_raw": 10453.24,
-            "flood_score": 0.45,
-            "heat_score": 0.67,
+            "flood_score": 0.37,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.72,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -30313,12 +31492,15 @@
             "built_pct": null,
             "pop_density": 0.25273562617116924,
             "pop_density_raw": 6027.952499999999,
-            "flood_score": 0.56,
-            "heat_score": 0.41,
+            "flood_score": 0.41,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.73,
-            "low_elev_risk": 0.67
+            "low_elev_risk": 0.67,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -30390,12 +31572,15 @@
             "built_pct": null,
             "pop_density": 0.27456740318641293,
             "pop_density_raw": 6548.658333333334,
-            "flood_score": 0.37,
-            "heat_score": 0.57,
+            "flood_score": 0.31,
+            "heat_score": 0.78,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.73,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -30467,12 +31652,15 @@
             "built_pct": null,
             "pop_density": 0.1897456594828811,
             "pop_density_raw": 4525.59,
-            "flood_score": 0.34,
-            "heat_score": 0.56,
+            "flood_score": 0.3,
+            "heat_score": 0.78,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.72,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -30544,12 +31732,15 @@
             "built_pct": null,
             "pop_density": 0.28217549168943257,
             "pop_density_raw": 6730.1175,
-            "flood_score": 0.43,
-            "heat_score": 0.49,
+            "flood_score": 0.33,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.7,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -30621,12 +31812,15 @@
             "built_pct": null,
             "pop_density": 0.41814292140249026,
             "pop_density_raw": 9973.0525,
-            "flood_score": 0.53,
-            "heat_score": 0.61,
+            "flood_score": 0.39,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.67
+            "low_elev_risk": 0.67,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -30698,12 +31892,15 @@
             "built_pct": 0.7,
             "pop_density": 0.3140892761083889,
             "pop_density_raw": 7491.2875,
-            "flood_score": 0.55,
-            "heat_score": 0.64,
+            "flood_score": 0.46,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.65,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -30775,12 +31972,15 @@
             "built_pct": null,
             "pop_density": 0.09851630999684644,
             "pop_density_raw": 2349.6949999999997,
-            "flood_score": 0.45,
-            "heat_score": 0.37,
+            "flood_score": 0.42,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.62,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -30852,12 +32052,15 @@
             "built_pct": null,
             "pop_density": 0.0046488963258849905,
             "pop_density_raw": 110.88,
-            "flood_score": 0.5,
-            "heat_score": 0.09,
+            "flood_score": 0.47,
+            "heat_score": 0.07,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.58,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -30929,12 +32132,15 @@
             "built_pct": null,
             "pop_density": 0.00221983961015495,
             "pop_density_raw": 52.945,
-            "flood_score": 0.43,
-            "heat_score": 0.26,
+            "flood_score": 0.42,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.54,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -31006,12 +32212,15 @@
             "built_pct": null,
             "pop_density": 0.008684606245149601,
             "pop_density_raw": 207.13500000000002,
-            "flood_score": 0.43,
-            "heat_score": 0.3,
+            "flood_score": 0.44,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.5,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -31083,12 +32292,15 @@
             "built_pct": null,
             "pop_density": 0.14412888837608046,
             "pop_density_raw": 3437.5925,
-            "flood_score": 0.43,
-            "heat_score": 0.34,
+            "flood_score": 0.48,
+            "heat_score": 0.56,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.46,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -31160,12 +32372,15 @@
             "built_pct": null,
             "pop_density": 0.2630237410741785,
             "pop_density_raw": 6273.3325,
-            "flood_score": 0.4,
-            "heat_score": 0.31,
+            "flood_score": 0.44,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.41,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -31237,12 +32452,15 @@
             "built_pct": null,
             "pop_density": 0.24247864227034235,
             "pop_density_raw": 5783.3150000000005,
-            "flood_score": 0.38,
-            "heat_score": 0.39,
+            "flood_score": 0.43,
+            "heat_score": 0.57,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -31314,12 +32532,15 @@
             "built_pct": null,
             "pop_density": 0.22183973118720277,
             "pop_density_raw": 5291.06,
-            "flood_score": 0.38,
-            "heat_score": 0.32,
+            "flood_score": 0.43,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.41,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -31391,12 +32612,15 @@
             "built_pct": null,
             "pop_density": 0.0007096890194457667,
             "pop_density_raw": 16.926666666666666,
-            "flood_score": 0.3,
-            "heat_score": 0.25,
+            "flood_score": 0.56,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -31468,12 +32692,15 @@
             "built_pct": null,
             "pop_density": 0.0009024846087182037,
             "pop_density_raw": 21.525,
-            "flood_score": 0.28,
-            "heat_score": 0.23,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -31545,12 +32772,15 @@
             "built_pct": null,
             "pop_density": 0.001891758678065754,
             "pop_density_raw": 45.120000000000005,
-            "flood_score": 0.28,
-            "heat_score": 0.22,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -31622,12 +32852,15 @@
             "built_pct": null,
             "pop_density": 0.001661892389224985,
             "pop_density_raw": 39.6375,
-            "flood_score": 0.53,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -31699,12 +32932,15 @@
             "built_pct": null,
             "pop_density": 0.0011327701703156363,
             "pop_density_raw": 27.017500000000002,
-            "flood_score": 0.29,
-            "heat_score": 0.23,
+            "flood_score": 0.44,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -31776,12 +33012,15 @@
             "built_pct": null,
             "pop_density": 0.009292761378690019,
             "pop_density_raw": 221.64,
-            "flood_score": 0.37,
-            "heat_score": 0.21,
+            "flood_score": 0.5,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -31853,12 +33092,15 @@
             "built_pct": null,
             "pop_density": 0.019746593838770463,
             "pop_density_raw": 470.9725,
-            "flood_score": 0.42,
-            "heat_score": 0.32,
+            "flood_score": 0.47,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -31930,12 +33172,15 @@
             "built_pct": null,
             "pop_density": 0.01391807361201269,
             "pop_density_raw": 331.95750000000004,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.49,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.11,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -32007,12 +33252,15 @@
             "built_pct": null,
             "pop_density": 0.007410541155838361,
             "pop_density_raw": 176.7475,
-            "flood_score": 0.48,
-            "heat_score": 0.13,
+            "flood_score": 0.54,
+            "heat_score": 0.1,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -32084,12 +33332,15 @@
             "built_pct": null,
             "pop_density": 0.006392861357226859,
             "pop_density_raw": 152.47500000000002,
-            "flood_score": 0.48,
-            "heat_score": 0.28,
+            "flood_score": 0.54,
+            "heat_score": 0.44,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.21,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -32161,12 +33412,15 @@
             "built_pct": null,
             "pop_density": 0.005764057040420761,
             "pop_density_raw": 137.47750000000002,
-            "flood_score": 0.51,
-            "heat_score": 0.23,
+            "flood_score": 0.55,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -32238,12 +33492,15 @@
             "built_pct": null,
             "pop_density": 0.051122765765495015,
             "pop_density_raw": 1219.32,
-            "flood_score": 0.41,
-            "heat_score": 0.26,
+            "flood_score": 0.46,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -32315,12 +33572,15 @@
             "built_pct": 0.7,
             "pop_density": 0.09286440841883317,
             "pop_density_raw": 2214.8925,
-            "flood_score": 0.46,
-            "heat_score": 0.43,
+            "flood_score": 0.47,
+            "heat_score": 0.68,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32392,12 +33652,15 @@
             "built_pct": null,
             "pop_density": 0.04049556402053421,
             "pop_density_raw": 965.8525,
-            "flood_score": 0.79,
-            "heat_score": 0.39,
+            "flood_score": 0.54,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.38,
-            "low_elev_risk": 0.67
+            "low_elev_risk": 0.67,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32469,12 +33732,15 @@
             "built_pct": null,
             "pop_density": 0.002306209798027633,
             "pop_density_raw": 55.005,
-            "flood_score": 0.5,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32546,12 +33812,15 @@
             "built_pct": null,
             "pop_density": 0.018212998913084512,
             "pop_density_raw": 434.395,
-            "flood_score": 0.36,
-            "heat_score": 0.26,
+            "flood_score": 0.4,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32623,12 +33892,15 @@
             "built_pct": null,
             "pop_density": 0.09129569939977665,
             "pop_density_raw": 2177.4775,
-            "flood_score": 0.36,
-            "heat_score": 0.43,
+            "flood_score": 0.41,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.51,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32700,12 +33972,15 @@
             "built_pct": null,
             "pop_density": 0.08167181736151162,
             "pop_density_raw": 1947.9399999999998,
-            "flood_score": 0.36,
-            "heat_score": 0.38,
+            "flood_score": 0.33,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.54,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.23,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -32777,12 +34052,15 @@
             "built_pct": null,
             "pop_density": 0.011954514474368308,
             "pop_density_raw": 285.125,
-            "flood_score": 0.52,
-            "heat_score": 0.26,
+            "flood_score": 0.35,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.58,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -32854,12 +34132,15 @@
             "built_pct": null,
             "pop_density": 0.00634600762666971,
             "pop_density_raw": 151.3575,
-            "flood_score": 0.3,
-            "heat_score": 0.1,
-            "landslide_score": 0.41,
+            "flood_score": 0.25,
+            "heat_score": 0.06,
+            "landslide_score": 0.33,
             "lakeside_risk": 0.32,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.15,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -32931,12 +34212,15 @@
             "built_pct": null,
             "pop_density": 0.1166803588155905,
             "pop_density_raw": 2782.9225,
-            "flood_score": 0.31,
-            "heat_score": 0.42,
-            "landslide_score": 0.58,
+            "flood_score": 0.26,
+            "heat_score": 0.65,
+            "landslide_score": 0.48,
             "lakeside_risk": 0.32,
             "delta_risk": 0.63,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -33008,12 +34292,15 @@
             "built_pct": 0.7,
             "pop_density": 0.29605237175310306,
             "pop_density_raw": 7061.0925,
-            "flood_score": 0.27,
-            "heat_score": 0.66,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.89,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.32,
             "delta_risk": 0.66,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -33085,12 +34372,15 @@
             "built_pct": null,
             "pop_density": 0.3365810583214136,
             "pop_density_raw": 8027.734999999999,
-            "flood_score": 0.37,
-            "heat_score": 0.61,
+            "flood_score": 0.3,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.67,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -33162,12 +34452,15 @@
             "built_pct": null,
             "pop_density": 0.27203328370574226,
             "pop_density_raw": 6488.2175,
-            "flood_score": 0.51,
-            "heat_score": 0.49,
+            "flood_score": 0.39,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.68,
-            "low_elev_risk": 0.69
+            "low_elev_risk": 0.69,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -33239,12 +34532,15 @@
             "built_pct": null,
             "pop_density": 0.3944082051023366,
             "pop_density_raw": 9406.960000000001,
-            "flood_score": 0.37,
-            "heat_score": 0.75,
+            "flood_score": 0.31,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.68,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -33316,12 +34612,15 @@
             "built_pct": null,
             "pop_density": 0.274858343540141,
             "pop_density_raw": 6555.5975,
-            "flood_score": 0.3,
-            "heat_score": 0.68,
+            "flood_score": 0.29,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.67,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -33393,12 +34692,15 @@
             "built_pct": null,
             "pop_density": 0.3394845221613085,
             "pop_density_raw": 8096.985000000001,
-            "flood_score": 0.4,
-            "heat_score": 0.48,
+            "flood_score": 0.32,
+            "heat_score": 0.67,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.66,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -33470,12 +34772,15 @@
             "built_pct": null,
             "pop_density": 0.4666726948043998,
             "pop_density_raw": 11130.5275,
-            "flood_score": 0.45,
-            "heat_score": 0.57,
+            "flood_score": 0.36,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.64,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -33547,12 +34852,15 @@
             "built_pct": null,
             "pop_density": 0.39169729227593947,
             "pop_density_raw": 9342.3025,
-            "flood_score": 0.51,
-            "heat_score": 0.69,
+            "flood_score": 0.44,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.61,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -33624,12 +34932,15 @@
             "built_pct": null,
             "pop_density": 0.18475233058739704,
             "pop_density_raw": 4406.495,
-            "flood_score": 0.38,
-            "heat_score": 0.52,
+            "flood_score": 0.43,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.58,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -33701,12 +35012,15 @@
             "built_pct": null,
             "pop_density": 0.060878194631163216,
             "pop_density_raw": 1451.995,
-            "flood_score": 0.4,
-            "heat_score": 0.25,
+            "flood_score": 0.41,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.55,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -33778,12 +35092,15 @@
             "built_pct": null,
             "pop_density": 0.02967539198931903,
             "pop_density_raw": 707.7825,
-            "flood_score": 0.39,
-            "heat_score": 0.27,
+            "flood_score": 0.41,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -33855,12 +35172,15 @@
             "built_pct": null,
             "pop_density": 0.012067194027721627,
             "pop_density_raw": 287.8125,
-            "flood_score": 0.39,
-            "heat_score": 0.23,
+            "flood_score": 0.43,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.32,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -33932,12 +35252,15 @@
             "built_pct": null,
             "pop_density": 0.11314012447651298,
             "pop_density_raw": 2698.4849999999997,
-            "flood_score": 0.4,
-            "heat_score": 0.29,
+            "flood_score": 0.47,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -34009,12 +35332,15 @@
             "built_pct": null,
             "pop_density": 0.21693235320683468,
             "pop_density_raw": 5174.014999999999,
-            "flood_score": 0.36,
-            "heat_score": 0.31,
+            "flood_score": 0.43,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.39,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -34086,12 +35412,15 @@
             "built_pct": null,
             "pop_density": 0.21311518921198094,
             "pop_density_raw": 5082.9725,
-            "flood_score": 0.35,
-            "heat_score": 0.31,
+            "flood_score": 0.42,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.35,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -34163,12 +35492,15 @@
             "built_pct": null,
             "pop_density": 0.17083100761152023,
             "pop_density_raw": 4074.4600000000005,
-            "flood_score": 0.43,
-            "heat_score": 0.1,
+            "flood_score": 0.46,
+            "heat_score": 0.03,
             "landslide_score": 0,
             "lakeside_risk": 0.32,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": true,
@@ -34240,12 +35572,15 @@
             "built_pct": null,
             "pop_density": 0.0011555157173646316,
             "pop_density_raw": 27.56,
-            "flood_score": 0.34,
-            "heat_score": 0.04,
+            "flood_score": 0.43,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -34317,12 +35652,15 @@
             "built_pct": null,
             "pop_density": 0.0012468123601281106,
             "pop_density_raw": 29.737499999999997,
-            "flood_score": 0.31,
-            "heat_score": 0.22,
+            "flood_score": 0.43,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.36,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -34394,12 +35732,15 @@
             "built_pct": null,
             "pop_density": 0.001147549534988025,
             "pop_density_raw": 27.37,
-            "flood_score": 0.27,
-            "heat_score": 0.21,
+            "flood_score": 0.55,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -34471,12 +35812,15 @@
             "built_pct": null,
             "pop_density": 0.0007828870548799377,
             "pop_density_raw": 18.6725,
-            "flood_score": 0.48,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -34548,12 +35892,15 @@
             "built_pct": null,
             "pop_density": 0.0005543834024983251,
             "pop_density_raw": 13.2225,
-            "flood_score": 0.25,
-            "heat_score": 0.24,
+            "flood_score": 0.41,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -34625,12 +35972,15 @@
             "built_pct": null,
             "pop_density": 0.004481187223219588,
             "pop_density_raw": 106.88000000000001,
-            "flood_score": 0.46,
-            "heat_score": 0.23,
+            "flood_score": 0.53,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -34702,12 +36052,15 @@
             "built_pct": null,
             "pop_density": 0.010589886469617752,
             "pop_density_raw": 252.57750000000001,
-            "flood_score": 0.37,
-            "heat_score": 0.27,
+            "flood_score": 0.44,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -34779,12 +36132,15 @@
             "built_pct": null,
             "pop_density": 0.00847025304830538,
             "pop_density_raw": 202.02249999999998,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.09,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -34856,12 +36212,15 @@
             "built_pct": null,
             "pop_density": 0.003303764504319287,
             "pop_density_raw": 78.7975,
-            "flood_score": 0.52,
-            "heat_score": 0.3,
+            "flood_score": 0.54,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.14,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -34933,12 +36292,15 @@
             "built_pct": null,
             "pop_density": 0.002944238115480328,
             "pop_density_raw": 70.2225,
-            "flood_score": 0.44,
-            "heat_score": 0.02,
+            "flood_score": 0.52,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.18,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -35010,12 +36372,15 @@
             "built_pct": null,
             "pop_density": 0.028213283068644204,
             "pop_density_raw": 672.91,
-            "flood_score": 0.46,
-            "heat_score": 0.25,
+            "flood_score": 0.53,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.23,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -35087,12 +36452,15 @@
             "built_pct": 0.7,
             "pop_density": 0.1520721854480526,
             "pop_density_raw": 3627.0466666666666,
-            "flood_score": 0.39,
-            "heat_score": 0.41,
+            "flood_score": 0.45,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.27,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.34,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": false,
@@ -35164,12 +36532,15 @@
             "built_pct": 0.7,
             "pop_density": 0.22621169785731146,
             "pop_density_raw": 5395.334999999999,
-            "flood_score": 0.38,
-            "heat_score": 0.42,
+            "flood_score": 0.44,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": false,
@@ -35241,12 +36612,15 @@
             "built_pct": null,
             "pop_density": 0.088373368285832,
             "pop_density_raw": 2107.7775,
-            "flood_score": 0.5,
-            "heat_score": 0.39,
+            "flood_score": 0.48,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.33,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -35318,12 +36692,15 @@
             "built_pct": null,
             "pop_density": 0.001853395220831043,
             "pop_density_raw": 44.205000000000005,
-            "flood_score": 0.48,
-            "heat_score": 0.21,
+            "flood_score": 0.42,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.4,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -35395,12 +36772,15 @@
             "built_pct": null,
             "pop_density": 0.011618467359902506,
             "pop_density_raw": 277.11,
-            "flood_score": 0.35,
-            "heat_score": 0.23,
+            "flood_score": 0.39,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.44,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -35472,12 +36852,15 @@
             "built_pct": 0.7,
             "pop_density": 0.06686499032356145,
             "pop_density_raw": 1594.7849999999999,
-            "flood_score": 0.33,
-            "heat_score": 0.39,
+            "flood_score": 0.39,
+            "heat_score": 0.63,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.32,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -35549,12 +36932,15 @@
             "built_pct": null,
             "pop_density": 0.07164962620441627,
             "pop_density_raw": 1708.9025,
-            "flood_score": 0.33,
-            "heat_score": 0.22,
+            "flood_score": 0.31,
+            "heat_score": 0.32,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.51,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -35626,12 +37012,15 @@
             "built_pct": null,
             "pop_density": 0.02870225992110302,
             "pop_density_raw": 684.5725,
-            "flood_score": 0.39,
-            "heat_score": 0.07,
+            "flood_score": 0.32,
+            "heat_score": 0.04,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.54,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -35703,12 +37092,15 @@
             "built_pct": null,
             "pop_density": 0.014694671575542674,
             "pop_density_raw": 350.48,
-            "flood_score": 0.33,
-            "heat_score": 0.27,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.42,
+            "landslide_score": 0.28,
             "lakeside_risk": 0.23,
             "delta_risk": 0.57,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -35780,12 +37172,15 @@
             "built_pct": null,
             "pop_density": 0.014331266913704578,
             "pop_density_raw": 341.8125,
-            "flood_score": 0.38,
-            "heat_score": 0.03,
-            "landslide_score": 0.19,
+            "flood_score": 0.3,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0.23,
             "delta_risk": 0.59,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -35857,12 +37252,15 @@
             "built_pct": null,
             "pop_density": 0.08896181759980923,
             "pop_density_raw": 2121.8125,
-            "flood_score": 0.4,
-            "heat_score": 0.42,
-            "landslide_score": 0.34,
+            "flood_score": 0.32,
+            "heat_score": 0.66,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.23,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -35934,12 +37332,15 @@
             "built_pct": 0.7,
             "pop_density": 0.2087751920895678,
             "pop_density_raw": 4979.46,
-            "flood_score": 0.45,
-            "heat_score": 0.57,
+            "flood_score": 0.32,
+            "heat_score": 0.82,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.62,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -36011,12 +37412,15 @@
             "built_pct": 0.7,
             "pop_density": 0.274505735151787,
             "pop_density_raw": 6547.1875,
-            "flood_score": 0.45,
-            "heat_score": 0.57,
+            "flood_score": 0.34,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.63,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -36088,12 +37492,15 @@
             "built_pct": null,
             "pop_density": 0.41693279540857026,
             "pop_density_raw": 9944.19,
-            "flood_score": 0.38,
-            "heat_score": 0.75,
+            "flood_score": 0.28,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.63,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -36165,12 +37572,15 @@
             "built_pct": null,
             "pop_density": 0.3408754595315397,
             "pop_density_raw": 8130.160000000001,
-            "flood_score": 0.23,
-            "heat_score": 0.69,
+            "flood_score": 0.24,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.62,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -36242,12 +37652,15 @@
             "built_pct": null,
             "pop_density": 0.33503614303129786,
             "pop_density_raw": 7990.887500000001,
-            "flood_score": 0.38,
-            "heat_score": 0.63,
+            "flood_score": 0.3,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.61,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -36319,12 +37732,15 @@
             "built_pct": null,
             "pop_density": 0.43261495914424464,
             "pop_density_raw": 10318.2225,
-            "flood_score": 0.39,
-            "heat_score": 0.68,
+            "flood_score": 0.32,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.59,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -36396,12 +37812,15 @@
             "built_pct": null,
             "pop_density": 0.4212770900767392,
             "pop_density_raw": 10047.805,
-            "flood_score": 0.47,
-            "heat_score": 0.65,
+            "flood_score": 0.45,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.57,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -36473,12 +37892,15 @@
             "built_pct": null,
             "pop_density": 0.29412193516323515,
             "pop_density_raw": 7015.050000000001,
-            "flood_score": 0.38,
-            "heat_score": 0.59,
+            "flood_score": 0.43,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.54,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.31,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -36550,12 +37972,15 @@
             "built_pct": null,
             "pop_density": 0.1413365318167015,
             "pop_density_raw": 3370.9925000000003,
-            "flood_score": 0.37,
-            "heat_score": 0.25,
+            "flood_score": 0.42,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.51,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.32,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -36627,12 +38052,15 @@
             "built_pct": null,
             "pop_density": 0.029939429007827874,
             "pop_density_raw": 714.08,
-            "flood_score": 0.36,
-            "heat_score": 0.27,
+            "flood_score": 0.41,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.32,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -36704,12 +38132,15 @@
             "built_pct": null,
             "pop_density": 0.011403904526679956,
             "pop_density_raw": 271.9925,
-            "flood_score": 0.35,
-            "heat_score": 0.24,
+            "flood_score": 0.42,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.44,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.32,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -36781,12 +38212,15 @@
             "built_pct": null,
             "pop_density": 0.04014306045036936,
             "pop_density_raw": 957.4449999999998,
-            "flood_score": 0.37,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.4,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -36858,12 +38292,15 @@
             "built_pct": null,
             "pop_density": 0.07201764286657766,
             "pop_density_raw": 1717.68,
-            "flood_score": 0.33,
-            "heat_score": 0.27,
+            "flood_score": 0.44,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -36935,12 +38372,15 @@
             "built_pct": null,
             "pop_density": 0.07607368751454045,
             "pop_density_raw": 1814.42,
-            "flood_score": 0.31,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -37012,12 +38452,15 @@
             "built_pct": null,
             "pop_density": 0.0808640185170066,
             "pop_density_raw": 1928.6733333333332,
-            "flood_score": 0.4,
-            "heat_score": 0.27,
+            "flood_score": 0.45,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0.23,
             "delta_risk": 0.28,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.35,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": true,
@@ -37089,12 +38532,15 @@
             "built_pct": null,
             "pop_density": 0.000980259705079285,
             "pop_density_raw": 23.380000000000003,
-            "flood_score": 0.31,
-            "heat_score": 0.04,
+            "flood_score": 0.48,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -37166,12 +38612,15 @@
             "built_pct": null,
             "pop_density": 0.0018819057682841617,
             "pop_density_raw": 44.885000000000005,
-            "flood_score": 0.32,
-            "heat_score": 0.23,
+            "flood_score": 0.45,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -37243,12 +38692,15 @@
             "built_pct": null,
             "pop_density": 0.0022297973381257084,
             "pop_density_raw": 53.182500000000005,
-            "flood_score": 0.27,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -37320,12 +38772,15 @@
             "built_pct": null,
             "pop_density": 0.0016765669357082077,
             "pop_density_raw": 39.9875,
-            "flood_score": 0.24,
-            "heat_score": 0.02,
+            "flood_score": 0.45,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -37397,12 +38852,15 @@
             "built_pct": null,
             "pop_density": 0.0011509037170413332,
             "pop_density_raw": 27.450000000000003,
-            "flood_score": 0.27,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -37474,12 +38932,15 @@
             "built_pct": null,
             "pop_density": 0.009224734373921366,
             "pop_density_raw": 220.0175,
-            "flood_score": 0.26,
-            "heat_score": 0.23,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -37551,12 +39012,15 @@
             "built_pct": null,
             "pop_density": 0.022901411696285037,
             "pop_density_raw": 546.2175,
-            "flood_score": 0.42,
-            "heat_score": 0.31,
+            "flood_score": 0.56,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.03,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -37628,12 +39092,15 @@
             "built_pct": null,
             "pop_density": 0.017859656797406337,
             "pop_density_raw": 425.9675,
-            "flood_score": 0.35,
-            "heat_score": 0.27,
+            "flood_score": 0.49,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -37705,12 +39172,15 @@
             "built_pct": null,
             "pop_density": 0.006141821794174582,
             "pop_density_raw": 146.4875,
-            "flood_score": 0.44,
-            "heat_score": 0.02,
+            "flood_score": 0.56,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -37782,12 +39252,15 @@
             "built_pct": null,
             "pop_density": 0.007116421317038909,
             "pop_density_raw": 169.73250000000002,
-            "flood_score": 0.38,
-            "heat_score": 0.23,
+            "flood_score": 0.53,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.48
+            "low_elev_risk": 0.48,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -37859,12 +39332,15 @@
             "built_pct": null,
             "pop_density": 0.0364908802852627,
             "pop_density_raw": 870.3375,
-            "flood_score": 0.48,
-            "heat_score": 0.33,
+            "flood_score": 0.58,
+            "heat_score": 0.56,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.2,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -37936,12 +39412,15 @@
             "built_pct": null,
             "pop_density": 0.287109877823209,
             "pop_density_raw": 6847.806666666667,
-            "flood_score": 0.38,
-            "heat_score": 0.62,
+            "flood_score": 0.53,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -38013,12 +39492,15 @@
             "built_pct": 0.7,
             "pop_density": 0.35188472357601014,
             "pop_density_raw": 8392.740000000002,
-            "flood_score": 0.38,
-            "heat_score": 0.68,
+            "flood_score": 0.53,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38090,12 +39572,15 @@
             "built_pct": 0.7,
             "pop_density": 0.10612852134863995,
             "pop_density_raw": 2531.2525,
-            "flood_score": 0.48,
-            "heat_score": 0.51,
+            "flood_score": 0.56,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.33,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38167,12 +39652,15 @@
             "built_pct": null,
             "pop_density": 0.003928480911747916,
             "pop_density_raw": 93.69749999999999,
-            "flood_score": 0.43,
-            "heat_score": 0.22,
+            "flood_score": 0.5,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.36,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38244,12 +39732,15 @@
             "built_pct": null,
             "pop_density": 0.003344329143526482,
             "pop_density_raw": 79.765,
-            "flood_score": 0.38,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.4,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38321,12 +39812,15 @@
             "built_pct": null,
             "pop_density": 0.01935719426601923,
             "pop_density_raw": 461.685,
-            "flood_score": 0.31,
-            "heat_score": 0.25,
+            "flood_score": 0.45,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.44,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38398,12 +39892,15 @@
             "built_pct": null,
             "pop_density": 0.08164246826854518,
             "pop_density_raw": 1947.24,
-            "flood_score": 0.37,
-            "heat_score": 0.4,
+            "flood_score": 0.36,
+            "heat_score": 0.57,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -38475,12 +39972,15 @@
             "built_pct": null,
             "pop_density": 0.12046681108101864,
             "pop_density_raw": 2873.2325,
-            "flood_score": 0.36,
-            "heat_score": 0.46,
+            "flood_score": 0.34,
+            "heat_score": 0.7,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.5,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.26,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -38552,12 +40052,15 @@
             "built_pct": null,
             "pop_density": 0.060130736124221346,
             "pop_density_raw": 1434.1675,
-            "flood_score": 0.41,
-            "heat_score": 0.27,
+            "flood_score": 0.36,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.52,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.26,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -38629,12 +40132,15 @@
             "built_pct": null,
             "pop_density": 0.0041069862878974055,
             "pop_density_raw": 97.95500000000001,
-            "flood_score": 0.37,
-            "heat_score": 0.02,
-            "landslide_score": 0.19,
+            "flood_score": 0.35,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0.14,
             "delta_risk": 0.54,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -38706,12 +40212,15 @@
             "built_pct": null,
             "pop_density": 0.034524595874700005,
             "pop_density_raw": 823.4399999999999,
-            "flood_score": 0.34,
-            "heat_score": 0.3,
-            "landslide_score": 0.45,
+            "flood_score": 0.32,
+            "heat_score": 0.46,
+            "landslide_score": 0.37,
             "lakeside_risk": 0.14,
             "delta_risk": 0.56,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.24,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -38783,12 +40292,15 @@
             "built_pct": null,
             "pop_density": 0.12736730692837586,
             "pop_density_raw": 3037.815,
-            "flood_score": 0.42,
-            "heat_score": 0.35,
-            "landslide_score": 0.28,
+            "flood_score": 0.29,
+            "heat_score": 0.23,
+            "landslide_score": 0.22,
             "lakeside_risk": 0.14,
             "delta_risk": 0.57,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -38860,12 +40372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.20532174721111962,
             "pop_density_raw": 4897.0925,
-            "flood_score": 0.34,
-            "heat_score": 0.57,
-            "landslide_score": 0.34,
+            "flood_score": 0.28,
+            "heat_score": 0.81,
+            "landslide_score": 0.29,
             "lakeside_risk": 0.14,
             "delta_risk": 0.58,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -38937,12 +40452,15 @@
             "built_pct": 0.7,
             "pop_density": 0.30071975101967763,
             "pop_density_raw": 7172.413333333333,
-            "flood_score": 0.52,
-            "heat_score": 0.56,
+            "flood_score": 0.32,
+            "heat_score": 0.78,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.58,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -39014,12 +40532,15 @@
             "built_pct": null,
             "pop_density": 0.2900504822414649,
             "pop_density_raw": 6917.9425,
-            "flood_score": 0.28,
-            "heat_score": 0.55,
+            "flood_score": 0.27,
+            "heat_score": 0.75,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.57,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -39091,12 +40612,15 @@
             "built_pct": null,
             "pop_density": 0.27674119267212766,
             "pop_density_raw": 6600.505,
-            "flood_score": 0.4,
-            "heat_score": 0.66,
+            "flood_score": 0.3,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.56,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -39168,12 +40692,15 @@
             "built_pct": null,
             "pop_density": 0.31350910743135574,
             "pop_density_raw": 7477.45,
-            "flood_score": 0.43,
-            "heat_score": 0.65,
+            "flood_score": 0.31,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.55,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -39245,12 +40772,15 @@
             "built_pct": null,
             "pop_density": 0.30345243109002484,
             "pop_density_raw": 7237.59,
-            "flood_score": 0.69,
-            "heat_score": 0.58,
+            "flood_score": 0.43,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.53,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -39322,12 +40852,15 @@
             "built_pct": null,
             "pop_density": 0.2576874470637436,
             "pop_density_raw": 6146.057499999999,
-            "flood_score": 0.43,
-            "heat_score": 0.52,
+            "flood_score": 0.37,
+            "heat_score": 0.73,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.5,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -39400,11 +40933,14 @@
             "pop_density": 0.2107629642289095,
             "pop_density_raw": 5026.87,
             "flood_score": 0.35,
-            "heat_score": 0.32,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.47,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -39476,12 +41012,15 @@
             "built_pct": null,
             "pop_density": 0.12449340181782582,
             "pop_density_raw": 2969.27,
-            "flood_score": 0.32,
-            "heat_score": 0.26,
+            "flood_score": 0.33,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.44,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.22,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -39553,12 +41092,15 @@
             "built_pct": null,
             "pop_density": 0.048587633042329104,
             "pop_density_raw": 1158.855,
-            "flood_score": 0.32,
-            "heat_score": 0.23,
+            "flood_score": 0.34,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.41,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -39630,12 +41172,15 @@
             "built_pct": null,
             "pop_density": 0.0005396040378259365,
             "pop_density_raw": 12.87,
-            "flood_score": 0.33,
-            "heat_score": 0.15,
+            "flood_score": 0.48,
+            "heat_score": 0.23,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -39707,12 +41252,15 @@
             "built_pct": null,
             "pop_density": 0.00004790191244880594,
             "pop_density_raw": 1.1425,
-            "flood_score": 0.34,
-            "heat_score": 0.21,
+            "flood_score": 0.48,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.33,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -39784,12 +41332,15 @@
             "built_pct": null,
             "pop_density": 0.00009087737000681564,
             "pop_density_raw": 2.1675,
-            "flood_score": 0.45,
-            "heat_score": 0.23,
+            "flood_score": 0.51,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -39861,12 +41412,15 @@
             "built_pct": null,
             "pop_density": 0.023119119075182566,
             "pop_density_raw": 551.41,
-            "flood_score": 0.37,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.14,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": true,
@@ -39938,12 +41492,15 @@
             "built_pct": null,
             "pop_density": 0.0006310054987785814,
             "pop_density_raw": 15.049999999999999,
-            "flood_score": 0.19,
-            "heat_score": 0.24,
+            "flood_score": 0.59,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -40015,12 +41572,15 @@
             "built_pct": null,
             "pop_density": 0.0015471164720883496,
             "pop_density_raw": 36.900000000000006,
-            "flood_score": 0.25,
-            "heat_score": 0.23,
+            "flood_score": 0.45,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -40092,12 +41652,15 @@
             "built_pct": null,
             "pop_density": 0.002201915699807585,
             "pop_density_raw": 52.517500000000005,
-            "flood_score": 0.39,
-            "heat_score": 0.04,
+            "flood_score": 0.49,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -40169,12 +41732,15 @@
             "built_pct": null,
             "pop_density": 0.0019307510444354604,
             "pop_density_raw": 46.050000000000004,
-            "flood_score": 0.31,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -40246,12 +41812,15 @@
             "built_pct": null,
             "pop_density": 0.0018235220369187677,
             "pop_density_raw": 43.4925,
-            "flood_score": 0.36,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -40323,12 +41892,15 @@
             "built_pct": null,
             "pop_density": 0.012406071233294907,
             "pop_density_raw": 295.895,
-            "flood_score": 0.41,
-            "heat_score": 0.27,
+            "flood_score": 0.55,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -40400,12 +41972,15 @@
             "built_pct": null,
             "pop_density": 0.027039109713608046,
             "pop_density_raw": 644.905,
-            "flood_score": 0.42,
-            "heat_score": 0.32,
+            "flood_score": 0.56,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -40477,12 +42052,15 @@
             "built_pct": null,
             "pop_density": 0.03230727190108504,
             "pop_density_raw": 770.555,
-            "flood_score": 0.48,
-            "heat_score": 0.37,
+            "flood_score": 0.56,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.05,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -40554,12 +42132,15 @@
             "built_pct": null,
             "pop_density": 0.0208701400084395,
             "pop_density_raw": 497.77,
-            "flood_score": 0.54,
-            "heat_score": 0.25,
+            "flood_score": 0.56,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.09,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -40631,12 +42212,15 @@
             "built_pct": null,
             "pop_density": 0.009072014272306682,
             "pop_density_raw": 216.375,
-            "flood_score": 0.33,
-            "heat_score": 0.31,
+            "flood_score": 0.47,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.14,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -40708,12 +42292,15 @@
             "built_pct": null,
             "pop_density": 0.018253144279535047,
             "pop_density_raw": 435.3525000000001,
-            "flood_score": 0.73,
-            "heat_score": 0.25,
+            "flood_score": 0.6,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.18,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -40785,12 +42372,15 @@
             "built_pct": null,
             "pop_density": 0.2221574700579609,
             "pop_density_raw": 5298.638333333333,
-            "flood_score": 0.35,
-            "heat_score": 0.5,
+            "flood_score": 0.47,
+            "heat_score": 0.7,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -40862,12 +42452,15 @@
             "built_pct": 0.7,
             "pop_density": 0.28897588616613634,
             "pop_density_raw": 6892.3125,
-            "flood_score": 0.33,
-            "heat_score": 0.66,
+            "flood_score": 0.45,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -40939,12 +42532,15 @@
             "built_pct": null,
             "pop_density": 0.09216652891536677,
             "pop_density_raw": 2198.2475,
-            "flood_score": 0.42,
-            "heat_score": 0.39,
+            "flood_score": 0.51,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -41016,12 +42612,15 @@
             "built_pct": null,
             "pop_density": 0.004837988339140234,
             "pop_density_raw": 115.39,
-            "flood_score": 0.52,
-            "heat_score": 0.21,
+            "flood_score": 0.56,
+            "heat_score": 0.45,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.33,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -41093,12 +42692,15 @@
             "built_pct": null,
             "pop_density": 0.0018565397665060192,
             "pop_density_raw": 44.28,
-            "flood_score": 0.43,
-            "heat_score": 0.21,
+            "flood_score": 0.49,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -41170,12 +42772,15 @@
             "built_pct": null,
             "pop_density": 0.015379553623552516,
             "pop_density_raw": 366.815,
-            "flood_score": 0.39,
-            "heat_score": 0.23,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.4,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -41247,12 +42852,15 @@
             "built_pct": null,
             "pop_density": 0.07975532159080273,
             "pop_density_raw": 1902.23,
-            "flood_score": 0.34,
-            "heat_score": 0.1,
+            "flood_score": 0.33,
+            "heat_score": 0.04,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -41324,12 +42932,15 @@
             "built_pct": 0.7,
             "pop_density": 0.18654933362245682,
             "pop_density_raw": 4449.355,
-            "flood_score": 0.36,
-            "heat_score": 0.52,
+            "flood_score": 0.34,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.46,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -41401,12 +43012,15 @@
             "built_pct": null,
             "pop_density": 0.16155564605223172,
             "pop_density_raw": 3853.2349999999997,
-            "flood_score": 0.37,
-            "heat_score": 0.28,
+            "flood_score": 0.34,
+            "heat_score": 0.18,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.48,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.26,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -41478,12 +43092,15 @@
             "built_pct": null,
             "pop_density": 0.054732599382178664,
             "pop_density_raw": 1305.4175,
-            "flood_score": 0.41,
-            "heat_score": 0.11,
+            "flood_score": 0.36,
+            "heat_score": 0.07,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.5,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -41555,12 +43172,15 @@
             "built_pct": null,
             "pop_density": 0.017987849442756207,
             "pop_density_raw": 429.025,
-            "flood_score": 0.42,
-            "heat_score": 0.28,
+            "flood_score": 0.39,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.51,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.3,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -41632,12 +43252,15 @@
             "built_pct": null,
             "pop_density": 0.024528504446706952,
             "pop_density_raw": 585.025,
-            "flood_score": 0.4,
-            "heat_score": 0.21,
-            "landslide_score": 0.46,
+            "flood_score": 0.27,
+            "heat_score": 0.34,
+            "landslide_score": 0.38,
             "lakeside_risk": 0.06,
             "delta_risk": 0.52,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -41709,12 +43332,15 @@
             "built_pct": null,
             "pop_density": 0.04640227861640972,
             "pop_density_raw": 1106.7324999999998,
-            "flood_score": 0.38,
-            "heat_score": 0.25,
-            "landslide_score": 0.69,
+            "flood_score": 0.23,
+            "heat_score": 0.38,
+            "landslide_score": 0.57,
             "lakeside_risk": 0.06,
             "delta_risk": 0.53,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.13,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -41786,12 +43412,15 @@
             "built_pct": null,
             "pop_density": 0.1919844362458787,
             "pop_density_raw": 4578.986666666667,
-            "flood_score": 0.32,
-            "heat_score": 0.49,
-            "landslide_score": 0.22,
+            "flood_score": 0.26,
+            "heat_score": 0.71,
+            "landslide_score": 0.19,
             "lakeside_risk": 0.06,
             "delta_risk": 0.53,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -41863,12 +43492,15 @@
             "built_pct": null,
             "pop_density": 0.2217707608187316,
             "pop_density_raw": 5289.415,
-            "flood_score": 0.37,
-            "heat_score": 0.5,
+            "flood_score": 0.27,
+            "heat_score": 0.72,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.53,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -41940,12 +43572,15 @@
             "built_pct": null,
             "pop_density": 0.28002210681120876,
             "pop_density_raw": 6678.7575,
-            "flood_score": 0.53,
-            "heat_score": 0.57,
+            "flood_score": 0.32,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.52,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -42017,12 +43652,15 @@
             "built_pct": null,
             "pop_density": 0.3307395406391993,
             "pop_density_raw": 7888.41,
-            "flood_score": 0.37,
-            "heat_score": 0.64,
+            "flood_score": 0.29,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.5,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -42094,12 +43732,15 @@
             "built_pct": null,
             "pop_density": 0.27261586320112624,
             "pop_density_raw": 6502.1125,
-            "flood_score": 0.4,
-            "heat_score": 0.64,
+            "flood_score": 0.36,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.48,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -42171,12 +43812,15 @@
             "built_pct": null,
             "pop_density": 0.2378734551293395,
             "pop_density_raw": 5673.4775,
-            "flood_score": 0.41,
-            "heat_score": 0.6,
+            "flood_score": 0.36,
+            "heat_score": 0.82,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.46,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -42248,12 +43892,15 @@
             "built_pct": null,
             "pop_density": 0.26378734158225187,
             "pop_density_raw": 6291.545,
-            "flood_score": 0.36,
-            "heat_score": 0.65,
+            "flood_score": 0.34,
+            "heat_score": 0.89,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.43,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -42325,12 +43972,15 @@
             "built_pct": 0.7,
             "pop_density": 0.27313670478309143,
             "pop_density_raw": 6514.535,
-            "flood_score": 0.37,
-            "heat_score": 0.62,
+            "flood_score": 0.34,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.4,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -42402,12 +44052,15 @@
             "built_pct": null,
             "pop_density": 0.12531024996599552,
             "pop_density_raw": 2988.7525,
-            "flood_score": 0.37,
-            "heat_score": 0.28,
+            "flood_score": 0.34,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -42479,12 +44132,15 @@
             "built_pct": null,
             "pop_density": 0.0009186266098497487,
             "pop_density_raw": 21.909999999999997,
-            "flood_score": 0.35,
-            "heat_score": 0.15,
+            "flood_score": 0.48,
+            "heat_score": 0.24,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -42556,12 +44212,15 @@
             "built_pct": null,
             "pop_density": 0.00007159082320029421,
             "pop_density_raw": 1.7075,
-            "flood_score": 0.34,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -42633,12 +44292,15 @@
             "built_pct": null,
             "pop_density": 0.000048635639772967084,
             "pop_density_raw": 1.1600000000000001,
-            "flood_score": 0.27,
-            "heat_score": 0.23,
+            "flood_score": 0.46,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -42710,12 +44372,15 @@
             "built_pct": null,
             "pop_density": 0.026777483513450016,
             "pop_density_raw": 638.665,
-            "flood_score": 0.36,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0.06,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": true,
@@ -42787,12 +44452,15 @@
             "built_pct": null,
             "pop_density": 0.0007756545998274922,
             "pop_density_raw": 18.5,
-            "flood_score": 0.18,
-            "heat_score": 0.24,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -42864,12 +44532,15 @@
             "built_pct": null,
             "pop_density": 0.0007288358086667337,
             "pop_density_raw": 17.383333333333333,
-            "flood_score": 0.25,
-            "heat_score": 0.22,
+            "flood_score": 0.6,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -42941,12 +44612,15 @@
             "built_pct": null,
             "pop_density": 0.0006136056793770459,
             "pop_density_raw": 14.635,
-            "flood_score": 0.39,
-            "heat_score": 0.22,
+            "flood_score": 0.48,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": false,
@@ -43018,12 +44692,15 @@
             "built_pct": null,
             "pop_density": 0.0007773316908541462,
             "pop_density_raw": 18.54,
-            "flood_score": 0.46,
-            "heat_score": 0.02,
+            "flood_score": 0.49,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -43095,12 +44772,15 @@
             "built_pct": null,
             "pop_density": 0.002157472787601253,
             "pop_density_raw": 51.4575,
-            "flood_score": 0.36,
-            "heat_score": 0.23,
+            "flood_score": 0.43,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -43172,12 +44852,15 @@
             "built_pct": null,
             "pop_density": 0.007896373462622201,
             "pop_density_raw": 188.33499999999998,
-            "flood_score": 0.4,
-            "heat_score": 0.26,
+            "flood_score": 0.55,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -43249,12 +44932,15 @@
             "built_pct": null,
             "pop_density": 0.01629723686969977,
             "pop_density_raw": 388.7025,
-            "flood_score": 0.48,
-            "heat_score": 0.27,
+            "flood_score": 0.57,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 74.58
           },
           "coverage": {
             "elevation": true,
@@ -43326,12 +45012,15 @@
             "built_pct": null,
             "pop_density": 0.02713606653858648,
             "pop_density_raw": 647.2175,
-            "flood_score": 0.41,
-            "heat_score": 0.31,
+            "flood_score": 0.53,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -43403,12 +45092,15 @@
             "built_pct": null,
             "pop_density": 0.0200115742209818,
             "pop_density_raw": 477.29249999999996,
-            "flood_score": 0.39,
-            "heat_score": 0.26,
-            "landslide_score": 0.34,
+            "flood_score": 0.48,
+            "heat_score": 0.42,
+            "landslide_score": 0.28,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -43480,12 +45172,15 @@
             "built_pct": null,
             "pop_density": 0.005233362548673922,
             "pop_density_raw": 124.82,
-            "flood_score": 0.34,
-            "heat_score": 0.25,
-            "landslide_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.38,
+            "landslide_score": 0.18,
             "lakeside_risk": 0,
             "delta_risk": 0.11,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -43557,12 +45252,15 @@
             "built_pct": null,
             "pop_density": 0.007541983165052371,
             "pop_density_raw": 179.8825,
-            "flood_score": 0.5,
-            "heat_score": 0.23,
+            "flood_score": 0.51,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -43634,12 +45332,15 @@
             "built_pct": null,
             "pop_density": 0.06958872590843317,
             "pop_density_raw": 1659.7483333333332,
-            "flood_score": 0.35,
-            "heat_score": 0.28,
-            "landslide_score": 0.34,
+            "flood_score": 0.44,
+            "heat_score": 0.43,
+            "landslide_score": 0.28,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.26
           },
           "coverage": {
             "elevation": true,
@@ -43711,12 +45412,15 @@
             "built_pct": 0.7,
             "pop_density": 0.147044196671351,
             "pop_density_raw": 3507.125,
-            "flood_score": 0.4,
-            "heat_score": 0.42,
-            "landslide_score": 0.33,
+            "flood_score": 0.46,
+            "heat_score": 0.65,
+            "landslide_score": 0.29,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -43788,12 +45492,15 @@
             "built_pct": 0.7,
             "pop_density": 0.06994758844874074,
             "pop_density_raw": 1668.3075,
-            "flood_score": 0.45,
-            "heat_score": 0.35,
+            "flood_score": 0.49,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -43865,12 +45572,15 @@
             "built_pct": null,
             "pop_density": 0.004127216198406419,
             "pop_density_raw": 98.4375,
-            "flood_score": 0.42,
-            "heat_score": 0.03,
+            "flood_score": 0.48,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.3,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -43942,12 +45652,15 @@
             "built_pct": null,
             "pop_density": 0.00080825305665808,
             "pop_density_raw": 19.2775,
-            "flood_score": 0.36,
-            "heat_score": 0.21,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -44019,12 +45732,15 @@
             "built_pct": null,
             "pop_density": 0.004672375600258148,
             "pop_density_raw": 111.44000000000001,
-            "flood_score": 0.4,
-            "heat_score": 0.03,
+            "flood_score": 0.47,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.36,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -44096,12 +45812,15 @@
             "built_pct": null,
             "pop_density": 0.038692900803259454,
             "pop_density_raw": 922.8575000000001,
-            "flood_score": 0.38,
-            "heat_score": 0.12,
+            "flood_score": 0.36,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.39,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.75
           },
           "coverage": {
             "elevation": true,
@@ -44173,12 +45892,15 @@
             "built_pct": null,
             "pop_density": 0.12021252215410223,
             "pop_density_raw": 2867.1675,
-            "flood_score": 0.35,
-            "heat_score": 0.46,
+            "flood_score": 0.33,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.41,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -44250,12 +45972,15 @@
             "built_pct": null,
             "pop_density": 0.18112897542431097,
             "pop_density_raw": 4320.075,
-            "flood_score": 0.41,
-            "heat_score": 0.33,
+            "flood_score": 0.35,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -44327,12 +46052,15 @@
             "built_pct": null,
             "pop_density": 0.12849221573450403,
             "pop_density_raw": 3064.645,
-            "flood_score": 0.7,
-            "heat_score": 0.48,
+            "flood_score": 0.44,
+            "heat_score": 0.7,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.45,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -44404,12 +46132,15 @@
             "built_pct": null,
             "pop_density": 0.03935839148627361,
             "pop_density_raw": 938.73,
-            "flood_score": 0.42,
-            "heat_score": 0.29,
+            "flood_score": 0.37,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -44481,12 +46212,15 @@
             "built_pct": null,
             "pop_density": 0.01504665105476169,
             "pop_density_raw": 358.875,
-            "flood_score": 0.36,
-            "heat_score": 0.22,
-            "landslide_score": 0.57,
+            "flood_score": 0.25,
+            "heat_score": 0.34,
+            "landslide_score": 0.47,
             "lakeside_risk": 0,
             "delta_risk": 0.48,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.64
           },
           "coverage": {
             "elevation": true,
@@ -44558,12 +46292,15 @@
             "built_pct": null,
             "pop_density": 0.01449719410715416,
             "pop_density_raw": 345.77,
-            "flood_score": 0.35,
-            "heat_score": 0.07,
-            "landslide_score": 0.2,
+            "flood_score": 0.19,
+            "heat_score": 0.05,
+            "landslide_score": 0.16,
             "lakeside_risk": 0,
             "delta_risk": 0.48,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.09,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -44635,12 +46372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.1702141176288826,
             "pop_density_raw": 4059.7466666666664,
-            "flood_score": 0.33,
-            "heat_score": 0.47,
-            "landslide_score": 0.69,
+            "flood_score": 0.25,
+            "heat_score": 0.71,
+            "landslide_score": 0.58,
             "lakeside_risk": 0,
             "delta_risk": 0.48,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.17,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -44712,12 +46452,15 @@
             "built_pct": null,
             "pop_density": 0.23304018360871173,
             "pop_density_raw": 5558.2,
-            "flood_score": 0.54,
-            "heat_score": 0.52,
+            "flood_score": 0.31,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.48,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -44789,12 +46532,15 @@
             "built_pct": null,
             "pop_density": 0.269082127589777,
             "pop_density_raw": 6417.830000000001,
-            "flood_score": 0.47,
-            "heat_score": 0.29,
+            "flood_score": 0.31,
+            "heat_score": 0.17,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.47,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 67.91
           },
           "coverage": {
             "elevation": true,
@@ -44866,12 +46612,15 @@
             "built_pct": null,
             "pop_density": 0.34664716829976955,
             "pop_density_raw": 8267.82,
-            "flood_score": 0.42,
-            "heat_score": 0.68,
+            "flood_score": 0.29,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.45,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -44943,12 +46692,15 @@
             "built_pct": null,
             "pop_density": 0.2963345423183376,
             "pop_density_raw": 7067.8225,
-            "flood_score": 0.47,
-            "heat_score": 0.57,
+            "flood_score": 0.37,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.44,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -45020,12 +46772,15 @@
             "built_pct": null,
             "pop_density": 0.2416938684880574,
             "pop_density_raw": 5764.5975,
-            "flood_score": 0.48,
-            "heat_score": 0.58,
+            "flood_score": 0.38,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.41,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.23,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": true,
@@ -45097,12 +46852,15 @@
             "built_pct": null,
             "pop_density": 0.2507774127611723,
             "pop_density_raw": 5981.2475,
-            "flood_score": 0.27,
-            "heat_score": 0.62,
+            "flood_score": 0.32,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.39,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -45174,12 +46932,15 @@
             "built_pct": null,
             "pop_density": 0.25774226697667735,
             "pop_density_raw": 6147.365,
-            "flood_score": 0.25,
-            "heat_score": 0.67,
+            "flood_score": 0.31,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -45251,12 +47012,15 @@
             "built_pct": null,
             "pop_density": 0.11709460029917405,
             "pop_density_raw": 2792.8025000000002,
-            "flood_score": 0.25,
-            "heat_score": 0.31,
+            "flood_score": 0.31,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.63
           },
           "coverage": {
             "elevation": false,
@@ -45328,12 +47092,15 @@
             "built_pct": null,
             "pop_density": 0.001947312318323669,
             "pop_density_raw": 46.445,
-            "flood_score": 0.26,
-            "heat_score": 0.16,
+            "flood_score": 0.45,
+            "heat_score": 0.24,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -45405,12 +47172,15 @@
             "built_pct": null,
             "pop_density": 0.0012976491818735612,
             "pop_density_raw": 30.95,
-            "flood_score": 0.33,
-            "heat_score": 0.19,
+            "flood_score": 0.47,
+            "heat_score": 0.28,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -45482,12 +47252,15 @@
             "built_pct": null,
             "pop_density": 0.0011727059003878355,
             "pop_density_raw": 27.97,
-            "flood_score": 0.42,
-            "heat_score": 0.21,
+            "flood_score": 0.49,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": false,
@@ -45559,12 +47332,15 @@
             "built_pct": null,
             "pop_density": 0.02622530129292417,
             "pop_density_raw": 625.4949999999999,
-            "flood_score": 0.47,
-            "heat_score": 0.22,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 78.76
           },
           "coverage": {
             "elevation": true,
@@ -45636,12 +47412,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.19,
-            "heat_score": 0.24,
+            "flood_score": 0.58,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -45713,12 +47492,15 @@
             "built_pct": null,
             "pop_density": 0.00032388820452256093,
             "pop_density_raw": 7.725,
-            "flood_score": 0.26,
-            "heat_score": 0.22,
+            "flood_score": 0.6,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -45790,12 +47572,15 @@
             "built_pct": null,
             "pop_density": 0.00046423975981567064,
             "pop_density_raw": 11.0725,
-            "flood_score": 0.34,
-            "heat_score": 0.21,
+            "flood_score": 0.47,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -45867,12 +47652,15 @@
             "built_pct": null,
             "pop_density": 0.0028038865601872185,
             "pop_density_raw": 66.875,
-            "flood_score": 0.51,
+            "flood_score": 0.52,
             "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -45944,12 +47732,15 @@
             "built_pct": null,
             "pop_density": 0.00715352695600363,
             "pop_density_raw": 170.6175,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.48,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -46021,12 +47812,15 @@
             "built_pct": null,
             "pop_density": 0.006956049487615116,
             "pop_density_raw": 165.9075,
-            "flood_score": 0.5,
-            "heat_score": 0.25,
+            "flood_score": 0.57,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -46098,12 +47892,15 @@
             "built_pct": null,
             "pop_density": 0.007447332340235584,
             "pop_density_raw": 177.625,
-            "flood_score": 0.45,
-            "heat_score": 0.03,
+            "flood_score": 0.56,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -46175,12 +47972,15 @@
             "built_pct": null,
             "pop_density": 0.00889895944199382,
             "pop_density_raw": 212.2475,
-            "flood_score": 0.34,
-            "heat_score": 0.05,
+            "flood_score": 0.46,
+            "heat_score": 0.03,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -46252,12 +48052,15 @@
             "built_pct": null,
             "pop_density": 0.005219736184082359,
             "pop_density_raw": 124.495,
-            "flood_score": 0.37,
-            "heat_score": 0.21,
-            "landslide_score": 0.46,
+            "flood_score": 0.43,
+            "heat_score": 0.34,
+            "landslide_score": 0.39,
             "lakeside_risk": 0,
             "delta_risk": 0.04,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -46329,12 +48132,15 @@
             "built_pct": null,
             "pop_density": 0.002164600424464533,
             "pop_density_raw": 51.627500000000005,
-            "flood_score": 0.3,
-            "heat_score": 0.22,
-            "landslide_score": 0.46,
+            "flood_score": 0.39,
+            "heat_score": 0.34,
+            "landslide_score": 0.39,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.37,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -46406,12 +48212,15 @@
             "built_pct": null,
             "pop_density": 0.0022879714331127702,
             "pop_density_raw": 54.57,
-            "flood_score": 0.34,
-            "heat_score": 0.21,
-            "landslide_score": 0.46,
+            "flood_score": 0.42,
+            "heat_score": 0.33,
+            "landslide_score": 0.39,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -46483,12 +48292,15 @@
             "built_pct": null,
             "pop_density": 0.0049285512545795525,
             "pop_density_raw": 117.55000000000001,
-            "flood_score": 0.32,
-            "heat_score": 0.02,
-            "landslide_score": 0.49,
+            "flood_score": 0.39,
+            "heat_score": 0.01,
+            "landslide_score": 0.41,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -46560,12 +48372,15 @@
             "built_pct": null,
             "pop_density": 0.02525321740659983,
             "pop_density_raw": 602.3100000000001,
-            "flood_score": 0.35,
-            "heat_score": 0.04,
-            "landslide_score": 0.29,
+            "flood_score": 0.43,
+            "heat_score": 0.01,
+            "landslide_score": 0.24,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -46637,12 +48452,15 @@
             "built_pct": null,
             "pop_density": 0.024449261895697547,
             "pop_density_raw": 583.135,
-            "flood_score": 0.44,
-            "heat_score": 0.3,
+            "flood_score": 0.47,
+            "heat_score": 0.45,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -46715,11 +48533,14 @@
             "pop_density": 0.013464001216546107,
             "pop_density_raw": 321.1275,
             "flood_score": 0.48,
-            "heat_score": 0.23,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -46791,12 +48612,15 @@
             "built_pct": null,
             "pop_density": 0.022381094205265618,
             "pop_density_raw": 533.8074999999999,
-            "flood_score": 0.4,
-            "heat_score": 0.25,
+            "flood_score": 0.46,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.29,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -46868,12 +48692,15 @@
             "built_pct": null,
             "pop_density": 0.06177187451199149,
             "pop_density_raw": 1473.31,
-            "flood_score": 0.4,
-            "heat_score": 0.31,
+            "flood_score": 0.47,
+            "heat_score": 0.44,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -46945,12 +48772,15 @@
             "built_pct": null,
             "pop_density": 0.1060718147083012,
             "pop_density_raw": 2529.8999999999996,
-            "flood_score": 0.38,
-            "heat_score": 0.22,
+            "flood_score": 0.36,
+            "heat_score": 0.12,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.34,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -47022,12 +48852,15 @@
             "built_pct": null,
             "pop_density": 0.06788088821295714,
             "pop_density_raw": 1619.0149999999999,
-            "flood_score": 0.35,
-            "heat_score": 0.22,
+            "flood_score": 0.34,
+            "heat_score": 0.14,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -47099,12 +48932,15 @@
             "built_pct": null,
             "pop_density": 0.08828070900660936,
             "pop_density_raw": 2105.5675,
-            "flood_score": 0.45,
-            "heat_score": 0.14,
+            "flood_score": 0.37,
+            "heat_score": 0.08,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.39,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -47176,12 +49012,15 @@
             "built_pct": null,
             "pop_density": 0.12989782765121846,
             "pop_density_raw": 3098.17,
-            "flood_score": 0.47,
-            "heat_score": 0.44,
+            "flood_score": 0.38,
+            "heat_score": 0.67,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.4,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -47253,12 +49092,15 @@
             "built_pct": null,
             "pop_density": 0.13258630938513405,
             "pop_density_raw": 3162.2925,
-            "flood_score": 0.45,
-            "heat_score": 0.37,
+            "flood_score": 0.38,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.42,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -47330,12 +49172,15 @@
             "built_pct": null,
             "pop_density": 0.15072341992926247,
             "pop_density_raw": 3594.8775,
-            "flood_score": 0.27,
-            "heat_score": 0.37,
-            "landslide_score": 0.69,
+            "flood_score": 0.22,
+            "heat_score": 0.52,
+            "landslide_score": 0.57,
             "lakeside_risk": 0,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -47407,12 +49252,15 @@
             "built_pct": 0.7,
             "pop_density": 0.07998204333396852,
             "pop_density_raw": 1907.6375,
-            "flood_score": 0.32,
-            "heat_score": 0.24,
-            "landslide_score": 0.46,
+            "flood_score": 0.2,
+            "heat_score": 0.48,
+            "landslide_score": 0.37,
             "lakeside_risk": 0,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.12,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -47484,12 +49332,15 @@
             "built_pct": null,
             "pop_density": 0.10709001859785855,
             "pop_density_raw": 2554.185,
-            "flood_score": 0.33,
-            "heat_score": 0.26,
-            "landslide_score": 0.57,
+            "flood_score": 0.2,
+            "heat_score": 0.38,
+            "landslide_score": 0.47,
             "lakeside_risk": 0,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.11,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -47561,12 +49412,15 @@
             "built_pct": null,
             "pop_density": 0.2810452371556569,
             "pop_density_raw": 6703.16,
-            "flood_score": 0.34,
-            "heat_score": 0.54,
+            "flood_score": 0.26,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.43,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -47638,12 +49492,15 @@
             "built_pct": null,
             "pop_density": 0.33083136137290864,
             "pop_density_raw": 7890.6,
-            "flood_score": 0.39,
-            "heat_score": 0.55,
+            "flood_score": 0.29,
+            "heat_score": 0.75,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.42,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -47715,12 +49572,15 @@
             "built_pct": null,
             "pop_density": 0.4032175449925935,
             "pop_density_raw": 9617.07,
-            "flood_score": 0.33,
-            "heat_score": 0.65,
+            "flood_score": 0.28,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.41,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -47792,12 +49652,15 @@
             "built_pct": null,
             "pop_density": 0.3574856835140887,
             "pop_density_raw": 8526.3275,
-            "flood_score": 0.37,
-            "heat_score": 0.66,
+            "flood_score": 0.31,
+            "heat_score": 0.88,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.39,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -47869,12 +49732,15 @@
             "built_pct": null,
             "pop_density": 0.2002800971304301,
             "pop_density_raw": 4776.845,
-            "flood_score": 0.4,
-            "heat_score": 0.44,
+            "flood_score": 0.35,
+            "heat_score": 0.66,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.37,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -47946,12 +49812,15 @@
             "built_pct": null,
             "pop_density": 0.2058636572491072,
             "pop_density_raw": 4910.0175,
-            "flood_score": 0.53,
-            "heat_score": 0.52,
+            "flood_score": 0.37,
+            "heat_score": 0.74,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.35,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -48023,12 +49892,15 @@
             "built_pct": null,
             "pop_density": 0.1781784482174807,
             "pop_density_raw": 4249.702499999999,
-            "flood_score": 0.27,
-            "heat_score": 0.48,
+            "flood_score": 0.31,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -48100,12 +49972,15 @@
             "built_pct": null,
             "pop_density": 0.04983517912978138,
             "pop_density_raw": 1188.6100000000001,
-            "flood_score": 0.34,
-            "heat_score": 0.26,
+            "flood_score": 0.33,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.29,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -48177,12 +50052,15 @@
             "built_pct": null,
             "pop_density": 0.0036621378930774217,
             "pop_density_raw": 87.345,
-            "flood_score": 0.53,
-            "heat_score": 0.15,
+            "flood_score": 0.51,
+            "heat_score": 0.24,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -48254,12 +50132,15 @@
             "built_pct": null,
             "pop_density": 0.03705993823424426,
             "pop_density_raw": 883.9100000000001,
-            "flood_score": 0.32,
-            "heat_score": 0.25,
+            "flood_score": 0.46,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -48331,12 +50212,15 @@
             "built_pct": null,
             "pop_density": 0.0527502777886736,
             "pop_density_raw": 1258.1375,
-            "flood_score": 0.29,
-            "heat_score": 0.09,
+            "flood_score": 0.45,
+            "heat_score": 0.11,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -48408,12 +50292,15 @@
             "built_pct": null,
             "pop_density": 0.014369036401200682,
             "pop_density_raw": 342.71333333333337,
-            "flood_score": 0.4,
-            "heat_score": 0.22,
+            "flood_score": 0.49,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.39,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -48485,12 +50372,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.28,
-            "heat_score": 0.23,
+            "flood_score": 0.62,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -48562,12 +50452,15 @@
             "built_pct": null,
             "pop_density": 0.00030439202133770776,
             "pop_density_raw": 7.26,
-            "flood_score": 0.28,
-            "heat_score": 0.21,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -48639,12 +50532,15 @@
             "built_pct": null,
             "pop_density": 0.0006365958022007615,
             "pop_density_raw": 15.183333333333332,
-            "flood_score": 0.4,
-            "heat_score": 0.2,
+            "flood_score": 0.48,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -48716,12 +50612,15 @@
             "built_pct": null,
             "pop_density": 0.0057150021278911285,
             "pop_density_raw": 136.30749999999998,
-            "flood_score": 0.42,
-            "heat_score": 0.2,
+            "flood_score": 0.49,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -48794,11 +50693,14 @@
             "pop_density": 0.0121858482178574,
             "pop_density_raw": 290.6425,
             "flood_score": 0.48,
-            "heat_score": 0.07,
+            "heat_score": 0.05,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -48870,12 +50772,15 @@
             "built_pct": null,
             "pop_density": 0.009513089212316693,
             "pop_density_raw": 226.89499999999998,
-            "flood_score": 0.48,
-            "heat_score": 0.26,
+            "flood_score": 0.57,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -48947,12 +50852,15 @@
             "built_pct": null,
             "pop_density": 0.005110305994593183,
             "pop_density_raw": 121.88499999999999,
-            "flood_score": 0.39,
-            "heat_score": 0.27,
+            "flood_score": 0.54,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -49024,12 +50932,15 @@
             "built_pct": null,
             "pop_density": 0.0037130795330120384,
             "pop_density_raw": 88.56,
-            "flood_score": 0.44,
-            "heat_score": 0.27,
-            "landslide_score": 0.21,
+            "flood_score": 0.5,
+            "heat_score": 0.51,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -49101,12 +51012,15 @@
             "built_pct": null,
             "pop_density": 0.0019417569542978775,
             "pop_density_raw": 46.3125,
-            "flood_score": 0.35,
-            "heat_score": 0.21,
-            "landslide_score": 0.22,
+            "flood_score": 0.44,
+            "heat_score": 0.33,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -49178,12 +51092,15 @@
             "built_pct": null,
             "pop_density": 0.0009418962478445734,
             "pop_density_raw": 22.464999999999996,
-            "flood_score": 0.31,
-            "heat_score": 0.22,
+            "flood_score": 0.43,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -49255,12 +51172,15 @@
             "built_pct": null,
             "pop_density": 0.0009718742499460145,
             "pop_density_raw": 23.18,
-            "flood_score": 0.35,
-            "heat_score": 0.22,
-            "landslide_score": 0.34,
+            "flood_score": 0.42,
+            "heat_score": 0.34,
+            "landslide_score": 0.29,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -49332,12 +51252,15 @@
             "built_pct": null,
             "pop_density": 0.007581709258746239,
             "pop_density_raw": 180.83,
-            "flood_score": 0.34,
-            "heat_score": 0.02,
-            "landslide_score": 0.29,
+            "flood_score": 0.39,
+            "heat_score": 0,
+            "landslide_score": 0.24,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.36,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -49409,12 +51332,15 @@
             "built_pct": null,
             "pop_density": 0.033686469634129655,
             "pop_density_raw": 803.45,
-            "flood_score": 0.35,
-            "heat_score": 0.03,
-            "landslide_score": 0.29,
+            "flood_score": 0.42,
+            "heat_score": 0.01,
+            "landslide_score": 0.24,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49486,12 +51412,15 @@
             "built_pct": null,
             "pop_density": 0.032097216249996625,
             "pop_density_raw": 765.5450000000001,
-            "flood_score": 0.39,
-            "heat_score": 0.31,
+            "flood_score": 0.45,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49563,12 +51492,15 @@
             "built_pct": null,
             "pop_density": 0.02510091657774181,
             "pop_density_raw": 598.6775,
-            "flood_score": 0.43,
-            "heat_score": 0.06,
+            "flood_score": 0.46,
+            "heat_score": 0.04,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49640,12 +51572,15 @@
             "built_pct": null,
             "pop_density": 0.1305835482447416,
             "pop_density_raw": 3114.5249999999996,
-            "flood_score": 0.37,
-            "heat_score": 0.39,
+            "flood_score": 0.43,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.25,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49717,12 +51652,15 @@
             "built_pct": null,
             "pop_density": 0.22472401329848016,
             "pop_density_raw": 5359.852499999999,
-            "flood_score": 0.33,
-            "heat_score": 0.62,
+            "flood_score": 0.43,
+            "heat_score": 0.86,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49794,12 +51732,15 @@
             "built_pct": null,
             "pop_density": 0.1626574948567434,
             "pop_density_raw": 3879.515,
-            "flood_score": 0.37,
-            "heat_score": 0.58,
+            "flood_score": 0.35,
+            "heat_score": 0.81,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.3,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -49871,12 +51812,15 @@
             "built_pct": null,
             "pop_density": 0.05309586335835349,
             "pop_density_raw": 1266.38,
-            "flood_score": 0.29,
-            "heat_score": 0.08,
+            "flood_score": 0.32,
+            "heat_score": 0.03,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -49948,12 +51892,15 @@
             "built_pct": null,
             "pop_density": 0.02049897880060313,
             "pop_density_raw": 488.91749999999996,
-            "flood_score": 0.29,
-            "heat_score": 0.03,
+            "flood_score": 0.33,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.34,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -50025,12 +51972,15 @@
             "built_pct": null,
             "pop_density": 0.0949298508363468,
             "pop_density_raw": 2264.155,
-            "flood_score": 0.35,
-            "heat_score": 0.42,
+            "flood_score": 0.34,
+            "heat_score": 0.65,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.36,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -50102,12 +52052,15 @@
             "built_pct": null,
             "pop_density": 0.22777390814863974,
             "pop_density_raw": 5432.595,
-            "flood_score": 0.43,
-            "heat_score": 0.42,
+            "flood_score": 0.37,
+            "heat_score": 0.63,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.29,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -50179,12 +52132,15 @@
             "built_pct": null,
             "pop_density": 0.298916109499304,
             "pop_density_raw": 7129.3949999999995,
-            "flood_score": 0.27,
-            "heat_score": 0.35,
+            "flood_score": 0.24,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.38,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -50256,12 +52212,15 @@
             "built_pct": null,
             "pop_density": 0.18276267172065036,
             "pop_density_raw": 4359.04,
-            "flood_score": 0.29,
-            "heat_score": 0.26,
-            "landslide_score": 0.22,
+            "flood_score": 0.21,
+            "heat_score": 0.36,
+            "landslide_score": 0.18,
             "lakeside_risk": 0,
             "delta_risk": 0.38,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.14,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -50333,12 +52292,15 @@
             "built_pct": null,
             "pop_density": 0.1259243797363184,
             "pop_density_raw": 3003.4,
-            "flood_score": 0.34,
-            "heat_score": 0.34,
-            "landslide_score": 0.34,
+            "flood_score": 0.24,
+            "heat_score": 0.49,
+            "landslide_score": 0.28,
             "lakeside_risk": 0,
             "delta_risk": 0.38,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.16,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -50410,12 +52372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.3575248855168368,
             "pop_density_raw": 8527.2625,
-            "flood_score": 0.37,
-            "heat_score": 0.64,
+            "flood_score": 0.26,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.38,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.18,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -50487,12 +52452,15 @@
             "built_pct": null,
             "pop_density": 0.5876213551010141,
             "pop_density_raw": 14015.2525,
-            "flood_score": 0.4,
-            "heat_score": 0.72,
+            "flood_score": 0.28,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.37,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -50564,12 +52532,15 @@
             "built_pct": null,
             "pop_density": 0.5497596625378399,
             "pop_density_raw": 13112.22,
-            "flood_score": 0.27,
-            "heat_score": 0.66,
+            "flood_score": 0.29,
+            "heat_score": 0.82,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.36,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -50641,12 +52612,15 @@
             "built_pct": null,
             "pop_density": 0.341740104773969,
             "pop_density_raw": 8150.782499999999,
-            "flood_score": 0.36,
-            "heat_score": 0.59,
+            "flood_score": 0.34,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.34,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -50718,12 +52692,15 @@
             "built_pct": 0.7,
             "pop_density": 0.31566343567328203,
             "pop_density_raw": 7528.8324999999995,
-            "flood_score": 0.45,
-            "heat_score": 0.55,
+            "flood_score": 0.36,
+            "heat_score": 0.77,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -50795,12 +52772,15 @@
             "built_pct": null,
             "pop_density": 0.2829005191038929,
             "pop_density_raw": 6747.41,
-            "flood_score": 0.34,
-            "heat_score": 0.62,
+            "flood_score": 0.33,
+            "heat_score": 0.85,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -50872,12 +52852,15 @@
             "built_pct": null,
             "pop_density": 0.11832935856754807,
             "pop_density_raw": 2822.2525,
-            "flood_score": 0.56,
-            "heat_score": 0.4,
+            "flood_score": 0.38,
+            "heat_score": 0.63,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -50949,12 +52932,15 @@
             "built_pct": null,
             "pop_density": 0.009942214878761797,
             "pop_density_raw": 237.13000000000002,
-            "flood_score": 0.3,
-            "heat_score": 0.17,
+            "flood_score": 0.32,
+            "heat_score": 0.25,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -51026,12 +53012,15 @@
             "built_pct": null,
             "pop_density": 0.052972911622461906,
             "pop_density_raw": 1263.4474999999998,
-            "flood_score": 0.37,
-            "heat_score": 0.23,
+            "flood_score": 0.47,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -51103,12 +53092,15 @@
             "built_pct": null,
             "pop_density": 0.16951889351954175,
             "pop_density_raw": 4043.165,
-            "flood_score": 0.3,
-            "heat_score": 0.33,
+            "flood_score": 0.46,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -51180,12 +53172,15 @@
             "built_pct": null,
             "pop_density": 0.1549483266799715,
             "pop_density_raw": 3695.6450000000004,
-            "flood_score": 0.37,
-            "heat_score": 0.26,
+            "flood_score": 0.49,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -51257,12 +53252,15 @@
             "built_pct": null,
             "pop_density": 0.02929905975081714,
             "pop_density_raw": 698.8066666666667,
-            "flood_score": 0.37,
-            "heat_score": 0.23,
+            "flood_score": 0.48,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.39,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -51334,12 +53332,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.27,
-            "heat_score": 0.23,
+            "flood_score": 0.62,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -51411,12 +53412,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.34,
-            "heat_score": 0.22,
+            "flood_score": 0.64,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -51488,12 +53492,15 @@
             "built_pct": null,
             "pop_density": 0.006287833531682649,
             "pop_density_raw": 149.97,
-            "flood_score": 0.29,
-            "heat_score": 0.22,
+            "flood_score": 0.61,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.59,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -51565,12 +53572,15 @@
             "built_pct": null,
             "pop_density": 0.011288499700408324,
             "pop_density_raw": 269.24,
-            "flood_score": 0.35,
-            "heat_score": 0.27,
+            "flood_score": 0.47,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -51643,11 +53653,14 @@
             "pop_density": 0.017132847473730145,
             "pop_density_raw": 408.63249999999994,
             "flood_score": 0.52,
-            "heat_score": 0.26,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -51719,12 +53732,15 @@
             "built_pct": null,
             "pop_density": 0.011915207653431105,
             "pop_density_raw": 284.1875,
-            "flood_score": 0.62,
-            "heat_score": 0.28,
+            "flood_score": 0.58,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -51796,12 +53812,15 @@
             "built_pct": null,
             "pop_density": 0.004009295735594808,
             "pop_density_raw": 95.625,
-            "flood_score": 0.46,
-            "heat_score": 0.24,
+            "flood_score": 0.56,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -51873,12 +53892,15 @@
             "built_pct": null,
             "pop_density": 0.0018587409484785023,
             "pop_density_raw": 44.332499999999996,
-            "flood_score": 0.53,
-            "heat_score": 0.23,
+            "flood_score": 0.57,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -51950,12 +53972,15 @@
             "built_pct": null,
             "pop_density": 0.001477307558103875,
             "pop_density_raw": 35.235,
-            "flood_score": 0.5,
-            "heat_score": 0.22,
+            "flood_score": 0.55,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -52027,12 +54052,15 @@
             "built_pct": null,
             "pop_density": 0.0010563577104137118,
             "pop_density_raw": 25.195,
-            "flood_score": 0.41,
-            "heat_score": 0.21,
+            "flood_score": 0.48,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -52104,12 +54132,15 @@
             "built_pct": null,
             "pop_density": 0.000679221865794885,
             "pop_density_raw": 16.2,
-            "flood_score": 0.34,
-            "heat_score": 0.21,
-            "landslide_score": 0.22,
+            "flood_score": 0.44,
+            "heat_score": 0.33,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -52181,12 +54212,15 @@
             "built_pct": null,
             "pop_density": 0.007049652130540246,
             "pop_density_raw": 168.14000000000001,
-            "flood_score": 0.41,
-            "heat_score": 0.01,
+            "flood_score": 0.43,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -52258,12 +54292,15 @@
             "built_pct": null,
             "pop_density": 0.03055942859674404,
             "pop_density_raw": 728.8675000000001,
-            "flood_score": 0.41,
-            "heat_score": 0.02,
-            "landslide_score": 0.19,
+            "flood_score": 0.45,
+            "heat_score": 0.01,
+            "landslide_score": 0.16,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52335,12 +54372,15 @@
             "built_pct": null,
             "pop_density": 0.038115667035522965,
             "pop_density_raw": 909.0899999999999,
-            "flood_score": 0.32,
-            "heat_score": 0.33,
-            "landslide_score": 0.22,
+            "flood_score": 0.43,
+            "heat_score": 0.57,
+            "landslide_score": 0.2,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52412,12 +54452,15 @@
             "built_pct": null,
             "pop_density": 0.06030976559131668,
             "pop_density_raw": 1438.4375000000002,
-            "flood_score": 0.39,
-            "heat_score": 0.15,
+            "flood_score": 0.44,
+            "heat_score": 0.1,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52489,12 +54532,15 @@
             "built_pct": null,
             "pop_density": 0.21096211878832466,
             "pop_density_raw": 5031.62,
-            "flood_score": 0.36,
-            "heat_score": 0.46,
+            "flood_score": 0.42,
+            "heat_score": 0.68,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52566,12 +54612,15 @@
             "built_pct": null,
             "pop_density": 0.2504933554685328,
             "pop_density_raw": 5974.4725,
-            "flood_score": 0.34,
-            "heat_score": 0.61,
+            "flood_score": 0.43,
+            "heat_score": 0.84,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52643,12 +54692,15 @@
             "built_pct": null,
             "pop_density": 0.09973062871833313,
             "pop_density_raw": 2378.6575,
-            "flood_score": 0.54,
-            "heat_score": 0.21,
+            "flood_score": 0.37,
+            "heat_score": 0.13,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -52720,12 +54772,15 @@
             "built_pct": null,
             "pop_density": 0.016921534004371738,
             "pop_density_raw": 403.5925,
-            "flood_score": 0.31,
-            "heat_score": 0.24,
+            "flood_score": 0.33,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -52797,12 +54852,15 @@
             "built_pct": null,
             "pop_density": 0.012638767613243156,
             "pop_density_raw": 301.445,
-            "flood_score": 0.38,
-            "heat_score": 0.24,
+            "flood_score": 0.35,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.29,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -52874,12 +54932,15 @@
             "built_pct": null,
             "pop_density": 0.11822841865138131,
             "pop_density_raw": 2819.8449999999993,
-            "flood_score": 0.39,
-            "heat_score": 0.37,
+            "flood_score": 0.34,
+            "heat_score": 0.6,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.31,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.27,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -52951,12 +55012,15 @@
             "built_pct": null,
             "pop_density": 0.26289177497401855,
             "pop_density_raw": 6270.1849999999995,
-            "flood_score": 0.31,
-            "heat_score": 0.3,
+            "flood_score": 0.33,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.28,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -53028,12 +55092,15 @@
             "built_pct": null,
             "pop_density": 0.3315748367886622,
             "pop_density_raw": 7908.3324999999995,
-            "flood_score": 0.39,
-            "heat_score": 0.33,
+            "flood_score": 0.27,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -53105,12 +55172,15 @@
             "built_pct": null,
             "pop_density": 0.2778997481169781,
             "pop_density_raw": 6628.1375,
-            "flood_score": 0.36,
-            "heat_score": 0.59,
+            "flood_score": 0.27,
+            "heat_score": 0.8,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -53182,12 +55252,15 @@
             "built_pct": null,
             "pop_density": 0.14983033401817278,
             "pop_density_raw": 3573.5766666666664,
-            "flood_score": 0.39,
-            "heat_score": 0.38,
+            "flood_score": 0.27,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -53259,12 +55332,15 @@
             "built_pct": null,
             "pop_density": 0.21988088886807083,
             "pop_density_raw": 5244.34,
-            "flood_score": 0.41,
-            "heat_score": 0.41,
+            "flood_score": 0.28,
+            "heat_score": 0.61,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.33,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.19,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -53336,12 +55412,15 @@
             "built_pct": null,
             "pop_density": 0.4782617082531468,
             "pop_density_raw": 11406.935000000001,
-            "flood_score": 0.36,
-            "heat_score": 0.54,
+            "flood_score": 0.27,
+            "heat_score": 0.71,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.32,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.2,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -53413,12 +55492,15 @@
             "built_pct": 0.7,
             "pop_density": 0.42305008974648006,
             "pop_density_raw": 10090.0925,
-            "flood_score": 0.43,
-            "heat_score": 0.59,
+            "flood_score": 0.35,
+            "heat_score": 0.79,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.31,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.21,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -53490,12 +55572,15 @@
             "built_pct": null,
             "pop_density": 0.30279281022560395,
             "pop_density_raw": 7221.8575,
-            "flood_score": 0.39,
-            "heat_score": 0.56,
+            "flood_score": 0.35,
+            "heat_score": 0.76,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.3,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -53567,12 +55652,15 @@
             "built_pct": null,
             "pop_density": 0.5002606353407136,
             "pop_density_raw": 11931.6275,
-            "flood_score": 0.34,
-            "heat_score": 0.71,
+            "flood_score": 0.33,
+            "heat_score": 0.9,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -53645,11 +55733,14 @@
             "pop_density": 0.3835165470661102,
             "pop_density_raw": 9147.185,
             "flood_score": 0.33,
-            "heat_score": 0.67,
+            "heat_score": 0.88,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.22,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -53721,12 +55812,15 @@
             "built_pct": null,
             "pop_density": 0.09879114328883938,
             "pop_density_raw": 2356.25,
-            "flood_score": 0.26,
-            "heat_score": 0.33,
+            "flood_score": 0.31,
+            "heat_score": 0.44,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.24,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -53798,12 +55892,15 @@
             "built_pct": null,
             "pop_density": 0.00037420093532218205,
             "pop_density_raw": 8.925,
-            "flood_score": 0.27,
-            "heat_score": 0.17,
+            "flood_score": 0.31,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.23,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -53875,12 +55972,15 @@
             "built_pct": null,
             "pop_density": 0.08800975398761555,
             "pop_density_raw": 2099.1049999999996,
-            "flood_score": 0.39,
-            "heat_score": 0.29,
+            "flood_score": 0.48,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -53952,12 +56052,15 @@
             "built_pct": null,
             "pop_density": 0.26845416181848425,
             "pop_density_raw": 6402.852500000001,
-            "flood_score": 0.36,
-            "heat_score": 0.31,
+            "flood_score": 0.49,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -54029,12 +56132,15 @@
             "built_pct": null,
             "pop_density": 0.2699761219251728,
             "pop_density_raw": 6439.1525,
-            "flood_score": 0.36,
-            "heat_score": 0.38,
+            "flood_score": 0.48,
+            "heat_score": 0.57,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.4,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -54106,12 +56212,15 @@
             "built_pct": null,
             "pop_density": 0.11233169672287296,
             "pop_density_raw": 2679.2033333333334,
-            "flood_score": 0.36,
-            "heat_score": 0.31,
+            "flood_score": 0.47,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.09,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.39,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -54183,12 +56292,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.17,
-            "heat_score": 0.24,
+            "flood_score": 0.63,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -54260,12 +56372,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.2,
-            "heat_score": 0.23,
+            "flood_score": 0.64,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -54337,12 +56452,15 @@
             "built_pct": null,
             "pop_density": 0.03352316289540922,
             "pop_density_raw": 799.5550000000001,
-            "flood_score": 0.27,
-            "heat_score": 0.24,
+            "flood_score": 0.65,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -54414,12 +56532,15 @@
             "built_pct": null,
             "pop_density": 0.02431320788616024,
             "pop_density_raw": 579.89,
-            "flood_score": 0.32,
-            "heat_score": 0.35,
+            "flood_score": 0.49,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -54491,12 +56612,15 @@
             "built_pct": null,
             "pop_density": 0.016452053335097774,
             "pop_density_raw": 392.395,
-            "flood_score": 0.38,
-            "heat_score": 0.28,
+            "flood_score": 0.51,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -54568,12 +56692,15 @@
             "built_pct": null,
             "pop_density": 0.010456767369377088,
             "pop_density_raw": 249.4025,
-            "flood_score": 0.28,
-            "heat_score": 0.12,
+            "flood_score": 0.66,
+            "heat_score": 0.09,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -54645,12 +56772,15 @@
             "built_pct": null,
             "pop_density": 0.0019106259521156116,
             "pop_density_raw": 45.56999999999999,
-            "flood_score": 0.41,
-            "heat_score": 0.22,
+            "flood_score": 0.68,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -54722,12 +56852,15 @@
             "built_pct": null,
             "pop_density": 0.0008743933340217486,
             "pop_density_raw": 20.855,
-            "flood_score": 0.37,
-            "heat_score": 0.22,
+            "flood_score": 0.64,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -54799,12 +56932,15 @@
             "built_pct": null,
             "pop_density": 0.001575731837730634,
             "pop_density_raw": 37.5825,
-            "flood_score": 0.43,
-            "heat_score": 0.25,
+            "flood_score": 0.69,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.58
+            "low_elev_risk": 0.58,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -54876,12 +57012,15 @@
             "built_pct": null,
             "pop_density": 0.0027675146485466586,
             "pop_density_raw": 66.0075,
-            "flood_score": 0.53,
-            "heat_score": 0.23,
+            "flood_score": 0.72,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -54953,12 +57092,15 @@
             "built_pct": null,
             "pop_density": 0.0034435919686665673,
             "pop_density_raw": 82.1325,
-            "flood_score": 0.37,
-            "heat_score": 0.24,
+            "flood_score": 0.63,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.63,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -55030,12 +57172,15 @@
             "built_pct": null,
             "pop_density": 0.003826981965238958,
             "pop_density_raw": 91.27666666666666,
-            "flood_score": 0.26,
-            "heat_score": 0.03,
-            "landslide_score": 0.19,
+            "flood_score": 0.42,
+            "heat_score": 0.01,
+            "landslide_score": 0.16,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -55107,12 +57252,15 @@
             "built_pct": null,
             "pop_density": 0.015070235147324012,
             "pop_density_raw": 359.4375,
-            "flood_score": 0.33,
-            "heat_score": 0.04,
-            "landslide_score": 0.29,
+            "flood_score": 0.46,
+            "heat_score": 0.02,
+            "landslide_score": 0.24,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55184,12 +57332,15 @@
             "built_pct": null,
             "pop_density": 0.03611311553150888,
             "pop_density_raw": 861.3275,
-            "flood_score": 0.58,
-            "heat_score": 0.31,
+            "flood_score": 0.53,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.11,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55261,12 +57412,15 @@
             "built_pct": null,
             "pop_density": 0.09119067157423244,
             "pop_density_raw": 2174.9725,
-            "flood_score": 0.29,
-            "heat_score": 0.35,
+            "flood_score": 0.46,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.14,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55338,12 +57492,15 @@
             "built_pct": null,
             "pop_density": 0.14510893844478143,
             "pop_density_raw": 3460.9675,
-            "flood_score": 0.42,
-            "heat_score": 0.38,
+            "flood_score": 0.49,
+            "heat_score": 0.53,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55415,12 +57572,15 @@
             "built_pct": null,
             "pop_density": 0.09524524876754692,
             "pop_density_raw": 2271.6775000000002,
-            "flood_score": 0.34,
-            "heat_score": 0.3,
+            "flood_score": 0.48,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55493,11 +57653,14 @@
             "pop_density": 0.017551596139447824,
             "pop_density_raw": 418.61999999999995,
             "flood_score": 0.33,
-            "heat_score": 0.23,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -55570,11 +57733,14 @@
             "pop_density": 0.015029880144495147,
             "pop_density_raw": 358.47499999999997,
             "flood_score": 0.32,
-            "heat_score": 0.24,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -55646,12 +57812,15 @@
             "built_pct": null,
             "pop_density": 0.0878201378834145,
             "pop_density_raw": 2094.5825,
-            "flood_score": 0.34,
-            "heat_score": 0.39,
+            "flood_score": 0.41,
+            "heat_score": 0.63,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.25,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -55723,12 +57892,15 @@
             "built_pct": null,
             "pop_density": 0.17750394317019827,
             "pop_density_raw": 4233.615,
-            "flood_score": 0.3,
-            "heat_score": 0.3,
+            "flood_score": 0.37,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -55801,11 +57973,14 @@
             "pop_density": 0.21838481885410624,
             "pop_density_raw": 5208.657499999999,
             "flood_score": 0.29,
-            "heat_score": 0.29,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.27,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -55877,12 +58052,15 @@
             "built_pct": null,
             "pop_density": 0.272776863939685,
             "pop_density_raw": 6505.952499999999,
-            "flood_score": 0.31,
-            "heat_score": 0.32,
+            "flood_score": 0.42,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -55954,12 +58132,15 @@
             "built_pct": null,
             "pop_density": 0.31542340202009217,
             "pop_density_raw": 7523.1075,
-            "flood_score": 0.34,
-            "heat_score": 0.48,
+            "flood_score": 0.43,
+            "heat_score": 0.67,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -56031,12 +58212,15 @@
             "built_pct": null,
             "pop_density": 0.14218755069453926,
             "pop_density_raw": 3391.2900000000004,
-            "flood_score": 0.39,
-            "heat_score": 0.39,
+            "flood_score": 0.45,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -56109,11 +58293,14 @@
             "pop_density": 0.10047661977062668,
             "pop_density_raw": 2396.45,
             "flood_score": 0.52,
-            "heat_score": 0.24,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.28,
-            "low_elev_risk": 0.52
+            "low_elev_risk": 0.52,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -56185,12 +58372,15 @@
             "built_pct": 0.7,
             "pop_density": 0.2508927127692548,
             "pop_density_raw": 5983.9974999999995,
-            "flood_score": 0.46,
-            "heat_score": 0.42,
+            "flood_score": 0.51,
+            "heat_score": 0.64,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.27,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -56262,12 +58452,15 @@
             "built_pct": null,
             "pop_density": 0.24490161953110076,
             "pop_density_raw": 5841.1050000000005,
-            "flood_score": 0.71,
-            "heat_score": 0.42,
+            "flood_score": 0.58,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.26,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -56339,12 +58532,15 @@
             "built_pct": null,
             "pop_density": 0.31782583491577404,
             "pop_density_raw": 7580.407499999999,
-            "flood_score": 0.44,
-            "heat_score": 0.5,
+            "flood_score": 0.54,
+            "heat_score": 0.69,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.25,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -56416,12 +58612,15 @@
             "built_pct": 0.7,
             "pop_density": 0.4436999019212928,
             "pop_density_raw": 10582.6075,
-            "flood_score": 0.29,
-            "heat_score": 0.68,
+            "flood_score": 0.49,
+            "heat_score": 0.87,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -56493,12 +58692,15 @@
             "built_pct": null,
             "pop_density": 0.3152706819184775,
             "pop_density_raw": 7519.465,
-            "flood_score": 0.53,
-            "heat_score": 0.59,
+            "flood_score": 0.55,
+            "heat_score": 0.78,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -56570,12 +58772,15 @@
             "built_pct": null,
             "pop_density": 0.11889307078888217,
             "pop_density_raw": 2835.6975,
-            "flood_score": 0.32,
-            "heat_score": 0.32,
+            "flood_score": 0.5,
+            "heat_score": 0.43,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -56648,11 +58853,14 @@
             "pop_density": 0.009455544026464627,
             "pop_density_raw": 225.5225,
             "flood_score": 0.54,
-            "heat_score": 0.17,
+            "heat_score": 0.24,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -56724,12 +58932,15 @@
             "built_pct": null,
             "pop_density": 0.040890309320932905,
             "pop_density_raw": 975.2675,
-            "flood_score": 0.41,
-            "heat_score": 0.22,
+            "flood_score": 0.68,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.14,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -56801,12 +59012,15 @@
             "built_pct": null,
             "pop_density": 0.15041567372587145,
             "pop_density_raw": 3587.5375,
-            "flood_score": 0.4,
-            "heat_score": 0.12,
+            "flood_score": 0.7,
+            "heat_score": 0.07,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.11,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -56878,12 +59092,15 @@
             "built_pct": null,
             "pop_density": 0.20966300215180278,
             "pop_density_raw": 5000.635,
-            "flood_score": 0.45,
-            "heat_score": 0.15,
+            "flood_score": 0.71,
+            "heat_score": 0.08,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -56955,12 +59172,15 @@
             "built_pct": null,
             "pop_density": 0.2084815614023178,
             "pop_density_raw": 4972.456666666667,
-            "flood_score": 0.52,
-            "heat_score": 0.28,
+            "flood_score": 0.72,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -57032,12 +59252,15 @@
             "built_pct": null,
             "pop_density": null,
             "pop_density_raw": null,
-            "flood_score": 0.18,
-            "heat_score": 0.24,
+            "flood_score": 0.63,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -57109,12 +59332,15 @@
             "built_pct": null,
             "pop_density": 0.02415849623895141,
             "pop_density_raw": 576.2,
-            "flood_score": 0.22,
-            "heat_score": 0.24,
+            "flood_score": 0.64,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -57186,12 +59412,15 @@
             "built_pct": null,
             "pop_density": 0.03899152782419303,
             "pop_density_raw": 929.9799999999999,
-            "flood_score": 0.35,
-            "heat_score": 0.27,
+            "flood_score": 0.67,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -57263,12 +59492,15 @@
             "built_pct": null,
             "pop_density": 0.028219991432750818,
             "pop_density_raw": 673.0699999999999,
-            "flood_score": 0.36,
-            "heat_score": 0.32,
+            "flood_score": 0.51,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -57340,12 +59572,15 @@
             "built_pct": null,
             "pop_density": 0.008831246891792663,
             "pop_density_raw": 210.63250000000002,
-            "flood_score": 0.5,
-            "heat_score": 0.24,
+            "flood_score": 0.55,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -57417,12 +59652,15 @@
             "built_pct": null,
             "pop_density": 0.004212328568009112,
             "pop_density_raw": 100.4675,
-            "flood_score": 0.38,
-            "heat_score": 0.22,
+            "flood_score": 0.7,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -57494,12 +59732,15 @@
             "built_pct": null,
             "pop_density": 0.0006537510458275769,
             "pop_density_raw": 15.592500000000001,
-            "flood_score": 0.43,
-            "heat_score": 0.02,
+            "flood_score": 0.7,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.69
+            "low_elev_risk": 0.69,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -57571,12 +59812,15 @@
             "built_pct": null,
             "pop_density": 0.0005147621269936236,
             "pop_density_raw": 12.277500000000002,
-            "flood_score": 0.32,
+            "flood_score": 0.6,
             "heat_score": 0.01,
-            "landslide_score": 0.18,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.61,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -57648,12 +59892,15 @@
             "built_pct": null,
             "pop_density": 0.0010658961656278064,
             "pop_density_raw": 25.4225,
-            "flood_score": 0.36,
-            "heat_score": 0.23,
+            "flood_score": 0.63,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -57725,12 +59972,15 @@
             "built_pct": null,
             "pop_density": 0.003001259210386566,
             "pop_density_raw": 71.58250000000001,
-            "flood_score": 0.73,
-            "heat_score": 0.22,
+            "flood_score": 0.78,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -57802,12 +60052,15 @@
             "built_pct": null,
             "pop_density": 0.006897456119871391,
             "pop_density_raw": 164.51,
-            "flood_score": 0.39,
-            "heat_score": 0.28,
+            "flood_score": 0.64,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -57879,12 +60132,15 @@
             "built_pct": null,
             "pop_density": 0.014498941076973594,
             "pop_density_raw": 345.8116666666667,
-            "flood_score": 0.39,
-            "heat_score": 0.26,
+            "flood_score": 0.5,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -57956,12 +60212,15 @@
             "built_pct": null,
             "pop_density": 0.03557864758495207,
             "pop_density_raw": 848.5799999999999,
-            "flood_score": 0.33,
-            "heat_score": 0.34,
+            "flood_score": 0.48,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.04,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58033,12 +60292,15 @@
             "built_pct": null,
             "pop_density": 0.04138693790120083,
             "pop_density_raw": 987.1125,
-            "flood_score": 0.29,
-            "heat_score": 0.37,
+            "flood_score": 0.46,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58110,12 +60372,15 @@
             "built_pct": null,
             "pop_density": 0.06318021170162422,
             "pop_density_raw": 1506.9,
-            "flood_score": 0.21,
-            "heat_score": 0.27,
+            "flood_score": 0.44,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58187,12 +60452,15 @@
             "built_pct": null,
             "pop_density": 0.08353841967417758,
             "pop_density_raw": 1992.46,
-            "flood_score": 0.49,
-            "heat_score": 0.27,
+            "flood_score": 0.52,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58264,12 +60532,15 @@
             "built_pct": 0.7,
             "pop_density": 0.05224819866256904,
             "pop_density_raw": 1246.1625,
-            "flood_score": 0.29,
-            "heat_score": 0.38,
+            "flood_score": 0.45,
+            "heat_score": 0.63,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.14,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58341,12 +60612,15 @@
             "built_pct": null,
             "pop_density": 0.017171525385532353,
             "pop_density_raw": 409.55499999999995,
-            "flood_score": 0.32,
-            "heat_score": 0.26,
+            "flood_score": 0.33,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -58418,12 +60692,15 @@
             "built_pct": null,
             "pop_density": 0.04648246453112163,
             "pop_density_raw": 1108.645,
-            "flood_score": 0.38,
-            "heat_score": 0.1,
+            "flood_score": 0.4,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -58495,12 +60772,15 @@
             "built_pct": null,
             "pop_density": 0.18445496138473344,
             "pop_density_raw": 4399.4025,
-            "flood_score": 0.4,
-            "heat_score": 0.36,
+            "flood_score": 0.48,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.2,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -58572,12 +60852,15 @@
             "built_pct": null,
             "pop_density": 0.21755109497748087,
             "pop_density_raw": 5188.7725,
-            "flood_score": 0.51,
-            "heat_score": 0.28,
+            "flood_score": 0.62,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -58650,11 +60933,14 @@
             "pop_density": 0.11613163559530713,
             "pop_density_raw": 2769.835,
             "flood_score": 0.36,
-            "heat_score": 0.27,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -58726,12 +61012,15 @@
             "built_pct": null,
             "pop_density": 0.18900920688580164,
             "pop_density_raw": 4508.025,
-            "flood_score": 0.35,
-            "heat_score": 0.29,
+            "flood_score": 0.44,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -58803,12 +61092,15 @@
             "built_pct": null,
             "pop_density": 0.30321313116415916,
             "pop_density_raw": 7231.882500000001,
-            "flood_score": 0.39,
-            "heat_score": 0.31,
+            "flood_score": 0.45,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -58880,12 +61172,15 @@
             "built_pct": null,
             "pop_density": 0.19189387333043936,
             "pop_density_raw": 4576.826666666667,
-            "flood_score": 0.36,
-            "heat_score": 0.37,
+            "flood_score": 0.44,
+            "heat_score": 0.58,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -58957,12 +61252,15 @@
             "built_pct": null,
             "pop_density": 0.24475267288429603,
             "pop_density_raw": 5837.5525,
-            "flood_score": 0.3,
-            "heat_score": 0.31,
+            "flood_score": 0.41,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.23,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -59034,12 +61332,15 @@
             "built_pct": 0.7,
             "pop_density": 0.34625525309047833,
             "pop_density_raw": 8258.4725,
-            "flood_score": 0.51,
-            "heat_score": 0.34,
+            "flood_score": 0.52,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.22,
-            "low_elev_risk": 0.67
+            "low_elev_risk": 0.67,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -59111,12 +61412,15 @@
             "built_pct": null,
             "pop_density": 0.29340969556785296,
             "pop_density_raw": 6998.0625,
-            "flood_score": 0.41,
-            "heat_score": 0.3,
+            "flood_score": 0.45,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.21,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -59188,12 +61492,15 @@
             "built_pct": null,
             "pop_density": 0.2867761716483012,
             "pop_density_raw": 6839.8475,
-            "flood_score": 0.35,
-            "heat_score": 0.33,
+            "flood_score": 0.49,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.2,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -59265,12 +61572,15 @@
             "built_pct": 0.7,
             "pop_density": 0.3045838386238813,
             "pop_density_raw": 7264.574999999999,
-            "flood_score": 0.34,
-            "heat_score": 0.42,
+            "flood_score": 0.51,
+            "heat_score": 0.62,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.19,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -59342,12 +61652,15 @@
             "built_pct": null,
             "pop_density": 0.2865761785433727,
             "pop_density_raw": 6835.077499999999,
-            "flood_score": 0.23,
-            "heat_score": 0.35,
+            "flood_score": 0.47,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.17,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -59419,12 +61732,15 @@
             "built_pct": null,
             "pop_density": 0.1544568341909727,
             "pop_density_raw": 3683.9225,
-            "flood_score": 0.24,
-            "heat_score": 0.3,
+            "flood_score": 0.47,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -59496,12 +61812,15 @@
             "built_pct": null,
             "pop_density": 0.01846351438519096,
             "pop_density_raw": 440.37,
-            "flood_score": 0.33,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -59573,12 +61892,15 @@
             "built_pct": null,
             "pop_density": 0.004877399978266603,
             "pop_density_raw": 116.33,
-            "flood_score": 0.6,
-            "heat_score": 0.2,
+            "flood_score": 0.73,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -59650,12 +61972,15 @@
             "built_pct": null,
             "pop_density": 0.08825754418680369,
             "pop_density_raw": 2105.015,
-            "flood_score": 0.42,
-            "heat_score": 0.24,
+            "flood_score": 0.68,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -59727,12 +62052,15 @@
             "built_pct": null,
             "pop_density": 0.18498062460340034,
             "pop_density_raw": 4411.9400000000005,
-            "flood_score": 0.41,
-            "heat_score": 0.3,
+            "flood_score": 0.7,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.04,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -59804,12 +62132,15 @@
             "built_pct": null,
             "pop_density": 0.22510069493094595,
             "pop_density_raw": 5368.836666666666,
-            "flood_score": 0.35,
-            "heat_score": 0.3,
+            "flood_score": 0.67,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.63,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -59881,12 +62212,15 @@
             "built_pct": null,
             "pop_density": 0.00016204892045044636,
             "pop_density_raw": 3.865,
-            "flood_score": 0.24,
-            "heat_score": 0.22,
+            "flood_score": 0.65,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -59958,12 +62292,15 @@
             "built_pct": null,
             "pop_density": 0.008369522768516973,
             "pop_density_raw": 199.62,
-            "flood_score": 0.27,
-            "heat_score": 0.22,
+            "flood_score": 0.65,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -60035,12 +62372,15 @@
             "built_pct": null,
             "pop_density": 0.016103742492499563,
             "pop_density_raw": 384.08750000000003,
-            "flood_score": 0.38,
-            "heat_score": 0.22,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -60112,12 +62452,15 @@
             "built_pct": null,
             "pop_density": 0.02097852201603702,
             "pop_density_raw": 500.35499999999996,
-            "flood_score": 0.63,
-            "heat_score": 0.22,
+            "flood_score": 0.57,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -60189,12 +62532,15 @@
             "built_pct": null,
             "pop_density": 0.01977143574960278,
             "pop_density_raw": 471.56500000000005,
-            "flood_score": 0.41,
-            "heat_score": 0.34,
+            "flood_score": 0.52,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": false,
@@ -60266,12 +62612,15 @@
             "built_pct": null,
             "pop_density": 0.00907945636373746,
             "pop_density_raw": 216.5525,
-            "flood_score": 0.43,
-            "heat_score": 0.28,
+            "flood_score": 0.71,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -60343,12 +62692,15 @@
             "built_pct": null,
             "pop_density": 0.0006000841329746476,
             "pop_density_raw": 14.3125,
-            "flood_score": 0.47,
-            "heat_score": 0.23,
+            "flood_score": 0.7,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.5
+            "low_elev_risk": 0.5,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 73.29
           },
           "coverage": {
             "elevation": true,
@@ -60420,12 +62772,15 @@
             "built_pct": null,
             "pop_density": 0.00028961265666531904,
             "pop_density_raw": 6.9075,
-            "flood_score": 0.37,
-            "heat_score": 0.03,
+            "flood_score": 0.61,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.61,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -60497,12 +62852,15 @@
             "built_pct": null,
             "pop_density": 0.0003963175732361821,
             "pop_density_raw": 9.452499999999999,
-            "flood_score": 0.38,
-            "heat_score": 0.03,
+            "flood_score": 0.64,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -60574,12 +62932,15 @@
             "built_pct": null,
             "pop_density": 0.0020697399632694136,
             "pop_density_raw": 49.365,
-            "flood_score": 0.34,
-            "heat_score": 0.24,
+            "flood_score": 0.63,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -60651,12 +63012,15 @@
             "built_pct": null,
             "pop_density": 0.005341849374460606,
             "pop_density_raw": 127.4075,
-            "flood_score": 0.35,
-            "heat_score": 0.23,
+            "flood_score": 0.63,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -60728,12 +63092,15 @@
             "built_pct": null,
             "pop_density": 0.020172889414108084,
             "pop_density_raw": 481.13999999999993,
-            "flood_score": 0.39,
-            "heat_score": 0.25,
+            "flood_score": 0.49,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 82.41
           },
           "coverage": {
             "elevation": true,
@@ -60805,12 +63172,15 @@
             "built_pct": null,
             "pop_density": 0.0407351784009674,
             "pop_density_raw": 971.5674999999999,
-            "flood_score": 0.31,
-            "heat_score": 0.38,
+            "flood_score": 0.46,
+            "heat_score": 0.54,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -60882,12 +63252,15 @@
             "built_pct": null,
             "pop_density": 0.02447410380652986,
             "pop_density_raw": 583.7275,
-            "flood_score": 0.23,
-            "heat_score": 0.34,
+            "flood_score": 0.44,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -60959,12 +63332,15 @@
             "built_pct": null,
             "pop_density": 0.02064876399292117,
             "pop_density_raw": 492.49,
-            "flood_score": 0.22,
-            "heat_score": 0.24,
+            "flood_score": 0.43,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -61036,12 +63412,15 @@
             "built_pct": null,
             "pop_density": 0.08294493908712039,
             "pop_density_raw": 1978.3050000000003,
-            "flood_score": 0.3,
-            "heat_score": 0.24,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -61113,12 +63492,15 @@
             "built_pct": 0.7,
             "pop_density": 0.10962190195716032,
             "pop_density_raw": 2614.5725,
-            "flood_score": 0.29,
-            "heat_score": 0.33,
+            "flood_score": 0.46,
+            "heat_score": 0.57,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -61190,12 +63572,15 @@
             "built_pct": null,
             "pop_density": 0.08326505383683297,
             "pop_density_raw": 1985.94,
-            "flood_score": 0.31,
-            "heat_score": 0.29,
+            "flood_score": 0.38,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 84.81
           },
           "coverage": {
             "elevation": true,
@@ -61267,12 +63652,15 @@
             "built_pct": null,
             "pop_density": 0.1047199745226289,
             "pop_density_raw": 2497.6575000000003,
-            "flood_score": 0.25,
-            "heat_score": 0.26,
+            "flood_score": 0.3,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.14,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -61344,12 +63732,15 @@
             "built_pct": null,
             "pop_density": 0.1985927339212378,
             "pop_density_raw": 4736.599999999999,
-            "flood_score": 0.29,
-            "heat_score": 0.28,
+            "flood_score": 0.35,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -61421,12 +63812,15 @@
             "built_pct": null,
             "pop_density": 0.18960059110907554,
             "pop_density_raw": 4522.13,
-            "flood_score": 0.32,
-            "heat_score": 0.27,
+            "flood_score": 0.39,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -61498,12 +63892,15 @@
             "built_pct": null,
             "pop_density": 0.0699330187204467,
             "pop_density_raw": 1667.96,
-            "flood_score": 0.2,
-            "heat_score": 0.3,
+            "flood_score": 0.21,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.17,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -61575,12 +63972,15 @@
             "built_pct": null,
             "pop_density": 0.13076257771183694,
             "pop_density_raw": 3118.795,
-            "flood_score": 0.31,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 70.45
           },
           "coverage": {
             "elevation": true,
@@ -61652,12 +64052,15 @@
             "built_pct": null,
             "pop_density": 0.21129648881176383,
             "pop_density_raw": 5039.595,
-            "flood_score": 0.34,
-            "heat_score": 0.28,
+            "flood_score": 0.43,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -61729,12 +64132,15 @@
             "built_pct": null,
             "pop_density": 0.15115691302025613,
             "pop_density_raw": 3605.2166666666667,
-            "flood_score": 0.32,
-            "heat_score": 0.25,
+            "flood_score": 0.42,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -61806,12 +64212,15 @@
             "built_pct": 0.7,
             "pop_density": 0.26627184712005064,
             "pop_density_raw": 6350.8025,
-            "flood_score": 0.34,
-            "heat_score": 0.3,
+            "flood_score": 0.43,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.18,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -61883,12 +64292,15 @@
             "built_pct": null,
             "pop_density": 0.3524058796125428,
             "pop_density_raw": 8405.17,
-            "flood_score": 0.34,
-            "heat_score": 0.33,
+            "flood_score": 0.43,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.17,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": 65.19
           },
           "coverage": {
             "elevation": true,
@@ -61960,12 +64372,15 @@
             "built_pct": null,
             "pop_density": 0.2988843495879867,
             "pop_density_raw": 7128.6375,
-            "flood_score": 0.33,
-            "heat_score": 0.3,
+            "flood_score": 0.42,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.16,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -62037,12 +64452,15 @@
             "built_pct": null,
             "pop_density": 0.29835774300561735,
             "pop_density_raw": 7116.0775,
-            "flood_score": 0.3,
-            "heat_score": 0.31,
+            "flood_score": 0.44,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.15,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -62114,12 +64532,15 @@
             "built_pct": null,
             "pop_density": 0.3272947956704519,
             "pop_density_raw": 7806.249999999999,
-            "flood_score": 0.3,
-            "heat_score": 0.41,
+            "flood_score": 0.51,
+            "heat_score": 0.59,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.14,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": true,
@@ -62191,12 +64612,15 @@
             "built_pct": null,
             "pop_density": 0.31722795196477194,
             "pop_density_raw": 7566.1475,
-            "flood_score": 0.24,
-            "heat_score": 0.39,
+            "flood_score": 0.47,
+            "heat_score": 0.55,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -62268,12 +64692,15 @@
             "built_pct": null,
             "pop_density": 0.17670774420529428,
             "pop_density_raw": 4214.625,
-            "flood_score": 0.3,
-            "heat_score": 0.3,
+            "flood_score": 0.49,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -62345,12 +64772,15 @@
             "built_pct": null,
             "pop_density": 0.02465826936489431,
             "pop_density_raw": 588.12,
-            "flood_score": 0.34,
-            "heat_score": 0.23,
+            "flood_score": 0.5,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": 68.33
           },
           "coverage": {
             "elevation": false,
@@ -62422,12 +64852,15 @@
             "built_pct": null,
             "pop_density": 0.0032790274116761406,
             "pop_density_raw": 78.20750000000001,
-            "flood_score": 0.38,
-            "heat_score": 0.01,
+            "flood_score": 0.67,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.06,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -62499,12 +64932,15 @@
             "built_pct": null,
             "pop_density": 0.08731554312076997,
             "pop_density_raw": 2082.5475,
-            "flood_score": 0.35,
-            "heat_score": 0.04,
+            "flood_score": 0.67,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -62576,12 +65012,15 @@
             "built_pct": null,
             "pop_density": 0.17559426058178518,
             "pop_density_raw": 4188.0675,
-            "flood_score": 0.3,
-            "heat_score": 0.28,
+            "flood_score": 0.65,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": false,
@@ -62653,12 +65092,15 @@
             "built_pct": null,
             "pop_density": 0.18258056758667288,
             "pop_density_raw": 4354.696666666668,
-            "flood_score": 0.4,
-            "heat_score": 0.27,
+            "flood_score": 0.68,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.63,
+            "hwm_raw": 10.97,
+            "precip_trigger": 82.7
           },
           "coverage": {
             "elevation": true,
@@ -62730,12 +65172,15 @@
             "built_pct": null,
             "pop_density": 0.00010873140156140343,
             "pop_density_raw": 2.5933333333333337,
-            "flood_score": 0.33,
-            "heat_score": 0.22,
+            "flood_score": 0.67,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.65,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -62807,12 +65252,15 @@
             "built_pct": null,
             "pop_density": 0.00025121426003421935,
             "pop_density_raw": 5.991666666666667,
-            "flood_score": 0.35,
-            "heat_score": 0.2,
+            "flood_score": 0.5,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -62884,12 +65332,15 @@
             "built_pct": null,
             "pop_density": 0.0009451106723123272,
             "pop_density_raw": 22.541666666666668,
-            "flood_score": 0.33,
-            "heat_score": 0.21,
+            "flood_score": 0.5,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -62961,12 +65412,15 @@
             "built_pct": null,
             "pop_density": 0.009104507910948105,
             "pop_density_raw": 217.15,
-            "flood_score": 0.32,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -63038,12 +65492,15 @@
             "built_pct": null,
             "pop_density": 0.015046581175968915,
             "pop_density_raw": 358.8733333333334,
-            "flood_score": 0.33,
-            "heat_score": 0.25,
+            "flood_score": 0.5,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -63115,12 +65572,15 @@
             "built_pct": null,
             "pop_density": 0.00907515881798166,
             "pop_density_raw": 216.45000000000005,
-            "flood_score": 0.38,
-            "heat_score": 0.27,
+            "flood_score": 0.7,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -63192,12 +65652,15 @@
             "built_pct": null,
             "pop_density": 0.0033177752022711267,
             "pop_density_raw": 79.13166666666667,
-            "flood_score": 0.39,
-            "heat_score": 0.28,
+            "flood_score": 0.64,
+            "heat_score": 0.42,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -63269,12 +65732,15 @@
             "built_pct": null,
             "pop_density": 0.0010647431655469819,
             "pop_density_raw": 25.395,
-            "flood_score": 0.33,
-            "heat_score": 0.03,
-            "landslide_score": 0.18,
+            "flood_score": 0.59,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.6,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -63346,12 +65812,15 @@
             "built_pct": null,
             "pop_density": 0.0002105448026378589,
             "pop_density_raw": 5.0216666666666665,
-            "flood_score": 0.31,
-            "heat_score": 0.05,
+            "flood_score": 0.6,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.62,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -63423,12 +65892,15 @@
             "built_pct": null,
             "pop_density": 0.0010293844964016925,
             "pop_density_raw": 24.551666666666666,
-            "flood_score": 0.36,
-            "heat_score": 0.04,
+            "flood_score": 0.63,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -63500,12 +65972,15 @@
             "built_pct": null,
             "pop_density": 0.0018355062498800665,
             "pop_density_raw": 43.778333333333336,
-            "flood_score": 0.29,
-            "heat_score": 0.25,
+            "flood_score": 0.61,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.63,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -63577,12 +66052,15 @@
             "built_pct": null,
             "pop_density": 0.00947062619923905,
             "pop_density_raw": 225.8822222222222,
-            "flood_score": 0.29,
-            "heat_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -63654,12 +66132,15 @@
             "built_pct": null,
             "pop_density": 0.01824919612774313,
             "pop_density_raw": 435.2583333333334,
-            "flood_score": 0.32,
-            "heat_score": 0.34,
+            "flood_score": 0.47,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -63731,12 +66212,15 @@
             "built_pct": null,
             "pop_density": 0.011275502244951755,
             "pop_density_raw": 268.93,
-            "flood_score": 0.35,
-            "heat_score": 0.28,
+            "flood_score": 0.48,
+            "heat_score": 0.39,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -63808,12 +66292,15 @@
             "built_pct": null,
             "pop_density": 0.023674236205005052,
             "pop_density_raw": 564.65,
-            "flood_score": 0.29,
-            "heat_score": 0.24,
+            "flood_score": 0.45,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -63885,12 +66372,15 @@
             "built_pct": null,
             "pop_density": 0.04836143539010915,
             "pop_density_raw": 1153.46,
-            "flood_score": 0.31,
-            "heat_score": 0.23,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -63962,12 +66452,15 @@
             "built_pct": 0.7,
             "pop_density": 0.07233139864614753,
             "pop_density_raw": 1725.1633333333336,
-            "flood_score": 0.33,
-            "heat_score": 0.23,
+            "flood_score": 0.47,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64040,11 +66533,14 @@
             "pop_density": 0.10981340478876636,
             "pop_density_raw": 2619.14,
             "flood_score": 0.24,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64116,12 +66612,15 @@
             "built_pct": null,
             "pop_density": 0.1585755251766603,
             "pop_density_raw": 3782.156666666667,
-            "flood_score": 0.22,
-            "heat_score": 0.27,
+            "flood_score": 0.27,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.09,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64193,12 +66692,15 @@
             "built_pct": null,
             "pop_density": 0.1808837707404556,
             "pop_density_raw": 4314.2266666666665,
-            "flood_score": 0.25,
-            "heat_score": 0.27,
+            "flood_score": 0.3,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64270,12 +66772,15 @@
             "built_pct": 0.7,
             "pop_density": 0.11060226648042876,
             "pop_density_raw": 2637.955,
-            "flood_score": 0.24,
-            "heat_score": 0.26,
+            "flood_score": 0.3,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.11,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64347,12 +66852,15 @@
             "built_pct": null,
             "pop_density": 0.032073247824074023,
             "pop_density_raw": 764.9733333333332,
-            "flood_score": 0.25,
-            "heat_score": 0.27,
+            "flood_score": 0.26,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64424,12 +66932,15 @@
             "built_pct": null,
             "pop_density": 0.052556189441734784,
             "pop_density_raw": 1253.5083333333334,
-            "flood_score": 0.25,
-            "heat_score": 0.26,
+            "flood_score": 0.4,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.13,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64501,12 +67012,15 @@
             "built_pct": null,
             "pop_density": 0.06125008956632375,
             "pop_density_raw": 1460.865,
-            "flood_score": 0.26,
-            "heat_score": 0.25,
+            "flood_score": 0.4,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.13,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64578,12 +67092,15 @@
             "built_pct": null,
             "pop_density": 0.10729515944052162,
             "pop_density_raw": 2559.0777777777776,
-            "flood_score": 0.3,
-            "heat_score": 0.26,
+            "flood_score": 0.4,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.13,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64655,12 +67172,15 @@
             "built_pct": null,
             "pop_density": 0.18301430525344126,
             "pop_density_raw": 4365.041666666667,
-            "flood_score": 0.33,
-            "heat_score": 0.28,
+            "flood_score": 0.42,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.13,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64732,12 +67252,15 @@
             "built_pct": null,
             "pop_density": 0.24760229511435594,
             "pop_density_raw": 5905.5183333333325,
-            "flood_score": 0.25,
-            "heat_score": 0.31,
+            "flood_score": 0.4,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.12,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64809,12 +67332,15 @@
             "built_pct": null,
             "pop_density": 0.23468645808775102,
             "pop_density_raw": 5597.465,
-            "flood_score": 0.25,
-            "heat_score": 0.3,
+            "flood_score": 0.39,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.11,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64886,12 +67412,15 @@
             "built_pct": null,
             "pop_density": 0.23212351360505973,
             "pop_density_raw": 5536.336666666666,
-            "flood_score": 0.23,
-            "heat_score": 0.3,
+            "flood_score": 0.42,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.1,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -64963,12 +67492,15 @@
             "built_pct": null,
             "pop_density": 0.310528776919406,
             "pop_density_raw": 7406.366666666668,
-            "flood_score": 0.35,
-            "heat_score": 0.34,
+            "flood_score": 0.51,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.09,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -65040,12 +67572,15 @@
             "built_pct": null,
             "pop_density": 0.3190886495194482,
             "pop_density_raw": 7610.526666666668,
-            "flood_score": 0.35,
-            "heat_score": 0.37,
+            "flood_score": 0.5,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65117,12 +67652,15 @@
             "built_pct": null,
             "pop_density": 0.18426744164431566,
             "pop_density_raw": 4394.929999999999,
-            "flood_score": 0.24,
-            "heat_score": 0.3,
+            "flood_score": 0.47,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.06,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65194,12 +67732,15 @@
             "built_pct": null,
             "pop_density": 0.030324321398444976,
             "pop_density_raw": 723.2600000000001,
-            "flood_score": 0.31,
-            "heat_score": 0.18,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65271,12 +67812,15 @@
             "built_pct": null,
             "pop_density": 0.0027830626799395975,
             "pop_density_raw": 66.37833333333333,
-            "flood_score": 0.35,
-            "heat_score": 0.23,
+            "flood_score": 0.66,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65348,12 +67892,15 @@
             "built_pct": null,
             "pop_density": 0.0334922065902089,
             "pop_density_raw": 798.8166666666667,
-            "flood_score": 0.36,
-            "heat_score": 0.24,
+            "flood_score": 0.68,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -65425,12 +67972,15 @@
             "built_pct": null,
             "pop_density": 0.15468104029759852,
             "pop_density_raw": 3689.2700000000004,
-            "flood_score": 0.27,
-            "heat_score": 0.28,
+            "flood_score": 0.64,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65502,12 +68052,15 @@
             "built_pct": null,
             "pop_density": 0.2512859556756088,
             "pop_density_raw": 5993.376666666667,
-            "flood_score": 0.46,
-            "heat_score": 0.3,
+            "flood_score": 0.71,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -65579,12 +68132,15 @@
             "built_pct": null,
             "pop_density": 0.00008385455133270186,
             "pop_density_raw": 2,
-            "flood_score": 0.36,
-            "heat_score": 0.23,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -65656,12 +68212,15 @@
             "built_pct": null,
             "pop_density": 0.00026110210921220046,
             "pop_density_raw": 6.227500000000001,
-            "flood_score": 0.38,
-            "heat_score": 0.22,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -65733,12 +68292,15 @@
             "built_pct": null,
             "pop_density": 0.0022048506091042292,
             "pop_density_raw": 52.5875,
-            "flood_score": 0.36,
-            "heat_score": 0.21,
+            "flood_score": 0.51,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -65810,12 +68372,15 @@
             "built_pct": null,
             "pop_density": 0.00734628760587968,
             "pop_density_raw": 175.21500000000003,
-            "flood_score": 0.44,
-            "heat_score": 0.01,
+            "flood_score": 0.52,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -65887,12 +68452,15 @@
             "built_pct": null,
             "pop_density": 0.0069945177630389935,
             "pop_density_raw": 166.825,
-            "flood_score": 0.41,
-            "heat_score": 0.26,
+            "flood_score": 0.53,
+            "heat_score": 0.4,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -65964,12 +68532,15 @@
             "built_pct": null,
             "pop_density": 0.004368926942622932,
             "pop_density_raw": 104.2025,
-            "flood_score": 0.5,
-            "heat_score": 0.24,
+            "flood_score": 0.72,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -66041,12 +68612,15 @@
             "built_pct": null,
             "pop_density": 0.003714022896714531,
             "pop_density_raw": 88.5825,
-            "flood_score": 0.31,
-            "heat_score": 0.24,
-            "landslide_score": 0.22,
+            "flood_score": 0.6,
+            "heat_score": 0.37,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.62,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -66118,12 +68692,15 @@
             "built_pct": null,
             "pop_density": 0.0013519450038614856,
             "pop_density_raw": 32.245,
-            "flood_score": 0.35,
-            "heat_score": 0.02,
-            "landslide_score": 0.19,
+            "flood_score": 0.59,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.6,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -66195,12 +68772,15 @@
             "built_pct": null,
             "pop_density": 0.0005402329469609317,
             "pop_density_raw": 12.885,
-            "flood_score": 0.3,
-            "heat_score": 0.24,
-            "landslide_score": 0.22,
+            "flood_score": 0.59,
+            "heat_score": 0.35,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.61,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -66272,12 +68852,15 @@
             "built_pct": null,
             "pop_density": 0.0002596346545638781,
             "pop_density_raw": 6.1925,
-            "flood_score": 0.19,
-            "heat_score": 0.04,
-            "landslide_score": 0.19,
+            "flood_score": 0.54,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -66349,12 +68932,15 @@
             "built_pct": null,
             "pop_density": 0.0005077393083195098,
             "pop_density_raw": 12.110000000000001,
-            "flood_score": 0.2,
-            "heat_score": 0.24,
-            "landslide_score": 0.22,
+            "flood_score": 0.57,
+            "heat_score": 0.35,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.61,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -66426,12 +69012,15 @@
             "built_pct": null,
             "pop_density": 0.0027354752220582887,
             "pop_density_raw": 65.24333333333333,
-            "flood_score": 0.33,
-            "heat_score": 0.25,
+            "flood_score": 0.48,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -66503,12 +69092,15 @@
             "built_pct": null,
             "pop_density": 0.006281125167576033,
             "pop_density_raw": 149.81,
-            "flood_score": 0.21,
-            "heat_score": 0.27,
+            "flood_score": 0.43,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66580,12 +69172,15 @@
             "built_pct": null,
             "pop_density": 0.00864771024256321,
             "pop_density_raw": 206.255,
-            "flood_score": 0.24,
-            "heat_score": 0.26,
+            "flood_score": 0.45,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66657,12 +69252,15 @@
             "built_pct": null,
             "pop_density": 0.029032332398786373,
             "pop_density_raw": 692.445,
-            "flood_score": 0.35,
-            "heat_score": 0.25,
+            "flood_score": 0.49,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66734,12 +69332,15 @@
             "built_pct": null,
             "pop_density": 0.02512303321565581,
             "pop_density_raw": 599.205,
-            "flood_score": 0.27,
-            "heat_score": 0.23,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66811,12 +69412,15 @@
             "built_pct": null,
             "pop_density": 0.002829881471100356,
             "pop_density_raw": 67.495,
-            "flood_score": 0.34,
-            "heat_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66889,11 +69493,14 @@
             "pop_density": 0.04148609590815175,
             "pop_density_raw": 989.4775,
             "flood_score": 0.25,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -66965,12 +69572,15 @@
             "built_pct": null,
             "pop_density": 0.11006035644244119,
             "pop_density_raw": 2625.03,
-            "flood_score": 0.27,
-            "heat_score": 0.23,
+            "flood_score": 0.32,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.04,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67042,12 +69652,15 @@
             "built_pct": null,
             "pop_density": 0.12629218676210144,
             "pop_density_raw": 3012.1725,
-            "flood_score": 0.49,
-            "heat_score": 0.25,
+            "flood_score": 0.59,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.05,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67119,12 +69732,15 @@
             "built_pct": null,
             "pop_density": 0.10729347070302951,
             "pop_density_raw": 2559.0375,
-            "flood_score": 0.24,
-            "heat_score": 0.24,
+            "flood_score": 0.3,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.06,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67196,12 +69812,15 @@
             "built_pct": 0.7,
             "pop_density": 0.057741405502185164,
             "pop_density_raw": 1377.1799999999998,
-            "flood_score": 0.24,
-            "heat_score": 0.23,
+            "flood_score": 0.3,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67273,12 +69892,15 @@
             "built_pct": null,
             "pop_density": 0.022844076146811304,
             "pop_density_raw": 544.85,
-            "flood_score": 0.21,
-            "heat_score": 0.24,
+            "flood_score": 0.39,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67350,12 +69972,15 @@
             "built_pct": null,
             "pop_density": 0.017706412604845824,
             "pop_density_raw": 422.31249999999994,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.45,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67427,12 +70052,15 @@
             "built_pct": null,
             "pop_density": 0.06011106524405456,
             "pop_density_raw": 1433.6983333333335,
-            "flood_score": 0.28,
-            "heat_score": 0.23,
+            "flood_score": 0.4,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67504,12 +70132,15 @@
             "built_pct": null,
             "pop_density": 0.11962878965863745,
             "pop_density_raw": 2853.245,
-            "flood_score": 0.3,
-            "heat_score": 0.24,
+            "flood_score": 0.41,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.08,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67581,12 +70212,15 @@
             "built_pct": null,
             "pop_density": 0.14913867372726355,
             "pop_density_raw": 3557.0799999999995,
-            "flood_score": 0.28,
-            "heat_score": 0.27,
+            "flood_score": 0.4,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67658,12 +70292,15 @@
             "built_pct": null,
             "pop_density": 0.1947105826491012,
             "pop_density_raw": 4644.0075,
-            "flood_score": 0.58,
-            "heat_score": 0.3,
+            "flood_score": 0.49,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.07,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67735,12 +70372,15 @@
             "built_pct": null,
             "pop_density": 0.21468788132222577,
             "pop_density_raw": 5120.4825,
-            "flood_score": 0.29,
-            "heat_score": 0.31,
+            "flood_score": 0.44,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.06,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.43,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67812,12 +70452,15 @@
             "built_pct": null,
             "pop_density": 0.36890258549622534,
             "pop_density_raw": 8798.630000000001,
-            "flood_score": 0.36,
-            "heat_score": 0.36,
+            "flood_score": 0.52,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.04,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -67889,12 +70532,15 @@
             "built_pct": null,
             "pop_density": 0.40423061279088174,
             "pop_density_raw": 9641.2325,
-            "flood_score": 0.26,
-            "heat_score": 0.37,
+            "flood_score": 0.47,
+            "heat_score": 0.52,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -67966,12 +70612,15 @@
             "built_pct": null,
             "pop_density": 0.15221487794290373,
             "pop_density_raw": 3630.45,
-            "flood_score": 0.33,
-            "heat_score": 0.3,
+            "flood_score": 0.49,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -68043,12 +70692,15 @@
             "built_pct": null,
             "pop_density": 0.007632441262302524,
             "pop_density_raw": 182.04000000000002,
-            "flood_score": 0.25,
-            "heat_score": 0.25,
+            "flood_score": 0.47,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -68120,12 +70772,15 @@
             "built_pct": null,
             "pop_density": 0.0008657982425101468,
             "pop_density_raw": 20.650000000000002,
-            "flood_score": 0.55,
-            "heat_score": 0.24,
+            "flood_score": 0.71,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -68197,12 +70852,15 @@
             "built_pct": null,
             "pop_density": 0.02771759785207877,
             "pop_density_raw": 661.0875,
-            "flood_score": 0.22,
-            "heat_score": 0.25,
+            "flood_score": 0.63,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -68274,12 +70932,15 @@
             "built_pct": null,
             "pop_density": 0.1681861302442976,
             "pop_density_raw": 4011.3774999999996,
-            "flood_score": 0.28,
-            "heat_score": 0.29,
+            "flood_score": 0.66,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.63,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -68351,12 +71012,15 @@
             "built_pct": null,
             "pop_density": 0.2934887634218804,
             "pop_density_raw": 6999.948333333334,
-            "flood_score": 0.36,
-            "heat_score": 0.33,
+            "flood_score": 0.68,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -68428,12 +71092,15 @@
             "built_pct": null,
             "pop_density": 0.0002293421978949396,
             "pop_density_raw": 5.470000000000001,
-            "flood_score": 0.24,
-            "heat_score": 0.04,
-            "landslide_score": 0.18,
+            "flood_score": 0.42,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -68505,12 +71172,15 @@
             "built_pct": null,
             "pop_density": 0.0004988297622404102,
             "pop_density_raw": 11.8975,
-            "flood_score": 0.39,
-            "heat_score": 0.22,
+            "flood_score": 0.48,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -68582,12 +71252,15 @@
             "built_pct": null,
             "pop_density": 0.003203348679098377,
             "pop_density_raw": 76.4025,
-            "flood_score": 0.36,
-            "heat_score": 0.21,
+            "flood_score": 0.47,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -68659,12 +71332,15 @@
             "built_pct": null,
             "pop_density": 0.0067877114758147184,
             "pop_density_raw": 161.8925,
-            "flood_score": 0.33,
-            "heat_score": 0.22,
+            "flood_score": 0.46,
+            "heat_score": 0.45,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -68736,12 +71412,15 @@
             "built_pct": null,
             "pop_density": 0.005168480089580246,
             "pop_density_raw": 123.27250000000001,
-            "flood_score": 0.34,
-            "heat_score": 0.22,
+            "flood_score": 0.5,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": false,
@@ -68813,12 +71492,15 @@
             "built_pct": null,
             "pop_density": 0.00312672658281812,
             "pop_density_raw": 74.57499999999999,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.71,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.65,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -68890,12 +71572,15 @@
             "built_pct": null,
             "pop_density": 0.0022384972478264762,
             "pop_density_raw": 53.39,
-            "flood_score": 0.45,
-            "heat_score": 0.22,
+            "flood_score": 0.65,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.64,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -68967,12 +71652,15 @@
             "built_pct": null,
             "pop_density": 0.0008930509716932748,
             "pop_density_raw": 21.3,
-            "flood_score": 0.32,
-            "heat_score": 0.02,
-            "landslide_score": 0.19,
+            "flood_score": 0.57,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.58,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -69044,12 +71732,15 @@
             "built_pct": null,
             "pop_density": 0.0010550998921437212,
             "pop_density_raw": 25.165,
-            "flood_score": 0.29,
-            "heat_score": 0.04,
+            "flood_score": 0.55,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.57,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -69121,12 +71812,15 @@
             "built_pct": null,
             "pop_density": 0.0008248143305462886,
             "pop_density_raw": 19.6725,
-            "flood_score": 0.25,
-            "heat_score": 0.23,
+            "flood_score": 0.56,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.59,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -69198,12 +71892,15 @@
             "built_pct": null,
             "pop_density": 0.0003867791180220873,
             "pop_density_raw": 9.225,
-            "flood_score": 0.3,
-            "heat_score": 0.22,
+            "flood_score": 0.59,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.61,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -69275,12 +71972,15 @@
             "built_pct": null,
             "pop_density": 0.001837043583321166,
             "pop_density_raw": 43.815,
-            "flood_score": 0.31,
-            "heat_score": 0.23,
+            "flood_score": 0.46,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -69352,12 +72052,15 @@
             "built_pct": null,
             "pop_density": 0.00370668562347292,
             "pop_density_raw": 88.4075,
-            "flood_score": 0.2,
-            "heat_score": 0.25,
+            "flood_score": 0.43,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69429,12 +72132,15 @@
             "built_pct": null,
             "pop_density": 0.0023106121619725995,
             "pop_density_raw": 55.11,
-            "flood_score": 0.19,
-            "heat_score": 0.27,
+            "flood_score": 0.43,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69506,12 +72212,15 @@
             "built_pct": null,
             "pop_density": 0.0018654493125851187,
             "pop_density_raw": 44.4925,
-            "flood_score": 0.45,
-            "heat_score": 0.25,
+            "flood_score": 0.49,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69583,12 +72292,15 @@
             "built_pct": null,
             "pop_density": 0.001532127471037629,
             "pop_density_raw": 36.542500000000004,
-            "flood_score": 0.39,
-            "heat_score": 0.23,
+            "flood_score": 0.49,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69660,12 +72372,15 @@
             "built_pct": null,
             "pop_density": 0.001108137895861655,
             "pop_density_raw": 26.43,
-            "flood_score": 0.43,
-            "heat_score": 0.21,
+            "flood_score": 0.51,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69738,11 +72453,14 @@
             "pop_density": 0.0057975988609538405,
             "pop_density_raw": 138.2775,
             "flood_score": 0.31,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69815,11 +72533,14 @@
             "pop_density": 0.041085900061916425,
             "pop_density_raw": 979.9324999999999,
             "flood_score": 0.25,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69891,12 +72612,15 @@
             "built_pct": null,
             "pop_density": 0.11862295431540168,
             "pop_density_raw": 2829.2549999999997,
-            "flood_score": 0.23,
-            "heat_score": 0.26,
+            "flood_score": 0.28,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -69969,11 +72693,14 @@
             "pop_density": 0.18359639559727572,
             "pop_density_raw": 4378.924999999999,
             "flood_score": 0.23,
-            "heat_score": 0.28,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.02,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70045,12 +72772,15 @@
             "built_pct": null,
             "pop_density": 0.11020877899830005,
             "pop_density_raw": 2628.5699999999997,
-            "flood_score": 0.22,
-            "heat_score": 0.26,
+            "flood_score": 0.26,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.02,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70122,12 +72852,15 @@
             "built_pct": null,
             "pop_density": 0.0096052244005935,
             "pop_density_raw": 229.0925,
-            "flood_score": 0.18,
-            "heat_score": 0.23,
+            "flood_score": 0.37,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.38,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70199,12 +72932,15 @@
             "built_pct": null,
             "pop_density": 0.0007796376910157955,
             "pop_density_raw": 18.595,
-            "flood_score": 0.21,
-            "heat_score": 0.24,
+            "flood_score": 0.38,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70276,12 +73012,15 @@
             "built_pct": null,
             "pop_density": 0.0031275651283314476,
             "pop_density_raw": 74.595,
-            "flood_score": 0.26,
-            "heat_score": 0.22,
+            "flood_score": 0.4,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70353,12 +73092,15 @@
             "built_pct": null,
             "pop_density": 0.017592370415033354,
             "pop_density_raw": 419.59250000000003,
-            "flood_score": 0.32,
-            "heat_score": 0.21,
+            "flood_score": 0.41,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.03,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70430,12 +73172,15 @@
             "built_pct": null,
             "pop_density": 0.0368849966765264,
             "pop_density_raw": 879.7375,
-            "flood_score": 0.36,
-            "heat_score": 0.23,
+            "flood_score": 0.43,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.02,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.4,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70507,12 +73252,15 @@
             "built_pct": null,
             "pop_density": 0.11284883472882101,
             "pop_density_raw": 2691.5375,
-            "flood_score": 0.34,
-            "heat_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.02,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70584,12 +73332,15 @@
             "built_pct": null,
             "pop_density": 0.2039074353847045,
             "pop_density_raw": 4863.360000000001,
-            "flood_score": 0.4,
-            "heat_score": 0.3,
+            "flood_score": 0.52,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0.01,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70661,12 +73412,15 @@
             "built_pct": null,
             "pop_density": 0.3265941908940672,
             "pop_density_raw": 7789.54,
-            "flood_score": 0.33,
-            "heat_score": 0.33,
+            "flood_score": 0.49,
+            "heat_score": 0.5,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -70738,12 +73492,15 @@
             "built_pct": null,
             "pop_density": 0.2991501685157114,
             "pop_density_raw": 7134.9775,
-            "flood_score": 0.37,
-            "heat_score": 0.32,
+            "flood_score": 0.52,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -70815,12 +73572,15 @@
             "built_pct": null,
             "pop_density": 0.08909137288161827,
             "pop_density_raw": 2124.9025,
-            "flood_score": 0.3,
-            "heat_score": 0.3,
+            "flood_score": 0.48,
+            "heat_score": 0.41,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -70892,12 +73652,15 @@
             "built_pct": null,
             "pop_density": 0.003945042185636125,
             "pop_density_raw": 94.0925,
-            "flood_score": 0.53,
-            "heat_score": 0.25,
+            "flood_score": 0.54,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.44,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -70969,12 +73732,15 @@
             "built_pct": null,
             "pop_density": 0.0005572134936058038,
             "pop_density_raw": 13.29,
-            "flood_score": 0.57,
-            "heat_score": 0.23,
+            "flood_score": 0.71,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -71046,12 +73812,15 @@
             "built_pct": null,
             "pop_density": 0.01057825165062034,
             "pop_density_raw": 252.3,
-            "flood_score": 0.26,
-            "heat_score": 0.22,
+            "flood_score": 0.64,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": 0.64,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -71123,12 +73892,15 @@
             "built_pct": null,
             "pop_density": 0.11080194513078973,
             "pop_density_raw": 2642.7174999999993,
-            "flood_score": 0.3,
-            "heat_score": 0.26,
+            "flood_score": 0.66,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.63,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -71200,12 +73972,15 @@
             "built_pct": null,
             "pop_density": 0.2540226887159371,
             "pop_density_raw": 6058.650000000001,
-            "flood_score": 0.31,
-            "heat_score": 0.31,
+            "flood_score": 0.66,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.63,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -71277,12 +74052,15 @@
             "built_pct": null,
             "pop_density": 0.0011906298107352005,
             "pop_density_raw": 28.397499999999997,
-            "flood_score": 0.23,
-            "heat_score": 0.05,
-            "landslide_score": 0.18,
+            "flood_score": 0.5,
+            "heat_score": 0.01,
+            "landslide_score": 0.15,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.52,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -71354,12 +74132,15 @@
             "built_pct": null,
             "pop_density": 0.001706964210566312,
             "pop_density_raw": 40.7125,
-            "flood_score": 0.3,
-            "heat_score": 0.03,
+            "flood_score": 0.51,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -71431,12 +74212,15 @@
             "built_pct": null,
             "pop_density": 0.0024499155353740506,
             "pop_density_raw": 58.4325,
-            "flood_score": 0.26,
-            "heat_score": 0.02,
+            "flood_score": 0.48,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.49,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -71508,12 +74292,15 @@
             "built_pct": null,
             "pop_density": 0.003050523759294528,
             "pop_density_raw": 72.75750000000001,
-            "flood_score": 0.25,
-            "heat_score": 0.21,
-            "landslide_score": 0.21,
+            "flood_score": 0.49,
+            "heat_score": 0.34,
+            "landslide_score": 0.18,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.51,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -71585,12 +74372,15 @@
             "built_pct": null,
             "pop_density": 0.001808008944922218,
             "pop_density_raw": 43.1225,
-            "flood_score": 0.35,
-            "heat_score": 0.2,
+            "flood_score": 0.52,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.51,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -71662,12 +74452,15 @@
             "built_pct": null,
             "pop_density": 0.0020603063262444846,
             "pop_density_raw": 49.13999999999999,
-            "flood_score": 0.44,
-            "heat_score": 0.24,
+            "flood_score": 0.57,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.48,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -71739,12 +74532,15 @@
             "built_pct": null,
             "pop_density": 0.0020452125070045983,
             "pop_density_raw": 48.78,
-            "flood_score": 0.35,
-            "heat_score": 0.23,
+            "flood_score": 0.48,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.46,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -71816,12 +74612,15 @@
             "built_pct": null,
             "pop_density": 0.0009085640636898247,
             "pop_density_raw": 21.67,
-            "flood_score": 0.41,
-            "heat_score": 0.02,
-            "landslide_score": 0.28,
+            "flood_score": 0.48,
+            "heat_score": 0.01,
+            "landslide_score": 0.23,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.45,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -71893,12 +74692,15 @@
             "built_pct": null,
             "pop_density": 0.0009877017965100618,
             "pop_density_raw": 23.557499999999997,
-            "flood_score": 0.36,
-            "heat_score": 0.24,
-            "landslide_score": 0.46,
+            "flood_score": 0.46,
+            "heat_score": 0.36,
+            "landslide_score": 0.39,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -71970,12 +74772,15 @@
             "built_pct": null,
             "pop_density": 0.001418399735792652,
             "pop_density_raw": 33.83,
-            "flood_score": 0.35,
-            "heat_score": 0.23,
+            "flood_score": 0.44,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -72047,12 +74852,15 @@
             "built_pct": null,
             "pop_density": 0.0015127361060419415,
             "pop_density_raw": 36.08,
-            "flood_score": 0.28,
-            "heat_score": 0.21,
+            "flood_score": 0.43,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.42,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -72125,11 +74933,14 @@
             "pop_density": 0.0019384377116409576,
             "pop_density_raw": 46.23333333333333,
             "flood_score": 0.23,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -72202,11 +75013,14 @@
             "pop_density": 0.0027145814630178907,
             "pop_density_raw": 64.74499999999999,
             "flood_score": 0.32,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72279,11 +75093,14 @@
             "pop_density": 0.0017784502155774404,
             "pop_density_raw": 42.4175,
             "flood_score": 0.2,
-            "heat_score": 0.26,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72356,11 +75173,14 @@
             "pop_density": 0.0011097101686991433,
             "pop_density_raw": 26.4675,
             "flood_score": 0.19,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72433,11 +75253,14 @@
             "pop_density": 0.0019821119571267402,
             "pop_density_raw": 47.275000000000006,
             "flood_score": 0.24,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72510,11 +75333,14 @@
             "pop_density": 0.002969708935447636,
             "pop_density_raw": 70.83,
             "flood_score": 0.34,
-            "heat_score": 0.21,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72587,11 +75413,14 @@
             "pop_density": 0.004674052691284802,
             "pop_density_raw": 111.48,
             "flood_score": 0.43,
-            "heat_score": 0.21,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72664,11 +75493,14 @@
             "pop_density": 0.020608828262848967,
             "pop_density_raw": 491.53749999999997,
             "flood_score": 0.25,
-            "heat_score": 0.04,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72740,12 +75572,15 @@
             "built_pct": null,
             "pop_density": 0.11111860088025986,
             "pop_density_raw": 2650.2699999999995,
-            "flood_score": 0.29,
-            "heat_score": 0.27,
+            "flood_score": 0.35,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72817,12 +75652,15 @@
             "built_pct": null,
             "pop_density": 0.18532306562740525,
             "pop_density_raw": 4420.1075,
-            "flood_score": 0.22,
-            "heat_score": 0.3,
+            "flood_score": 0.26,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72894,12 +75732,15 @@
             "built_pct": 0.7,
             "pop_density": 0.11320710329938999,
             "pop_density_raw": 2700.0825,
-            "flood_score": 0.24,
-            "heat_score": 0.27,
+            "flood_score": 0.29,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -72972,11 +75813,14 @@
             "pop_density": 0.021991275359757725,
             "pop_density_raw": 524.51,
             "flood_score": 0.23,
-            "heat_score": 0.23,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73049,11 +75893,14 @@
             "pop_density": 0.0009047906088798529,
             "pop_density_raw": 21.58,
             "flood_score": 0.21,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73126,11 +75973,14 @@
             "pop_density": 0.0005180114908577656,
             "pop_density_raw": 12.354999999999999,
             "flood_score": 0.41,
-            "heat_score": 0.23,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73203,11 +76053,14 @@
             "pop_density": 0.0008930509716932748,
             "pop_density_raw": 21.3,
             "flood_score": 0.28,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73280,11 +76133,14 @@
             "pop_density": 0.01789036852683194,
             "pop_density_raw": 426.7,
             "flood_score": 0.38,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73357,11 +76213,14 @@
             "pop_density": 0.07683540129520888,
             "pop_density_raw": 1832.5875,
             "flood_score": 0.41,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73434,11 +76293,14 @@
             "pop_density": 0.14656475827410628,
             "pop_density_raw": 3495.69,
             "flood_score": 0.49,
-            "heat_score": 0.26,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73510,12 +76372,15 @@
             "built_pct": null,
             "pop_density": 0.14499437216402308,
             "pop_density_raw": 3458.2349999999997,
-            "flood_score": 0.42,
-            "heat_score": 0.26,
+            "flood_score": 0.51,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73588,11 +76453,14 @@
             "pop_density": 0.07668917992132249,
             "pop_density_raw": 1829.1000000000001,
             "flood_score": 0.34,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73664,12 +76532,15 @@
             "built_pct": null,
             "pop_density": 0.021013007200272594,
             "pop_density_raw": 501.1775,
-            "flood_score": 0.3,
-            "heat_score": 0.26,
+            "flood_score": 0.31,
+            "heat_score": 0.38,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73742,11 +76613,14 @@
             "pop_density": 0.0027282078276094548,
             "pop_density_raw": 65.07,
             "flood_score": 0.23,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -73819,11 +76693,14 @@
             "pop_density": 0.0003731527534305233,
             "pop_density_raw": 8.9,
             "flood_score": 0.34,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -73896,11 +76773,14 @@
             "pop_density": 0.00929506737885167,
             "pop_density_raw": 221.69500000000002,
             "flood_score": 0.37,
-            "heat_score": 0.21,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -73972,12 +76852,15 @@
             "built_pct": null,
             "pop_density": 0.12042142480510981,
             "pop_density_raw": 2872.1499999999996,
-            "flood_score": 0.34,
-            "heat_score": 0.24,
+            "flood_score": 0.41,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -74049,12 +76932,15 @@
             "built_pct": null,
             "pop_density": 0.24029150593520715,
             "pop_density_raw": 5731.150000000001,
-            "flood_score": 0.3,
-            "heat_score": 0.3,
+            "flood_score": 0.36,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -74126,12 +77012,15 @@
             "built_pct": null,
             "pop_density": 0.0013152586376534287,
             "pop_density_raw": 31.37,
-            "flood_score": 0.42,
-            "heat_score": 0.24,
+            "flood_score": 0.6,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": 0.52,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -74203,12 +77092,15 @@
             "built_pct": null,
             "pop_density": 0.0015419803808192215,
             "pop_density_raw": 36.7775,
-            "flood_score": 0.31,
-            "heat_score": 0.02,
+            "flood_score": 0.51,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -74280,12 +77172,15 @@
             "built_pct": null,
             "pop_density": 0.0011190389875349064,
             "pop_density_raw": 26.69,
-            "flood_score": 0.28,
-            "heat_score": 0.2,
+            "flood_score": 0.5,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.51,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -74357,12 +77252,15 @@
             "built_pct": null,
             "pop_density": 0.0012606483610980066,
             "pop_density_raw": 30.067500000000003,
-            "flood_score": 0.21,
-            "heat_score": 0.01,
-            "landslide_score": 0.19,
+            "flood_score": 0.43,
+            "heat_score": 0,
+            "landslide_score": 0.16,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -74434,12 +77332,15 @@
             "built_pct": null,
             "pop_density": 0.0013714411870463386,
             "pop_density_raw": 32.709999999999994,
-            "flood_score": 0.27,
-            "heat_score": 0.21,
-            "landslide_score": 0.22,
+            "flood_score": 0.47,
+            "heat_score": 0.34,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.48,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -74511,12 +77412,15 @@
             "built_pct": null,
             "pop_density": 0.0017837959432249004,
             "pop_density_raw": 42.545,
-            "flood_score": 0.45,
-            "heat_score": 0.03,
+            "flood_score": 0.53,
+            "heat_score": 0.01,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -74588,12 +77492,15 @@
             "built_pct": null,
             "pop_density": 0.0019668085015085222,
             "pop_density_raw": 46.910000000000004,
-            "flood_score": 0.42,
-            "heat_score": 0.23,
+            "flood_score": 0.5,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.47,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -74665,12 +77572,15 @@
             "built_pct": null,
             "pop_density": 0.0017566480322309377,
             "pop_density_raw": 41.897499999999994,
-            "flood_score": 0.34,
-            "heat_score": 0.02,
-            "landslide_score": 0.28,
+            "flood_score": 0.46,
+            "heat_score": 0.01,
+            "landslide_score": 0.23,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -74742,12 +77652,15 @@
             "built_pct": null,
             "pop_density": 0.0016292939323943971,
             "pop_density_raw": 38.86,
-            "flood_score": 0.27,
-            "heat_score": 0.03,
-            "landslide_score": 0.39,
+            "flood_score": 0.4,
+            "heat_score": 0.01,
+            "landslide_score": 0.32,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.39,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -74819,12 +77732,15 @@
             "built_pct": null,
             "pop_density": 0.001402886643796102,
             "pop_density_raw": 33.46,
-            "flood_score": 0.25,
-            "heat_score": 0.02,
-            "landslide_score": 0.19,
+            "flood_score": 0.41,
+            "heat_score": 0,
+            "landslide_score": 0.16,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.41,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -74896,12 +77812,15 @@
             "built_pct": null,
             "pop_density": 0.0015297166526868136,
             "pop_density_raw": 36.485,
-            "flood_score": 0.62,
-            "heat_score": 0.21,
+            "flood_score": 0.53,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": 0.44,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -74974,11 +77893,14 @@
             "pop_density": 0.0009323228532340902,
             "pop_density_raw": 22.236666666666668,
             "flood_score": 0.25,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -75051,11 +77973,14 @@
             "pop_density": 0.0011685131728212004,
             "pop_density_raw": 27.87,
             "flood_score": 0.27,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75128,11 +78053,14 @@
             "pop_density": 0.0018707950402325783,
             "pop_density_raw": 44.62,
             "flood_score": 0.22,
-            "heat_score": 0.26,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75205,11 +78133,14 @@
             "pop_density": 0.0012011116296517883,
             "pop_density_raw": 28.6475,
             "flood_score": 0.19,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75282,11 +78213,14 @@
             "pop_density": 0.0020227814145231003,
             "pop_density_raw": 48.245,
             "flood_score": 0.48,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75363,7 +78297,10 @@
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75436,11 +78373,14 @@
             "pop_density": 0.005429582198792446,
             "pop_density_raw": 129.5,
             "flood_score": 0.42,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75513,11 +78453,14 @@
             "pop_density": 0.023175511260953807,
             "pop_density_raw": 552.755,
             "flood_score": 0.34,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75589,12 +78532,15 @@
             "built_pct": null,
             "pop_density": 0.09068639126615542,
             "pop_density_raw": 2162.945,
-            "flood_score": 0.26,
-            "heat_score": 0.28,
+            "flood_score": 0.31,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75666,12 +78612,15 @@
             "built_pct": null,
             "pop_density": 0.14721641295615054,
             "pop_density_raw": 3511.2325,
-            "flood_score": 0.24,
-            "heat_score": 0.31,
+            "flood_score": 0.29,
+            "heat_score": 0.51,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75743,12 +78692,15 @@
             "built_pct": null,
             "pop_density": 0.11852201439923495,
             "pop_density_raw": 2826.8475,
-            "flood_score": 0.4,
-            "heat_score": 0.25,
+            "flood_score": 0.48,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75821,11 +78773,14 @@
             "pop_density": 0.05320214900216769,
             "pop_density_raw": 1268.915,
             "flood_score": 0.3,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75898,11 +78853,14 @@
             "pop_density": 0.03614026344250284,
             "pop_density_raw": 861.9749999999999,
             "flood_score": 0.24,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -75975,11 +78933,14 @@
             "pop_density": 0.01787918791998758,
             "pop_density_raw": 426.43333333333334,
             "flood_score": 0.25,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76052,11 +79013,14 @@
             "pop_density": 0.0006909615029814634,
             "pop_density_raw": 16.48,
             "flood_score": 0.29,
-            "heat_score": 0.23,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.5
+            "low_elev_risk": 0.5,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76129,11 +79093,14 @@
             "pop_density": 0.07382198317487908,
             "pop_density_raw": 1760.715,
             "flood_score": 0.36,
-            "heat_score": 0.27,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.69
+            "low_elev_risk": 0.69,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76205,12 +79172,15 @@
             "built_pct": null,
             "pop_density": 0.10161180075929312,
             "pop_density_raw": 2423.5249999999996,
-            "flood_score": 0.35,
-            "heat_score": 0.26,
+            "flood_score": 0.43,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76283,11 +79253,14 @@
             "pop_density": 0.06699045769599303,
             "pop_density_raw": 1597.7775000000001,
             "flood_score": 0.78,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.69
+            "low_elev_risk": 0.69,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76360,11 +79333,14 @@
             "pop_density": 0.05307227926579116,
             "pop_density_raw": 1265.8174999999999,
             "flood_score": 0.38,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76437,11 +79413,14 @@
             "pop_density": 0.018150632090530815,
             "pop_density_raw": 432.9075,
             "flood_score": 0.31,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76514,11 +79493,14 @@
             "pop_density": 0.004963350893382623,
             "pop_density_raw": 118.38,
             "flood_score": 0.27,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76591,11 +79573,14 @@
             "pop_density": 0.0012432485416964708,
             "pop_density_raw": 29.6525,
             "flood_score": 0.2,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -76668,11 +79653,14 @@
             "pop_density": 0.00016697537534124258,
             "pop_density_raw": 3.9825,
             "flood_score": 0.3,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -76745,11 +79733,14 @@
             "pop_density": 0.005612594757076068,
             "pop_density_raw": 133.865,
             "flood_score": 0.41,
-            "heat_score": 0.21,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76821,12 +79812,15 @@
             "built_pct": null,
             "pop_density": 0.11173283546877193,
             "pop_density_raw": 2664.92,
-            "flood_score": 0.36,
-            "heat_score": 0.24,
+            "flood_score": 0.44,
+            "heat_score": 0.46,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.63
+            "low_elev_risk": 0.63,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76898,12 +79892,15 @@
             "built_pct": null,
             "pop_density": 0.227615073652657,
             "pop_density_raw": 5428.806666666666,
-            "flood_score": 0.28,
-            "heat_score": 0.3,
+            "flood_score": 0.34,
+            "heat_score": 0.49,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -76976,11 +79973,14 @@
             "pop_density": 0.0009266976104155214,
             "pop_density_raw": 22.1025,
             "flood_score": 0.22,
-            "heat_score": 0.25,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -77053,11 +80053,14 @@
             "pop_density": 0.0003256701137383808,
             "pop_density_raw": 7.7675,
             "flood_score": 0.28,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -77130,11 +80133,14 @@
             "pop_density": 0.00021896519716751772,
             "pop_density_raw": 5.2225,
             "flood_score": 0.19,
-            "heat_score": 0.22,
-            "landslide_score": 0.22,
+            "heat_score": 0.34,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 10.92,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -77207,11 +80213,14 @@
             "pop_density": 0.0007858219641765822,
             "pop_density_raw": 18.7425,
             "flood_score": 0.21,
-            "heat_score": 0.22,
-            "landslide_score": 0.34,
+            "heat_score": 0.34,
+            "landslide_score": 0.29,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -77284,11 +80293,14 @@
             "pop_density": 0.0012880059084703006,
             "pop_density_raw": 30.720000000000002,
             "flood_score": 0.37,
-            "heat_score": 0.03,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -77361,11 +80373,14 @@
             "pop_density": 0.0011722866276311721,
             "pop_density_raw": 27.960000000000004,
             "flood_score": 0.28,
-            "heat_score": 0.04,
+            "heat_score": 0.02,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -77437,12 +80452,15 @@
             "built_pct": null,
             "pop_density": 0.0014658823754847942,
             "pop_density_raw": 34.9625,
-            "flood_score": 0.35,
-            "heat_score": 0.24,
+            "flood_score": 0.36,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 78.77
           },
           "coverage": {
             "elevation": true,
@@ -77514,12 +80532,15 @@
             "built_pct": null,
             "pop_density": 0.0029199202955938444,
             "pop_density_raw": 69.6425,
-            "flood_score": 0.42,
-            "heat_score": 0.05,
+            "flood_score": 0.43,
+            "heat_score": 0.06,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -77596,7 +80617,10 @@
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -77669,11 +80693,14 @@
             "pop_density": 0.0013904132792853627,
             "pop_density_raw": 33.1625,
             "flood_score": 0.22,
-            "heat_score": 0.22,
-            "landslide_score": 0.22,
+            "heat_score": 0.34,
+            "landslide_score": 0.19,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -77746,11 +80773,14 @@
             "pop_density": 0.0005823698590056145,
             "pop_density_raw": 13.89,
             "flood_score": 0.22,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -77823,11 +80853,14 @@
             "pop_density": 0.0005648302820185242,
             "pop_density_raw": 13.471666666666666,
             "flood_score": 0.31,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": 76.75
           },
           "coverage": {
             "elevation": true,
@@ -77900,11 +80933,14 @@
             "pop_density": 0.0007530138709676628,
             "pop_density_raw": 17.96,
             "flood_score": 0.26,
-            "heat_score": 0.25,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -77977,11 +81013,14 @@
             "pop_density": 0.0012360160866440254,
             "pop_density_raw": 29.48,
             "flood_score": 0.23,
-            "heat_score": 0.26,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78054,11 +81093,14 @@
             "pop_density": 0.001082562257705181,
             "pop_density_raw": 25.82,
             "flood_score": 0.17,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78131,11 +81173,14 @@
             "pop_density": 0.0014657775572956286,
             "pop_density_raw": 34.96,
             "flood_score": 0.35,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78208,11 +81253,14 @@
             "pop_density": 0.0032147738617174576,
             "pop_density_raw": 76.675,
             "flood_score": 0.27,
-            "heat_score": 0.21,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78285,11 +81333,14 @@
             "pop_density": 0.004635479597671758,
             "pop_density_raw": 110.55999999999999,
             "flood_score": 0.33,
-            "heat_score": 0.21,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78362,11 +81413,14 @@
             "pop_density": 0.031082995451627595,
             "pop_density_raw": 741.355,
             "flood_score": 0.36,
-            "heat_score": 0.23,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78439,11 +81493,14 @@
             "pop_density": 0.09805060278238245,
             "pop_density_raw": 2338.5875,
             "flood_score": 0.24,
-            "heat_score": 0.28,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78516,11 +81573,14 @@
             "pop_density": 0.15397655724821463,
             "pop_density_raw": 3672.4675,
             "flood_score": 0.31,
-            "heat_score": 0.28,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78593,11 +81653,14 @@
             "pop_density": 0.12492609130270257,
             "pop_density_raw": 2979.59,
             "flood_score": 0.37,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78670,11 +81733,14 @@
             "pop_density": 0.05975506773425084,
             "pop_density_raw": 1425.2075,
             "flood_score": 0.34,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78746,12 +81812,15 @@
             "built_pct": 0.7,
             "pop_density": 0.06482407536231266,
             "pop_density_raw": 1546.1074999999998,
-            "flood_score": 0.28,
-            "heat_score": 0.24,
+            "flood_score": 0.35,
+            "heat_score": 0.48,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78824,11 +81893,14 @@
             "pop_density": 0.033301437485927,
             "pop_density_raw": 794.2666666666668,
             "flood_score": 0.26,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78901,11 +81973,14 @@
             "pop_density": 0.0006986132307905723,
             "pop_density_raw": 16.662499999999998,
             "flood_score": 0.25,
-            "heat_score": 0.23,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -78978,11 +82053,14 @@
             "pop_density": 0.06370084364721113,
             "pop_density_raw": 1519.3174999999999,
             "flood_score": 0.21,
-            "heat_score": 0.26,
+            "heat_score": 0.36,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79055,11 +82133,14 @@
             "pop_density": 0.0703043895646614,
             "pop_density_raw": 1676.8174999999999,
             "flood_score": 0.42,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79132,11 +82213,14 @@
             "pop_density": 0.014745298760909792,
             "pop_density_raw": 351.6875,
             "flood_score": 0.38,
-            "heat_score": 0.21,
+            "heat_score": 0.33,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.42
+            "low_elev_risk": 0.42,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79208,12 +82292,15 @@
             "built_pct": null,
             "pop_density": 0.01314944183085931,
             "pop_density_raw": 313.625,
-            "flood_score": 0.31,
-            "heat_score": 0.21,
+            "flood_score": 0.38,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 11.02,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79286,11 +82373,14 @@
             "pop_density": 0.005676009761521422,
             "pop_density_raw": 135.3775,
             "flood_score": 0.31,
-            "heat_score": 0.08,
+            "heat_score": 0.11,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79363,11 +82453,14 @@
             "pop_density": 0.00037220938972803037,
             "pop_density_raw": 8.8775,
             "flood_score": 0.26,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79440,11 +82533,14 @@
             "pop_density": 0.00034181211486992595,
             "pop_density_raw": 8.1525,
             "flood_score": 0.18,
-            "heat_score": 0.24,
+            "heat_score": 0.35,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -79517,11 +82613,14 @@
             "pop_density": 0.00041853902933934817,
             "pop_density_raw": 9.9825,
             "flood_score": 0.26,
-            "heat_score": 0.22,
+            "heat_score": 0.34,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.56
+            "low_elev_risk": 0.56,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": false,
@@ -79594,11 +82693,14 @@
             "pop_density": 0.004955279892816851,
             "pop_density_raw": 118.18750000000001,
             "flood_score": 0.48,
-            "heat_score": 0.01,
+            "heat_score": 0,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0.83
+            "low_elev_risk": 0.83,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79670,12 +82772,15 @@
             "built_pct": null,
             "pop_density": 0.06278557121941468,
             "pop_density_raw": 1497.4874999999997,
-            "flood_score": 0.26,
-            "heat_score": 0.23,
+            "flood_score": 0.33,
+            "heat_score": 0.47,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,
@@ -79748,11 +82853,14 @@
             "pop_density": 0.1943539562301625,
             "pop_density_raw": 4635.501666666666,
             "flood_score": 0.2,
-            "heat_score": 0.29,
+            "heat_score": 0.37,
             "landslide_score": 0,
             "lakeside_risk": 0,
             "delta_risk": 0,
-            "low_elev_risk": 0
+            "low_elev_risk": 0,
+            "fri_raw": null,
+            "hwm_raw": 10.97,
+            "precip_trigger": null
           },
           "coverage": {
             "elevation": true,

--- a/scripts/recalc-scores-v2.ts
+++ b/scripts/recalc-scores-v2.ts
@@ -1,0 +1,349 @@
+/**
+ * Enhanced Risk Score Calculator v2
+ *
+ * Uses OEF's pre-computed raster indices (FRI, HWM) as foundation,
+ * enhanced with high-resolution local factors (terrain, land use, infrastructure).
+ *
+ * Philosophy:
+ * - FRI and HWM are computed by climate scientists with proper methodology
+ * - We don't replace them — we USE them as primary inputs
+ * - Local factors (river proximity, building density, vegetation) add urban-scale detail
+ * - Final score = raster foundation + local modifiers
+ *
+ * Usage: npx tsx scripts/recalc-scores-v2.ts
+ */
+
+import * as fs from 'fs';
+import { sampleValue, sampleAllLayers, SAMPLE_LAYERS, type LayerEncoding } from './tile-sampler.js';
+
+const gridPath = 'client/public/sample-data/porto-alegre-grid.json';
+const gridData = JSON.parse(fs.readFileSync(gridPath, 'utf-8'));
+
+const CELL_SIZE_METERS = gridData.cellSizeMeters || 1000;
+
+// Porto Alegre geography constants
+const LAKE_WEST_BOUNDARY = -51.23;
+const DELTA_CENTER_LAT = -30.05;
+const DELTA_CENTER_LNG = -51.22;
+
+// ── Normalization helpers ─────────────────────────────────────────────────────
+function clamp01(v: number): number { return Math.max(0, Math.min(1, v)); }
+function round2(v: number): number { return Math.round(v * 100) / 100; }
+
+// ── Stats tracking ────────────────────────────────────────────────────────────
+interface Stats {
+  count: number;
+  sum: number;
+  min: number;
+  max: number;
+  values: number[];
+}
+
+function newStats(): Stats { return { count: 0, sum: 0, min: Infinity, max: -Infinity, values: [] }; }
+function addStat(s: Stats, v: number) { s.count++; s.sum += v; s.min = Math.min(s.min, v); s.max = Math.max(s.max, v); s.values.push(v); }
+function avgStat(s: Stats): number { return s.count > 0 ? s.sum / s.count : 0; }
+function p50Stat(s: Stats): number { const sorted = [...s.values].sort((a, b) => a - b); return sorted[Math.floor(sorted.length / 2)] ?? 0; }
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  const cells = gridData.geoJson.features;
+  console.log(`Processing ${cells.length} cells with raster-enhanced scoring...\n`);
+
+  // First pass: elevation statistics for normalization
+  const elevations = cells.map((f: any) => f.properties.metrics.elevation_mean).filter((e: any) => e != null);
+  const p25Elev = [...elevations].sort((a: number, b: number) => a - b)[Math.floor(elevations.length * 0.25)];
+  console.log(`Elevation p25: ${p25Elev}m`);
+
+  // Sample raster layers at each cell centroid
+  console.log('Sampling raster tiles at cell centroids...');
+  const friLayer = SAMPLE_LAYERS.find(l => l.id === 'fri_2024')!;
+  const hwmLayer = SAMPLE_LAYERS.find(l => l.id === 'hwm_2024')!;
+  const hwm2030Layer = SAMPLE_LAYERS.find(l => l.id === 'hwm_2030s_245')!;
+  const chirpsRx1Layer = SAMPLE_LAYERS.find(l => l.id === 'chirps_rx1day_2024')!;
+  const chirpsR99pLayer = SAMPLE_LAYERS.find(l => l.id === 'chirps_r99p_2024')!;
+  const dwLayer = SAMPLE_LAYERS.find(l => l.id === 'dynamic_world')!;
+
+  // Batch sample all cells
+  const rasterData: Record<string, Record<string, number | null>> = {};
+  let sampled = 0;
+
+  for (const cell of cells) {
+    const [lng, lat] = cell.properties.centroid;
+    const cellId = cell.properties.id;
+
+    // Sample key layers (parallel per cell)
+    const [fri, hwm, hwm2030, rx1day, r99p, dw] = await Promise.all([
+      sampleValue(lat, lng, friLayer),
+      sampleValue(lat, lng, hwmLayer),
+      sampleValue(lat, lng, hwm2030Layer),
+      sampleValue(lat, lng, chirpsRx1Layer),
+      sampleValue(lat, lng, chirpsR99pLayer),
+      sampleValue(lat, lng, dwLayer),
+    ]);
+
+    rasterData[cellId] = { fri, hwm, hwm2030, rx1day, r99p, dw };
+    sampled++;
+    if (sampled % 100 === 0) process.stdout.write(`  ${sampled}/${cells.length}\r`);
+  }
+  console.log(`  Sampled ${sampled} cells\n`);
+
+  // ── Compute FRI statistics for normalization ────────────────────────────────
+  const friValues = Object.values(rasterData).map(d => d.fri).filter(v => v != null) as number[];
+  const friMax = Math.max(...friValues, 0.01);
+  const friP90 = [...friValues].sort((a, b) => a - b)[Math.floor(friValues.length * 0.9)] ?? friMax;
+  console.log(`FRI stats: max=${friMax.toFixed(3)}, p90=${friP90.toFixed(3)}, coverage=${friValues.length}/${cells.length}`);
+
+  const hwmValues = Object.values(rasterData).map(d => d.hwm ?? d.hwm2030).filter(v => v != null) as number[];
+  const hwmMax = Math.max(...hwmValues, 1);
+  const hwmP90 = [...hwmValues].sort((a, b) => a - b)[Math.floor(hwmValues.length * 0.9)] ?? hwmMax;
+  console.log(`HWM stats: max=${hwmMax.toFixed(1)}, p90=${hwmP90.toFixed(1)}, coverage=${hwmValues.length}/${cells.length}`);
+
+  const rx1Values = Object.values(rasterData).map(d => d.rx1day).filter(v => v != null) as number[];
+  const rx1Max = Math.max(...rx1Values, 1);
+  console.log(`CHIRPS Rx1day stats: max=${rx1Max.toFixed(1)}mm, coverage=${rx1Values.length}/${cells.length}`);
+
+  // ── Score tracking ──────────────────────────────────────────────────────────
+  const floodStats = newStats();
+  const heatStats = newStats();
+  const landslideStats = newStats();
+  const friCorrelation: Array<[number, number]> = []; // [our_score, fri_value]
+  const hwmCorrelation: Array<[number, number]> = [];
+
+  // ── Recalculate scores ──────────────────────────────────────────────────────
+  for (const cell of cells) {
+    const m = cell.properties.metrics;
+    const [lng, lat] = cell.properties.centroid;
+    const cellId = cell.properties.id;
+    const raster = rasterData[cellId] || {};
+
+    // Fix slope calculation
+    if (m.elevation_max != null && m.elevation_min != null) {
+      const elevRange = m.elevation_max - m.elevation_min;
+      m.slope_mean = Math.atan(elevRange / CELL_SIZE_METERS) * (180 / Math.PI);
+    }
+
+    // ── Extract local metrics ─────────────────────────────────────────────────
+    const flowAccumPct = m.flow_accum_pct ?? 0;
+    const depressionPct = m.depression_pct ?? 0;
+    const riverProx = m.river_prox_pct ?? 0;
+    const waterProx = m.floodplain_adj_pct ?? 0;
+    const lowLying = m.low_lying_pct ?? 0.5;
+    const imperv = m.imperv_pct ?? m.building_density ?? 0;
+    const slope = m.slope_mean ?? 0;
+    const elevation = m.elevation_mean ?? p25Elev;
+    const canopy = m.canopy_pct ?? 0;
+    const green = m.green_pct ?? 0;
+    const vegetation = Math.max(canopy, green);
+    const popDensity = m.pop_density ?? 0;
+    const buildingDensity = m.building_density ?? imperv;
+
+    m.vegetation_pct = vegetation;
+
+    // Water cooling
+    let waterCooling = 0;
+    if (m.dist_water_m != null) {
+      waterCooling = Math.max(0, 1 - m.dist_water_m / 5000);
+    } else if ((m.floodplain_adj_pct || 0) > 0 || (m.river_prox_pct || 0) > 0) {
+      waterCooling = Math.max(m.floodplain_adj_pct || 0, m.river_prox_pct || 0);
+    }
+    m.water_cooling = waterCooling;
+
+    // Dynamic World land class
+    const dwClass = raster.dw;
+    const isBuilt = dwClass === 6;
+    const isWater = dwClass === 0;
+    const isVegetated = dwClass === 1 || dwClass === 2 || dwClass === 3 || dwClass === 5;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FLOOD SCORE v2
+    // Foundation: OEF's FRI (Flood Risk Index) — calibrated composite index
+    // Enhancement: local hydrology + terrain + imperviousness
+    // ══════════════════════════════════════════════════════════════════════════
+
+    const fri = raster.fri;
+    const friNorm = fri != null ? clamp01(fri / Math.max(friMax, 0.01)) : null;
+
+    // Local physical factors (same as v1 but with DW-enhanced imperviousness)
+    const localImperv = isBuilt ? Math.max(imperv, 0.7) : imperv; // DW confirms built = high imperv
+    const flatness = slope > 0 ? Math.max(0, 1 - slope / 50) : 0.5;
+
+    const physicalFlood = (
+      0.25 * flowAccumPct +
+      0.20 * depressionPct +
+      0.20 * riverProx +
+      0.15 * lowLying +
+      0.10 * waterProx +
+      0.10 * flatness
+    );
+
+    // Location factors (Porto Alegre specific)
+    const distToLake = Math.max(0, lng - LAKE_WEST_BOUNDARY) / 0.10;
+    const lakesideRisk = Math.max(0, 1 - distToLake);
+    const distToDelta = Math.sqrt(Math.pow((lng - DELTA_CENTER_LNG) * 111, 2) + Math.pow((lat - DELTA_CENTER_LAT) * 111, 2));
+    const deltaRisk = Math.max(0, 1 - distToDelta / 20);
+    const lowElevRisk = elevation < 40 ? Math.max(0, 1 - (elevation - 20) / 30) : 0;
+
+    const locationFlood = 0.40 * lakesideRisk + 0.35 * lowElevRisk + 0.25 * deltaRisk;
+
+    // Imperviousness amplifier: impervious surfaces increase runoff
+    const runoffAmplifier = 1 + (localImperv * 0.3); // up to 30% boost
+
+    // Combine: if FRI is available, weight it heavily; otherwise fall back to local
+    let floodScore: number;
+    if (friNorm != null) {
+      // FRI-enhanced: 55% FRI + 25% local physical + 20% location
+      // No runoff amplifier on FRI path — FRI already accounts for land cover
+      floodScore = clamp01(
+        0.55 * friNorm +
+        0.25 * physicalFlood +
+        0.20 * locationFlood
+      );
+    } else {
+      // Fallback: same as v1
+      const combined = Math.max(physicalFlood, locationFlood * 0.8) + (physicalFlood * locationFlood * 0.3);
+      floodScore = clamp01(combined * runoffAmplifier);
+    }
+
+    m.flood_score = round2(floodScore);
+    m.fri_raw = fri != null ? round2(fri) : null;
+    m.lakeside_risk = round2(lakesideRisk);
+    m.delta_risk = round2(deltaRisk);
+    m.low_elev_risk = round2(lowElevRisk);
+
+    addStat(floodStats, floodScore);
+    if (fri != null) friCorrelation.push([floodScore, fri]);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // HEAT SCORE v2
+    // Foundation: OEF's HWM (Heatwave Magnitude) — °C·days above threshold
+    // Enhancement: urban heat island (building density, vegetation, albedo proxy)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    const hwm = raster.hwm ?? raster.hwm2030; // fall back to projection if 2024 unavailable
+    const hwmNorm = hwm != null ? clamp01(hwm / Math.max(hwmP90, 1)) : null;
+
+    // Urban Heat Island factors (high resolution)
+    // These drive local differentiation — which neighborhoods are hotter
+    const uhiFactor = (
+      0.40 * buildingDensity +           // Dense buildings trap heat (dominant)
+      0.30 * (1 - vegetation) +           // Lack of green = less cooling
+      0.15 * localImperv +                // Impervious surfaces
+      0.10 * popDensity +                 // Human heat generation
+      0.05 * (1 - waterCooling)           // Lack of water cooling
+    );
+
+    // HWM is a regional metric (~same value across the whole city).
+    // Use it as a gentle multiplier, not a direct input.
+    // If HWM is high (>8 °C·days), boost urban heat; if low, dampen it.
+    const hwmMultiplier = hwm != null ? 0.8 + (clamp01(hwm / 15) * 0.4) : 1.0; // range 0.8–1.2
+
+    let heatScore = clamp01(uhiFactor * hwmMultiplier);
+
+    // Green areas and water bodies should have genuinely low heat risk
+    if (isVegetated && vegetation > 0.5) heatScore *= 0.5;
+    if (isWater) heatScore = 0;
+
+    // Cap at 0.90 — 1.0 should be reserved for truly extreme cases
+    heatScore = Math.min(heatScore, 0.90);
+
+    m.heat_score = round2(heatScore);
+    m.hwm_raw = hwm != null ? round2(hwm) : null;
+
+    addStat(heatStats, heatScore);
+    if (hwm != null) hwmCorrelation.push([heatScore, hwm]);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // LANDSLIDE SCORE v2
+    // No pre-computed index available — terrain-based with precipitation trigger
+    // Enhancement: CHIRPS extreme precipitation as trigger intensity
+    // ══════════════════════════════════════════════════════════════════════════
+
+    const slopeRisk = slope >= 5 ? clamp01((slope - 3) / 12) : 0;
+    const lackOfVeg = 1 - vegetation;
+    const elevated = 1 - lowLying;
+
+    // Precipitation trigger: intense rainfall destabilizes slopes
+    const rx1day = raster.rx1day;
+    const precipTrigger = rx1day != null ? clamp01((rx1day - 40) / 80) : 0.5; // >40mm triggers, saturates at 120mm
+
+    // Deforestation amplifier: areas that lost forest are more unstable
+    // (we don't have this directly but DW bare/built on steep terrain is a proxy)
+    const bareOnSlope = (dwClass === 7 || dwClass === 6) && slope >= 5 ? 0.2 : 0;
+
+    let landslideScore: number;
+    if (slopeRisk > 0) {
+      landslideScore = clamp01(
+        0.50 * slopeRisk +                    // Slope is still dominant
+        0.20 * precipTrigger * slopeRisk +     // Rain on steep = trigger
+        0.15 * lackOfVeg * slopeRisk +         // No vegetation = less root cohesion
+        0.10 * elevated * slopeRisk +          // Higher = more potential energy
+        0.05 * bareOnSlope                     // Bare/built on steep = extra risk
+      );
+    } else {
+      landslideScore = 0;
+    }
+
+    m.landslide_score = round2(landslideScore);
+    m.precip_trigger = rx1day != null ? round2(rx1day) : null;
+
+    addStat(landslideStats, landslideScore);
+  }
+
+  // ── Print results ───────────────────────────────────────────────────────────
+  console.log('\n════════════════════════════════════════════════════════');
+  console.log('RISK SCORE DISTRIBUTION (v2 raster-enhanced)');
+  console.log('════════════════════════════════════════════════════════');
+  console.log(`Flood:     avg=${avgStat(floodStats).toFixed(3)}, median=${p50Stat(floodStats).toFixed(3)}, max=${floodStats.max.toFixed(2)}, min=${floodStats.min.toFixed(2)}`);
+  console.log(`Heat:      avg=${avgStat(heatStats).toFixed(3)}, median=${p50Stat(heatStats).toFixed(3)}, max=${heatStats.max.toFixed(2)}, min=${heatStats.min.toFixed(2)}`);
+  console.log(`Landslide: avg=${avgStat(landslideStats).toFixed(3)}, median=${p50Stat(landslideStats).toFixed(3)}, max=${landslideStats.max.toFixed(2)}, min=${landslideStats.min.toFixed(2)}`);
+
+  // Correlation with raw FRI
+  if (friCorrelation.length > 10) {
+    const friMean = friCorrelation.reduce((s, [, f]) => s + f, 0) / friCorrelation.length;
+    const scoreMean = friCorrelation.reduce((s, [sc]) => s + sc, 0) / friCorrelation.length;
+    let num = 0, denA = 0, denB = 0;
+    for (const [sc, f] of friCorrelation) {
+      num += (sc - scoreMean) * (f - friMean);
+      denA += (sc - scoreMean) ** 2;
+      denB += (f - friMean) ** 2;
+    }
+    const r = denA > 0 && denB > 0 ? num / Math.sqrt(denA * denB) : 0;
+    console.log(`\nFlood-FRI correlation: r=${r.toFixed(3)} (${friCorrelation.length} cells with FRI data)`);
+  }
+
+  if (hwmCorrelation.length > 10) {
+    const hwmMean = hwmCorrelation.reduce((s, [, h]) => s + h, 0) / hwmCorrelation.length;
+    const scoreMean = hwmCorrelation.reduce((s, [sc]) => s + sc, 0) / hwmCorrelation.length;
+    let num = 0, denA = 0, denB = 0;
+    for (const [sc, h] of hwmCorrelation) {
+      num += (sc - scoreMean) * (h - hwmMean);
+      denA += (sc - scoreMean) ** 2;
+      denB += (h - hwmMean) ** 2;
+    }
+    const r = denA > 0 && denB > 0 ? num / Math.sqrt(denA * denB) : 0;
+    console.log(`Heat-HWM correlation: r=${r.toFixed(3)} (${hwmCorrelation.length} cells with HWM data)`);
+  }
+
+  // Cell distribution
+  let floodDom = 0, heatDom = 0, landslideDom = 0, lowRisk = 0;
+  for (const cell of cells) {
+    const m = cell.properties.metrics;
+    const f = m.flood_score || 0;
+    const h = m.heat_score || 0;
+    const l = m.landslide_score || 0;
+    const max = Math.max(f, h, l);
+    if (max < 0.30) lowRisk++;
+    else if (max === l) landslideDom++;
+    else if (max === f) floodDom++;
+    else heatDom++;
+  }
+  console.log(`\nCells by dominant risk (threshold 0.30):`);
+  console.log(`  Flood: ${floodDom}, Heat: ${heatDom}, Landslide: ${landslideDom}, Low: ${lowRisk}`);
+
+  // ── Save ────────────────────────────────────────────────────────────────────
+  fs.writeFileSync(gridPath, JSON.stringify(gridData, null, 2));
+  console.log(`\n✓ Grid updated: ${gridPath}`);
+  console.log(`  New fields per cell: fri_raw, hwm_raw, precip_trigger`);
+}
+
+main().catch(console.error);

--- a/scripts/render-risk-maps.ts
+++ b/scripts/render-risk-maps.ts
@@ -1,0 +1,143 @@
+/**
+ * Render risk score maps as PNG images for visual validation.
+ * Uses the grid data to create color-coded maps of flood, heat, and landslide risk.
+ */
+
+import * as fs from 'fs';
+import { PNG } from 'pngjs';
+
+const gridPath = 'client/public/sample-data/porto-alegre-grid.json';
+const gridData = JSON.parse(fs.readFileSync(gridPath, 'utf-8'));
+
+const cells = gridData.geoJson.features;
+
+// Find grid bounds
+let minLng = Infinity, maxLng = -Infinity, minLat = Infinity, maxLat = -Infinity;
+for (const cell of cells) {
+  const [lng, lat] = cell.properties.centroid;
+  minLng = Math.min(minLng, lng);
+  maxLng = Math.max(maxLng, lng);
+  minLat = Math.min(minLat, lat);
+  maxLat = Math.max(maxLat, lat);
+}
+
+const CELL_SIZE = 0.009; // ~1km in degrees
+const width = Math.ceil((maxLng - minLng) / CELL_SIZE) + 2;
+const height = Math.ceil((maxLat - minLat) / CELL_SIZE) + 2;
+
+console.log(`Grid bounds: lng [${minLng.toFixed(3)}, ${maxLng.toFixed(3)}], lat [${minLat.toFixed(3)}, ${maxLat.toFixed(3)}]`);
+console.log(`Image size: ${width}×${height} pixels (1 pixel = ~1km)\n`);
+
+// Color scales
+function floodColor(v: number): [number, number, number] {
+  if (v >= 0.7) return [29, 78, 216];   // dark blue
+  if (v >= 0.5) return [59, 130, 246];  // blue
+  if (v >= 0.3) return [96, 165, 250];  // light blue
+  if (v >= 0.15) return [147, 197, 253]; // very light blue
+  return [219, 234, 254];                // near white
+}
+
+function heatColor(v: number): [number, number, number] {
+  if (v >= 0.7) return [153, 27, 27];   // dark red
+  if (v >= 0.5) return [220, 38, 38];   // red
+  if (v >= 0.3) return [248, 113, 113]; // light red
+  if (v >= 0.15) return [252, 165, 165]; // pink
+  return [254, 226, 226];                // near white
+}
+
+function landslideColor(v: number): [number, number, number] {
+  if (v >= 0.5) return [120, 53, 15];   // dark amber
+  if (v >= 0.3) return [161, 98, 7];    // amber
+  if (v >= 0.15) return [202, 138, 4];  // yellow-amber
+  if (v >= 0.05) return [234, 179, 8];  // yellow
+  return [254, 243, 199];                // near white
+}
+
+function compositeColor(f: number, h: number, l: number): [number, number, number] {
+  // Blend flood (blue), heat (red), landslide (amber) by dominance
+  const max = Math.max(f, h, l);
+  if (max < 0.15) return [240, 240, 240]; // gray for low risk
+  const total = f + h + l || 1;
+  const rf = f / total, rh = h / total, rl = l / total;
+  const fc = floodColor(f), hc = heatColor(h), lc = landslideColor(l);
+  return [
+    Math.round(rf * fc[0] + rh * hc[0] + rl * lc[0]),
+    Math.round(rf * fc[1] + rh * hc[1] + rl * lc[1]),
+    Math.round(rf * fc[2] + rh * hc[2] + rl * lc[2]),
+  ];
+}
+
+// Render function
+function renderMap(
+  name: string,
+  getColor: (m: any) => [number, number, number],
+  getAlpha: (m: any) => number = () => 255,
+) {
+  const scale = 4; // 4x upscale for better visibility
+  const png = new PNG({ width: width * scale, height: height * scale });
+
+  // Fill with white
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = 250; png.data[i + 1] = 250; png.data[i + 2] = 250; png.data[i + 3] = 255;
+  }
+
+  for (const cell of cells) {
+    const [lng, lat] = cell.properties.centroid;
+    const m = cell.properties.metrics;
+    const col = Math.round((lng - minLng) / CELL_SIZE);
+    const row = Math.round((maxLat - lat) / CELL_SIZE); // flip Y
+    const [r, g, b] = getColor(m);
+    const alpha = getAlpha(m);
+
+    // Fill scaled pixel block
+    for (let dy = 0; dy < scale; dy++) {
+      for (let dx = 0; dx < scale; dx++) {
+        const px = col * scale + dx;
+        const py = row * scale + dy;
+        if (px >= 0 && px < width * scale && py >= 0 && py < height * scale) {
+          const idx = (py * width * scale + px) * 4;
+          png.data[idx] = r;
+          png.data[idx + 1] = g;
+          png.data[idx + 2] = b;
+          png.data[idx + 3] = alpha;
+        }
+      }
+    }
+  }
+
+  const outPath = `scripts/output/${name}.png`;
+  fs.mkdirSync('scripts/output', { recursive: true });
+  fs.writeFileSync(outPath, PNG.sync.write(png));
+  console.log(`  ✓ ${outPath} (${width * scale}×${height * scale})`);
+}
+
+console.log('Rendering risk maps...\n');
+
+renderMap('flood-risk-v2', m => floodColor(m.flood_score || 0));
+renderMap('heat-risk-v2', m => heatColor(m.heat_score || 0));
+renderMap('landslide-risk-v2', m => landslideColor(m.landslide_score || 0));
+renderMap('composite-risk-v2', m => compositeColor(m.flood_score || 0, m.heat_score || 0, m.landslide_score || 0));
+
+// FRI raw comparison
+renderMap('fri-raw', m => {
+  const v = m.fri_raw ?? 0;
+  return floodColor(v);
+});
+
+// Difference map: our flood score vs FRI
+renderMap('flood-vs-fri-diff', m => {
+  const diff = (m.flood_score || 0) - (m.fri_raw || 0); // positive = our score higher
+  if (diff > 0.2) return [220, 38, 38];  // red: we're much higher
+  if (diff > 0.1) return [248, 113, 113]; // light red
+  if (diff > -0.1) return [200, 200, 200]; // gray: similar
+  if (diff > -0.2) return [96, 165, 250]; // light blue: we're lower
+  return [29, 78, 216]; // dark blue: we're much lower
+});
+
+console.log('\nDone. Open scripts/output/ to view maps.');
+console.log('Legend:');
+console.log('  Flood:     dark blue (high) → light blue → white (low)');
+console.log('  Heat:      dark red (high) → pink → white (low)');
+console.log('  Landslide: dark amber (high) → yellow → white (low)');
+console.log('  Composite: blend of all three by dominance');
+console.log('  Flood-vs-FRI: red = our score higher, blue = FRI higher, gray = similar');

--- a/scripts/tile-sampler.ts
+++ b/scripts/tile-sampler.ts
@@ -1,0 +1,207 @@
+/**
+ * Server-side tile value sampler.
+ * Fetches PNG value tiles from S3, decodes RGB→numeric values.
+ * Used by recalc-scores-v2.ts to sample FRI, HWM, CHIRPS, Dynamic World
+ * at grid cell centroids.
+ */
+
+import { PNG } from 'pngjs';
+
+const S3_BASE = 'https://geo-test-api.s3.us-east-1.amazonaws.com';
+
+// ── Tile coordinate conversion (same as client-side valueTileUtils.ts) ────────
+export function latLngToTilePixel(lat: number, lng: number, z: number) {
+  const n = Math.pow(2, z);
+  const latR = (lat * Math.PI) / 180;
+  const mercY = (1 - Math.log(Math.tan(latR) + 1 / Math.cos(latR)) / Math.PI) / 2;
+
+  const tileX = Math.floor(((lng + 180) / 360) * n);
+  const tileY = Math.floor(mercY * n);
+  const px = Math.floor((((lng + 180) / 360) * n - tileX) * 256);
+  const py = Math.floor((mercY * n - tileY) * 256);
+
+  return {
+    tileX: Math.max(0, Math.min(n - 1, tileX)),
+    tileY: Math.max(0, Math.min(n - 1, tileY)),
+    px: Math.max(0, Math.min(255, px)),
+    py: Math.max(0, Math.min(255, py)),
+  };
+}
+
+// ── Layer definitions with value tile encoding ────────────────────────────────
+export interface LayerEncoding {
+  id: string;
+  name: string;
+  type: 'numeric' | 'categorical';
+  scale?: number;
+  offset?: number;
+  unit?: string;
+  urlTemplate: string;
+  classes?: Record<number, string>;
+}
+
+const vtUrl = (path: string) => `${S3_BASE}/${path}/tiles_values/{z}/{x}/{y}.png`;
+
+export const SAMPLE_LAYERS: LayerEncoding[] = [
+  // Flood Risk Index
+  { id: 'fri_2024', name: 'Flood Risk Index 2024', type: 'numeric', scale: 100, offset: 6, unit: 'index 0–1',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/floods/flood_risk_index/oef_calculation/2024') },
+
+  // Heatwave Magnitude
+  { id: 'hwm_2024', name: 'Heatwave Magnitude 2024', type: 'numeric', scale: 100, offset: 600, unit: '°C·days',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/heatwave_indices/hwm/2024') },
+
+  // Precipitation extremes (key ones)
+  { id: 'chirps_rx1day_2024', name: 'Max 1-Day Precip 2024', type: 'numeric', scale: 100, offset: 6459, unit: 'mm',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/extreme_precipitation/chirps/V2_0/2024/rx1day') },
+  { id: 'chirps_r99p_2024', name: 'Precip 99th Percentile 2024', type: 'numeric', scale: 100, offset: 12196, unit: 'mm',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/extreme_precipitation/chirps/V2_0/2024/r99p') },
+
+  // Land use (categorical)
+  { id: 'dynamic_world', name: 'Land Use (Dynamic World)', type: 'categorical',
+    urlTemplate: vtUrl('dynamic_world/release/v1/2023/porto_alegre'),
+    classes: { 0: 'Water', 1: 'Trees', 2: 'Grass', 3: 'Flooded veg', 4: 'Crops', 5: 'Shrub', 6: 'Built', 7: 'Bare', 8: 'Snow' } },
+
+  // Future projections for comparison
+  { id: 'fri_2050s_585', name: 'FRI 2050s SSP5-8.5', type: 'numeric', scale: 100, offset: 0, unit: 'index 0–1',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/floods/flood_risk_index/oef_calculation/2050s_ssp585') },
+  { id: 'hwm_2030s_245', name: 'HWM 2030s SSP2-4.5', type: 'numeric', scale: 100, offset: 1035, unit: '°C·days',
+    urlTemplate: vtUrl('nbs/porto_alegre/climate_hazards/heatwave_indices/hwm/2030s_ssp245') },
+];
+
+// ── Tile cache ────────────────────────────────────────────────────────────────
+const tileCache = new Map<string, Buffer | null>();
+const pendingFetches = new Map<string, Promise<Buffer | null>>();
+
+async function fetchTileBuffer(url: string): Promise<Buffer | null> {
+  if (tileCache.has(url)) return tileCache.get(url)!;
+  if (pendingFetches.has(url)) return pendingFetches.get(url)!;
+
+  const promise = (async () => {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      if (!response.ok) { tileCache.set(url, null); return null; }
+      const buffer = Buffer.from(await response.arrayBuffer());
+      tileCache.set(url, buffer);
+      return buffer;
+    } catch {
+      tileCache.set(url, null);
+      return null;
+    }
+  })();
+
+  pendingFetches.set(url, promise);
+  const result = await promise;
+  pendingFetches.delete(url);
+  return result;
+}
+
+function decodePNG(buffer: Buffer): { width: number; height: number; data: Uint8Array } | null {
+  try {
+    const png = PNG.sync.read(buffer);
+    return { width: png.width, height: png.height, data: png.data };
+  } catch {
+    return null;
+  }
+}
+
+// ── Sample a single value at lat/lng ──────────────────────────────────────────
+export async function sampleValue(
+  lat: number, lng: number,
+  layer: LayerEncoding,
+  z = 11
+): Promise<number | null> {
+  const { tileX, tileY, px, py } = latLngToTilePixel(lat, lng, z);
+  const url = layer.urlTemplate
+    .replace('{z}', String(z))
+    .replace('{x}', String(tileX))
+    .replace('{y}', String(tileY));
+
+  const buffer = await fetchTileBuffer(url);
+  if (!buffer) return null;
+
+  const png = decodePNG(buffer);
+  if (!png) return null;
+
+  const i = (py * 256 + px) * 4;
+  const r = png.data[i];
+  const g = png.data[i + 1];
+  const b = png.data[i + 2];
+  const a = png.data[i + 3];
+
+  if (a < 10) return null; // nodata
+
+  if (layer.type === 'categorical') return r;
+
+  const raw = r + 256 * g + 65536 * b;
+  const scale = layer.scale ?? 100;
+  const offset = layer.offset ?? 0;
+  const value = (raw + offset) / scale;
+  return isFinite(value) ? value : null;
+}
+
+// ── Batch sample all layers at a single point ─────────────────────────────────
+export async function sampleAllLayers(
+  lat: number, lng: number,
+  layers: LayerEncoding[] = SAMPLE_LAYERS,
+  z = 11
+): Promise<Record<string, number | null>> {
+  const results: Record<string, number | null> = {};
+  await Promise.all(
+    layers.map(async (layer) => {
+      results[layer.id] = await sampleValue(lat, lng, layer, z);
+    })
+  );
+  return results;
+}
+
+// ── Sample with grid-level averaging (sample multiple points within cell) ─────
+export async function sampleCellAverage(
+  lat: number, lng: number,
+  cellSizeKm: number,
+  layer: LayerEncoding,
+  z = 11,
+  samples = 5 // 5x5 grid within cell
+): Promise<number | null> {
+  const halfDeg = (cellSizeKm / 111) / 2;
+  const values: number[] = [];
+
+  for (let dy = 0; dy < samples; dy++) {
+    for (let dx = 0; dx < samples; dx++) {
+      const sLat = lat - halfDeg + (dy / (samples - 1)) * halfDeg * 2;
+      const sLng = lng - halfDeg + (dx / (samples - 1)) * halfDeg * 2;
+      const v = await sampleValue(sLat, sLng, layer, z);
+      if (v !== null) values.push(v);
+    }
+  }
+
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+// ── CLI test ──────────────────────────────────────────────────────────────────
+if (process.argv[1]?.includes('tile-sampler')) {
+  (async () => {
+    // Test: sample all layers at Porto Alegre city center
+    const lat = -30.0346;
+    const lng = -51.2177;
+    console.log(`Sampling at Porto Alegre center (${lat}, ${lng})...\n`);
+
+    for (const layer of SAMPLE_LAYERS) {
+      const value = await sampleValue(lat, lng, layer);
+      if (layer.type === 'categorical' && value !== null) {
+        console.log(`  ${layer.name}: ${layer.classes?.[value] || `Class ${value}`}`);
+      } else if (value !== null) {
+        console.log(`  ${layer.name}: ${value.toFixed(3)} ${layer.unit}`);
+      } else {
+        console.log(`  ${layer.name}: nodata`);
+      }
+    }
+
+    // Test cell averaging
+    console.log(`\n--- Cell average (1km) ---`);
+    const friLayer = SAMPLE_LAYERS.find(l => l.id === 'fri_2024')!;
+    const avg = await sampleCellAverage(lat, lng, 1, friLayer, 11, 3);
+    console.log(`  FRI 2024 (3x3 avg): ${avg?.toFixed(3) ?? 'nodata'}`);
+  })();
+}


### PR DESCRIPTION
## Summary

Risk scores now use OEF's pre-computed satellite indices (FRI, HWM, CHIRPS) as foundation, enhanced with high-resolution local factors.

| Risk | Foundation | Correlation | Avg | Max |
|------|-----------|-------------|-----|-----|
| Flood | FRI 2024 (55%) | r=0.898 | 0.443 | 0.78 |
| Heat | HWM regional mult. | r=0.330 | 0.374 | 0.90 |
| Landslide | Slope + CHIRPS trigger | — | 0.026 | 0.58 |

New scripts: tile-sampler.ts (server-side S3 decoder), recalc-scores-v2.ts (enhanced pipeline), render-risk-maps.ts (PNG validation).

## Test plan

- [ ] Run `npx tsx scripts/recalc-scores-v2.ts` — should sample 1036 cells, output stats
- [ ] Run `npx tsx scripts/render-risk-maps.ts` — generates 6 PNG maps in scripts/output/
- [ ] Verify flood map shows high risk near Lake Guaíba (west)
- [ ] Verify heat map shows high risk in urban core
- [ ] Check grid on map in the app — colors should reflect updated scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)