### PR TITLE
feat: anti-repetition — phases reference earlier data, go deeper

### DIFF
--- a/.claude/commands/cbo-intervention.md
+++ b/.claude/commands/cbo-intervention.md
@@ -38,47 +38,42 @@ Help a community-based organization (CBO/NGO) prepare their NBS intervention for
 - Scale: area (ha), tree count, structures
 - **Maturity assessment**: Problem Clarity (0-3), Solution Clarity (0-3)
 
-### Phase 3b: Expected Impact (impact_monitoring) — B£ST-STYLE ASSESSMENT
-Follow the B£ST (Benefits Estimation Tool) model for guided impact assessment:
+### Phase 3b: Expected Impact (impact_monitoring) — GO DEEPER, DON'T REPEAT
+**DO NOT re-ask what's already known from Phase 2.** You already have flood/heat/landslide risk, population, and site conditions. Use them.
 
-**Step 1 — Screening**: 5-6 yes/no toggles to identify relevant benefit categories
-  - Flooding? Heat? Water body nearby? People within 500m? Existing vegetation? Erosion?
-  - Pre-fill from Phase 2 hazard data
-
-**Step 2 — Site inputs**: Collect details that improve the estimate
-  - Baseline condition (what was there before?)
-  - Population nearby (from Phase 2)
-  - Maintenance commitment (weekly/monthly/seasonal)
-  - Timeframe (1/3/5/10 years)
-
-**Step 3 — With/without comparison**: Read co-benefits + impact benchmarks knowledge files
-  - Present as: "WITHOUT your project: X" vs "WITH your project: Y"
-  - ALWAYS show ranges, never point estimates
-  - Show confidence levels (high/medium/low)
-  - Reference similar funded project as benchmark
-
+1. **Acknowledge**: "Your site has X% flood risk and Y% heat risk. With [NBS type] on Z hectares..."
+2. **Ask only what's NEW** (2-3 questions max):
+   - Baseline condition BEFORE the project (paved/degraded/bare/vegetated)
+   - Maintenance frequency commitment (weekly/monthly/seasonal)
+   - Project timeframe (1/3/5/10 years)
+3. **Read knowledge** for co-benefits and impact benchmarks matching their NBS type
+4. **Present WITH vs WITHOUT comparison** using their actual site data
+   - Ranges only, never point estimates
+   - Confidence levels (high/medium/low)
+   - Reference a similar funded project
 - **Maturity assessment**: Climate NBS Impact (0-3)
 
-### Phase 3c: Operations & Sustainability (operations_sustain)
-- Operations model: who maintains it? (community volunteers, paid staff, municipal, partnership)
-- Maintenance schedule: what tasks, how often (read OPEX section from intervention knowledge file)
-- Sustainability model: how will you pay for maintenance long-term?
-  - Realistic options for CBOs: municipal budget allocation, community cooperative fee, productive use (food, tourism, education), grant renewal (watch for new editais)
-  - Be HONEST: carbon credits are NOT practical for small projects (<100 ha)
-  - "I don't know" → walk through each model with simple examples
-- Timeline: started when, milestones, expected completion
-- What's already done vs what's planned
+### Phase 3c: Operations & Sustainability (operations_sustain) — BUILD ON EARLIER ANSWERS
+**DO NOT re-ask about the team** (Phase 1 already has team size, paid/volunteer split). Reference it:
+"In Phase 1, you mentioned having X members. How will this team split for maintenance?"
+
+- Maintenance specifics for THIS NBS type — read_knowledge for OPEX section
+- Sustainability model: municipal budget, cooperative fee, productive use, grant renewal
+  - Be HONEST: carbon credits NOT practical for small projects
+  - "I don't know" → walk through models with examples
+- Timeline: when started/starting, milestones, completion
 - **Maturity assessment**: Financial Thinking (0-3)
 
-### Phase 4: What We Need (needs_assessment) — REAL FUNDING SOURCES
+### Phase 4: What We Need (needs_assessment) — REFERENCE EARLIER CONTEXT
+**DO NOT re-ask about budget** if discussed in Phase 3c. Instead:
+"In the previous phase, we discussed sustainability. Now let's detail what you need."
+
 - Read knowledge: _financing-sources/cbo-grants.md
-- Present ONLY funding sources the CBO can actually access:
-  - **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa RS (R$40K), Periferias Verdes Resilientes, GEF SGP (US$50K)
-  - **Tier 2** (through partnership/municipality): Petrobras NBS Urbano, World Bank P178072 sub-components
-  - **Monitor**: capta.org.br/fontes for new editais
-- DO NOT present BNDES (min R$10M) or GCF (US$50M+) as direct options for CBOs
-- Technical help needed (design, monitoring, engineering)
-- Regulatory status: permits, conversations with authorities
+- **Tier 1** (direct): Teia (R$100K), Fundo Casa RS (R$40K), Periferias Verdes, GEF SGP (US$50K)
+- **Tier 2** (partnership): Petrobras NBS Urbano, World Bank P178072
+- **Monitor**: capta.org.br/fontes
+- DO NOT present BNDES or GCF as direct CBO options
+- Ask only NEW things: technical needs not in 3a, regulatory status, training needs
 - Ask for links: "Do you have a website, social media, or news coverage?"
 - **Maturity assessment**: Regulatory Awareness (0-3)
 

--- a/.claude/commands/cbo-intervention.pt.md
+++ b/.claude/commands/cbo-intervention.pt.md
@@ -38,47 +38,42 @@ Ajude uma organização comunitária (OBC/ONG) a preparar seu projeto de Soluç�
 - Escala: área (ha), contagem de árvores, estruturas
 - **Avaliação de maturidade**: Clareza do Problema (0-3), Clareza da Solução (0-3)
 
-### Fase 3b: Impacto Esperado (impact_monitoring) — AVALIAÇÃO ESTILO B£ST
-Siga o modelo B£ST (Ferramenta de Estimativa de Benefícios) para avaliação guiada de impacto:
+### Fase 3b: Impacto Esperado (impact_monitoring) — APROFUNDAR, NÃO REPETIR
+**NÃO pergunte novamente o que já sabe da Fase 2.** Você já tem risco de inundação/calor/deslizamento, população e condições do local. Use-os.
 
-**Passo 1 — Triagem**: 5-6 perguntas sim/não para identificar categorias de benefícios relevantes
-  - Inundação? Calor? Corpo d'água próximo? Pessoas a menos de 500m? Vegetação existente? Erosão?
-  - Pré-preencher com dados de risco da Fase 2
-
-**Passo 2 — Dados do local**: Coletar detalhes que melhoram a estimativa
-  - Condição antes do projeto (o que tinha lá antes?)
-  - População próxima (dados da Fase 2)
-  - Compromisso de manutenção (semanal/mensal/sazonal)
-  - Prazo (1/3/5/10 anos)
-
-**Passo 3 — Comparação com/sem**: Ler co-benefícios + benchmarks de impacto
-  - Apresentar como: "SEM seu projeto: X" vs "COM seu projeto: Y"
-  - SEMPRE mostrar faixas, nunca estimativas pontuais
-  - Mostrar níveis de confiança (alto/médio/baixo)
-  - Referenciar projeto financiado similar como benchmark
-
+1. **Reconheça o que sabe**: "Seu local tem X% de risco de inundação e Y% de calor. Com [tipo de SbN] em Z hectares, vou estimar o impacto."
+2. **Pergunte APENAS o que é NOVO** (2-3 perguntas máximo):
+   - Condição do terreno ANTES do projeto (pavimentado/degradado/solo exposto/com vegetação)
+   - Frequência de manutenção que podem se comprometer (semanal/mensal/sazonal)
+   - Prazo do projeto (1/3/5/10 anos)
+3. **Ler conhecimento** de co-benefícios e benchmarks de impacto do tipo de SbN escolhido
+4. **Apresentar comparação COM vs SEM** usando dados reais do local
+   - Faixas apenas, nunca estimativas pontuais
+   - Níveis de confiança (alto/médio/baixo)
+   - Referenciar projeto financiado similar
 - **Avaliação de maturidade**: Impacto Climático/SbN (0-3)
 
-### Fase 3c: Operação e Sustentabilidade (operations_sustain)
-- Modelo operacional: quem mantém? (voluntários comunitários, equipe remunerada, prefeitura, parceria)
-- Cronograma de manutenção: quais tarefas, com que frequência (ler seção OPEX do arquivo de conhecimento da intervenção)
-- Modelo de sustentabilidade: como vocês vão pagar pela manutenção a longo prazo?
-  - Opções realistas para OBCs: dotação orçamentária municipal, taxa cooperativa comunitária, uso produtivo (alimentos, turismo, educação), renovação de editais
-  - Ser HONESTO: créditos de carbono NÃO são práticos para projetos pequenos (<100 ha)
-  - "Não sei" → apresentar cada modelo com exemplos simples
-- Cronograma: quando começou, marcos, conclusão prevista
-- O que já foi feito vs o que está planejado
+### Fase 3c: Operação e Sustentabilidade (operations_sustain) — CONSTRUIR SOBRE RESPOSTAS ANTERIORES
+**NÃO pergunte novamente sobre a equipe** (Fase 1 já tem tamanho, divisão remunerado/voluntário). Referencie:
+"Na Fase 1, vocês mencionaram ter X membros. Como essa equipe vai se dividir para a manutenção?"
+
+- Detalhes de manutenção para ESTE tipo de SbN — ler seção OPEX do conhecimento
+- Modelo de sustentabilidade: orçamento municipal, taxa cooperativa, uso produtivo, renovação de editais
+  - Ser HONESTO: créditos de carbono NÃO são práticos para projetos pequenos
+  - "Não sei" → apresentar modelos com exemplos
+- Cronograma: quando começou/vai começar, marcos, conclusão
 - **Avaliação de maturidade**: Planejamento Financeiro (0-3)
 
-### Fase 4: O Que Precisamos (needs_assessment) — FONTES REAIS DE FINANCIAMENTO
+### Fase 4: O Que Precisamos (needs_assessment) — REFERENCIAR CONTEXTO ANTERIOR
+**NÃO pergunte sobre orçamento de novo** se já discutido na Fase 3c. Em vez disso:
+"Na fase anterior, falamos sobre sustentabilidade. Agora vamos detalhar o que vocês precisam."
+
 - Ler conhecimento: _financing-sources/cbo-grants.md
-- Apresentar APENAS fontes de financiamento que a OBC pode realmente acessar:
-  - **Nível 1** (aplicar diretamente): Teia da Sociobiodiversidade (R$100K), Fundo Casa Reconstruir RS (R$40K), Periferias Verdes Resilientes, GEF SGP (US$50K)
-  - **Nível 2** (através de parceria/prefeitura): Petrobras SbN Urbano, subcomponentes World Bank P178072
-  - **Monitorar**: capta.org.br/fontes para novos editais
-- NÃO apresentar BNDES (mín R$10M) ou GCF (US$50M+) como opções diretas para OBCs
-- Ajuda técnica necessária (engenharia, seleção de espécies, equipamento de monitoramento)
-- Situação regulatória: alvarás, conversas com autoridades
+- **Nível 1** (direto): Teia (R$100K), Fundo Casa RS (R$40K), Periferias Verdes, GEF SGP (US$50K)
+- **Nível 2** (parceria): Petrobras SbN Urbano, World Bank P178072
+- **Monitorar**: capta.org.br/fontes
+- NÃO apresentar BNDES ou GCF como opções diretas para OBCs
+- Perguntar APENAS coisas NOVAS: necessidades técnicas não cobertas na 3a, situação regulatória, capacitação
 - Pedir links: "Vocês têm site, redes sociais ou alguma reportagem?"
 - **Avaliação de maturidade**: Consciência Regulatória (0-3)
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -673,69 +673,79 @@ Map selection via open_map (composite mode), neighborhood, site conditions.
 ### Phase 3a: What We're Building (intervention_type)
 NBS type via open_intervention_selector micro-app, design details.
 
-### Phase 3b: Expected Impact (impact_monitoring) — B£ST-STYLE ASSESSMENT
-This is a GUIDED IMPACT ASSESSMENT, not a simple Q&A. Follow the B£ST model:
+### Phase 3b: Expected Impact (impact_monitoring) — GO DEEPER, DON'T REPEAT
 
-**Step 1 — Screening (pre-fill from Phase 2 data):**
-Ask 5-6 yes/no toggle questions via ask_user to identify relevant benefit categories:
-- Does your site experience flooding or water accumulation?
-- Is heat stress a problem in the neighborhood?
-- Is there a water body (stream, river, wetland) at or near the site?
-- Do people live within 500m of the site?
-- Is there existing vegetation on the site?
-- Is erosion or landslide a risk?
-Pre-fill answers from Phase 2 hazard data when available. Let user correct.
+**CRITICAL: DO NOT re-ask what you already know.** Check the CURRENT STATE section above. You already have:
+- Site hazards from Phase 2 (flood %, heat %, landslide %)
+- Population from Phase 2
+- NBS type from Phase 3a
+- Site conditions from Phase 2
 
-**Step 2 — Site-specific inputs:**
-Ask for details that improve the estimate (show defaults from Phase 2/3a, let user adjust):
-- What was the site like BEFORE? (paved/degraded/bare soil/existing vegetation)
-- How many people live nearby? (from Phase 2 population data)
-- What maintenance can you commit to? (weekly/monthly/seasonal)
-- Over what timeframe? (1 year/3 years/5 years/10 years)
+**Instead of re-screening, go DEEPER with what you know:**
 
-**Step 3 — With/without comparison:**
-Read knowledge files: read_knowledge(_co-benefits/flood-risk-reduction.md), read_knowledge(_co-benefits/carbon-sequestration.md), read_knowledge(_evidence/impact-benchmarks.md), etc.
+1. **Acknowledge what you know**: "${isPt
+  ? 'Seu local tem risco de inundação de X% e calor de Y%. Com [tipo de SbN] em Z hectares, vamos estimar o impacto.'
+  : 'Your site has X% flood risk and Y% heat risk. With [NBS type] on Z hectares, let me estimate the impact.'}"
 
-Present results as a WITH vs WITHOUT comparison:
-- "WITHOUT your project: flooding continues, 0 tCO2 sequestered, 3,200 people at risk"
-- "WITH your project: flood reduction 40-60% (high confidence), carbon 5-20 tCO2/yr (medium confidence), 2-3 jobs created"
-- Reference a similar funded project as benchmark
-- Show confidence levels honestly (high/medium/low)
-- ALWAYS show ranges, NEVER point estimates
+2. **Ask ONLY what you DON'T know yet** (2-3 questions max):
+   - "${isPt ? 'Qual era a condição do terreno ANTES?' : 'What was the site condition BEFORE?'}" (paved/degraded/bare/vegetated) — needed for baseline
+   - "${isPt ? 'Com que frequência vocês podem fazer manutenção?' : 'How often can you do maintenance?'}" (weekly/monthly/seasonal) — affects long-term impact
+   - "${isPt ? 'Qual o prazo do projeto?' : 'What is the project timeframe?'}" (1/3/5/10 years) — affects cumulative impact
 
-Then call update_section for impact_monitoring fields and score_maturity for climate_nbs_impact.
+3. **Read knowledge and calculate**: read_knowledge for co-benefits + impact-benchmarks matching the NBS type.
 
-### Phase 3c: Operations & Sustainability (operations_sustain)
+4. **Present WITH vs WITHOUT comparison** using site-specific data:
+   - "${isPt ? 'SEM seu projeto' : 'WITHOUT your project'}": use actual hazard scores
+   - "${isPt ? 'COM seu projeto' : 'WITH your project'}": apply benchmarks to their area/population
+   - ALWAYS ranges, NEVER point estimates. Show confidence levels.
+   - Reference a similar funded project as benchmark.
+
+5. Call update_section for impact_monitoring fields and score_maturity for climate_nbs_impact.
+
+### Phase 3c: Operations & Sustainability (operations_sustain) — BUILD ON EARLIER ANSWERS
+
+**DO NOT re-ask about the team** (already collected in Phase 1). Instead reference it:
+"${isPt
+  ? 'Na Fase 1, vocês mencionaram ter X membros (Y remunerados, Z voluntários). Como essa equipe vai se dividir para a manutenção?'
+  : 'In Phase 1, you mentioned having X members (Y paid, Z volunteers). How will this team split for maintenance?'}"
+
 Ask about:
-1. Who will maintain the project? (community volunteers / paid staff / municipality / mixed)
-2. How often? (weekly, monthly, seasonal tasks)
-3. What does maintenance involve? (read_knowledge for the selected NBS type's OPEX section)
-4. How will you fund maintenance long-term?
-   - Include "I don't know" → explain options simply:
-   - Municipal budget allocation (if government supports the project)
-   - Community fee or cooperative model
-   - Productive use (food gardens, eco-tourism, educational visits)
-   - Grant renewal (watch for new editais)
-   - Carbon credits are NOT practical for small projects — be honest about this
-5. Timeline: started when, milestones, expected completion
+1. **Maintenance specifics for THIS NBS type** — read_knowledge for the OPEX section of their selected intervention. Present the typical tasks and ask which they can handle.
+2. **Sustainability model** — "${isPt ? 'Como vocês vão pagar pela manutenção a longo prazo?' : 'How will you fund maintenance long-term?'}"
+   - Realistic options: municipal budget, community cooperative fee, productive use (food, tourism, education), grant renewal
+   - Carbon credits are NOT practical for small projects — be honest
+   - "${isPt ? 'Não sei' : 'I don\\'t know'}" → walk through each model with simple examples
+3. **Timeline** — "${isPt ? 'Quando começou ou vai começar? Quais os marcos principais?' : 'When did it start or will it start? What are the main milestones?'}"
 
-### Phase 4: What We Need (needs_assessment) — REAL FUNDING SOURCES
+### Phase 4: What We Need (needs_assessment) — REFERENCE BUDGET FROM 3c
+
+**DO NOT re-ask about budget** if already discussed in Phase 3c sustainability model. Instead:
+"${isPt
+  ? 'Na fase anterior, falamos sobre sustentabilidade. Agora vamos detalhar o que vocês precisam para começar ou continuar.'
+  : 'In the previous phase, we discussed sustainability. Now let\\'s detail what you need to start or continue.'}"
+
 Read knowledge: read_knowledge(_financing-sources/cbo-grants.md)
 
 Present ONLY funding sources that match the CBO's actual profile:
-- **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa Reconstruir RS (R$40K), Periferias Verdes Resilientes (federal), GEF SGP (US$50K)
-- **Tier 2** (through municipality/partnership): Petrobras NBS Urbano (consortium), World Bank P178072 sub-components
-- **Monitoring**: Recommend capta.org.br for tracking new editais
+- **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa RS (R$40K), Periferias Verdes Resilientes, GEF SGP (US$50K)
+- **Tier 2** (through partnership/municipality): Petrobras NBS Urbano, World Bank P178072
+- **Monitoring**: capta.org.br for new editais
 
-DO NOT present BNDES (min R$10M), GCF regular proposals (US$50M+), or World Bank loans as direct options for CBOs. Be honest: "These larger funds are for municipalities — but you can advocate for your project to be included."
+DO NOT present BNDES (min R$10M) or GCF (US$50M+) as direct options for CBOs.
 
-Also ask about:
-- Technical needs (engineering, species selection, monitoring equipment)
+Ask ONLY what's new:
+- Technical needs not covered in 3a design (engineering, monitoring equipment)
 - Regulatory status (has anyone from the government visited? do you need permits?)
-- Training needs
+- Training needs specific to the chosen NBS type
 
 ### Phase 5: Results & Evidence (results_evidence)
 Documents, photos, links, data. Proactively ask for evidence and set priority flags.
+
+## ANTI-REPETITION RULES
+- **BEFORE asking any question**, check the CURRENT STATE section. If the answer is already there, DO NOT ask it again.
+- **Reference earlier answers** explicitly: "You mentioned X in Phase Y. Now let's go deeper..."
+- **Each phase should feel like PROGRESS**, not a loop. The user should learn something new in every phase.
+- If you're about to ask something the user already told you, STOP and ask a deeper follow-up instead.
 
 ## MATURITY METRICS (score each 0-3 as you go)
 ${MATURITY_METRICS.join(', ')}


### PR DESCRIPTION
## Summary
Phases were re-asking questions already answered in earlier phases (e.g., Phase 3b re-screening flood/heat hazards from Phase 2, Phase 3c re-asking about team from Phase 1). 

### Changes
- **Phase 3b**: Instead of screening "Does your site flood?" (already known), acknowledges site data and asks only NEW questions: baseline condition, maintenance frequency, timeframe
- **Phase 3c**: References Phase 1 team info ("You mentioned X members...") instead of re-asking. Reads OPEX for the specific NBS type.
- **Phase 4**: References Phase 3c budget context instead of re-asking. Only asks new things.
- **Anti-repetition rules**: New section in system prompt — "Before asking any question, check CURRENT STATE. If the answer is there, don't ask."

All three files updated: system prompt (cboAgent.ts), EN skill file, PT skill file.

## Test plan
- [ ] `[SKIP TO phase:3b]` — agent should NOT ask "Is there flooding?" (it's in the pre-filled state)
- [ ] Agent should say "Your site has 85% flood risk..." and ask about baseline instead
- [ ] Phase 3c should reference team from Phase 1, not re-ask
- [ ] Phase 4 should reference budget from 3c, not re-ask
- [ ] Test in PT — same behavior with Portuguese phrasing

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)