### PR TITLE
feat: CBO knowledge + phase prompts + real funding + i18n

### DIFF
--- a/.claude/commands/cbo-intervention.md
+++ b/.claude/commands/cbo-intervention.md
@@ -37,32 +37,46 @@ Help a community-based organization (CBO/NGO) prepare their NBS intervention for
 - Scale: area (ha), tree count, structures
 - **Maturity assessment**: Problem Clarity (0-3), Solution Clarity (0-3)
 
-### Phase 3b: Expected Impact (impact_monitoring)
-- Read co-benefits files for the selected intervention type
-- Expected impact areas (multi-select): flood reduction, heat cooling, biodiversity, carbon, jobs, health
-- For each: provide benchmarks from knowledge ("bioswales typically reduce runoff by 65%")
-- Baseline: "Do you have current measurements?" → "I don't know" → explain what to measure and how
-- Monitoring plan: "How will you know it's working?" → "I don't know" → suggest simple indicators
-- Ask for existing data or studies: "Do you have any documents about this project?"
+### Phase 3b: Expected Impact (impact_monitoring) — B£ST-STYLE ASSESSMENT
+Follow the B£ST (Benefits Estimation Tool) model for guided impact assessment:
+
+**Step 1 — Screening**: 5-6 yes/no toggles to identify relevant benefit categories
+  - Flooding? Heat? Water body nearby? People within 500m? Existing vegetation? Erosion?
+  - Pre-fill from Phase 2 hazard data
+
+**Step 2 — Site inputs**: Collect details that improve the estimate
+  - Baseline condition (what was there before?)
+  - Population nearby (from Phase 2)
+  - Maintenance commitment (weekly/monthly/seasonal)
+  - Timeframe (1/3/5/10 years)
+
+**Step 3 — With/without comparison**: Read co-benefits + impact benchmarks knowledge files
+  - Present as: "WITHOUT your project: X" vs "WITH your project: Y"
+  - ALWAYS show ranges, never point estimates
+  - Show confidence levels (high/medium/low)
+  - Reference similar funded project as benchmark
+
 - **Maturity assessment**: Climate NBS Impact (0-3)
 
 ### Phase 3c: Operations & Sustainability (operations_sustain)
 - Operations model: who maintains it? (community volunteers, paid staff, municipal, partnership)
-- Maintenance schedule: what tasks, how often
+- Maintenance schedule: what tasks, how often (read OPEX section from intervention knowledge file)
 - Sustainability model: how will you pay for maintenance long-term?
-  - Options: grants, carbon credits, PES, productive use (food, tourism), municipal budget, social enterprise
-  - "I don't know" → walk through each model with examples from funded projects
+  - Realistic options for CBOs: municipal budget allocation, community cooperative fee, productive use (food, tourism, education), grant renewal (watch for new editais)
+  - Be HONEST: carbon credits are NOT practical for small projects (<100 ha)
+  - "I don't know" → walk through each model with simple examples
 - Timeline: started when, milestones, expected completion
 - What's already done vs what's planned
-- Show relevant funded project cards from evidence database
 - **Maturity assessment**: Financial Thinking (0-3)
 
-### Phase 4: What We Need (needs_assessment)
+### Phase 4: What We Need (needs_assessment) — REAL FUNDING SOURCES
+- Read knowledge: _financing-sources/cbo-grants.md
+- Present ONLY funding sources the CBO can actually access:
+  - **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa RS (R$40K), Periferias Verdes Resilientes, GEF SGP (US$50K)
+  - **Tier 2** (through partnership/municipality): Petrobras NBS Urbano, World Bank P178072 sub-components
+  - **Monitor**: capta.org.br/fontes for new editais
+- DO NOT present BNDES (min R$10M) or GCF (US$50M+) as direct options for CBOs
 - Technical help needed (design, monitoring, engineering)
-- Financial gap: funding needed and for what
-- Equipment / materials needed
-- Partnerships sought
-- Training needs
 - Regulatory status: permits, conversations with authorities
 - Ask for links: "Do you have a website, social media, or news coverage?"
 - **Maturity assessment**: Regulatory Awareness (0-3)

--- a/client/src/core/components/concept-note/InterventionSelector.tsx
+++ b/client/src/core/components/concept-note/InterventionSelector.tsx
@@ -70,7 +70,8 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
     setDetailLoading(true);
     setActiveSection('description');
     try {
-      const res = await fetch(`/api/knowledge/interventions/${id}`);
+      const lang = isPt ? 'pt' : 'en';
+      const res = await fetch(`/api/knowledge/interventions/${id}?lang=${lang}`);
       if (res.ok) {
         const data = await res.json();
         setDetailSections(data.sections);

--- a/knowledge/_financing-sources/cbo-grants.md
+++ b/knowledge/_financing-sources/cbo-grants.md
@@ -1,0 +1,101 @@
+---
+last_updated: 2026-04-07
+source: "web research — verified funding sources for small CBOs"
+audience: "Community-based organizations (5-50 people, budgets R$50K-2M)"
+---
+
+# Funding Sources for Community NBS Projects in Brazil
+
+This file covers grants and programs that small community organizations (CBOs, NGOs, cooperatives) can actually access for Nature-Based Solutions projects. Large-scale financing (BNDES, World Bank loans, GCF regular proposals) requires municipal or state-level borrowers and is covered in the other financing files.
+
+## Tier 1: CBOs Can Apply Directly
+
+### Teia da Sociobiodiversidade (Fundo Casa + CAIXA)
+- **Type**: Non-reimbursable grant
+- **Amount**: Up to R$100,000 per project (R$20M total program, ~400 projects nationally)
+- **Eligibility**: Nonprofits with annual budget up to R$500K. Prioritizes women, youth, community networks, traditional communities.
+- **Focus**: Community-led environmental and biodiversity projects, including NBS
+- **Status**: Recurring program. 2nd call closed Dec 2025; 203 projects selected March 2026. Watch for 3rd call.
+- **How to apply**: Through Fundo Casa website during open call periods
+- **URL**: https://casa.org.br/teia/
+- **Best for**: Small CBOs with community roots. The R$500K budget cap is designed specifically for grassroots organizations.
+
+### Fundo Casa Socioambiental — Reconstruir RS
+- **Type**: Non-reimbursable grant
+- **Amount**: Up to R$40,000 per project
+- **Eligibility**: Nonprofits representing local or traditional communities in Rio Grande do Sul affected by the May 2024 floods
+- **Focus**: Reconstruction, resilience, and environmental recovery in flood-affected areas
+- **Status**: First round completed (62 of 78 proposals selected). May recur — monitor the editais page.
+- **How to apply**: Through Fundo Casa editais page during open calls
+- **URL**: https://casa.org.br/category/editais/
+- **Best for**: RS-based CBOs working in flood-affected neighborhoods. Directly relevant to Porto Alegre post-2024 flood recovery.
+
+### Edital Periferias Verdes Resilientes (Ministério das Cidades)
+- **Type**: Non-reimbursable grant (Termo de Fomento)
+- **Amount**: R$25M total program; individual project sizes vary
+- **Eligibility**: CSOs (Organizações da Sociedade Civil) — apply via Transferegov platform
+- **Focus**: NBS in urban peripheries for climate adaptation — exactly what community NBS projects are
+- **Status**: First edition deadline July 2025, 61 of 91 proposals classified. Watch for next edition.
+- **How to apply**: Through Transferegov (federal grants platform) during open calls
+- **URL**: https://www.gov.br/cidades/
+- **Best for**: CBOs working in peripheral/vulnerable urban neighborhoods. NBS is the explicit focus.
+
+### GEF Small Grants Programme (SGP) — Brazil
+- **Type**: Grant
+- **Amount**: Up to US$50,000 (~R$275K) per project
+- **Eligibility**: CBOs and NGOs apply directly through the SGP National Coordinator
+- **Focus**: Biodiversity, climate change, land degradation, international waters, chemicals
+- **Status**: Brazil is an "upgraded country programme." Active globally; contact the National Coordinator for current Brazil cycle.
+- **How to apply**: Contact SGP National Coordinator via https://sgp.undp.org/about-us-157/how-to-apply.html
+- **Best for**: Well-organized CBOs that can navigate the GEF application process. Larger grant size but more competitive.
+
+## Tier 2: Through Partnership or Municipality
+
+### Petrobras Programa Socioambiental — NBS Urbano
+- **Type**: Grant
+- **Amount**: R$5.5-6M per project (too large for one small CBO alone)
+- **Eligibility**: Nonprofits, but projects must span 2+ municipalities in RS metro area (Canoas, Esteio, Porto Alegre, Gravataí, Viamão, Novo Hamburgo, São Leopoldo)
+- **How CBOs can access**: Partner as sub-grantee with a larger NGO leading the consortium
+- **Status**: Current round results expected 2026
+- **URL**: https://petrobras.com.br/sustentabilidade/selecoes-publicas
+
+### Teia de Soluções — Resiliência Climática RS (Fundação Boticário + BRDE)
+- **Type**: Grant
+- **Amount**: R$11M total for 15 projects (~R$700K average)
+- **Eligibility**: CSOs, companies, universities — RS flood-affected areas
+- **How CBOs can access**: Apply directly if project scale fits, or partner with larger institution
+- **Status**: First round completed. May recur.
+
+### World Bank P178072 — Porto Alegre Green Resilient Regeneration
+- **Type**: Municipal loan (US$85M IBRD + AFD)
+- **Amount**: US$173M total program
+- **Focus**: NBS drainage, green retrofitting, heritage conservation, social inclusion in Centro Histórico and 4° Distrito
+- **How CBOs can access**: This is a municipal project — CBOs cannot apply directly. But the project includes community sub-components. Engage with Prefeitura's SMAMUS to understand how community organizations can participate or benefit.
+- **URL**: Contact Porto Alegre's Secretaria de Meio Ambiente
+
+### C40 Gap Fund / ICLEI Support
+- **Type**: Technical assistance to the municipality (not direct grants to CBOs)
+- **How CBOs can access**: Porto Alegre receives Gap Fund support for climate action planning. CBOs should engage with the municipal climate team to ensure community NBS priorities are included.
+
+## Monitoring New Opportunities
+
+### Capta — Oportunidades de Financiamento
+- **What**: Brazilian grants aggregator that lists open calls across all sectors
+- **URL**: https://capta.org.br/fontes-de-financiamento/oportunidades/
+- **Why useful**: Best single place to monitor new editais as they open. Filter by "meio ambiente" and "comunidades"
+- **Recommendation**: Check monthly for new calls
+
+### What Doesn't Work for Small CBOs
+- **Carbon credits**: Transaction costs and MRV requirements make voluntary carbon markets inaccessible for projects under 100 ha
+- **BNDES Fundo Clima**: Minimum R$10M financing — requires municipal borrower with CAPAG A/B rating
+- **GCF regular proposals**: US$50M+ — requires Accredited Entity (BNDES, UNDP)
+- **FEPAM (RS)**: Environmental regulator, not a funder — issues licenses, not grants
+- **Crowdfunding**: No Brazil-specific NBS crowdfunding platform exists
+
+## Tips for CBO Funding Applications
+
+1. **Build the maturity scorecard first**: A completed CBO profile with a score of 19+ ("Investment Ready with Conditions") is a strong attachment to any grant application
+2. **Document everything**: Photos, baseline measurements, community support letters — these are what differentiate winning proposals
+3. **Start small**: R$40-100K grants build track record for larger applications
+4. **Partner up**: For Tier 2 programs, approach a larger NGO or university as consortium lead
+5. **Engage the municipality**: Many larger funds flow through city governments — make sure your project is visible to SMAMUS and the climate action planning team

--- a/server/routes/knowledgeRoutes.ts
+++ b/server/routes/knowledgeRoutes.ts
@@ -279,17 +279,41 @@ export function registerKnowledgeRoutes(app: Express): void {
 
   // ── Intervention knowledge files (parsed into structured JSON) ──────────
 
+  // Section header translations for Portuguese
+  const SECTION_HEADERS_PT: Record<string, string> = {
+    description: '## Descrição',
+    how_it_works: '## Como Funciona',
+    costs: '## Custos',
+    key_performance_indicators_kpis: '## Indicadores de Desempenho',
+    climate_benefits: '## Benefícios Climáticos',
+    optimal_site_conditions: '## Condições Ideais do Local',
+    typical_scale_and_timeline: '## Escala e Prazo Típicos',
+    risks_and_failure_modes: '## Riscos e Modos de Falha',
+    brazilian_and_latin_american_examples: '## Exemplos Brasileiros e Latino-Americanos',
+    key_references: '## Referências',
+  };
+
   app.get("/api/knowledge/interventions/:id", async (req: Request, res: Response) => {
     try {
       const fs = await import('fs/promises');
       const pathMod = await import('path');
       const id = req.params.id;
-      const filePath = pathMod.join(process.cwd(), 'knowledge', '_interventions', `${id}.md`);
-      const raw = await fs.readFile(filePath, 'utf-8');
+      const lang = (req.query.lang as string) || 'en';
+
+      // Try language-specific file first, fall back to default
+      let filePath = pathMod.join(process.cwd(), 'knowledge', '_interventions', `${id}.${lang}.md`);
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, 'utf-8');
+      } catch {
+        filePath = pathMod.join(process.cwd(), 'knowledge', '_interventions', `${id}.md`);
+        raw = await fs.readFile(filePath, 'utf-8');
+      }
       const body = raw.replace(/^---[\s\S]*?---\s*/, ''); // strip frontmatter
 
       // Parse markdown sections
       const sections: Record<string, string> = {};
+      const sectionHeaders: Record<string, string> = {}; // original headers for display
       let currentKey = '';
       for (const line of body.split('\n')) {
         const h2 = line.match(/^## (.+)/);
@@ -299,6 +323,7 @@ export function registerKnowledgeRoutes(app: Express): void {
             .replace(/[^a-z0-9]+/g, '_')
             .replace(/^_|_$/g, '');
           sections[currentKey] = '';
+          sectionHeaders[currentKey] = h2[1].trim();
         } else if (currentKey) {
           sections[currentKey] += line + '\n';
         }
@@ -309,7 +334,10 @@ export function registerKnowledgeRoutes(app: Express): void {
         sections[key] = sections[key].trim();
       }
 
-      res.json({ id, sections });
+      // If Portuguese was requested but we served English, include translated headers
+      const translatedHeaders = lang === 'pt' ? SECTION_HEADERS_PT : undefined;
+
+      res.json({ id, lang: lang === 'pt' && !filePath.includes('.pt.md') ? 'en' : lang, sections, sectionHeaders, translatedHeaders });
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         res.status(404).json({ error: `Intervention not found: ${req.params.id}` });
@@ -321,16 +349,18 @@ export function registerKnowledgeRoutes(app: Express): void {
   });
 
   // List all available intervention types
-  app.get("/api/knowledge/interventions", async (_req: Request, res: Response) => {
+  app.get("/api/knowledge/interventions", async (req: Request, res: Response) => {
     try {
       const fs = await import('fs/promises');
       const pathMod = await import('path');
+      const lang = (req.query.lang as string) || 'en';
       const dir = pathMod.join(process.cwd(), 'knowledge', '_interventions');
       const files = await fs.readdir(dir);
-      const ids = files.filter(f => f.endsWith('.md')).map(f => f.replace('.md', ''));
-      res.json({ interventions: ids });
+      // Only list base files (not .pt.md variants)
+      const ids = files.filter(f => f.endsWith('.md') && !f.includes('.'+ 'pt.')).map(f => f.replace('.md', ''));
+      res.json({ interventions: ids, lang });
     } catch {
-      res.json({ interventions: [] });
+      res.json({ interventions: [], lang: 'en' });
     }
   });
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -619,7 +619,7 @@ async function buildSystemContext(state: CboState): Promise<string> {
       }
     } catch {}
     // Available knowledge listing
-    for (const folder of ['_interventions', '_co-benefits']) {
+    for (const folder of ['_interventions', '_co-benefits', '_financing-sources', '_evidence', '_success-cases']) {
       try {
         const files = await fs.readdir(path.join(process.cwd(), 'knowledge', folder));
         chunks.push(`### Available in ${folder}/\n${files.filter((f: string) => f.endsWith('.md')).map((f: string) => `- ${f}`).join('\n')}`);
@@ -647,13 +647,79 @@ Phase: ${state.phase}. Organization: ${state.orgName || '(not set)'}.
 9. **read_knowledge** — read knowledge files for interventions, co-benefits, case studies, benchmarks. USE THIS PROACTIVELY.
 
 ## PHASE FLOW
-- Phase 1: Who We Are (org_profile) — org info, team, experience
-- Phase 2: Where We Work (intervention_site) — map selection, neighborhood, site conditions
-- Phase 3a: What We're Building (intervention_type) — NBS type via selector micro-app, design details
-- Phase 3b: Expected Impact (impact_monitoring) — outcomes, baseline, monitoring indicators
-- Phase 3c: Operations & Sustainability (operations_sustain) — ops model, maintenance, revenue/sustainability
-- Phase 4: What We Need (needs_assessment) — technical, financial, regulatory
-- Phase 5: Results & Evidence (results_evidence) — documents, photos, links, data
+
+### Phase 1: Who We Are (org_profile)
+Org info, team, experience. Straightforward Q&A via ask_user.
+
+### Phase 2: Where We Work (intervention_site)
+Map selection via open_map (composite mode), neighborhood, site conditions.
+
+### Phase 3a: What We're Building (intervention_type)
+NBS type via open_intervention_selector micro-app, design details.
+
+### Phase 3b: Expected Impact (impact_monitoring) — B£ST-STYLE ASSESSMENT
+This is a GUIDED IMPACT ASSESSMENT, not a simple Q&A. Follow the B£ST model:
+
+**Step 1 — Screening (pre-fill from Phase 2 data):**
+Ask 5-6 yes/no toggle questions via ask_user to identify relevant benefit categories:
+- Does your site experience flooding or water accumulation?
+- Is heat stress a problem in the neighborhood?
+- Is there a water body (stream, river, wetland) at or near the site?
+- Do people live within 500m of the site?
+- Is there existing vegetation on the site?
+- Is erosion or landslide a risk?
+Pre-fill answers from Phase 2 hazard data when available. Let user correct.
+
+**Step 2 — Site-specific inputs:**
+Ask for details that improve the estimate (show defaults from Phase 2/3a, let user adjust):
+- What was the site like BEFORE? (paved/degraded/bare soil/existing vegetation)
+- How many people live nearby? (from Phase 2 population data)
+- What maintenance can you commit to? (weekly/monthly/seasonal)
+- Over what timeframe? (1 year/3 years/5 years/10 years)
+
+**Step 3 — With/without comparison:**
+Read knowledge files: read_knowledge(_co-benefits/flood-risk-reduction.md), read_knowledge(_co-benefits/carbon-sequestration.md), read_knowledge(_evidence/impact-benchmarks.md), etc.
+
+Present results as a WITH vs WITHOUT comparison:
+- "WITHOUT your project: flooding continues, 0 tCO2 sequestered, 3,200 people at risk"
+- "WITH your project: flood reduction 40-60% (high confidence), carbon 5-20 tCO2/yr (medium confidence), 2-3 jobs created"
+- Reference a similar funded project as benchmark
+- Show confidence levels honestly (high/medium/low)
+- ALWAYS show ranges, NEVER point estimates
+
+Then call update_section for impact_monitoring fields and score_maturity for climate_nbs_impact.
+
+### Phase 3c: Operations & Sustainability (operations_sustain)
+Ask about:
+1. Who will maintain the project? (community volunteers / paid staff / municipality / mixed)
+2. How often? (weekly, monthly, seasonal tasks)
+3. What does maintenance involve? (read_knowledge for the selected NBS type's OPEX section)
+4. How will you fund maintenance long-term?
+   - Include "I don't know" → explain options simply:
+   - Municipal budget allocation (if government supports the project)
+   - Community fee or cooperative model
+   - Productive use (food gardens, eco-tourism, educational visits)
+   - Grant renewal (watch for new editais)
+   - Carbon credits are NOT practical for small projects — be honest about this
+5. Timeline: started when, milestones, expected completion
+
+### Phase 4: What We Need (needs_assessment) — REAL FUNDING SOURCES
+Read knowledge: read_knowledge(_financing-sources/cbo-grants.md)
+
+Present ONLY funding sources that match the CBO's actual profile:
+- **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa Reconstruir RS (R$40K), Periferias Verdes Resilientes (federal), GEF SGP (US$50K)
+- **Tier 2** (through municipality/partnership): Petrobras NBS Urbano (consortium), World Bank P178072 sub-components
+- **Monitoring**: Recommend capta.org.br for tracking new editais
+
+DO NOT present BNDES (min R$10M), GCF regular proposals (US$50M+), or World Bank loans as direct options for CBOs. Be honest: "These larger funds are for municipalities — but you can advocate for your project to be included."
+
+Also ask about:
+- Technical needs (engineering, species selection, monitoring equipment)
+- Regulatory status (has anyone from the government visited? do you need permits?)
+- Training needs
+
+### Phase 5: Results & Evidence (results_evidence)
+Documents, photos, links, data. Proactively ask for evidence and set priority flags.
 
 ## MATURITY METRICS (score each 0-3 as you go)
 ${MATURITY_METRICS.join(', ')}


### PR DESCRIPTION
## Summary
- **New CBO grants knowledge file** with 4 real, verified funding sources CBOs can actually access (Teia da Sociobiodiversidade R$100K, Fundo Casa RS R$40K, Periferias Verdes Resilientes, GEF SGP US$50K) plus Tier 2 municipal options and capta.org.br monitoring
- **Phase 3b prompt**: B£ST-style guided impact assessment — screening toggles → site inputs → with/without comparison with confidence ranges (conversational, not micro-app)
- **Phase 3c prompt**: Realistic sustainability models — no carbon credits myth for small projects, practical options (cooperative fees, productive use, grant renewal)
- **Phase 4 prompt**: Only shows funding CBOs can access. Honest about BNDES/GCF/World Bank being for municipalities.
- **Knowledge API i18n**: `/api/knowledge/interventions/:id?lang=pt` tries pt-specific files first, returns translated section headers
- **Agent knowledge listing** now includes `_financing-sources`, `_evidence`, `_success-cases` folders

## Test plan
- [ ] `[SKIP TO phase:3b]` — agent should ask B£ST screening questions, then present with/without comparison
- [ ] `[SKIP TO phase:3c]` — agent should ask about sustainability without suggesting carbon credits
- [ ] `[SKIP TO phase:4]` — agent should present Tier 1 grants (Teia, Fundo Casa, etc.) not BNDES
- [ ] `/api/knowledge/interventions/flood-parks?lang=pt` — should return translatedHeaders
- [ ] NBS selector "Learn more" should pass lang to API

🤖 Generated with [Claude Code](https://claude.com/claude-code)