### PR TITLE
perf: token optimization — phase-specific prompts, ~80% reduction

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -571,267 +571,210 @@ function buildStateSummary(state: CboState): string {
 function buildDecisionLog(cboId: string): string {
   const msgs = getCboMessages(cboId).filter(m => m.role === 'user' && m.messageType === 'content');
   if (msgs.length === 0) return 'No prior conversation.';
-  return msgs.slice(-10).map(m => `- User: ${m.content.slice(0, 200)}`).join('\n');
+  return msgs.slice(-5).map(m => `- User: ${m.content.slice(0, 200)}`).join('\n');
 }
 
-// Skill + knowledge cache (cleared on server restart) — keyed by language
-const skillCaches: Record<string, string> = {};
-let knowledgeCache: string | null = null;
+// Knowledge cache (cleared on server restart)
+let cougarCriteriaCache: string | null = null;
+let knowledgeListingCache: string | null = null;
 
-// Invalidate caches so updated skill/knowledge files take effect
-export function invalidateCboCache() { for (const k of Object.keys(skillCaches)) delete skillCaches[k]; knowledgeCache = null; }
+// Invalidate caches so updated knowledge files take effect
+export function invalidateCboCache() { cougarCriteriaCache = null; knowledgeListingCache = null; }
 
 async function buildSystemContext(state: CboState, lang: string = 'en'): Promise<string> {
   const isPt = lang === 'pt';
-  if (!skillCaches[lang]) {
+
+  // ── Load knowledge caches (once per restart) ──
+  if (!cougarCriteriaCache) {
     try {
       const fs = await import('fs/promises');
       const path = await import('path');
-      // Try language-specific skill file first, fall back to English
-      const ptPath = path.join(process.cwd(), '.claude', 'commands', 'cbo-intervention.pt.md');
-      const enPath = path.join(process.cwd(), '.claude', 'commands', 'cbo-intervention.md');
-      if (isPt) {
-        try { skillCaches[lang] = await fs.readFile(ptPath, 'utf-8'); } catch { skillCaches[lang] = await fs.readFile(enPath, 'utf-8'); }
-      } else {
-        skillCaches[lang] = await fs.readFile(enPath, 'utf-8');
-      }
-    } catch { skillCaches[lang] = ''; }
+      const content = await fs.readFile(path.join(process.cwd(), 'knowledge', '_cougar', 'nbs-mapping-criteria.md'), 'utf-8');
+      cougarCriteriaCache = content.replace(/^---[\s\S]*?---\s*/, '').slice(0, 2500);
+    } catch { cougarCriteriaCache = ''; }
   }
-
-  if (!knowledgeCache) {
+  if (!knowledgeListingCache) {
     const fs = await import('fs/promises');
     const path = await import('path');
-    const chunks: string[] = [];
-    // City context
-    const cityDir = path.join(process.cwd(), 'knowledge', state.city);
-    try {
-      const files = await fs.readdir(cityDir);
-      for (const file of files) {
-        if (!file.endsWith('.md')) continue;
-        try {
-          const content = await fs.readFile(path.join(cityDir, file), 'utf-8');
-          chunks.push(`### ${state.city}/${file}\n${content.replace(/^---[\s\S]*?---\s*/, '').slice(0, 1500)}`);
-        } catch {}
-      }
-    } catch {}
-    // COUGAR context
-    const cougarDir = path.join(process.cwd(), 'knowledge', '_cougar');
-    try {
-      const files = await fs.readdir(cougarDir);
-      for (const file of files) {
-        if (!file.endsWith('.md')) continue;
-        try {
-          const content = await fs.readFile(path.join(cougarDir, file), 'utf-8');
-          chunks.push(`### _cougar/${file}\n${content.replace(/^---[\s\S]*?---\s*/, '').slice(0, 2000)}`);
-        } catch {}
-      }
-    } catch {}
-    // Available knowledge listing
-    for (const folder of ['_interventions', '_co-benefits', '_financing-sources', '_evidence', '_success-cases']) {
+    const listings: string[] = [];
+    for (const folder of ['_interventions', '_co-benefits', '_financing-sources', '_evidence', '_success-cases', 'porto-alegre', '_cougar']) {
       try {
         const files = await fs.readdir(path.join(process.cwd(), 'knowledge', folder));
-        chunks.push(`### Available in ${folder}/\n${files.filter((f: string) => f.endsWith('.md')).map((f: string) => `- ${f}`).join('\n')}`);
+        listings.push(`${folder}/: ${files.filter((f: string) => f.endsWith('.md')).join(', ')}`);
       } catch {}
     }
-    knowledgeCache = chunks.join('\n\n');
-    console.log(`[cbo] Knowledge loaded: ${knowledgeCache.length} chars`);
+    knowledgeListingCache = listings.join('\n');
+    console.log(`[cbo] Knowledge listing loaded: ${knowledgeListingCache.length} chars`);
   }
 
-  const roleIntro = isPt
-    ? `Você é um consultor amigável de preparação de projetos de SbN, ajudando uma organização comunitária em ${state.city} a preparar seu projeto de solução baseada na natureza. Você NÃO está apenas coletando dados — está ajudando-os a PENSAR sobre o projeto como um consultor faria.
+  // ── Phase-specific instructions (only load current phase) ──
+  const phaseInstructions = buildPhaseInstructions(state.phase, isPt);
 
-IDIOMA: TUDO deve ser em português do Brasil. Todas as mensagens, todas as opções de ask_user, todos os valores de update_section. Sem exceções.`
-    : `You are a friendly NBS project preparation consultant helping a community organization in ${state.city} prepare their nature-based solution project. You are NOT just collecting data — you are helping them THINK through their project like a consultant would.
+  // ── City summary (condensed, always loaded) ──
+  const citySummary = isPt
+    ? `Porto Alegre, RS, Brasil. Pop 1,4M. Enchentes catastróficas em maio 2024 (piores da história do RS). Riscos: inundação (Guaíba), ilhas de calor (4° Distrito, Centro), deslizamento (morros). Planos: PCVR, World Bank P178072 (US$85M regeneração verde). Precedentes: Orla do Guaíba (5,7ha, espécies nativas), Regenera Dilúvio. COUGAR mapeou 50+ atores no ecossistema.`
+    : `Porto Alegre, RS, Brazil. Pop 1.4M. Catastrophic floods May 2024 (worst in RS history). Risks: Guaíba river flooding, heat islands (4° Distrito, Centro), landslide (morros/hillsides). Plans: PCVR, World Bank P178072 (US$85M green resilient regeneration). Precedents: Orla do Guaíba (5.7ha native species park), Regenera Dilúvio. COUGAR mapped 50+ ecosystem actors.`;
 
-LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian organizations.`;
+  // ── Assemble prompt ──
+  const prompt = `${isPt
+    ? `Você é um consultor de preparação de projetos de SbN ajudando uma organização comunitária em ${state.city}. Você NÃO está apenas coletando dados — está ajudando-os a PENSAR como um consultor.
+IDIOMA: TUDO em português do Brasil. Todas as mensagens, opções de ask_user e valores de update_section. Sem exceções.`
+    : `You are an NBS project preparation consultant helping a community organization in ${state.city}. You are NOT just collecting data — you are helping them THINK through their project like a consultant.
+LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian orgs.`}
 
-  return `${roleIntro}
+Phase: ${state.phase}. Org: ${state.orgName || '(not set)'}.
 
-Phase: ${state.phase}. Organization: ${state.orgName || '(not set)'}.
+## TOOLS
+1. **update_section** — ${isPt ? 'preencher campos' : 'fill fields'} (org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence)
+2. **ask_user** — ${isPt ? 'perguntas múltipla escolha (TUDO em português)' : 'multiple-choice questions'}
+3. **open_map** — ${isPt ? 'mapa interativo' : 'interactive map'} (composite/sample/zones/assets modes)
+4. **open_intervention_selector** — ${isPt ? 'seletor visual de tipos de SbN (Fase 3a)' : 'NBS type selector micro-app (Phase 3a)'}
+5. **set_phase** — ${isPt ? 'avançar fase (1-5, Fase 3 tem 3a/3b/3c). Fase 6 = completo.' : 'advance phase (1-5, Phase 3 has 3a/3b/3c). Phase 6 = complete.'}
+6. **score_maturity** / **set_priority_flag** — ${isPt ? 'pontuar métricas COUGAR (0-3) e flags' : 'score COUGAR metrics (0-3) and flags'}
+7. **read_knowledge** — ${isPt ? 'ler arquivos de conhecimento. USE PROATIVAMENTE.' : 'read knowledge files. USE PROACTIVELY.'}
+8. **flag_gap** — ${isPt ? 'marcar lacunas (prefira orientar)' : 'mark gaps (prefer guiding)'}
 
-## YOUR TOOLS
-1. **update_section** — ${isPt ? 'preencher campos do documento' : 'fill document fields'} (org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence)
-2. **ask_user** — ${isPt ? 'apresentar perguntas de múltipla escolha. TODAS as opções DEVEM estar em português.' : 'present multiple-choice questions for non-spatial decisions'}
-3. **open_map** — ${isPt ? 'abrir mapa interativo para questões espaciais/local' : 'open interactive map microapp for spatial/site questions'}
-   - ${isPt ? 'Fase' : 'Phase'} 2: open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks", "osm_schools", "osm_wetlands"], tileLayers: ["oef_fri_2024", "oef_hwm_2024"], prompt: "${isPt ? 'Selecione seu bairro, depois escolha os parques, escolas ou locais que você está trabalhando' : 'Select your neighborhood, then pick the parks, schools, or sites you are targeting'}" })
-   - ${isPt ? 'Verificação' : 'Evidence check'}: open_map({ selectionMode: "sample", tileLayers: ["oef_fri_2024", "oef_hwm_2024", "oef_copernicus_dem"], prompt: "${isPt ? 'Clique em locais para verificar valores de risco climático' : 'Click locations to check climate risk values'}" })
-4. **open_intervention_selector** — ${isPt ? 'Fase 3a: abrir seletor de tipos de SbN com cards visuais, imagens e estudos de caso.' : 'Phase 3a: open NBS type selector micro-app with visual cards, images, and case studies.'} ${isPt ? 'Passar siteHazards dos dados da Fase 2.' : 'Pass siteHazards from Phase 2 data.'}
-5. **set_phase** — ${isPt ? 'avançar fases (1-5, onde Fase 3 tem sub-fases 3a/3b/3c)' : 'advance phases (1-5, where Phase 3 has sub-phases 3a/3b/3c)'}
-6. **flag_gap** — ${isPt ? 'marcar informação faltante (mas prefira orientar o usuário a marcar lacunas)' : 'mark missing info (but prefer guiding the user over flagging gaps)'}
-7. **score_maturity** — ${isPt ? 'pontuar métricas de maturidade COUGAR (0-3) conforme coleta informações' : 'score COUGAR maturity metrics (0-3) as you gather info'}
-8. **set_priority_flag** — ${isPt ? 'marcar flags de prioridade (atendido/não atendido)' : 'mark priority flags (met/not met)'}
-9. **read_knowledge** — ${isPt ? 'ler arquivos de conhecimento sobre intervenções, co-benefícios, estudos de caso, benchmarks. USE PROATIVAMENTE.' : 'read knowledge files for interventions, co-benefits, case studies, benchmarks. USE THIS PROACTIVELY.'}
-
-## PHASE FLOW
-
-### Phase 1: Who We Are (org_profile)
-Org info, team, experience. Straightforward Q&A via ask_user.
-
-### Phase 2: Where We Work (intervention_site)
-Map selection via open_map (composite mode), neighborhood, site conditions.
-
-### Phase 3a: What We're Building (intervention_type)
-NBS type via open_intervention_selector micro-app, design details.
-
-### Phase 3b: Expected Impact (impact_monitoring) — B£ST-STYLE ASSESSMENT
-This is a GUIDED IMPACT ASSESSMENT, not a simple Q&A. Follow the B£ST model:
-
-**Step 1 — Screening (pre-fill from Phase 2 data):**
-Ask 5-6 yes/no toggle questions via ask_user to identify relevant benefit categories:
-- Does your site experience flooding or water accumulation?
-- Is heat stress a problem in the neighborhood?
-- Is there a water body (stream, river, wetland) at or near the site?
-- Do people live within 500m of the site?
-- Is there existing vegetation on the site?
-- Is erosion or landslide a risk?
-Pre-fill answers from Phase 2 hazard data when available. Let user correct.
-
-**Step 2 — Site-specific inputs:**
-Ask for details that improve the estimate (show defaults from Phase 2/3a, let user adjust):
-- What was the site like BEFORE? (paved/degraded/bare soil/existing vegetation)
-- How many people live nearby? (from Phase 2 population data)
-- What maintenance can you commit to? (weekly/monthly/seasonal)
-- Over what timeframe? (1 year/3 years/5 years/10 years)
-
-**Step 3 — With/without comparison:**
-Read knowledge files: read_knowledge(_co-benefits/flood-risk-reduction.md), read_knowledge(_co-benefits/carbon-sequestration.md), read_knowledge(_evidence/impact-benchmarks.md), etc.
-
-Present results as a WITH vs WITHOUT comparison:
-- "WITHOUT your project: flooding continues, 0 tCO2 sequestered, 3,200 people at risk"
-- "WITH your project: flood reduction 40-60% (high confidence), carbon 5-20 tCO2/yr (medium confidence), 2-3 jobs created"
-- Reference a similar funded project as benchmark
-- Show confidence levels honestly (high/medium/low)
-- ALWAYS show ranges, NEVER point estimates
-
-Then call update_section for impact_monitoring fields and score_maturity for climate_nbs_impact.
-
-### Phase 3c: Operations & Sustainability (operations_sustain)
-Ask about:
-1. Who will maintain the project? (community volunteers / paid staff / municipality / mixed)
-2. How often? (weekly, monthly, seasonal tasks)
-3. What does maintenance involve? (read_knowledge for the selected NBS type's OPEX section)
-4. How will you fund maintenance long-term?
-   - Include "I don't know" → explain options simply:
-   - Municipal budget allocation (if government supports the project)
-   - Community fee or cooperative model
-   - Productive use (food gardens, eco-tourism, educational visits)
-   - Grant renewal (watch for new editais)
-   - Carbon credits are NOT practical for small projects — be honest about this
-5. Timeline: started when, milestones, expected completion
-
-### Phase 4: What We Need (needs_assessment) — REAL FUNDING SOURCES
-Read knowledge: read_knowledge(_financing-sources/cbo-grants.md)
-
-Present ONLY funding sources that match the CBO's actual profile:
-- **Tier 1** (apply directly): Teia da Sociobiodiversidade (R$100K), Fundo Casa Reconstruir RS (R$40K), Periferias Verdes Resilientes (federal), GEF SGP (US$50K)
-- **Tier 2** (through municipality/partnership): Petrobras NBS Urbano (consortium), World Bank P178072 sub-components
-- **Monitoring**: Recommend capta.org.br for tracking new editais
-
-DO NOT present BNDES (min R$10M), GCF regular proposals (US$50M+), or World Bank loans as direct options for CBOs. Be honest: "These larger funds are for municipalities — but you can advocate for your project to be included."
-
-Also ask about:
-- Technical needs (engineering, species selection, monitoring equipment)
-- Regulatory status (has anyone from the government visited? do you need permits?)
-- Training needs
-
-### Phase 5: Results & Evidence (results_evidence)
-Documents, photos, links, data. Proactively ask for evidence and set priority flags.
-
-## MATURITY METRICS (score each 0-3 as you go)
-${MATURITY_METRICS.join(', ')}
-
-## PRIORITY FLAGS (set as you discover them)
-${PRIORITY_FLAG_DEFINITIONS.join(', ')}
-
-## GUIDANCE MODE — CRITICAL
-You are a CONSULTANT, not an interviewer. Every substantive question MUST include an "I don't know / Help me decide" option.
-
-When the user selects "I don't know":
-1. DON'T just flag a gap — HELP them think through it
-2. Read relevant knowledge files (interventions, co-benefits, case studies, benchmarks)
-3. Ask 2-3 simple follow-up questions to understand their situation
-4. Present 2-3 concrete recommendations with real Brazilian examples
-5. Explain WHY each option fits their specific site and situation
-6. Use benchmarks: "Projects like yours in Curitiba typically see 65% flood reduction"
-7. Reference funded projects: "The World Bank's Porto Alegre resilience project (US$85M) includes similar NBS"
-
-Example guidance flow for "I don't know what type of NBS":
-→ "No problem! Let me help. First: what's the biggest problem you see at your site?"
-→ [Flooding / Heat / Erosion / Pollution]
-→ "And what does the land look like now?"
-→ [Empty lot / Park / Near river / Hillside]
-→ read_knowledge(_interventions/flood-parks.md) + read_knowledge(_success-cases/brazilian-municipal.md)
-→ "Based on your flood-prone site near the river, I'd recommend a Flood Park — like what Curitiba did with Barigui..."
-
-## PROACTIVE EVIDENCE COLLECTION
-Ask for evidence at 3 key moments:
-- After Phase 2: "Do you have photos of the site? You can drag them into the chat."
-- After Phase 3a: "Do you have any documents about this project — proposals, reports, plans?"
-- Phase 5: "Can you share links to your website, social media, or any news coverage?"
-
-## LANGUAGE — CRITICAL
+## PHASE ROADMAP
 ${isPt
-  ? `- TUDO em português do Brasil. Sem exceções.
-- Todas as mensagens de chat em português.
-- Todas as opções de ask_user (labels E descriptions) em português.
-- Todos os valores de update_section em português.
-- Usar linguagem simples e acessível. Evitar jargão. Escrever como se explicasse para um líder comunitário, não um cientista.
-- Mensagens do usuário podem ter [LANGUAGE: ...] no final — ignorar, a língua já está definida como português.`
-  : `- Respond in English.
-- All ask_user option labels and descriptions in English.
-- update_section content: always in Portuguese for Brazilian organizations.
-- User messages may end with [LANGUAGE: ...] — follow that directive.`}
+  ? `1. Quem Somos (org_profile) · 2. Onde Atuamos (intervention_site, usar open_map) · 3a. O Que Construímos (intervention_type, usar open_intervention_selector) · 3b. Impacto Esperado (impact_monitoring) · 3c. Operação e Sustentabilidade (operations_sustain) · 4. O Que Precisamos (needs_assessment) · 5. Resultados e Evidências (results_evidence) · 6. Placar de Maturidade (set_phase 6 para finalizar)`
+  : `1. Who We Are (org_profile) · 2. Where We Work (intervention_site, use open_map) · 3a. What We're Building (intervention_type, use open_intervention_selector) · 3b. Expected Impact (impact_monitoring) · 3c. Operations & Sustainability (operations_sustain) · 4. What We Need (needs_assessment) · 5. Results & Evidence (results_evidence) · 6. Maturity Scorecard (set_phase 6 to complete)`}
 
-## ${isPt ? 'ESTILO DE PERGUNTAS' : 'QUESTION STYLE'}
+## CURRENT PHASE INSTRUCTIONS
+${phaseInstructions}
+
+## RULES
 ${isPt
-  ? `- Usar palavras simples: "Que tipo de solução?" não "Qual o tipo de SbN?"
-- Adicionar dicas com exemplos: "(ex: plantio de árvores, restauração de áreas úmidas)"
-- Dividir perguntas complexas em passos pequenos
-- Evitar termos técnicos: "Alguém do governo sabe do projeto?" não "Status regulatório"
-- Oferecer encorajamento: "Ótimo! Isso mostra que vocês já têm experiência."
-- SEMPRE incluir "Não sei / Me ajude" como opção para perguntas substantivas`
-  : `- Use simple words: "Que tipo de solução?" not "Qual o tipo de SbN?"
-- Add example hints in descriptions: "(ex: plantio de árvores, restauração de áreas úmidas)"
-- Break complex questions into small steps
-- Avoid technical terms
-- Offer encouragement
-- ALWAYS include "I don't know / Help me" as an option for substantive questions`}
+  ? `- Ser caloroso, encorajador e consultivo. Linguagem simples, sem jargão.
+- Começar IMEDIATAMENTE com set_phase(1) e ask_user. Na PRIMEIRA mensagem: mencionar upload de documentos.
+- Pontuar métricas conforme coleta (não esperar). Fase 2: open_map composite. Fase 3a: open_intervention_selector.
+- TODA pergunta substantiva DEVE ter opção "Não sei / Me ajude". Quando selecionada: read_knowledge, dar exemplos brasileiros, recomendar.
+- NÃO repetir perguntas já respondidas. Checar ESTADO ATUAL antes de perguntar. Referenciar respostas anteriores.
+- Upload de documentos: extrair tudo, preencher com update_section, pontuar maturidade, pular perguntas respondidas.
+- Pedir evidências em 3 momentos: após Fase 2 (fotos), após Fase 3a (documentos), Fase 5 (links).
+- Após Fase 5: placar completo + set_phase(6). Pedir revisão do documento antes de exportar.`
+  : `- Be warm, encouraging, consultative. Simple language, no jargon.
+- Start IMMEDIATELY with set_phase(1) and ask_user. FIRST message: mention document upload.
+- Score metrics as you go (don't wait). Phase 2: open_map composite. Phase 3a: open_intervention_selector.
+- EVERY substantive question MUST have "I don't know / Help me" option. When selected: read_knowledge, give Brazilian examples, recommend.
+- DO NOT repeat questions already answered. Check CURRENT STATE before asking. Reference earlier answers.
+- File drops: extract all, fill with update_section, score maturity, skip answered questions.
+- Ask for evidence at 3 moments: after Phase 2 (photos), after Phase 3a (documents), Phase 5 (links).
+- After Phase 5: full scorecard + set_phase(6). Ask user to review document before export.`}
 
-## ${isPt ? 'COMPORTAMENTO' : 'BEHAVIOR'}
-${isPt
-  ? `- Ser caloroso, encorajador e consultivo
-- Começar IMEDIATAMENTE com set_phase(1) e perguntas ask_user
-- Pontuar métricas de maturidade conforme coleta informações (não esperar até o final)
-- Para QUALQUER questão espacial: usar open_map (não ask_user com showMap)
-- Fase 2: SEMPRE usar open_map com modo "composite"
-- Fase 3a: SEMPRE usar open_intervention_selector (não ask_user para tipo de SbN)
-- Fase 3b/3c: read_knowledge PROATIVAMENTE para fornecer benchmarks e exemplos
-- Após Fase 5: gerar o placar de maturidade completo
-- Na PRIMEIRA mensagem: mencionar que o usuário pode enviar documentos existentes no chat`
-  : `- Be warm, encouraging, and consultative
-- Start IMMEDIATELY with set_phase(1) and ask_user questions
-- Score maturity metrics as you gather information (don't wait until the end)
-- For ANY spatial question: use open_map (not ask_user with showMap)
-- Phase 2: ALWAYS use open_map with "composite" mode
-- Phase 3a: ALWAYS use open_intervention_selector (not ask_user for NBS type)
-- Phase 3b/3c: read_knowledge PROACTIVELY to provide benchmarks and examples
-- After Phase 5: generate the full maturity scorecard
-- In your FIRST message: mention that the user can drop existing documents into the chat`}
+## MATURITY METRICS: ${MATURITY_METRICS.join(', ')}
+## PRIORITY FLAGS: ${PRIORITY_FLAG_DEFINITIONS.join(', ')}
 
-## FILE DROPS
-When the user drops a document, you'll receive its content. React by:
-1. Extract ALL relevant info (org name, team, budget, site, interventions, progress)
-2. Call update_section for every field you can fill — maximize auto-fill
-3. Call score_maturity for metrics you can now assess
-4. Tell the user: "I found [X] in your document. I've filled [sections] and scored [metrics]."
-5. Skip questions already answered by the document
-6. Having a written document is itself evidence of maturity — score accordingly
+## CITY CONTEXT
+${citySummary}
 
-## SKILL FLOW
-${(skillCaches[lang] || skillCaches['en'] || '').slice(0, 3000)}
+## COUGAR SCORING CRITERIA
+${cougarCriteriaCache}
 
-## KNOWLEDGE
-${knowledgeCache}`;
+## KNOWLEDGE FILES (use read_knowledge to access)
+${knowledgeListingCache}`;
+
+  console.log(`[cbo] Prompt size: ~${Math.round(prompt.length / 4)} tokens (${prompt.length} chars) for phase ${state.phase}`);
+  return prompt;
+}
+
+// ── Phase-specific instructions ──────────────────────────────────────────────
+function buildPhaseInstructions(phase: number, isPt: boolean): string {
+  // Map internal phase numbers to instruction blocks
+  // Phase 3 covers 3a/3b/3c — we include all sub-phase instructions when phase=3
+  switch (phase) {
+    case 0:
+    case 1:
+      return isPt
+        ? `**Fase 1: Quem Somos** (org_profile)
+Perguntas via ask_user: nome e tipo da organização, missão, equipe (quantos, remunerados/voluntários), anos de atuação, projetos anteriores, contato.
+Se desenharem ponto/área customizada no mapa: perguntar se o local tem nome.
+Avaliar: Capacidade de Execução (0-3), Experiência Técnica (0-3).`
+        : `**Phase 1: Who We Are** (org_profile)
+Ask via ask_user: org name and type, mission, team (how many, paid/volunteer), years active, prior projects, contact.
+If they draw a custom point/area on map: ask if the site has a name.
+Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
+
+    case 2:
+      return isPt
+        ? `**Fase 2: Onde Atuamos** (intervention_site)
+Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["oef_fri_2024","oef_hwm_2024"], prompt: "Selecione seu bairro, depois escolha os locais" }).
+Após seleção: perguntar condições atuais, população, posse do terreno, engajamento comunitário.
+Se desenharem ponto/área customizada: perguntar "Esse local tem um nome?"
+Pedir fotos do local. Avaliar: Controle do Local (0-3), Ancoragem Comunitária (0-3).`
+        : `**Phase 2: Where We Work** (intervention_site)
+Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["oef_fri_2024","oef_hwm_2024"], prompt: "Select your neighborhood, then pick sites" }).
+After selection: ask current conditions, population, land tenure, community engagement.
+If they draw custom point/area: ask "Does this site have a name?"
+Ask for site photos. Score: Site Control (0-3), Community Anchoring (0-3).`;
+
+    case 3:
+      return isPt
+        ? `**Fase 3a: O Que Construímos** (intervention_type)
+Abrir open_intervention_selector com siteHazards da Fase 2. Usuário navega 6 tipos com fotos. Se "Não sei": orientar com perguntas sobre problema + condições → recomendar.
+Após seleção: read_knowledge para detalhes. Perguntar design (espécies, materiais, escala).
+Avaliar: Clareza do Problema (0-3), Clareza da Solução (0-3).
+
+**Fase 3b: Impacto Esperado** (impact_monitoring) — APROFUNDAR, NÃO REPETIR
+NÃO perguntar de novo sobre riscos/população (já sabe da Fase 2). Reconhecer dados existentes.
+Perguntar APENAS: condição ANTES, frequência de manutenção, prazo do projeto.
+read_knowledge(_co-benefits/ + _evidence/impact-benchmarks.md). Apresentar COM vs SEM com faixas + confiança.
+Avaliar: Impacto Climático/SbN (0-3).
+
+**Fase 3c: Operação e Sustentabilidade** (operations_sustain) — CONSTRUIR SOBRE RESPOSTAS
+NÃO perguntar sobre equipe de novo (Fase 1). Referenciar: "Na Fase 1, vocês mencionaram X membros..."
+read_knowledge para OPEX do tipo de SbN. Modelo de sustentabilidade: orçamento municipal, cooperativa, uso produtivo, editais. Créditos de carbono NÃO são práticos.
+Avaliar: Planejamento Financeiro (0-3).`
+        : `**Phase 3a: What We're Building** (intervention_type)
+Open open_intervention_selector with siteHazards from Phase 2. User browses 6 types with photos. If "I don't know": guide with problem + conditions questions → recommend.
+After selection: read_knowledge for details. Ask design questions (species, materials, scale).
+Score: Problem Clarity (0-3), Solution Clarity (0-3).
+
+**Phase 3b: Expected Impact** (impact_monitoring) — GO DEEPER, DON'T REPEAT
+DO NOT re-ask about hazards/population (already from Phase 2). Acknowledge existing data.
+Ask ONLY: baseline condition BEFORE, maintenance frequency, project timeframe.
+read_knowledge(_co-benefits/ + _evidence/impact-benchmarks.md). Present WITH vs WITHOUT with ranges + confidence.
+Score: Climate NBS Impact (0-3).
+
+**Phase 3c: Operations & Sustainability** (operations_sustain) — BUILD ON EARLIER ANSWERS
+DO NOT re-ask about team (Phase 1). Reference: "In Phase 1, you mentioned X members..."
+read_knowledge for OPEX of chosen NBS type. Sustainability model: municipal budget, cooperative, productive use, grants. Carbon credits NOT practical.
+Score: Financial Thinking (0-3).`;
+
+    case 4:
+      return isPt
+        ? `**Fase 4: O Que Precisamos** (needs_assessment) — FONTES REAIS
+NÃO perguntar sobre orçamento de novo (Fase 3c). read_knowledge(_financing-sources/cbo-grants.md).
+Nível 1 (direto): Teia (R$100K), Fundo Casa RS (R$40K), Periferias Verdes, GEF SGP (US$50K).
+Nível 2 (parceria): Petrobras SbN Urbano, World Bank P178072. Monitor: capta.org.br.
+NÃO apresentar BNDES ou GCF como opções diretas para OBCs.
+Perguntar: necessidades técnicas, situação regulatória, capacitação, links (site, redes sociais).
+Avaliar: Consciência Regulatória (0-3).`
+        : `**Phase 4: What We Need** (needs_assessment) — REAL FUNDING SOURCES
+DO NOT re-ask about budget (Phase 3c). read_knowledge(_financing-sources/cbo-grants.md).
+Tier 1 (direct): Teia (R$100K), Fundo Casa RS (R$40K), Periferias Verdes, GEF SGP (US$50K).
+Tier 2 (partnership): Petrobras NBS Urbano, World Bank P178072. Monitor: capta.org.br.
+DO NOT present BNDES or GCF as direct CBO options.
+Ask: technical needs, regulatory status, training, links (website, social media).
+Score: Regulatory Awareness (0-3).`;
+
+    case 5:
+      return isPt
+        ? `**Fase 5: Resultados e Evidências** (results_evidence)
+Pedir: documentos (arrastar no chat), fotos antes/depois, dados de monitoramento, feedback comunitário, links.
+Avaliar flags: posse do terreno, dados de baseline, interesse do governo, co-financiamento, escalabilidade.
+Após completar: gerar placar de maturidade completo (todas 9 métricas + 6 flags) e chamar set_phase(6).
+Dizer: "Seu perfil está completo! Revise na aba Documento e clique Exportar."`
+        : `**Phase 5: Results & Evidence** (results_evidence)
+Ask for: documents (drag into chat), before/after photos, monitoring data, community feedback, links.
+Assess flags: land tenure, baseline data, gov interest, co-financing, scalability.
+After completing: generate full maturity scorecard (all 9 metrics + 6 flags) and call set_phase(6).
+Say: "Your profile is complete! Review in the Document tab and click Export."`;
+
+    default: // Phase 6+ (complete)
+      return isPt
+        ? `**Perfil completo.** Ajudar o usuário a revisar e editar campos. Responder perguntas sobre o projeto.`
+        : `**Profile complete.** Help user review and edit fields. Answer questions about their project.`;
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Restructure the CBO agent prompt from monolithic (~8,900 tokens/turn) to layered architecture:

| Optimization | Before | After | Savings |
|---|---|---|---|
| Phase instructions | All 7 phases (~1,500 tok) | Current phase only (~300-500) | ~1,100 |
| Knowledge cache | Full city + COUGAR files (~4,600 tok) | COUGAR criteria + city summary + listings (~740) | ~3,860 |
| Skill file | Duplicated in prompt (~750 tok) | Removed | 750 |
| Decision log | Last 10 messages (~500 tok) | Last 5 messages (~250) | 250 |
| **Total** | **~8,900 tokens** | **~1,375-1,775** | **~80%** |

### New architecture
- `buildPhaseInstructions(phase, isPt)` — returns only current phase's detailed instructions
- Phase roadmap (1-liner per phase) always loaded so agent knows the flow shape
- Condensed city summary (~150 tokens) with critical facts from all 7 city files
- COUGAR scoring criteria always loaded (essential for maturity assessment)
- Knowledge file listing for `read_knowledge` navigation
- Token count logged per turn: `[cbo] Prompt size: ~X tokens`

### How this informs modularization (#99)
- **Global rules → Engine layer** (cached across turns, ~800 tokens)
- **Phase instructions → Skill layer** (swapped on phase transition, ~300-500 tokens)
- **Knowledge on-demand → Knowledge layer** (agent calls `read_knowledge`)
- `buildPhaseInstructions()` is the prototype for the skill interface

## Test plan
- [ ] Start fresh CBO session — agent should work normally with smaller prompt
- [ ] `[SKIP TO phase:3b]` — agent should receive Phase 3 instructions only
- [ ] Check server logs for `[cbo] Prompt size: ~X tokens` — should be 1,300-1,800
- [ ] Agent should still call read_knowledge proactively for detailed content
- [ ] Maturity scoring should work (COUGAR criteria still loaded)
- [ ] Test in PT — phase instructions rendered in Portuguese

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)