### PR TITLE
fix: remove duplicate grid selector + fix site-explorer risk tiles

### DIFF
--- a/client/src/core/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/core/components/concept-note/ConceptNoteMap.tsx
@@ -577,22 +577,6 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
             </button>
             {expandedGroups.has('risk_analysis') && (
               <div className="px-1 pb-1 space-y-0.5">
-                {/* Grid coloring selector */}
-                {showGrid && (
-                  <div className="flex items-center gap-0.5 px-1 py-1 mb-1">
-                    <span className="text-[9px] text-muted-foreground mr-1">Grid:</span>
-                    {(['flood', 'heat', 'landslide'] as const).map(r => (
-                      <button key={r} onClick={() => setActiveLayer(r)}
-                        className={`px-1.5 py-0.5 rounded text-[9px] transition-all ${
-                          activeLayer === r
-                            ? r === 'flood' ? 'bg-blue-100 text-blue-700' : r === 'heat' ? 'bg-red-100 text-red-700' : 'bg-amber-100 text-amber-700'
-                            : 'text-muted-foreground hover:bg-muted/50'
-                        }`}>
-                        {r.charAt(0).toUpperCase() + r.slice(1)}
-                      </button>
-                    ))}
-                  </div>
-                )}
                 {LOCAL_RISK_LAYERS.filter(l => l.id !== 'risk_composite_hotspot').map(layer => {
                   const isOn = enabledTileLayers.has(layer.id);
                   return (

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -1664,12 +1664,16 @@ export default function SiteExplorerPage() {
 
   const createTileLayer = useCallback((layerConfig: LayerState): L.TileLayer | null => {
     if (!layerConfig.tileLayerId) return null;
-    const tileUrl = `/api/geospatial/tiles/${layerConfig.tileLayerId}/{z}/{x}/{y}.png`;
+    // Local risk tiles use /tiles/ path, S3 tiles use the proxy
+    const isLocal = layerConfig.tileLayerId.startsWith('_local_');
+    const tileUrl = isLocal
+      ? `/tiles/${layerConfig.tileLayerId.replace('_local_', '')}/{z}/{x}/{y}.png`
+      : `/api/geospatial/tiles/${layerConfig.tileLayerId}/{z}/{x}/{y}.png`;
     return L.tileLayer(tileUrl, {
       opacity: 0.7,
-      maxNativeZoom: 15,
+      maxNativeZoom: isLocal ? 14 : 15,
       maxZoom: 19,
-      minZoom: 10,
+      minZoom: isLocal ? 10 : 10,
       errorTileUrl: '',
       className: 'oef-tile-layer',
     });


### PR DESCRIPTION
Removes Grid:Flood/Heat/Landslide from sidebar. Fixes site-explorer local tile path for 250m risk layers.