### PR TITLE
fix: map draw mode — disable dragging so drawing works

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -489,11 +489,13 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
     map.on('click', handleClick);
     map.on('dblclick', handleDblClick);
     map.doubleClickZoom.disable();
+    map.dragging.disable(); // Disable drag so clicks register for drawing
     map.getContainer().style.cursor = 'crosshair';
     return () => {
       map.off('click', handleClick);
       map.off('dblclick', handleDblClick);
       map.doubleClickZoom.enable();
+      map.dragging.enable(); // Re-enable drag when draw mode exits
       map.getContainer().style.cursor = '';
       polygonPointsRef.current = [];
       if (polygonPreviewRef.current) { map.removeLayer(polygonPreviewRef.current); polygonPreviewRef.current = null; }


### PR DESCRIPTION
## Summary
When entering point or polygon draw mode in the map microapp, the map pans instead of drawing because Leaflet's drag handler intercepts clicks before the draw handlers.

**Fix**: `map.dragging.disable()` when draw mode activates, `map.dragging.enable()` when it deactivates.

2-line fix.

## Test plan
- [ ] Open map in CBO Phase 2 → select a neighborhood → click "Area" draw button
- [ ] Click points on the map → should create polygon vertices, NOT pan the map
- [ ] Double-click to finish polygon → area is created
- [ ] Exit draw mode → map dragging works again normally
- [ ] Click "Point" → click on map → custom point created, NOT map pan

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)