### PR TITLE
feat: site naming for custom areas + completion flow

### DIFF
--- a/.claude/commands/cbo-intervention.md
+++ b/.claude/commands/cbo-intervention.md
@@ -16,6 +16,7 @@ Help a community-based organization (CBO/NGO) prepare their NBS intervention for
 ### Phase 2: Where We Work (intervention_site)
 - **Show map** — open_map with composite mode for neighborhood + site selection
 - Neighborhood / bairro
+- **Custom site naming**: When the user draws a custom point or area (not a named OSM feature), ask: "Does this site have a name?" Options: "Yes, it's called [name]" / "No, use the location". Store the name in the site_name field.
 - Area estimate (ha or m²)
 - Current conditions (what's there now)
 - Who lives nearby, population, vulnerabilities
@@ -99,6 +100,8 @@ Follow the B£ST (Benefits Estimation Tool) model for guided impact assessment:
   - 19-24: Investment ready with conditions
   - 25-27: Investment ready
 - Recommend specific next steps based on lowest scores
+- **Call set_phase(6)** to signal completion — this activates the Export button and shows a review prompt
+- Tell the user: "Your profile is complete! Review each section in the Document tab — you can click any field to edit it. When you're ready, click Export."
 
 ## Guidance Mode
 

--- a/.claude/commands/cbo-intervention.pt.md
+++ b/.claude/commands/cbo-intervention.pt.md
@@ -16,6 +16,7 @@ Ajude uma organização comunitária (OBC/ONG) a preparar seu projeto de Soluç�
 ### Fase 2: Onde Atuamos (intervention_site)
 - **Abrir mapa** — open_map com modo composto para seleção de bairro + local
 - Bairro
+- **Nome do local**: Quando o usuário desenha um ponto ou área personalizada (não um local do OSM), perguntar: "Esse local tem um nome?" Opções: "Sim, se chama [nome]" / "Não, pode usar a localização". Salvar o nome no campo site_name.
 - Estimativa de área (ha ou m²)
 - Condições atuais (o que tem lá agora)
 - Quem mora perto, população, vulnerabilidades
@@ -99,6 +100,8 @@ Siga o modelo B£ST (Ferramenta de Estimativa de Benefícios) para avaliação g
   - 19-24: Pronto para investimento com condições
   - 25-27: Pronto para investimento
 - Recomendar próximos passos específicos baseados nas pontuações mais baixas
+- **Chamar set_phase(6)** para sinalizar conclusão — isso ativa o botão Exportar e mostra um prompt de revisão
+- Dizer ao usuário: "Seu perfil está completo! Revise cada seção na aba Documento — você pode clicar em qualquer campo para editar. Quando estiver pronto, clique em Exportar."
 
 ## Modo de Orientação
 

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -494,7 +494,7 @@ export default function CboProfilePage() {
               </div>
             </div>
             <div className="flex gap-1">
-              <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.export')}</TooltipContent></Tooltip>
+              <Tooltip><TooltipTrigger asChild><Button variant={state.phase >= 6 ? 'default' : 'outline'} size="sm" className={state.phase >= 6 ? 'bg-green-600 hover:bg-green-700 animate-pulse' : ''} onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" />{state.phase >= 6 && <span className="ml-1 text-xs">{t('cbo.export')}</span>}</Button></TooltipTrigger><TooltipContent>{t('cbo.export')}</TooltipContent></Tooltip>
               <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.startOver')}</TooltipContent></Tooltip>
             </div>
           </div>
@@ -567,13 +567,35 @@ export default function CboProfilePage() {
 
             {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
 
-            {/* Resume */}
+            {/* Resume / Completion */}
             {!isStreaming && state.phase > 0 && !currentQuestion && messages.length > 0 && (
               <div className="text-center py-4">
-                <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-dashed border-green-300 bg-green-50">
-                  <p className="text-sm text-muted-foreground">{t('cbo.phase', { num: state.phase, count: filledCount })}</p>
-                  <Button variant="outline" onClick={() => sendMessage(lang === 'pt' ? `Continuar da Fase ${state.phase}.` : `Continue from Phase ${state.phase}.`)}>{t('cbo.continue')}</Button>
-                </div>
+                {state.phase >= 6 ? (
+                  <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-green-400 bg-green-50">
+                    <Star className="w-6 h-6 text-green-600" />
+                    <p className="text-sm font-semibold text-green-800">
+                      {lang === 'pt' ? 'Perfil completo!' : 'Profile complete!'}
+                    </p>
+                    <p className="text-xs text-green-600">
+                      {lang === 'pt'
+                        ? `Maturidade: ${state.totalMaturityScore}/27 · ${filledCount}/7 seções preenchidas`
+                        : `Maturity: ${state.totalMaturityScore}/27 · ${filledCount}/7 sections filled`}
+                    </p>
+                    <div className="flex gap-2 mt-1">
+                      <Button variant="outline" size="sm" onClick={() => setRightTab('document')}>
+                        {lang === 'pt' ? 'Revisar documento' : 'Review document'}
+                      </Button>
+                      <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}>
+                        <Download className="w-3 h-3 mr-1" /> {t('cbo.export')}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-dashed border-green-300 bg-green-50">
+                    <p className="text-sm text-muted-foreground">{t('cbo.phase', { num: state.phase, count: filledCount })}</p>
+                    <Button variant="outline" onClick={() => sendMessage(lang === 'pt' ? `Continuar da Fase ${state.phase}.` : `Continue from Phase ${state.phase}.`)}>{t('cbo.continue')}</Button>
+                  </div>
+                )}
               </div>
             )}
 
@@ -631,6 +653,21 @@ export default function CboProfilePage() {
 
           {rightTab === 'document' && (
             <div className="flex-1 overflow-y-auto p-3 space-y-2">
+              {state.phase >= 6 && (
+                <div className="p-3 bg-green-50 border border-green-200 rounded-lg flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-green-800">{lang === 'pt' ? 'Perfil completo!' : 'Profile complete!'}</p>
+                    <p className="text-xs text-green-600">
+                      {lang === 'pt'
+                        ? `Maturidade: ${state.totalMaturityScore}/27. Revise as seções e clique em Exportar quando estiver pronto.`
+                        : `Maturity: ${state.totalMaturityScore}/27. Review sections below and click Export when ready.`}
+                    </p>
+                  </div>
+                  <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}>
+                    <Download className="w-3 h-3 mr-1" /> {t('cbo.export')}
+                  </Button>
+                </div>
+              )}
               {CBO_SECTIONS.map(sec => {
                 const section = state.sections[sec.id];
                 if (!section) return null;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1623,6 +1623,7 @@
       "contact_email": "Contact Email",
       "contact_phone": "Contact Phone",
       "neighborhood": "Neighborhood",
+      "site_name": "Site Name",
       "area": "Area",
       "area_estimate": "Area Estimate",
       "current_conditions": "Current Conditions",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1602,6 +1602,7 @@
       "contact_email": "Email do Contato",
       "contact_phone": "Telefone do Contato",
       "neighborhood": "Bairro",
+      "site_name": "Nome do Local",
       "area": "Área",
       "area_estimate": "Estimativa de Área",
       "current_conditions": "Condições Atuais",


### PR DESCRIPTION
## Summary

### Site naming (#97)
- Agent asks "Does this site have a name?" when user draws a custom point or area on the map
- Updated both EN and PT skill files with the instruction
- New `site_name` field in both locale files

### Completion flow (#100)  
- **Export button**: Highlights green with pulse animation when phase >= 6 (profile complete)
- **Document banner**: Shows maturity score and Export button at top of document panel when complete
- **Chat card**: "Resume" card becomes a "Review & Export" card with star icon, score, and dual buttons (Review / Export)
- **Agent instruction**: Both EN/PT skill files tell agent to call `set_phase(6)` after scorecard and prompt user to review

## Test plan
- [ ] Draw a custom point on map → agent asks for site name
- [ ] Complete all phases through scorecard → agent calls set_phase(6)
- [ ] Phase 6: export button pulses green, document panel shows completion banner
- [ ] Chat shows "Profile complete!" card with Review + Export buttons
- [ ] PT language: all completion text in Portuguese

Closes #97, closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)