### PR TITLE
fix: keyboard nav for multi-select questions + input focus

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -159,7 +159,7 @@ export default function CboProfilePage() {
       if (e.key === 'ArrowDown') {
         if (isInInput) return;
         e.preventDefault();
-        if (selectedOptionIdx >= opts.length - 1) { inputRef.current?.focus(); } else { setSelectedOptionIdx(p => p + 1); }
+        if (selectedOptionIdx >= opts.length - 1) { setSelectedOptionIdx(-1); inputRef.current?.focus(); } else { setSelectedOptionIdx(p => p + 1); }
         return;
       }
       if (e.key === 'ArrowUp') {
@@ -674,16 +674,18 @@ function CboQuestionCard({
       <div className="space-y-1.5">
         {question.options.map((opt: any, i: number) => {
           const letter = String.fromCharCode(65 + i);
-          const isSelected = isMulti ? multiSet.has(opt.label) : (i === selectedIdx);
+          const isChecked = isMulti && multiSet.has(opt.label);
+          const isFocused = i === selectedIdx;
+          const isHighlighted = isMulti ? isChecked : isFocused;
           return (
             <button key={i} onClick={() => handleClick(opt.label)}
               className={`w-full text-left px-3 py-2 rounded-md border text-sm transition-all flex items-start gap-2 ${
-                isSelected ? 'border-green-600 bg-green-50 ring-1 ring-green-600' : 'border-muted hover:border-green-400'
+                isHighlighted ? 'border-green-600 bg-green-50 ring-1 ring-green-600' : isFocused ? 'border-green-400 bg-green-50/50 ring-1 ring-green-400' : 'border-muted hover:border-green-400'
               } ${disabled ? 'opacity-50' : 'cursor-pointer'}`}>
               <span className={`inline-flex items-center justify-center w-6 h-6 rounded text-xs font-mono shrink-0 ${
-                isSelected ? 'bg-green-600 text-white' : 'bg-muted text-muted-foreground'
+                isChecked ? 'bg-green-600 text-white' : isFocused ? 'bg-green-100 text-green-700' : 'bg-muted text-muted-foreground'
               }`}>
-                {isMulti && isSelected ? <Check className="w-3 h-3" /> : letter}
+                {isMulti && isChecked ? <Check className="w-3 h-3" /> : letter}
               </span>
               <div className="flex-1">
                 <span className="font-medium">{opt.label}</span>

--- a/client/src/core/pages/concept-note.tsx
+++ b/client/src/core/pages/concept-note.tsx
@@ -256,7 +256,8 @@ export default function ConceptNotePage() {
         if (isInInput) return; // let input handle it
         e.preventDefault();
         if (selectedOptionIdx >= opts.length - 1) {
-          // Past last option → focus input
+          // Past last option → focus input, deselect option
+          setSelectedOptionIdx(-1);
           inputRef.current?.focus();
         } else {
           setSelectedOptionIdx(prev => prev + 1);
@@ -1175,25 +1176,29 @@ function QuestionCard({
       <div className="space-y-1.5">
         {question.options.map((opt, i) => {
           const letter = String.fromCharCode(65 + i);
-          const isSelected = isMulti ? multiSet.has(opt.label) : (isActive && i === selectedIdx);
+          const isChecked = isMulti && multiSet.has(opt.label);
+          const isFocused = isActive && i === selectedIdx;
+          const isHighlighted = isMulti ? isChecked : isFocused;
           const isRecommended = opt.recommended;
 
           return (
             <button
               key={i}
               role="option"
-              aria-selected={isSelected}
+              aria-selected={isHighlighted}
               onClick={() => handleOptionClick(opt.label)}
               className={`w-full text-left px-3 py-2 rounded-md border text-sm transition-all flex items-start gap-2 ${
-                isSelected
+                isHighlighted
                   ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : isFocused
+                  ? 'border-primary/50 bg-primary/5 ring-1 ring-primary/50'
                   : 'border-muted hover:border-primary/50 hover:bg-muted/50'
               } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
               <span className={`inline-flex items-center justify-center w-6 h-6 rounded text-xs font-mono shrink-0 ${
-                isSelected ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+                isChecked ? 'bg-primary text-primary-foreground' : isFocused ? 'bg-primary/20 text-primary' : 'bg-muted text-muted-foreground'
               }`}>
-                {isMulti && isSelected ? <Check className="w-3 h-3" /> : letter}
+                {isMulti && isChecked ? <Check className="w-3 h-3" /> : letter}
               </span>
               <div className="flex-1 min-w-0">
                 <span className="font-medium">{opt.label}</span>


### PR DESCRIPTION
## Summary
- **Multi-select focus ring**: Arrow keys now show a lighter focus ring on the navigated option, separate from the checked state (solid green). Previously arrows changed internal index but nothing was visually indicated.
- **Input focus deselection**: Arrow-down past the last option now deselects it (no highlight) before focusing the text input. Previously the last option stayed green-highlighted even when typing in the input.

Applied to both `CboQuestionCard` (cbo-profile.tsx) and `QuestionCard` (concept-note.tsx).

## Test plan
- [ ] Multi-select question: press arrow down/up — verify focus ring moves between options
- [ ] Press Enter on focused option — verify it toggles the checkmark
- [ ] Arrow down past last option — verify last option loses highlight and input gets focus
- [ ] Arrow up from input — verify it returns to last option with focus ring
- [ ] Single-select: verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)