### PR TITLE
feat: NBS selector deep-dive panel with knowledge content

### DIFF
--- a/client/src/core/components/concept-note/InterventionSelector.tsx
+++ b/client/src/core/components/concept-note/InterventionSelector.tsx
@@ -1,9 +1,14 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Button } from '@/core/components/ui/button';
 import { Badge } from '@/core/components/ui/badge';
 import { Card, CardContent } from '@/core/components/ui/card';
-import { Check, HelpCircle, ChevronDown, ChevronUp, Camera } from 'lucide-react';
+import {
+  Check, HelpCircle, ChevronRight, ArrowLeft, Camera, Loader2,
+  Droplets, Thermometer, TreePine, DollarSign, AlertTriangle, MapPin, Clock,
+} from 'lucide-react';
 import {
   NBS_INTERVENTION_TYPES,
   type OpenInterventionSelectorParams,
@@ -24,6 +29,25 @@ const HAZARD_WEIGHTS: Record<string, Record<NbsInterventionTypeId, number>> = {
   landslide: { 'urban-forests': 0.9, 'green-corridors': 0.7, 'bioswales-rain-gardens': 0.3, 'flood-parks': 0.1, 'green-roofs-walls': 0.1, 'wetland-restoration': 0.2 },
 };
 
+// Section labels and icons for the detail panel
+const SECTION_CONFIG: Record<string, { icon: typeof Droplets; label: string; labelPt: string }> = {
+  description: { icon: TreePine, label: 'What is it?', labelPt: 'O que é?' },
+  how_it_works: { icon: Droplets, label: 'How it works', labelPt: 'Como funciona' },
+  key_performance_indicators_kpis: { icon: Check, label: 'Key numbers', labelPt: 'Números-chave' },
+  costs: { icon: DollarSign, label: 'Costs', labelPt: 'Custos' },
+  climate_benefits: { icon: Thermometer, label: 'Climate benefits', labelPt: 'Benefícios climáticos' },
+  optimal_site_conditions: { icon: MapPin, label: 'Best site conditions', labelPt: 'Condições ideais do local' },
+  typical_scale_and_timeline: { icon: Clock, label: 'Scale & timeline', labelPt: 'Escala e prazo' },
+  risks_and_failure_modes: { icon: AlertTriangle, label: 'Risks to watch', labelPt: 'Riscos a observar' },
+  brazilian_and_latin_american_examples: { icon: MapPin, label: 'Brazilian examples', labelPt: 'Exemplos brasileiros' },
+};
+
+const DETAIL_SECTION_ORDER = [
+  'description', 'how_it_works', 'key_performance_indicators_kpis', 'costs',
+  'climate_benefits', 'optimal_site_conditions', 'typical_scale_and_timeline',
+  'risks_and_failure_modes', 'brazilian_and_latin_american_examples',
+];
+
 export default function InterventionSelector({ params, onConfirm, onCancel }: Props) {
   const { i18n } = useTranslation();
   const isPt = i18n.resolvedLanguage === 'pt';
@@ -31,29 +55,44 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
     if (params.preSelectedType) return new Set([params.preSelectedType]);
     return new Set();
   });
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const multiSelect = params.multiSelect ?? true; // default to multi-select
+  const multiSelect = params.multiSelect ?? true;
   const maxRecs = params.maxRecommendations ?? 2;
+
+  // Detail panel state
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detailSections, setDetailSections] = useState<Record<string, string> | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [activeSection, setActiveSection] = useState<string>('description');
+
+  // Fetch detail content when opening a card
+  const openDetail = useCallback(async (id: string) => {
+    setDetailId(id);
+    setDetailLoading(true);
+    setActiveSection('description');
+    try {
+      const res = await fetch(`/api/knowledge/interventions/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setDetailSections(data.sections);
+      }
+    } catch { /* ignore */ }
+    setDetailLoading(false);
+  }, []);
 
   // Calculate relevance scores for each type
   const typeScores = useMemo(() => {
     const scores = new Map<NbsInterventionTypeId, number>();
-
-    // If agent passed explicit recommendations, use those as primary ranking
     if (params.recommendedTypes && params.recommendedTypes.length > 0) {
       for (const type of NBS_INTERVENTION_TYPES) {
         const idx = params.recommendedTypes.indexOf(type.id);
-        scores.set(type.id, idx >= 0 ? 1000 - idx : 0); // recommended types get high scores in order
+        scores.set(type.id, idx >= 0 ? 1000 - idx : 0);
       }
       return scores;
     }
-
-    // Otherwise, score based on hazards
     if (!params.siteHazards) {
       for (const type of NBS_INTERVENTION_TYPES) scores.set(type.id, 0);
       return scores;
     }
-
     const { flood, heat, landslide } = params.siteHazards;
     for (const type of NBS_INTERVENTION_TYPES) {
       const score = (HAZARD_WEIGHTS.flood[type.id] || 0) * flood
@@ -64,14 +103,12 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
     return scores;
   }, [params.siteHazards, params.recommendedTypes]);
 
-  // Sort types by score (highest first)
   const sortedTypes = useMemo(() => {
     return [...NBS_INTERVENTION_TYPES].sort((a, b) =>
       (typeScores.get(b.id) || 0) - (typeScores.get(a.id) || 0)
     );
   }, [typeScores]);
 
-  // Only top N types get "Recommended" badge
   const recommendedSet = useMemo(() => {
     const sorted = [...typeScores.entries()].sort((a, b) => b[1] - a[1]);
     const topN = sorted.slice(0, maxRecs).filter(([, score]) => score > 0);
@@ -81,12 +118,7 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
   const toggleSelect = (id: NbsInterventionTypeId) => {
     setSelected(prev => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        if (!multiSelect) next.clear();
-        next.add(id);
-      }
+      if (next.has(id)) { next.delete(id); } else { if (!multiSelect) next.clear(); next.add(id); }
       return next;
     });
   };
@@ -100,26 +132,130 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
       labels: types.map(t => t.label),
       primaryBenefits: types.map(t => t.primaryBenefit),
       knowledgeFiles: types.map(t => t.knowledgeFile),
-      interventionType: first.id,
-      label: first.label,
-      primaryBenefit: first.primaryBenefit,
-      knowledgeFile: first.knowledgeFile,
+      interventionType: first.id, label: first.label,
+      primaryBenefit: first.primaryBenefit, knowledgeFile: first.knowledgeFile,
     });
   };
 
   const handleHelpMe = () => {
     onConfirm({
-      interventionTypes: [],
-      labels: ['I don\'t know — help me decide'],
-      primaryBenefits: [],
-      knowledgeFiles: [],
-      interventionType: '' as NbsInterventionTypeId,
-      label: 'I don\'t know — help me decide',
-      primaryBenefit: '',
-      knowledgeFile: '',
+      interventionTypes: [], labels: ['I don\'t know — help me decide'],
+      primaryBenefits: [], knowledgeFiles: [],
+      interventionType: '' as NbsInterventionTypeId, label: 'I don\'t know — help me decide',
+      primaryBenefit: '', knowledgeFile: '',
     });
   };
 
+  const detailType = detailId ? NBS_INTERVENTION_TYPES.find(t => t.id === detailId) : null;
+
+  // ── Detail panel view ──────────────────────────────────────────────────────
+  if (detailId && detailType) {
+    const isSelected = selected.has(detailType.id);
+    const cs = detailType.caseStudy;
+    return (
+      <div className="flex flex-col h-full">
+        {/* Detail header with photo */}
+        <div className="relative">
+          <div className="h-40 relative overflow-hidden bg-muted">
+            <img src={cs.image} alt={cs.project} className="w-full h-full object-cover" />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+            <button
+              onClick={() => { setDetailId(null); setDetailSections(null); }}
+              className="absolute top-3 left-3 w-8 h-8 bg-black/40 hover:bg-black/60 rounded-full flex items-center justify-center text-white transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </button>
+            {recommendedSet.has(detailType.id) && (
+              <Badge className="absolute top-3 right-3 bg-green-600 text-[10px]">
+                {isPt ? 'Recomendado' : 'Recommended'}
+              </Badge>
+            )}
+            <div className="absolute bottom-3 left-3 right-3">
+              <h2 className="text-lg font-bold text-white flex items-center gap-2">
+                <span>{detailType.emoji}</span> {detailType.label}
+              </h2>
+              <p className="text-xs text-white/80 mt-0.5">{detailType.description}</p>
+              <p className="text-[10px] text-white/60 mt-1">📍 {cs.city} — {cs.project}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Section tabs */}
+        <div className="border-b bg-background overflow-x-auto">
+          <div className="flex px-2 gap-0 min-w-max">
+            {DETAIL_SECTION_ORDER.filter(key => !detailSections || detailSections[key]).map(key => {
+              const cfg = SECTION_CONFIG[key];
+              if (!cfg) return null;
+              const Icon = cfg.icon;
+              return (
+                <button key={key} onClick={() => setActiveSection(key)}
+                  className={`px-3 py-2 text-[11px] font-medium border-b-2 transition-colors whitespace-nowrap flex items-center gap-1 ${
+                    activeSection === key ? 'border-green-600 text-green-700' : 'border-transparent text-muted-foreground hover:text-foreground'
+                  }`}>
+                  <Icon className="w-3 h-3" />
+                  {isPt ? cfg.labelPt : cfg.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Section content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {detailLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : detailSections && detailSections[activeSection] ? (
+            <div className="prose prose-sm max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {detailSections[activeSection]}
+              </ReactMarkdown>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {isPt ? 'Conteúdo não disponível.' : 'Content not available.'}
+            </p>
+          )}
+
+          {/* Case study summary card at bottom */}
+          {activeSection === 'brazilian_and_latin_american_examples' && (
+            <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-md text-xs space-y-1">
+              <p className="font-semibold text-green-800">{cs.project} — {cs.city}</p>
+              <p className="text-green-700">{cs.outcome}</p>
+              <div className="flex gap-4 mt-1">
+                <span className="text-green-600"><strong>{isPt ? 'Custo' : 'Cost'}:</strong> {cs.cost}</span>
+                <span className="text-green-600"><strong>{isPt ? 'Prazo' : 'Timeline'}:</strong> {cs.timeline}</span>
+              </div>
+              <p className="text-[9px] text-green-500 flex items-center gap-1 mt-1">
+                <Camera className="w-3 h-3" /> {cs.photoCredit}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Detail footer */}
+        <div className="p-3 border-t bg-background flex items-center justify-between">
+          <Button variant="outline" size="sm" onClick={() => { setDetailId(null); setDetailSections(null); }}>
+            <ArrowLeft className="w-3 h-3 mr-1" />
+            {isPt ? 'Voltar' : 'Back'}
+          </Button>
+          <Button
+            size="sm"
+            className={isSelected ? 'bg-green-700' : 'bg-green-600 hover:bg-green-700'}
+            onClick={() => { toggleSelect(detailType.id); setDetailId(null); setDetailSections(null); }}
+          >
+            <Check className="w-4 h-4 mr-1" />
+            {isSelected
+              ? (isPt ? 'Selecionado' : 'Selected')
+              : (isPt ? 'Selecionar este tipo' : 'Select this type')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Card list view ─────────────────────────────────────────────────────────
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -154,30 +290,25 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
         {sortedTypes.map((type) => {
           const isRec = recommendedSet.has(type.id);
           const isSelected = selected.has(type.id);
-          const isExpanded = expandedId === type.id;
-          const score = typeScores.get(type.id) || 0;
           const cs = type.caseStudy;
 
           return (
             <Card
               key={type.id}
-              className={`cursor-pointer transition-all overflow-hidden ${
+              className={`transition-all overflow-hidden ${
                 isSelected
                   ? 'ring-2 ring-green-500 border-green-500'
                   : isRec
                     ? 'hover:border-green-300 hover:shadow-md'
                     : 'opacity-70 hover:opacity-90'
               }`}
-              onClick={() => toggleSelect(type.id)}
             >
-              {/* Real photo */}
-              <div className="h-36 relative overflow-hidden bg-muted">
-                <img
-                  src={cs.image}
-                  alt={`${cs.project} — ${cs.city}`}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                />
+              {/* Real photo — clicking opens detail */}
+              <div
+                className="h-36 relative overflow-hidden bg-muted cursor-pointer"
+                onClick={() => openDetail(type.id)}
+              >
+                <img src={cs.image} alt={`${cs.project} — ${cs.city}`} className="w-full h-full object-cover" loading="lazy" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
                 {isRec && (
                   <Badge className="absolute top-2 right-2 bg-green-600 text-[10px]">
@@ -190,9 +321,7 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
                   </div>
                 )}
                 <div className="absolute bottom-2 left-2 right-2 flex items-end justify-between">
-                  <span className="text-[10px] text-white/90 bg-black/40 px-1.5 py-0.5 rounded">
-                    📍 {cs.city}
-                  </span>
+                  <span className="text-[10px] text-white/90 bg-black/40 px-1.5 py-0.5 rounded">📍 {cs.city}</span>
                   <span className="text-4xl">{type.emoji}</span>
                 </div>
               </div>
@@ -213,46 +342,24 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
                   </Badge>
                 </div>
 
-                {/* Expandable real case study */}
-                {params.showCaseStudies !== false && (
-                  <div className="mt-2">
-                    <button
-                      className="text-[11px] text-green-700 hover:text-green-900 flex items-center gap-1"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setExpandedId(isExpanded ? null : type.id);
-                      }}
-                    >
-                      {isExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-                      {isPt ? 'Ver exemplo real' : 'See real example'}: {cs.project}
-                    </button>
-                    {isExpanded && (
-                      <div className="mt-2 p-3 bg-muted/50 rounded-md text-xs space-y-2 border border-muted">
-                        <div>
-                          <p className="font-semibold text-foreground">{cs.project}</p>
-                          <p className="text-muted-foreground">{cs.city}</p>
-                        </div>
-                        <div>
-                          <p className="font-medium text-foreground">{isPt ? 'Resultados' : 'Outcomes'}:</p>
-                          <p className="text-muted-foreground">{cs.outcome}</p>
-                        </div>
-                        <div className="flex gap-4">
-                          <div>
-                            <p className="font-medium text-foreground">{isPt ? 'Custo' : 'Cost'}:</p>
-                            <p className="text-muted-foreground">{cs.cost}</p>
-                          </div>
-                          <div>
-                            <p className="font-medium text-foreground">{isPt ? 'Prazo' : 'Timeline'}:</p>
-                            <p className="text-muted-foreground">{cs.timeline}</p>
-                          </div>
-                        </div>
-                        <p className="text-[9px] text-muted-foreground/60 flex items-center gap-1">
-                          <Camera className="w-3 h-3" /> {cs.photoCredit}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                )}
+                {/* Action buttons */}
+                <div className="flex items-center gap-2 mt-2.5">
+                  <Button
+                    variant="outline" size="sm" className="text-[11px] h-7 flex-1"
+                    onClick={(e) => { e.stopPropagation(); openDetail(type.id); }}
+                  >
+                    {isPt ? 'Saiba mais' : 'Learn more'}
+                    <ChevronRight className="w-3 h-3 ml-1" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    className={`text-[11px] h-7 ${isSelected ? 'bg-green-700' : 'bg-green-600 hover:bg-green-700'}`}
+                    onClick={(e) => { e.stopPropagation(); toggleSelect(type.id); }}
+                  >
+                    <Check className="w-3 h-3 mr-1" />
+                    {isSelected ? (isPt ? 'Selecionado' : 'Selected') : (isPt ? 'Selecionar' : 'Select')}
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           );
@@ -294,12 +401,7 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
                 : `${selected.size} ${isPt ? 'selecionados' : 'selected'}`}
             </span>
           )}
-          <Button
-            size="sm"
-            className="bg-green-600 hover:bg-green-700"
-            disabled={selected.size === 0}
-            onClick={handleConfirm}
-          >
+          <Button size="sm" className="bg-green-600 hover:bg-green-700" disabled={selected.size === 0} onClick={handleConfirm}>
             <Check className="w-4 h-4 mr-1" />
             {isPt ? 'Confirmar' : 'Confirm'}{selected.size > 1 ? ` (${selected.size})` : ''}
           </Button>

--- a/server/routes/knowledgeRoutes.ts
+++ b/server/routes/knowledgeRoutes.ts
@@ -277,6 +277,63 @@ export function registerKnowledgeRoutes(app: Express): void {
     }
   });
 
+  // ── Intervention knowledge files (parsed into structured JSON) ──────────
+
+  app.get("/api/knowledge/interventions/:id", async (req: Request, res: Response) => {
+    try {
+      const fs = await import('fs/promises');
+      const pathMod = await import('path');
+      const id = req.params.id;
+      const filePath = pathMod.join(process.cwd(), 'knowledge', '_interventions', `${id}.md`);
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const body = raw.replace(/^---[\s\S]*?---\s*/, ''); // strip frontmatter
+
+      // Parse markdown sections
+      const sections: Record<string, string> = {};
+      let currentKey = '';
+      for (const line of body.split('\n')) {
+        const h2 = line.match(/^## (.+)/);
+        if (h2) {
+          currentKey = h2[1].trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_|_$/g, '');
+          sections[currentKey] = '';
+        } else if (currentKey) {
+          sections[currentKey] += line + '\n';
+        }
+      }
+
+      // Trim whitespace from each section
+      for (const key of Object.keys(sections)) {
+        sections[key] = sections[key].trim();
+      }
+
+      res.json({ id, sections });
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        res.status(404).json({ error: `Intervention not found: ${req.params.id}` });
+      } else {
+        console.error('Intervention knowledge error:', error);
+        res.status(500).json({ error: 'Failed to load intervention data' });
+      }
+    }
+  });
+
+  // List all available intervention types
+  app.get("/api/knowledge/interventions", async (_req: Request, res: Response) => {
+    try {
+      const fs = await import('fs/promises');
+      const pathMod = await import('path');
+      const dir = pathMod.join(process.cwd(), 'knowledge', '_interventions');
+      const files = await fs.readdir(dir);
+      const ids = files.filter(f => f.endsWith('.md')).map(f => f.replace('.md', ''));
+      res.json({ interventions: ids });
+    } catch {
+      res.json({ interventions: [] });
+    }
+  });
+
   app.get("/api/knowledge/stats", async (_req: Request, res: Response) => {
     try {
       const stats = await getKnowledgeStats(GLOBAL_PROJECT_ID);


### PR DESCRIPTION
## Summary
- **"Learn more" button** on each NBS type card opens a slide-out detail panel
- **Knowledge API endpoint** (`/api/knowledge/interventions/:id`) parses markdown files into structured JSON sections
- **9 tabbed sections** in the detail panel: What is it, How it works, Key numbers, Costs, Climate benefits, Site conditions, Scale & timeline, Risks, Brazilian examples
- **Rich content** from knowledge files rendered with ReactMarkdown (tables, lists, formatted data)
- **"Select this type" button** in the detail panel for direct selection without going back
- **Photo header** with back navigation and recommendation badge

## Test plan
- [ ] `[SKIP TO phase:3a]` — click "Learn more" on any card
- [ ] Detail panel should show photo header, tabbed sections, and real content
- [ ] Click through all 9 tabs — each should show relevant knowledge content
- [ ] "Select this type" should select and return to card list
- [ ] Back button should return to card list without selecting
- [ ] Test with multiple interventions to verify API handles all 6 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)