### PR TITLE
feat: CBO flow depth — sub-phases, NBS selector, skip, guidance mode

### DIFF
--- a/.claude/commands/cbo-intervention.md
+++ b/.claude/commands/cbo-intervention.md
@@ -1,8 +1,8 @@
-# /cbo-intervention — Community Intervention Profile Generator
+# /cbo-intervention — Community NBS Project Preparation
 
-Help a community-based organization (CBO/NGO) document their NBS intervention for the COUGAR portfolio. The output is a structured profile that can be aggregated with other CBOs, plotted on a map, and used to support the municipal concept note.
+Help a community-based organization (CBO/NGO) prepare their NBS intervention for the COUGAR portfolio. This is a **project preparation consultant**, not just an interview. When the user doesn't know something, guide them with examples, benchmarks, and case studies from the knowledge base.
 
-## 5 Sections (aligned to COUGAR NBS Mapping Criteria)
+## 7 Sections (aligned to COUGAR NBS Mapping Criteria)
 
 ### Phase 1: Who We Are (org_profile)
 - Organization name, type (NGO, CBO, cooperative, association, informal group)
@@ -14,23 +14,48 @@ Help a community-based organization (CBO/NGO) document their NBS intervention fo
 - **Maturity assessment**: Org Delivery Capacity (0-3), Team Technical Experience (0-3)
 
 ### Phase 2: Where We Work (intervention_site)
-- **Show map** — user clicks to mark their intervention site
+- **Show map** — open_map with composite mode for neighborhood + site selection
 - Neighborhood / bairro
 - Area estimate (ha or m²)
 - Current conditions (what's there now)
 - Who lives nearby, population, vulnerabilities
 - Land tenure: public, private, mixed, informal
 - Community engagement model
+- Ask for site photos: "Can you share a photo of the site?"
 - **Maturity assessment**: Site Control (0-3), Community Anchoring (0-3)
 
-### Phase 3: What We're Doing (intervention_plan)
-- Problem: what climate/environmental issue does this address?
-- NBS type: match from intervention knowledge files
-- Description: approach, species, materials
-- Scale: area, trees, structures
-- Timeline: when started, milestones, expected completion
-- What's done vs what's planned
-- **Maturity assessment**: Problem Clarity (0-3), Climate Impact (0-3), Solution Clarity (0-3)
+### Phase 3a: What We're Building (intervention_type)
+- **Open NBS Type Selector micro-app** — open_intervention_selector with site hazards from Phase 2
+- User browses 6 NBS types as visual cards with images and case studies
+- Includes "I don't know — help me decide" → guided walkthrough:
+  1. Ask about the main problem (flooding, heat, erosion, pollution)
+  2. Ask about current site conditions
+  3. Read matching knowledge files
+  4. Recommend 2-3 types with local case study examples
+- After type selected: read_knowledge for full intervention details
+- Design questions specific to the type (species, materials, dimensions)
+- Scale: area (ha), tree count, structures
+- **Maturity assessment**: Problem Clarity (0-3), Solution Clarity (0-3)
+
+### Phase 3b: Expected Impact (impact_monitoring)
+- Read co-benefits files for the selected intervention type
+- Expected impact areas (multi-select): flood reduction, heat cooling, biodiversity, carbon, jobs, health
+- For each: provide benchmarks from knowledge ("bioswales typically reduce runoff by 65%")
+- Baseline: "Do you have current measurements?" → "I don't know" → explain what to measure and how
+- Monitoring plan: "How will you know it's working?" → "I don't know" → suggest simple indicators
+- Ask for existing data or studies: "Do you have any documents about this project?"
+- **Maturity assessment**: Climate NBS Impact (0-3)
+
+### Phase 3c: Operations & Sustainability (operations_sustain)
+- Operations model: who maintains it? (community volunteers, paid staff, municipal, partnership)
+- Maintenance schedule: what tasks, how often
+- Sustainability model: how will you pay for maintenance long-term?
+  - Options: grants, carbon credits, PES, productive use (food, tourism), municipal budget, social enterprise
+  - "I don't know" → walk through each model with examples from funded projects
+- Timeline: started when, milestones, expected completion
+- What's already done vs what's planned
+- Show relevant funded project cards from evidence database
+- **Maturity assessment**: Financial Thinking (0-3)
 
 ### Phase 4: What We Need (needs_assessment)
 - Technical help needed (design, monitoring, engineering)
@@ -39,13 +64,15 @@ Help a community-based organization (CBO/NGO) document their NBS intervention fo
 - Partnerships sought
 - Training needs
 - Regulatory status: permits, conversations with authorities
-- **Maturity assessment**: Financial Thinking (0-3), Regulatory Awareness (0-3)
+- Ask for links: "Do you have a website, social media, or news coverage?"
+- **Maturity assessment**: Regulatory Awareness (0-3)
 
 ### Phase 5: Results & Evidence (results_evidence)
-- Documents produced
-- Data collected (baseline, photos, surveys)
+- Documents produced (drag-and-drop to upload)
+- Data collected (baseline, photos, surveys, CSV/Excel)
 - Monitoring results
 - Community feedback / support
+- Links to web presence (website, social media, news articles)
 - Challenges and lessons learned
 - **Priority flags**: land tenure, baseline data, gov interest, co-financing, scalability
 
@@ -59,16 +86,32 @@ Help a community-based organization (CBO/NGO) document their NBS intervention fo
   - 25-27: Investment ready
 - Recommend specific next steps based on lowest scores
 
+## Guidance Mode
+
+**CRITICAL**: Every substantive question MUST include an "I don't know / Help me decide" option.
+
+When the user selects it:
+1. Read their site data from Phase 2 (neighborhood, risk scores, hazards)
+2. Ask 2-3 simple follow-up questions about the problem and site conditions
+3. Call read_knowledge for matching intervention files and case studies
+4. Present 2-3 recommendations with real examples from Brazilian projects
+5. Explain in simple language WHY each option fits their situation
+6. Let them pick or ask more questions
+
+You are a **consultant**, not an interviewer. Help them think through decisions they haven't made yet.
+
 ## Key Differences from BPJP Concept Note
 - Single site, not city-wide
 - Community org perspective, not municipal
-- Simpler language, fewer sections
+- Simpler language, guided approach
 - Output: portfolio-ready profile, not funder application
 - Maturity scorecard replaces gap analysis
-- File upload for existing documents
+- File upload + link collection for existing documents
+- NBS Type Selector micro-app for visual intervention browsing
 
 ## Rules
 - Use ask_user tool for ALL questions (interactive buttons)
+- Use open_intervention_selector for Phase 3a NBS type selection
 - Use update_section to fill fields (document panel updates live)
 - Use set_phase to advance phases
 - Show map for site selection (Phase 2)
@@ -76,3 +119,5 @@ Help a community-based organization (CBO/NGO) document their NBS intervention fo
 - Score maturity metrics based on user's answers
 - Be encouraging — CBOs may have limited experience with formal documentation
 - Adapt language to the user (if they write in Portuguese, respond in Portuguese)
+- Proactively ask for evidence at 3 moments: after Phase 2, after Phase 3a, and in Phase 5
+- When user doesn't know → switch to guidance mode, don't just flag a gap

--- a/client/src/core/components/concept-note/InterventionSelector.tsx
+++ b/client/src/core/components/concept-note/InterventionSelector.tsx
@@ -1,0 +1,249 @@
+import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/core/components/ui/button';
+import { Badge } from '@/core/components/ui/badge';
+import { Card, CardContent } from '@/core/components/ui/card';
+import { Check, HelpCircle, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
+import {
+  NBS_INTERVENTION_TYPES,
+  type OpenInterventionSelectorParams,
+  type InterventionSelectorResult,
+  type NbsInterventionTypeId,
+} from '@shared/cbo-schema';
+
+interface Props {
+  params: OpenInterventionSelectorParams;
+  onConfirm: (result: InterventionSelectorResult) => void;
+  onCancel: () => void;
+}
+
+// Placeholder images — will be replaced with real case study photos
+const PLACEHOLDER_GRADIENTS: Record<string, string> = {
+  'bioswales-rain-gardens': 'from-emerald-400 to-teal-600',
+  'flood-parks': 'from-blue-400 to-cyan-600',
+  'green-corridors': 'from-green-500 to-emerald-700',
+  'green-roofs-walls': 'from-lime-400 to-green-600',
+  'urban-forests': 'from-green-600 to-emerald-800',
+  'wetland-restoration': 'from-teal-500 to-blue-700',
+};
+
+// Hazard → which intervention types address it
+const HAZARD_RELEVANCE: Record<string, NbsInterventionTypeId[]> = {
+  flood: ['bioswales-rain-gardens', 'flood-parks', 'wetland-restoration'],
+  heat: ['green-corridors', 'green-roofs-walls', 'urban-forests'],
+  landslide: ['urban-forests', 'green-corridors'],
+};
+
+export default function InterventionSelector({ params, onConfirm, onCancel }: Props) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.resolvedLanguage === 'pt';
+  const [selected, setSelected] = useState<NbsInterventionTypeId | null>(params.preSelectedType || null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [helpMode, setHelpMode] = useState(false);
+
+  // Sort types by relevance to site hazards
+  const sortedTypes = useMemo(() => {
+    if (!params.siteHazards) return [...NBS_INTERVENTION_TYPES];
+    const { flood, heat, landslide } = params.siteHazards;
+    return [...NBS_INTERVENTION_TYPES].sort((a, b) => {
+      const scoreA = (HAZARD_RELEVANCE.flood?.includes(a.id) ? flood : 0)
+        + (HAZARD_RELEVANCE.heat?.includes(a.id) ? heat : 0)
+        + (HAZARD_RELEVANCE.landslide?.includes(a.id) ? landslide : 0);
+      const scoreB = (HAZARD_RELEVANCE.flood?.includes(b.id) ? flood : 0)
+        + (HAZARD_RELEVANCE.heat?.includes(b.id) ? heat : 0)
+        + (HAZARD_RELEVANCE.landslide?.includes(b.id) ? landslide : 0);
+      return scoreB - scoreA;
+    });
+  }, [params.siteHazards]);
+
+  // Check if a type is relevant to the site hazards
+  const isRelevant = (typeId: NbsInterventionTypeId): boolean => {
+    if (!params.siteHazards) return true;
+    const { flood, heat, landslide } = params.siteHazards;
+    return (HAZARD_RELEVANCE.flood?.includes(typeId) && flood > 0.3)
+      || (HAZARD_RELEVANCE.heat?.includes(typeId) && heat > 0.3)
+      || (HAZARD_RELEVANCE.landslide?.includes(typeId) && landslide > 0.3);
+  };
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    const type = NBS_INTERVENTION_TYPES.find(t => t.id === selected);
+    if (!type) return;
+    onConfirm({
+      interventionType: type.id,
+      label: type.label,
+      primaryBenefit: type.primaryBenefit,
+      knowledgeFile: type.knowledgeFile,
+    });
+  };
+
+  const handleHelpMe = () => {
+    // Send "I don't know" as the result — agent will enter guidance mode
+    onConfirm({
+      interventionType: '' as NbsInterventionTypeId,
+      label: 'I don\'t know — help me decide',
+      primaryBenefit: '',
+      knowledgeFile: '',
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="p-4 border-b bg-background">
+        <h3 className="text-sm font-semibold text-foreground">{params.prompt}</h3>
+        {params.siteHazards && (
+          <div className="flex gap-2 mt-2">
+            {params.siteHazards.flood > 0.3 && (
+              <Badge variant="outline" className="text-[10px] border-blue-300 text-blue-700">
+                🌊 {isPt ? 'Risco de inundação' : 'Flood risk'}: {(params.siteHazards.flood * 100).toFixed(0)}%
+              </Badge>
+            )}
+            {params.siteHazards.heat > 0.3 && (
+              <Badge variant="outline" className="text-[10px] border-red-300 text-red-700">
+                🔥 {isPt ? 'Risco de calor' : 'Heat risk'}: {(params.siteHazards.heat * 100).toFixed(0)}%
+              </Badge>
+            )}
+            {params.siteHazards.landslide > 0.3 && (
+              <Badge variant="outline" className="text-[10px] border-amber-300 text-amber-700">
+                ⛰️ {isPt ? 'Risco de deslizamento' : 'Landslide risk'}: {(params.siteHazards.landslide * 100).toFixed(0)}%
+              </Badge>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Cards grid */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {sortedTypes.map((type) => {
+          const relevant = isRelevant(type.id);
+          const isSelected = selected === type.id;
+          const isExpanded = expandedId === type.id;
+          const gradient = PLACEHOLDER_GRADIENTS[type.id] || 'from-gray-400 to-gray-600';
+
+          return (
+            <Card
+              key={type.id}
+              className={`cursor-pointer transition-all overflow-hidden ${
+                isSelected
+                  ? 'ring-2 ring-green-500 border-green-500'
+                  : relevant
+                    ? 'hover:border-green-300 hover:shadow-md'
+                    : 'opacity-60 hover:opacity-80'
+              }`}
+              onClick={() => setSelected(type.id)}
+            >
+              {/* Image placeholder — gradient with emoji */}
+              <div className={`h-28 bg-gradient-to-br ${gradient} relative flex items-center justify-center`}>
+                <span className="text-4xl">{type.emoji}</span>
+                {relevant && params.siteHazards && (
+                  <Badge className="absolute top-2 right-2 bg-green-600 text-[10px]">
+                    {isPt ? 'Recomendado' : 'Recommended'}
+                  </Badge>
+                )}
+                {isSelected && (
+                  <div className="absolute top-2 left-2 w-6 h-6 bg-green-600 rounded-full flex items-center justify-center">
+                    <Check className="w-4 h-4 text-white" />
+                  </div>
+                )}
+                {type.caseStudy && (
+                  <span className="absolute bottom-2 left-2 text-[10px] text-white/80 bg-black/30 px-1.5 py-0.5 rounded">
+                    📍 {type.caseStudy.city}
+                  </span>
+                )}
+              </div>
+
+              <CardContent className="p-3">
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <h4 className="text-sm font-semibold">{type.label}</h4>
+                    <p className="text-xs text-muted-foreground mt-0.5">{type.description}</p>
+                    <p className="text-[11px] text-muted-foreground mt-1 italic">
+                      {isPt ? 'Ex' : 'e.g.'}: {type.example}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="text-[10px] ml-2 shrink-0">
+                    {type.primaryBenefit === 'adaptation' ? (isPt ? 'Adaptação' : 'Adaptation')
+                      : type.primaryBenefit === 'both' ? (isPt ? 'Ambos' : 'Both')
+                      : (isPt ? 'Mitigação' : 'Mitigation')}
+                  </Badge>
+                </div>
+
+                {/* Expandable case study section */}
+                {params.showCaseStudies && type.caseStudy && (
+                  <div className="mt-2">
+                    <button
+                      className="text-[11px] text-green-700 hover:text-green-900 flex items-center gap-1"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setExpandedId(isExpanded ? null : type.id);
+                      }}
+                    >
+                      {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+                      {isPt ? 'Ver exemplo real' : 'See real example'}: {type.caseStudy.project}
+                    </button>
+                    {isExpanded && (
+                      <div className="mt-2 p-2 bg-muted/50 rounded-md text-xs text-muted-foreground space-y-1">
+                        <p><strong>{type.caseStudy.project}</strong> — {type.caseStudy.city}</p>
+                        <p className="text-[10px]">
+                          {isPt
+                            ? 'Clique em "Confirmar" para ver detalhes completos, custos e indicadores deste tipo de intervenção.'
+                            : 'Click "Confirm" to see full details, costs, and indicators for this intervention type.'}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+
+        {/* "I don't know" card */}
+        <Card
+          className="cursor-pointer hover:border-amber-300 hover:shadow-md transition-all border-dashed"
+          onClick={handleHelpMe}
+        >
+          <CardContent className="p-4 flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+              <HelpCircle className="w-5 h-5 text-amber-600" />
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-amber-800">
+                {isPt ? 'Não sei — me ajude a decidir' : "I don't know — help me decide"}
+              </h4>
+              <p className="text-xs text-muted-foreground">
+                {isPt
+                  ? 'Vou te fazer algumas perguntas sobre seu local e problemas para recomendar a melhor opção'
+                  : "I'll ask a few questions about your site and problems to recommend the best option"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Footer */}
+      <div className="p-3 border-t bg-background flex items-center justify-between">
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          {isPt ? 'Cancelar' : 'Cancel'}
+        </Button>
+        <div className="flex items-center gap-2">
+          {selected && (
+            <span className="text-xs text-muted-foreground">
+              {NBS_INTERVENTION_TYPES.find(t => t.id === selected)?.label}
+            </span>
+          )}
+          <Button
+            size="sm"
+            className="bg-green-600 hover:bg-green-700"
+            disabled={!selected}
+            onClick={handleConfirm}
+          >
+            <Check className="w-4 h-4 mr-1" />
+            {isPt ? 'Confirmar' : 'Confirm'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -20,6 +20,8 @@ import {
   type Confidence,
   type MaturityScore,
   type PriorityFlag,
+  type OpenInterventionSelectorParams,
+  type InterventionSelectorResult,
 } from '@shared/cbo-schema';
 import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/concept-note-schema';
 import {
@@ -30,6 +32,7 @@ import {
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
 const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
+const InterventionSelector = lazy(() => import('@/core/components/concept-note/InterventionSelector'));
 
 function formatMapResult(result: MapSelectionResult): string {
   const lines: string[] = [`Map selection (${result.selectionMode} mode):`];
@@ -86,9 +89,10 @@ export default function CboProfilePage() {
   const [questionAnswers, setQuestionAnswers] = useState<Record<number, string>>({});
   const [selectedOptionIdx, setSelectedOptionIdx] = useState(0);
   const [multiSelectedOptions, setMultiSelectedOptions] = useState<Set<string>>(new Set());
-  const [rightTab, setRightTab] = useState<'document' | 'map' | 'scorecard'>(getSavedMapParams() ? 'map' : 'document');
+  const [rightTab, setRightTab] = useState<'document' | 'map' | 'scorecard' | 'interventions'>(getSavedMapParams() ? 'map' : 'document');
   const [mapRelevant, setMapRelevant] = useState(!!getSavedMapParams());
   const [openMapParams, _setOpenMapParams] = useState<OpenMapParams | null>(getSavedMapParams);
+  const [interventionSelectorParams, setInterventionSelectorParams] = useState<OpenInterventionSelectorParams | null>(null);
   const setOpenMapParams = useCallback((p: OpenMapParams | null) => { _setOpenMapParams(p); saveMapParams(p); }, []);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -263,6 +267,11 @@ export default function CboProfilePage() {
         setMapRelevant(true);
         setIsStreaming(false);
         break;
+      case 'open_intervention_selector':
+        setInterventionSelectorParams((event as any).params);
+        setRightTab('interventions');
+        setIsStreaming(false);
+        break;
       case 'done': setIsStreaming(false); break;
       case 'error': setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
     }
@@ -314,7 +323,7 @@ export default function CboProfilePage() {
 
   const handleRestart = useCallback(async () => {
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
-    clearId(); saveMapParams(null); setOpenMapParams(null); setRightTab('document'); setMapRelevant(false);
+    clearId(); saveMapParams(null); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false);
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
@@ -354,13 +363,29 @@ export default function CboProfilePage() {
               <Link href="/sample/project/sample-ada-1"><Button variant="ghost" size="sm" className="h-7 px-2"><ArrowLeft className="w-4 h-4" /></Button></Link>
               <div>
                 <h2 className="text-sm font-semibold flex items-center gap-1.5"><Leaf className="w-4 h-4 text-green-600" /> {t('cbo.title')}</h2>
-                <div className="flex items-center gap-1.5 mt-0.5">
-                  {[1,2,3,4,5].map(p => (
-                    <button key={p} onClick={() => !isStreaming && sendMessage(`Jump to Phase ${p}`)}
-                      className={`w-5 h-5 rounded text-[10px] font-medium transition-all ${p === state.phase ? 'bg-green-600 text-white' : p < state.phase ? 'bg-green-200 text-green-700' : 'bg-muted text-muted-foreground'}`}
-                    >{p}</button>
-                  ))}
-                  <span className="text-[10px] text-muted-foreground ml-1">{filledCount}/5</span>
+                <div className="flex items-center gap-1 mt-0.5">
+                  {[
+                    { label: '1', phase: 1, skip: '1' },
+                    { label: '2', phase: 2, skip: '2' },
+                    { label: '3a', phase: 3, skip: '3a' },
+                    { label: '3b', phase: 3, skip: '3b' },
+                    { label: '3c', phase: 3, skip: '3c' },
+                    { label: '4', phase: 4, skip: '4' },
+                    { label: '5', phase: 5, skip: '5' },
+                  ].map(p => {
+                    // Determine if this sub-phase is active or completed
+                    const sectionMap: Record<string, string> = { '1': 'org_profile', '2': 'intervention_site', '3a': 'intervention_type', '3b': 'impact_monitoring', '3c': 'operations_sustain', '4': 'needs_assessment', '5': 'results_evidence' };
+                    const sectionId = sectionMap[p.skip];
+                    const sectionFilled = sectionId && state.sections[sectionId as CboSectionId] && Object.keys(state.sections[sectionId as CboSectionId].fields).length > 0;
+                    const isActive = p.phase === state.phase;
+                    const isPast = p.phase < state.phase || sectionFilled;
+                    return (
+                      <button key={p.skip} onClick={() => !isStreaming && sendMessage(`[SKIP TO phase:${p.skip}]`)}
+                        className={`h-5 px-1.5 rounded text-[10px] font-medium transition-all ${isActive ? 'bg-green-600 text-white' : isPast ? 'bg-green-200 text-green-700' : 'bg-muted text-muted-foreground'}`}
+                      >{p.label}</button>
+                    );
+                  })}
+                  <span className="text-[10px] text-muted-foreground ml-1">{filledCount}/7</span>
                   {state.totalMaturityScore > 0 && <Badge variant="outline" className="text-[10px] h-4 ml-1">{state.totalMaturityScore}/27</Badge>}
                 </div>
               </div>
@@ -484,15 +509,17 @@ export default function CboProfilePage() {
             <div className="px-4 pt-3 pb-0">
               <h2 className="text-base font-semibold">{state.orgName || t('cbo.interventionProfile')}</h2>
               <div className="flex items-center gap-3 mt-1.5 mb-2">
-                <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden"><div className="h-full bg-green-500 rounded-full transition-all duration-500" style={{ width: `${(filledCount / 5) * 100}%` }} /></div>
-                <span className="text-xs text-muted-foreground shrink-0">{filledCount}/5</span>
+                <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden"><div className="h-full bg-green-500 rounded-full transition-all duration-500" style={{ width: `${(filledCount / 7) * 100}%` }} /></div>
+                <span className="text-xs text-muted-foreground shrink-0">{filledCount}/7</span>
               </div>
             </div>
             <div className="flex px-4 gap-0 border-t">
-              {(['document', 'map', 'scorecard'] as const).map(tab => (
+              {(['document', 'map', 'interventions', 'scorecard'] as const).map(tab => (
                 <button key={tab} onClick={() => setRightTab(tab)}
                   className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${rightTab === tab ? 'border-green-600 text-green-700' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
-                  {t(`cbo.tabs.${tab}`)}{tab === 'map' && mapRelevant && rightTab !== 'map' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
+                  {tab === 'interventions' ? (t('cbo.tabs.interventions', 'NBS Types')) : t(`cbo.tabs.${tab}`)}
+                  {tab === 'map' && mapRelevant && rightTab !== 'map' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
+                  {tab === 'interventions' && interventionSelectorParams && rightTab !== 'interventions' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
                   {tab === 'scorecard' && state.totalMaturityScore > 0 && <span className="ml-1 text-xs text-muted-foreground">{state.totalMaturityScore}/27</span>}
                 </button>
               ))}
@@ -568,6 +595,34 @@ export default function CboProfilePage() {
                     if (currentQuestion) handleSelectOption(description); else sendMessage(description);
                     setRightTab('document'); setMapRelevant(false);
                   }} />
+                )}
+              </Suspense>
+            </div>
+          )}
+
+          {rightTab === 'interventions' && (
+            <div className="flex-1 min-h-0 relative">
+              <Suspense fallback={<div className="flex items-center justify-center h-full"><Loader2 className="w-6 h-6 animate-spin" /></div>}>
+                {interventionSelectorParams ? (
+                  <InterventionSelector
+                    params={interventionSelectorParams}
+                    onConfirm={(result: InterventionSelectorResult) => {
+                      const message = result.interventionType
+                        ? `Selected NBS type: ${result.label} (${result.interventionType}). Primary benefit: ${result.primaryBenefit}. Knowledge file: ${result.knowledgeFile}`
+                        : result.label; // "I don't know — help me decide"
+                      if (currentQuestion) handleSelectOption(message); else sendMessage(message);
+                      setInterventionSelectorParams(null);
+                      setRightTab('document');
+                    }}
+                    onCancel={() => {
+                      setInterventionSelectorParams(null);
+                      setRightTab('document');
+                    }}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-full text-sm text-muted-foreground p-8 text-center">
+                    {t('cbo.interventionsEmpty', 'The NBS Type Selector will open here when the agent asks you to choose your intervention type (Phase 3a).')}
+                  </div>
                 )}
               </Suspense>
             </div>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1577,6 +1577,7 @@
     "tabs": {
       "document": "Document",
       "map": "Map",
+      "interventions": "NBS Types",
       "scorecard": "Scorecard"
     },
     "export": "Export profile",
@@ -1654,7 +1655,9 @@
     "sections": {
       "org_profile": "1. Who We Are",
       "intervention_site": "2. Where We Work",
-      "intervention_plan": "3. What We're Doing",
+      "intervention_type": "3a. What We're Building",
+      "impact_monitoring": "3b. Expected Impact",
+      "operations_sustain": "3c. Operations & Sustainability",
       "needs_assessment": "4. What We Need",
       "results_evidence": "5. Results & Evidence"
     }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1556,6 +1556,7 @@
     "tabs": {
       "document": "Documento",
       "map": "Mapa",
+      "interventions": "Tipos de SbN",
       "scorecard": "Placar"
     },
     "export": "Exportar perfil",
@@ -1633,7 +1634,9 @@
     "sections": {
       "org_profile": "1. Quem Somos",
       "intervention_site": "2. Onde Atuamos",
-      "intervention_plan": "3. O Que Fazemos",
+      "intervention_type": "3a. O Que Estamos Construindo",
+      "impact_monitoring": "3b. Impacto Esperado",
+      "operations_sustain": "3c. Operação e Sustentabilidade",
       "needs_assessment": "4. O Que Precisamos",
       "results_evidence": "5. Resultados e Evidências"
     }

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -81,7 +81,7 @@ function createCboMcpTools(cboId: string) {
     "update_section",
     "Update a field in the CBO intervention profile. The document panel updates in real-time.",
     {
-      sectionId: z.string().describe("Section ID: org_profile, intervention_site, intervention_plan, needs_assessment, results_evidence"),
+      sectionId: z.string().describe("Section ID: org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence"),
       field: z.string().describe("Field name"),
       value: z.string().describe("Content to set"),
       confidence: z.enum(["high", "medium", "low"]).default("medium"),
@@ -247,7 +247,18 @@ STOP and wait for the user's map selection after calling this tool.`,
 
   const readKnowledge = sdkTool(
     "read_knowledge",
-    "Read a knowledge file for detailed data about interventions, co-benefits, or city context.",
+    `Read a knowledge file for detailed data about interventions, co-benefits, city context, or case studies.
+
+## Key folders
+- _interventions/: bioswales-rain-gardens.md, flood-parks.md, green-corridors.md, green-roofs-walls.md, urban-forests.md, wetland-restoration.md
+- _co-benefits/: public-health.md, carbon-sequestration.md, flood-risk-reduction.md, heat-island-mitigation.md, economic-social.md, biodiversity.md
+- _success-cases/: brazilian-municipal.md (Curitiba, Recife, BH, São Paulo, Salvador examples)
+- _evidence/: impact-benchmarks.md, funded-projects-brazil.md (GCF, World Bank, GEF projects)
+- _financing-sources/: preparation-facilities.md, international.md, brazilian-domestic.md
+- porto-alegre/: climate-risks.md, local-precedents.md, existing-plans.md, stakeholders.md, baseline-data.md
+- _cougar/: nbs-mapping-criteria.md, ecosystem-assessment-summary.md, sample-cbo-vilaflores.md
+
+USE THIS TOOL PROACTIVELY when guiding the user. Don't just ask questions — read relevant files and share insights.`,
     { folder: z.string(), file: z.string() },
     async (args: any) => {
       const fs = require('fs');
@@ -263,10 +274,42 @@ STOP and wait for the user's map selection after calling this tool.`,
     { annotations: { readOnlyHint: true } }
   );
 
+  const openInterventionSelector = sdkTool(
+    "open_intervention_selector",
+    `Open the NBS Intervention Type Selector micro-app. Shows 6 NBS types as visual cards with images, descriptions, cost ranges, and Brazilian case studies. The user browses and selects their intervention type.
+
+Use this in Phase 3a after collecting site information. Pass siteHazards from Phase 2 data to highlight the most relevant intervention types.
+
+STOP and wait for the user's selection after calling this tool.`,
+    {
+      prompt: z.string().describe("Instruction shown to the user, e.g. 'Choose the type of nature-based solution that best matches your project'"),
+      preSelectedType: z.string().optional().describe("Pre-select a type if the user already mentioned one"),
+      showCaseStudies: z.boolean().optional().default(true),
+      siteHazards: z.object({
+        flood: z.number().min(0).max(1),
+        heat: z.number().min(0).max(1),
+        landslide: z.number().min(0).max(1),
+      }).optional().describe("Hazard scores from Phase 2 neighborhood data to highlight relevant types"),
+    },
+    async (args: any) => {
+      pushEvent({
+        type: 'open_intervention_selector',
+        params: {
+          prompt: args.prompt,
+          preSelectedType: args.preSelectedType,
+          showCaseStudies: args.showCaseStudies ?? true,
+          siteHazards: args.siteHazards,
+        },
+      });
+      return { content: [{ type: "text" as const, text: `Intervention selector opened. STOP and wait for selection.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge],
+    tools: [updateSection, flagGap, setPhase, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
   });
 }
 
@@ -284,6 +327,99 @@ function getMcpServer(cboId: string) {
 // STREAMING
 // ============================================================================
 
+// ── Skip mechanism: [SKIP TO phase:X] ────────────────────────────────────────
+// Pre-fills previous phases with CEA Bom Jesus sample data and jumps to target phase.
+// Supports: 1, 2, 3a, 3b, 3c, 4, 5
+
+const SKIP_PATTERN = /^\[SKIP TO phase:(\w+)\]/i;
+
+const SAMPLE_CBO_DATA: Record<string, Record<string, { value: string; confidence: 'high' | 'medium'; source?: string }>> = {
+  org_profile: {
+    org_name: { value: 'CEA Bom Jesus', confidence: 'high', source: 'sample' },
+    org_type: { value: 'ONG / Organização Não-Governamental', confidence: 'high', source: 'sample' },
+    mission: { value: 'Gestão de resíduos sólidos, energia renovável e economia circular na comunidade Bom Jesus, Porto Alegre', confidence: 'high', source: 'sample' },
+    team_size: { value: '12 membros (8 remunerados, 4 voluntários)', confidence: 'medium', source: 'sample' },
+    years_active: { value: '6 anos (desde 2020)', confidence: 'high', source: 'sample' },
+    prior_projects: { value: 'Cooperativa de reciclagem (2020-presente), Horta comunitária Bom Jesus (2022), Capacitação em compostagem (2023)', confidence: 'medium', source: 'sample' },
+    contact_name: { value: 'Maria Santos', confidence: 'high', source: 'sample' },
+    contact_role: { value: 'Coordenadora', confidence: 'high', source: 'sample' },
+    contact_email: { value: 'maria@ceabomjesus.org.br', confidence: 'high', source: 'sample' },
+  },
+  intervention_site: {
+    neighborhood: { value: 'Arquipélago (Ilhas)', confidence: 'high', source: 'map selection' },
+    area: { value: '2.5 hectares', confidence: 'medium', source: 'map selection' },
+    current_conditions: { value: 'Área degradada próxima ao arroio, com vegetação rasteira e acúmulo de resíduos. Solo argiloso, parcialmente inundável durante cheias.', confidence: 'medium', source: 'sample' },
+    population: { value: 'Aproximadamente 3.200 moradores no entorno direto', confidence: 'medium', source: 'sample' },
+    land_tenure: { value: 'Terreno público municipal com cessão de uso pendente', confidence: 'medium', source: 'sample' },
+    community_engagement: { value: 'Modelo cooperativo com assembleia mensal e núcleos por rua', confidence: 'high', source: 'sample' },
+  },
+  intervention_type: {
+    nbs_type: { value: 'wetland-restoration', confidence: 'high', source: 'intervention selector' },
+    problem: { value: 'Inundações recorrentes no bairro Arquipélago, agravadas pelas enchentes de 2024. Água contaminada do arroio afeta a saúde da comunidade.', confidence: 'high', source: 'sample' },
+    description: { value: 'Restauração de área úmida (várzea) ao longo do arroio, com plantio de espécies nativas para filtragem natural da água e retenção de cheias. Inclui construção de caminhos elevados e espaço de educação ambiental.', confidence: 'medium', source: 'sample' },
+    scale: { value: '2.5 ha de área úmida restaurada, 800 mudas nativas, 3 bacias de retenção', confidence: 'medium', source: 'sample' },
+  },
+  impact_monitoring: {
+    impact_areas: { value: 'Redução de inundação, melhoria da qualidade da água, biodiversidade, saúde pública', confidence: 'medium', source: 'sample' },
+    expected_outcomes: { value: 'Redução de 40-60% do volume de enchente local, filtragem natural reduzindo coliformes em 70%, habitat para fauna ribeirinha', confidence: 'medium', source: 'knowledge benchmarks' },
+    baseline: { value: 'Nível de inundação medido em 2024 (1.2m acima do normal). Análise de qualidade da água pendente.', confidence: 'medium', source: 'sample' },
+    monitoring_plan: { value: 'Medição mensal do nível da água, análise trimestral de qualidade, contagem anual de espécies', confidence: 'medium', source: 'sample' },
+  },
+  operations_sustain: {
+    operations_model: { value: 'Manutenção por equipe comunitária com apoio técnico da prefeitura', confidence: 'medium', source: 'sample' },
+    maintenance: { value: 'Limpeza semanal, replantio trimestral, monitoramento mensal das bacias', confidence: 'medium', source: 'sample' },
+    sustainability_model: { value: 'Combinação: taxa municipal de drenagem (40%), ecoturismo educacional (30%), pagamento por serviços ambientais (30%)', confidence: 'medium', source: 'sample' },
+    timeline_start: { value: '2025-06', confidence: 'medium', source: 'sample' },
+    timeline_milestones: { value: 'Limpeza do terreno (Jun 2025), Plantio fase 1 (Set 2025), Bacias de retenção (Dez 2025), Inauguração (Mar 2026)', confidence: 'medium', source: 'sample' },
+  },
+  needs_assessment: {
+    technical_needs: { value: 'Projeto hidráulico detalhado, seleção de espécies nativas, engenharia das bacias de retenção', confidence: 'medium', source: 'sample' },
+    financial_gap: { value: 'Custo total estimado: R$ 480.000. Já obtido: R$ 120.000 (edital FEPAM). Faltam: R$ 360.000', confidence: 'medium', source: 'sample' },
+    regulatory_status: { value: 'Licença ambiental em análise na SMAMUS. Prefeito visitou o local em fevereiro.', confidence: 'medium', source: 'sample' },
+  },
+};
+
+function applySkipData(state: CboState, targetPhase: string): { phase: number; agentMessage: string } {
+  // Map phase labels to ordered phases
+  const phaseOrder = ['1', '2', '3a', '3b', '3c', '4', '5'];
+  const phaseToNumber: Record<string, number> = { '1': 1, '2': 2, '3a': 3, '3b': 3, '3c': 3, '4': 4, '5': 5 };
+  const phaseToSection: Record<string, string> = {
+    '1': 'org_profile', '2': 'intervention_site', '3a': 'intervention_type',
+    '3b': 'impact_monitoring', '3c': 'operations_sustain', '4': 'needs_assessment', '5': 'results_evidence',
+  };
+
+  const targetIdx = phaseOrder.indexOf(targetPhase.toLowerCase());
+  if (targetIdx === -1) return { phase: 1, agentMessage: `Unknown phase "${targetPhase}". Starting from Phase 1.` };
+
+  // Fill all sections before the target phase
+  const filledSections: string[] = [];
+  for (let i = 0; i < targetIdx; i++) {
+    const sectionId = phaseToSection[phaseOrder[i]];
+    const sampleData = SAMPLE_CBO_DATA[sectionId];
+    if (sampleData && state.sections[sectionId as keyof typeof state.sections]) {
+      const section = state.sections[sectionId as keyof typeof state.sections];
+      for (const [field, data] of Object.entries(sampleData)) {
+        section.fields[field] = { value: data.value, confidence: data.confidence, source: data.source, userEdited: false };
+      }
+      section.confidence = 'medium';
+      section.lastUpdatedBy = 'agent';
+      filledSections.push(sectionId);
+    }
+  }
+
+  // Set org name from sample data
+  state.orgName = 'CEA Bom Jesus';
+  state.phase = phaseToNumber[targetPhase.toLowerCase()] || 1;
+
+  const phaseNum = phaseToNumber[targetPhase.toLowerCase()];
+  const subPhase = targetPhase.toLowerCase().includes('a') ? 'a' : targetPhase.toLowerCase().includes('b') ? 'b' : targetPhase.toLowerCase().includes('c') ? 'c' : '';
+
+  return {
+    phase: phaseNum,
+    agentMessage: `[SKIP] Pre-filled ${filledSections.length} sections with CEA Bom Jesus sample data. Now at Phase ${phaseNum}${subPhase}. Continue the interview from this phase. The user is testing — proceed as if previous phases were completed naturally.`,
+  };
+}
+
 export async function streamCboChat(cboId: string, userMessage: string, res: Response, state: CboState) {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
@@ -299,6 +435,23 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
       addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: 'thinking', timestamp: new Date().toISOString() });
     }
   };
+
+  // Handle [SKIP TO phase:X] magic prefix
+  const skipMatch = userMessage.match(SKIP_PATTERN);
+  if (skipMatch) {
+    const targetPhase = skipMatch[1];
+    const { phase, agentMessage } = applySkipData(state, targetPhase);
+    setCboState(cboId, state);
+    // Push field updates for all pre-filled sections so the UI updates
+    for (const [sectionId, section] of Object.entries(state.sections)) {
+      for (const [field, data] of Object.entries(section.fields)) {
+        pushEvent({ type: 'field_update', sectionId, field, value: String(data.value), confidence: data.confidence, source: data.source });
+      }
+    }
+    pushEvent({ type: 'phase_change', phase });
+    // Replace user message with the skip instruction for the agent
+    userMessage = agentMessage;
+  }
 
   setActivePushEvent(cboId, pushEvent);
   const isSdkReady = await loadSdk();
@@ -320,7 +473,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
 
   const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## USER DECISIONS\n${decisionLog}\n\nUser message: ${userMessage}`;
 
-  console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/5 sections)`);
+  console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 
   try {
     for await (const message of sdkQuery({
@@ -334,6 +487,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__set_phase",
           "mcp__cbo__ask_user",
           "mcp__cbo__open_map",
+          "mcp__cbo__open_intervention_selector",
           "mcp__cbo__score_maturity",
           "mcp__cbo__set_priority_flag",
           "mcp__cbo__read_knowledge",
@@ -384,9 +538,12 @@ function buildDecisionLog(cboId: string): string {
   return msgs.slice(-10).map(m => `- User: ${m.content.slice(0, 200)}`).join('\n');
 }
 
-// Skill + knowledge cache
+// Skill + knowledge cache (cleared on server restart)
 let skillCache: string | null = null;
 let knowledgeCache: string | null = null;
+
+// Invalidate caches so updated skill/knowledge files take effect
+export function invalidateCboCache() { skillCache = null; knowledgeCache = null; }
 
 async function buildSystemContext(state: CboState): Promise<string> {
   if (!skillCache) {
@@ -436,27 +593,63 @@ async function buildSystemContext(state: CboState): Promise<string> {
     console.log(`[cbo] Knowledge loaded: ${knowledgeCache.length} chars`);
   }
 
-  return `You are a friendly CBO intervention profile advisor helping a community organization in ${state.city} document their NBS project.
+  return `You are a friendly NBS project preparation consultant helping a community organization in ${state.city} prepare their nature-based solution project. You are NOT just collecting data — you are helping them THINK through their project like a consultant would.
+
 Phase: ${state.phase}. Organization: ${state.orgName || '(not set)'}.
 
 ## YOUR TOOLS
-1. **update_section** — fill document fields (org_profile, intervention_site, intervention_plan, needs_assessment, results_evidence)
+1. **update_section** — fill document fields (org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence)
 2. **ask_user** — present multiple-choice questions for non-spatial decisions
-3. **open_map** — open interactive map microapp. Use for ALL spatial/site questions instead of ask_user.
-   - Phase 2 (Where We Work): open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks", "osm_schools", "osm_wetlands"], tileLayers: ["oef_fri_2024", "oef_hwm_2024"], prompt: "Select your neighborhood, then pick the parks, schools, or sites you're targeting" })
-   - Phase 3 (What intervention): open_map({ selectionMode: "assets", layers: ["osm_parks", "osm_wetlands"], tileLayers: ["oef_dynamic_world", "oef_fri_2024"], prompt: "Select the green spaces or wetlands your NBS will transform" })
+3. **open_map** — open interactive map microapp for spatial/site questions
+   - Phase 2: open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks", "osm_schools", "osm_wetlands"], tileLayers: ["oef_fri_2024", "oef_hwm_2024"], prompt: "Select your neighborhood, then pick the parks, schools, or sites you're targeting" })
    - Evidence check: open_map({ selectionMode: "sample", tileLayers: ["oef_fri_2024", "oef_hwm_2024", "oef_copernicus_dem"], prompt: "Click locations to check climate risk values" })
-4. **set_phase** — advance phases (1-6)
-5. **flag_gap** — mark missing info
-6. **score_maturity** — score COUGAR maturity metrics (0-3) as you gather info
-7. **set_priority_flag** — mark priority flags (met/not met)
-8. **read_knowledge** — read detailed knowledge files
+4. **open_intervention_selector** — Phase 3a: open NBS type selector micro-app with visual cards, images, and case studies. Pass siteHazards from Phase 2 data.
+5. **set_phase** — advance phases (1-5, where Phase 3 has sub-phases 3a/3b/3c)
+6. **flag_gap** — mark missing info (but prefer guiding the user over flagging gaps)
+7. **score_maturity** — score COUGAR maturity metrics (0-3) as you gather info
+8. **set_priority_flag** — mark priority flags (met/not met)
+9. **read_knowledge** — read knowledge files for interventions, co-benefits, case studies, benchmarks. USE THIS PROACTIVELY.
+
+## PHASE FLOW
+- Phase 1: Who We Are (org_profile) — org info, team, experience
+- Phase 2: Where We Work (intervention_site) — map selection, neighborhood, site conditions
+- Phase 3a: What We're Building (intervention_type) — NBS type via selector micro-app, design details
+- Phase 3b: Expected Impact (impact_monitoring) — outcomes, baseline, monitoring indicators
+- Phase 3c: Operations & Sustainability (operations_sustain) — ops model, maintenance, revenue/sustainability
+- Phase 4: What We Need (needs_assessment) — technical, financial, regulatory
+- Phase 5: Results & Evidence (results_evidence) — documents, photos, links, data
 
 ## MATURITY METRICS (score each 0-3 as you go)
 ${MATURITY_METRICS.join(', ')}
 
 ## PRIORITY FLAGS (set as you discover them)
 ${PRIORITY_FLAG_DEFINITIONS.join(', ')}
+
+## GUIDANCE MODE — CRITICAL
+You are a CONSULTANT, not an interviewer. Every substantive question MUST include an "I don't know / Help me decide" option.
+
+When the user selects "I don't know":
+1. DON'T just flag a gap — HELP them think through it
+2. Read relevant knowledge files (interventions, co-benefits, case studies, benchmarks)
+3. Ask 2-3 simple follow-up questions to understand their situation
+4. Present 2-3 concrete recommendations with real Brazilian examples
+5. Explain WHY each option fits their specific site and situation
+6. Use benchmarks: "Projects like yours in Curitiba typically see 65% flood reduction"
+7. Reference funded projects: "The World Bank's Porto Alegre resilience project (US$85M) includes similar NBS"
+
+Example guidance flow for "I don't know what type of NBS":
+→ "No problem! Let me help. First: what's the biggest problem you see at your site?"
+→ [Flooding / Heat / Erosion / Pollution]
+→ "And what does the land look like now?"
+→ [Empty lot / Park / Near river / Hillside]
+→ read_knowledge(_interventions/flood-parks.md) + read_knowledge(_success-cases/brazilian-municipal.md)
+→ "Based on your flood-prone site near the river, I'd recommend a Flood Park — like what Curitiba did with Barigui..."
+
+## PROACTIVE EVIDENCE COLLECTION
+Ask for evidence at 3 key moments:
+- After Phase 2: "Do you have photos of the site? You can drag them into the chat."
+- After Phase 3a: "Do you have any documents about this project — proposals, reports, plans?"
+- Phase 5: "Can you share links to your website, social media, or any news coverage?"
 
 ## LANGUAGE
 - Each user message ends with [LANGUAGE: ...]. Follow it strictly.
@@ -467,33 +660,33 @@ ${PRIORITY_FLAG_DEFINITIONS.join(', ')}
 ## QUESTION STYLE
 - Use simple words: "Que tipo de solução?" not "Qual o tipo de SbN?"
 - Add example hints in descriptions: "(ex: plantio de árvores, restauração de áreas úmidas)"
-- Break complex questions into small steps: ask team size, THEN ask about paid vs volunteer
-- For financial questions: ask "Quanto custa o projeto todo?" then "Quanto vocês já têm?" then "Quanto falta?"
+- Break complex questions into small steps
 - Avoid technical terms: "Alguém do governo sabe do projeto?" not "Status regulatório"
 - Offer encouragement: "Ótimo! Isso mostra que vocês já têm experiência."
+- ALWAYS include "I don't know / Help me" as an option for substantive questions
 
 ## BEHAVIOR
-- Be warm and encouraging — many CBOs have limited formal documentation experience
+- Be warm, encouraging, and consultative
 - Start IMMEDIATELY with set_phase(1) and ask_user questions
 - Score maturity metrics as you gather information (don't wait until the end)
 - For ANY spatial question: use open_map (not ask_user with showMap)
 - Phase 2: ALWAYS use open_map with "composite" mode
-- Phase 3: use open_map with "assets" mode if asking about specific intervention sites
-- The tool description has recipes — follow them
-- After Phase 5: generate the full maturity scorecard using score_maturity for remaining metrics + set_priority_flag for all 6 flags
+- Phase 3a: ALWAYS use open_intervention_selector (not ask_user for NBS type)
+- Phase 3b/3c: read_knowledge PROACTIVELY to provide benchmarks and examples
+- After Phase 5: generate the full maturity scorecard
 - In your FIRST message: mention that the user can drop existing documents into the chat
 
 ## FILE DROPS
 When the user drops a document, you'll receive its content. React by:
 1. Extract ALL relevant info (org name, team, budget, site, interventions, progress)
 2. Call update_section for every field you can fill — maximize auto-fill
-3. Call score_maturity for metrics you can now assess (e.g., "Problem Clarity" → 2 if doc has a clear problem statement)
+3. Call score_maturity for metrics you can now assess
 4. Tell the user: "I found [X] in your document. I've filled [sections] and scored [metrics]."
 5. Skip questions already answered by the document
 6. Having a written document is itself evidence of maturity — score accordingly
 
 ## SKILL FLOW
-${skillCache?.slice(0, 2000) || ''}
+${skillCache?.slice(0, 3000) || ''}
 
 ## KNOWLEDGE
 ${knowledgeCache}`;

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -8,8 +8,10 @@ import type { OpenMapParams } from './concept-note-schema';
 export const CBO_SECTIONS = [
   { id: 'org_profile', title: '1. Who We Are', phase: 1, maturityMetrics: ['org_delivery_capacity', 'team_technical_experience'] },
   { id: 'intervention_site', title: '2. Where We Work', phase: 2, maturityMetrics: ['site_control', 'community_anchoring'] },
-  { id: 'intervention_plan', title: '3. What We\'re Doing', phase: 3, maturityMetrics: ['problem_clarity', 'climate_nbs_impact', 'solution_clarity'] },
-  { id: 'needs_assessment', title: '4. What We Need', phase: 4, maturityMetrics: ['financial_thinking', 'regulatory_awareness'] },
+  { id: 'intervention_type', title: '3a. What We\'re Building', phase: 3, subPhase: 'a', maturityMetrics: ['problem_clarity', 'solution_clarity'] },
+  { id: 'impact_monitoring', title: '3b. Expected Impact', phase: 3, subPhase: 'b', maturityMetrics: ['climate_nbs_impact'] },
+  { id: 'operations_sustain', title: '3c. Operations & Sustainability', phase: 3, subPhase: 'c', maturityMetrics: ['financial_thinking'] },
+  { id: 'needs_assessment', title: '4. What We Need', phase: 4, maturityMetrics: ['regulatory_awareness'] },
   { id: 'results_evidence', title: '5. Results & Evidence', phase: 5, maturityMetrics: [] },
 ] as const;
 
@@ -74,6 +76,52 @@ export interface CboState {
   };
 }
 
+// NBS intervention types available in the selector micro-app
+export const NBS_INTERVENTION_TYPES = [
+  { id: 'bioswales-rain-gardens', label: 'Bioswales & Rain Gardens', emoji: '🌿', primaryBenefit: 'adaptation', knowledgeFile: 'bioswales-rain-gardens.md',
+    description: 'Channels and planted areas that filter rainwater naturally',
+    example: 'Rain garden in a park, bioswale along a street',
+    caseStudy: { city: 'Recife, PE', project: 'Municipal Rain Gardens', image: '/assets/interventions/bioswales.jpg' } },
+  { id: 'flood-parks', label: 'Flood Parks', emoji: '🌊', primaryBenefit: 'adaptation', knowledgeFile: 'flood-parks.md',
+    description: 'Parks that absorb floodwater and serve the community',
+    example: 'Praça that becomes a retention pond during rain',
+    caseStudy: { city: 'Curitiba, PR', project: 'Barigui River Basin Parks', image: '/assets/interventions/flood-parks.jpg' } },
+  { id: 'green-corridors', label: 'Green Corridors', emoji: '🌳', primaryBenefit: 'both', knowledgeFile: 'green-corridors.md',
+    description: 'Linear green spaces connecting neighborhoods and ecosystems',
+    example: 'Tree-lined avenue, riverside walking path with native plants',
+    caseStudy: { city: 'Recife, PE', project: 'Parque Capibaribe', image: '/assets/interventions/green-corridors.jpg' } },
+  { id: 'green-roofs-walls', label: 'Green Roofs & Walls', emoji: '🏗️', primaryBenefit: 'both', knowledgeFile: 'green-roofs-walls.md',
+    description: 'Vegetation on rooftops and building facades for cooling and insulation',
+    example: 'Garden on a school roof, vertical garden on a community center',
+    caseStudy: { city: 'São Paulo, SP', project: 'Green Roof Research Program', image: '/assets/interventions/green-roofs.jpg' } },
+  { id: 'urban-forests', label: 'Urban Forests', emoji: '🌲', primaryBenefit: 'both', knowledgeFile: 'urban-forests.md',
+    description: 'Tree planting to cool neighborhoods, clean air, and absorb water',
+    example: 'Reforestation of a hillside, street tree program, community orchard',
+    caseStudy: { city: 'Porto Alegre, RS', project: 'Orla do Guaíba', image: '/assets/interventions/urban-forests.jpg' } },
+  { id: 'wetland-restoration', label: 'Wetland Restoration', emoji: '🌾', primaryBenefit: 'adaptation', knowledgeFile: 'wetland-restoration.md',
+    description: 'Restoring natural water areas for filtration, flood control, and habitat',
+    example: 'Recovering a degraded stream or várzea area',
+    caseStudy: { city: 'Belo Horizonte, MG', project: 'DRENURBS Stream Rehabilitation', image: '/assets/interventions/wetland-restoration.jpg' } },
+] as const;
+
+export type NbsInterventionTypeId = typeof NBS_INTERVENTION_TYPES[number]['id'];
+
+// Params for the NBS Type Selector micro-app
+export interface OpenInterventionSelectorParams {
+  prompt: string;
+  preSelectedType?: NbsInterventionTypeId;
+  showCaseStudies?: boolean;
+  siteHazards?: { flood: number; heat: number; landslide: number }; // from Phase 2 to highlight relevant types
+}
+
+// Result returned when user confirms selection in the micro-app
+export interface InterventionSelectorResult {
+  interventionType: NbsInterventionTypeId;
+  label: string;
+  primaryBenefit: string;
+  knowledgeFile: string;
+}
+
 // SSE events — same structure as concept note but with CBO types
 export type CboEvent =
   | { type: 'chat'; content: string; role: 'assistant'; messageType?: 'content' | 'thinking' | 'tool_status' }
@@ -83,8 +131,9 @@ export type CboEvent =
   | { type: 'gap'; sectionId: string; field: string; reason: string; severity: string }
   | { type: 'phase_change'; phase: number }
   | { type: 'maturity_update'; scores: MaturityScore[]; total: number; flags: PriorityFlag[] }
-  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
   | { type: 'open_map'; params: OpenMapParams }
+  | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 


### PR DESCRIPTION
## Summary
- **Schema expansion**: Split Phase 3 into 3a (Intervention Type), 3b (Impact & Monitoring), 3c (Operations & Sustainability) — 5 → 7 sections
- **NBS Type Selector micro-app**: Gallery of 6 intervention types with images, case study references, hazard-based ranking, and "I don't know — help me decide" guidance trigger
- **Skip mechanism**: `[SKIP TO phase:3a]` magic prefix pre-fills previous phases with CEA Bom Jesus sample data for rapid testing
- **Guidance mode**: Agent reframed as consultant — every question includes "I don't know" option that triggers knowledge-based walkthroughs with Brazilian case studies and benchmarks
- **UI updates**: Phase buttons show 1/2/3a/3b/3c/4/5, new "NBS Types" tab, progress bar /7

## Test plan
- [ ] Start fresh CBO session — verify 7 sections appear in document panel
- [ ] Type `[SKIP TO phase:3a]` — verify previous phases pre-fill with sample data
- [ ] At Phase 3a, verify NBS Type Selector opens in right panel with 6 cards
- [ ] Select an NBS type — verify it returns to chat with selection
- [ ] Click "I don't know — help me decide" — verify agent enters guidance mode
- [ ] Check phase buttons show 3a/3b/3c sub-phases
- [ ] Test in Portuguese language mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)