### PR TITLE
fix: migrate old 5-section CBO states to 7 sections

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -66,6 +66,27 @@ function fixMarkdownTables(text: string): string {
 
 const STORAGE_KEY = 'cbo-session-id';
 const MAP_PARAMS_KEY = 'cbo-map-params';
+// Migrate old 5-section states to 7 sections (adds intervention_type, impact_monitoring, operations_sustain)
+function migrateCboState(state: CboState): CboState {
+  for (const sec of CBO_SECTIONS) {
+    if (!state.sections[sec.id]) {
+      state.sections[sec.id] = { id: sec.id, title: sec.title, phase: sec.phase, fields: {}, confidence: 'empty', sources: [], lastUpdatedBy: null };
+    }
+  }
+  // Remove old section that was replaced
+  if ((state.sections as any).intervention_plan) {
+    const old = (state.sections as any).intervention_plan;
+    // Move old fields to intervention_type if it's empty
+    if (old.fields && Object.keys(old.fields).length > 0 && Object.keys(state.sections.intervention_type.fields).length === 0) {
+      state.sections.intervention_type.fields = old.fields;
+      state.sections.intervention_type.confidence = old.confidence;
+      state.sections.intervention_type.sources = old.sources;
+    }
+    delete (state.sections as any).intervention_plan;
+  }
+  return state;
+}
+
 function getSavedId(): string | null { try { return localStorage.getItem(STORAGE_KEY); } catch { return null; } }
 function saveId(id: string) { try { localStorage.setItem(STORAGE_KEY, id); } catch {} }
 function clearId() { try { localStorage.removeItem(STORAGE_KEY); } catch {} }
@@ -135,7 +156,7 @@ export default function CboProfilePage() {
           if (res.ok) {
             const data = await res.json();
             setCboId(saved);
-            setState(data.state);
+            setState(migrateCboState(data.state));
             const msgRes = await fetch(`/api/cbo/${saved}/messages`);
             if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) setMessages(msgs); }
             return;
@@ -530,6 +551,7 @@ export default function CboProfilePage() {
             <div className="flex-1 overflow-y-auto p-3 space-y-2">
               {CBO_SECTIONS.map(sec => {
                 const section = state.sections[sec.id];
+                if (!section) return null;
                 const fields = Object.entries(section.fields);
                 const hasGaps = state.gaps.some(g => g.sectionId === sec.id);
                 const isHL = highlightedSections.includes(sec.id);

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -8,6 +8,7 @@ import {
   type MaturityScore,
   type PriorityFlag,
   ALL_CBO_SECTION_IDS,
+  CBO_SECTIONS,
   MATURITY_METRICS,
   PRIORITY_FLAG_DEFINITIONS,
 } from "@shared/cbo-schema";
@@ -45,10 +46,35 @@ loadSdk();
 const cboStates = new Map<string, CboState>();
 const cboMessages = new Map<string, CboChatMessage[]>();
 
-export function getCboState(id: string): CboState | undefined { return cboStates.get(id); }
+// Ensure old 5-section states get the new sections added
+function migrateSections(state: CboState): CboState {
+  for (const sec of CBO_SECTIONS) {
+    if (!state.sections[sec.id as keyof typeof state.sections]) {
+      (state.sections as any)[sec.id] = { id: sec.id, title: sec.title, phase: sec.phase, fields: {}, confidence: 'empty', sources: [], lastUpdatedBy: null };
+    }
+  }
+  // Move data from old intervention_plan → intervention_type
+  if ((state.sections as any).intervention_plan) {
+    const old = (state.sections as any).intervention_plan;
+    if (old.fields && Object.keys(old.fields).length > 0 && Object.keys((state.sections as any).intervention_type?.fields || {}).length === 0) {
+      (state.sections as any).intervention_type.fields = old.fields;
+      (state.sections as any).intervention_type.confidence = old.confidence;
+      (state.sections as any).intervention_type.sources = old.sources;
+    }
+    delete (state.sections as any).intervention_plan;
+  }
+  return state;
+}
+
+export function getCboState(id: string): CboState | undefined {
+  const state = cboStates.get(id);
+  if (state) migrateSections(state);
+  return state;
+}
 export function setCboState(id: string, state: CboState): void {
   if (!state) { cboStates.delete(id); cboMessages.delete(id); return; }
   state.metadata.updatedAt = new Date().toISOString();
+  migrateSections(state);
   cboStates.set(id, state);
 }
 export function getCboMessages(id: string): CboChatMessage[] { return cboMessages.get(id) || []; }


### PR DESCRIPTION
## Summary
- Existing CBO sessions crash because they have the old 5-section state but code now expects 7 sections
- Adds `migrateCboState()` on client side when loading saved state from localStorage
- Adds `migrateSections()` on server side in `getCboState()`/`setCboState()`
- Moves old `intervention_plan` field data to new `intervention_type` section
- Adds guard `if (!section) return null` in document panel render

## Test plan
- [ ] Load the CBO page with an existing session from before PR #88 — should not crash
- [ ] New sessions should work normally with 7 sections
- [ ] Old `intervention_plan` data should appear under "3a. What We're Building"

🤖 Generated with [Claude Code](https://claude.com/claude-code)