### PR TITLE
fix: zones toggle + Risk Analysis 250m in site-explorer

### DIFF
--- a/client/src/core/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/core/components/concept-note/ConceptNoteMap.tsx
@@ -107,7 +107,7 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const gridLayerRef = useRef<L.GeoJSON | null>(null);
   const zonesLayerRef = useRef<L.GeoJSON | null>(null);
-  const zonesGroupRef = useRef<L.LayerGroup | null>(null); // contains zones + labels as one unit
+  const zoneLabelMarkersRef = useRef<L.Marker[]>([]);
 
   const [selectedZones, setSelectedZones] = useState<Set<string>>(new Set());
   const [zoneData, setZoneData] = useState<ZoneProperties[]>([]);
@@ -196,10 +196,11 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
           gridLayerRef.current = gridLayer;
         }
 
-        // Zones — outlined, clickable, wrapped in a single layer group for clean toggle
+        // Zones — outlined, clickable
+        // Labels tracked separately for clean toggle
         setZoneData(zonesData.zones || []);
         if (zonesData.geoJson) {
-          const zonesGroup = L.layerGroup();
+          const labels: L.Marker[] = [];
           const zonesLayer = L.geoJSON(zonesData.geoJson, {
             style: () => ({
               color: '#1e293b',
@@ -212,17 +213,17 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
               const props = feature.properties as ZoneProperties;
               if (!props?.zoneId) return;
 
-              // Zone label — added to group, not directly to map
+              // Zone label — collect now, add to map after
               const center = (layer as any).getBounds?.()?.getCenter?.();
               if (center) {
-                L.marker(center, {
+                labels.push(L.marker(center, {
                   icon: L.divIcon({
                     className: 'zone-label',
                     html: `<div style="background:white;border:1px solid #cbd5e1;border-radius:4px;padding:1px 5px;font-size:10px;font-weight:600;white-space:nowrap;box-shadow:0 1px 2px rgba(0,0,0,0.1)">${props.zoneId.replace('zone_', 'Z')}</div>`,
                     iconSize: [0, 0],
                     iconAnchor: [20, 10],
                   }),
-                }).addTo(zonesGroup);
+                }));
               }
 
               layer.on({
@@ -244,10 +245,11 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
               });
             },
           });
-          zonesLayer.addTo(zonesGroup);
-          zonesGroup.addTo(map);
+          zonesLayer.addTo(map);
           zonesLayerRef.current = zonesLayer;
-          zonesGroupRef.current = zonesGroup;
+          // Add labels to map and track them
+          for (const m of labels) m.addTo(map);
+          zoneLabelMarkersRef.current = labels;
         }
       } catch (e) {
         console.error('[map] Load error:', e);
@@ -272,15 +274,19 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
     });
   }, [activeLayer, showGrid]);
 
-  // Toggle entire zones group (polygons + labels) on/off the map
+  // Toggle zones: remove/add BOTH the GeoJSON layer AND label markers individually
   useEffect(() => {
     const map = mapRef.current;
-    const group = zonesGroupRef.current;
-    if (!map || !group) return;
+    if (!map) return;
+    const zl = zonesLayerRef.current;
+    const labels = zoneLabelMarkersRef.current;
+
     if (showZones) {
-      if (!map.hasLayer(group)) group.addTo(map);
+      if (zl && !map.hasLayer(zl)) zl.addTo(map);
+      for (const m of labels) { if (!map.hasLayer(m)) m.addTo(map); }
     } else {
-      if (map.hasLayer(group)) map.removeLayer(group);
+      if (zl && map.hasLayer(zl)) map.removeLayer(zl);
+      for (const m of labels) { if (map.hasLayer(m)) map.removeLayer(m); }
     }
   }, [showZones]);
 

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -36,7 +36,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES } from '@shared/geospatial-layers';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS } from '@shared/geospatial-layers';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
 import ValueTooltip from '@/core/components/concept-note/ValueTooltip';
 
@@ -78,7 +78,7 @@ interface CityInfo {
 }
 
 type LayerSource = 'geojson' | 'tiles';
-type LayerGroupId = 'analysis' | 'environment' | 'osm_reference' | 'spatial_queries' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
+type LayerGroupId = 'analysis' | 'environment' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
 
 interface LayerState {
   id: string;
@@ -131,6 +131,19 @@ const LAYER_CONFIGS: LayerConfig[] = [
     group: 'spatial_queries' as LayerGroupId,
     available: true,
   })),
+  // Local 250m risk layers (pre-rendered tiles)
+  ...LOCAL_RISK_LAYERS.map(l => ({
+    id: l.id,
+    name: l.name,
+    icon: AlertTriangle,
+    color: l.color,
+    source: 'tiles' as LayerSource,
+    group: 'risk_250m' as LayerGroupId,
+    available: true,
+    tileLayerId: l.tileLayerId,
+    hasValueTiles: l.hasValueTiles,
+    valueEncoding: l.valueEncoding,
+  })),
   // OEF tile layers — generated from shared catalog (48 layers)
   ...TILE_LAYERS.filter(l => l.available).map(l => ({
     id: l.id,
@@ -147,7 +160,8 @@ const LAYER_CONFIGS: LayerConfig[] = [
 ];
 
 const LAYER_GROUPS: readonly { id: LayerGroupId; label: string }[] = [
-  { id: 'analysis', label: 'Risk Analysis' },
+  { id: 'risk_250m', label: 'Risk Analysis (250m)' },
+  { id: 'analysis', label: 'Grid Analysis' },
   { id: 'environment', label: 'Environment' },
   { id: 'osm_reference', label: 'OSM Reference' },
   { id: 'spatial_queries', label: 'Spatial Queries' },


### PR DESCRIPTION
Zones toggle now uses direct map.removeLayer (no LayerGroup wrapper). Also adds Risk Analysis (250m) group to site-explorer sidebar.