### PR TITLE
fix: census layer gradient by poverty rate

### DIFF
--- a/client/src/core/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/core/components/concept-note/ConceptNoteMap.tsx
@@ -668,7 +668,18 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
                             const rawData = await res.json();
                             const geojson = rawData.geoJson || rawData;
                             const lyr = L.geoJSON(geojson, {
-                              style: { color: layer.color, weight: 1.5, fillColor: layer.color, fillOpacity: 0.3, opacity: 0.7 },
+                              style: (feature) => {
+                                const p = feature?.properties || {};
+                                // Census: color by poverty rate (darker = higher poverty)
+                                if (p.poverty_rate != null) {
+                                  const pov = p.poverty_rate;
+                                  const r = Math.round(100 + pov * 800); // 100-255
+                                  const g = Math.round(50 - pov * 50);   // 50-0
+                                  const b = Math.round(180 - pov * 80);  // 180-100
+                                  return { color: `rgb(${Math.min(255,r)},${Math.max(0,g)},${Math.max(0,b)})`, weight: 1.5, fillColor: `rgb(${Math.min(255,r)},${Math.max(0,g)},${Math.max(0,b)})`, fillOpacity: 0.15 + pov * 3, opacity: 0.8 };
+                                }
+                                return { color: layer.color, weight: 1.5, fillColor: layer.color, fillOpacity: 0.3, opacity: 0.7 };
+                              },
                               onEachFeature: (f, l) => {
                                 const p = f.properties || {};
                                 const name = p.neighbourhood_name || p.settlement_name || p.event || 'Feature';

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -1378,8 +1378,11 @@ export default function SiteExplorerPage() {
           return L.geoJSON(data.geoJson, {
             style: (feature) => {
               const pov = feature?.properties?.poverty_rate ?? 0;
-              const opacity = Math.min(0.7, pov * 5);
-              return { color: '#a855f7', weight: 1.5, fillColor: '#a855f7', fillOpacity: opacity, opacity: 0.8 };
+              const r = Math.min(255, Math.round(100 + pov * 800));
+              const g = Math.max(0, Math.round(50 - pov * 50));
+              const b = Math.max(0, Math.round(180 - pov * 80));
+              const c = `rgb(${r},${g},${b})`;
+              return { color: c, weight: 1.5, fillColor: c, fillOpacity: 0.15 + pov * 3, opacity: 0.8 };
             },
             onEachFeature: (feature, layer) => {
               const p = feature.properties || {};


### PR DESCRIPTION
Neighborhoods colored by poverty rate (light→dark). Both ConceptNoteMap and site-explorer.