### PR TITLE
fix: stop page-state jitter from unstable updateModule + agent event loop

### DIFF
--- a/client/src/core/components/agent/ChatDrawer.tsx
+++ b/client/src/core/components/agent/ChatDrawer.tsx
@@ -120,9 +120,6 @@ export function ChatDrawer() {
           if (moduleName) {
             updateModule(moduleName, data.data);
             console.log(`[ChatDrawer] Synced ${blockType} to localStorage`);
-            window.dispatchEvent(new CustomEvent('nbs-block-updated', { 
-              detail: { blockType, moduleName, data: data.data } 
-            }));
           }
         }
       }

--- a/client/src/core/contexts/project-context.tsx
+++ b/client/src/core/contexts/project-context.tsx
@@ -660,10 +660,27 @@ const getDbProjectId = (projectId: string): string => {
   return projectId;
 };
 
+const DB_SYNC_DEBOUNCE_MS = 400;
+
 export function ProjectContextProvider({ children }: { children: ReactNode }) {
   const [context, setContext] = useState<ProjectContextData | null>(null);
   const dbSyncedProjects = useRef<Set<string>>(new Set());
   const dbSyncInProgress = useRef<Set<string>>(new Set());
+  // Mirror of latest context — lets callbacks below have [] deps, so their
+  // identity is stable across renders and consumer effects don't loop.
+  const contextRef = useRef<ProjectContextData | null>(null);
+  useEffect(() => { contextRef.current = context; }, [context]);
+  // Debounce + generation counter prevents ping-pong writes and lets a late
+  // response lose to a newer local edit.
+  const dbSyncTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const dbSyncGenerationRef = useRef<Map<string, number>>(new Map());
+  useEffect(() => {
+    const timers = dbSyncTimersRef.current;
+    return () => {
+      timers.forEach(t => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
 
   const syncAllModulesToDatabase = useCallback(async (projectId: string, contextData: ProjectContextData) => {
     const dbProjectId = getDbProjectId(projectId);
@@ -762,18 +779,19 @@ export function ProjectContextProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const saveContext = useCallback((data: Partial<ProjectContextData>) => {
-    if (!data.projectId && !context?.projectId) return;
-    
-    const projectId = data.projectId || context!.projectId;
+    const current = contextRef.current;
+    const projectId = data.projectId || current?.projectId;
+    if (!projectId) return;
+
     const updated: ProjectContextData = {
-      ...context,
+      ...current,
       ...data,
       projectId,
     } as ProjectContextData;
-    
+
     setContext(updated);
     localStorage.setItem(`${PROJECT_CONTEXT_KEY}_${projectId}`, JSON.stringify(updated));
-  }, [context]);
+  }, []);
 
   const syncModuleToDatabase = useCallback(async (
     projectId: string,
@@ -852,30 +870,50 @@ export function ProjectContextProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const scheduleDbSync = useCallback((projectId: string, module: string, data: unknown) => {
+    const key = `${projectId}:${module}`;
+    const timers = dbSyncTimersRef.current;
+    const generations = dbSyncGenerationRef.current;
+    const existing = timers.get(key);
+    if (existing) clearTimeout(existing);
+    const generation = (generations.get(key) ?? 0) + 1;
+    generations.set(key, generation);
+    const timer = setTimeout(() => {
+      timers.delete(key);
+      // Only sync if our generation is still the latest — a newer write
+      // will have bumped the generation and queued its own timer.
+      if (generations.get(key) === generation) {
+        syncModuleToDatabase(projectId, module, data);
+      }
+    }, DB_SYNC_DEBOUNCE_MS);
+    timers.set(key, timer);
+  }, [syncModuleToDatabase]);
+
   const updateModule = useCallback(<K extends keyof Pick<ProjectContextData, 'funderSelection' | 'operations' | 'businessModel' | 'siteExplorer' | 'impactModel'>>(
     module: K,
     data: ProjectContextData[K],
     options?: { skipDbSync?: boolean }
   ) => {
-    if (!context) return;
-    
+    const current = contextRef.current;
+    if (!current) return;
+
     const updated: ProjectContextData = {
-      ...context,
+      ...current,
       [module]: data,
       lastUpdated: {
-        ...context.lastUpdated,
+        ...current.lastUpdated,
         [module]: new Date().toISOString(),
       },
     };
-    
+
     setContext(updated);
-    localStorage.setItem(`${PROJECT_CONTEXT_KEY}_${context.projectId}`, JSON.stringify(updated));
-    
+    localStorage.setItem(`${PROJECT_CONTEXT_KEY}_${current.projectId}`, JSON.stringify(updated));
+
     // Skip DB sync for navigation-only updates to prevent overwriting domain data
     if (!options?.skipDbSync) {
-      syncModuleToDatabase(context.projectId, module, data);
+      scheduleDbSync(current.projectId, module, data);
     }
-  }, [context, syncModuleToDatabase]);
+  }, [scheduleDbSync]);
 
   const getContextSummary = useCallback(() => {
     if (!context) return {};

--- a/client/src/core/pages/business-model.tsx
+++ b/client/src/core/pages/business-model.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link } from 'wouter';
 import { ArrowLeft, Check, Building2, Users, Landmark, DollarSign, AlertTriangle, FileText, Copy, ChevronDown, ChevronUp, Plus, Trash2, Info, Edit, RotateCcw, CheckCircle, Loader2 } from 'lucide-react';
 import { useNavigationPersistence } from '@/core/hooks/useNavigationPersistence';
@@ -478,7 +478,7 @@ export default function BusinessModelPage() {
   const { toast } = useToast();
   const { sampleActions } = useSampleData();
   const { routePrefix } = useSampleRoute();
-  const { loadContext, updateModule } = useProjectContext();
+  const { loadContext, updateModule, context } = useProjectContext();
 
   // Separate navigation persistence from domain data
   const { 
@@ -530,20 +530,17 @@ export default function BusinessModelPage() {
     updateNavigationState({ currentStep });
   }, [currentStep, navigationRestored, updateNavigationState]);
 
+  // React to external updates to businessModel (agent/ChatDrawer).
+  const lastSyncedBusinessModelRef = useRef<unknown>(undefined);
   useEffect(() => {
-    const handleBlockUpdate = (event: Event) => {
-      const customEvent = event as CustomEvent<{ blockType: string; moduleName: string; data: any }>;
-      if (customEvent.detail?.blockType === 'business_model' && customEvent.detail?.data) {
-        console.log('[BusinessModel] Received nbs-block-updated event, applying data directly');
-        const stored = getStoredBMData(projectId || '');
-        if (stored) {
-          setBMData(stored);
-        }
-      }
-    };
-    window.addEventListener('nbs-block-updated', handleBlockUpdate);
-    return () => window.removeEventListener('nbs-block-updated', handleBlockUpdate);
-  }, [projectId]);
+    const slice = context?.businessModel;
+    if (!slice || slice === lastSyncedBusinessModelRef.current) return;
+    lastSyncedBusinessModelRef.current = slice;
+    const stored = getStoredBMData(projectId || '');
+    if (stored) {
+      setBMData(stored);
+    }
+  }, [context?.businessModel, projectId]);
 
   useEffect(() => {
     if (projectId && bmData) {

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -563,7 +563,7 @@ export default function FunderSelectionPage() {
   const { t } = useTranslation();
   const { isSampleMode, sampleActions } = useSampleData();
   const { isSampleRoute, routePrefix } = useSampleRoute();
-  const { updateModule, loadContext } = useProjectContext();
+  const { updateModule, loadContext, context } = useProjectContext();
   const { setPageContext, openChatWithMessage } = useChatState();
   
   // Separate navigation persistence from domain data to prevent race conditions
@@ -729,31 +729,28 @@ export default function FunderSelectionPage() {
     }
   }, [projectId, fundsData, hydrationComplete, hydrateFromDB]);
 
+  // React to external updates to funderSelection (e.g. from ChatDrawer/agent).
+  // We skip self-writes by tracking the last slice reference we synced from.
+  const lastSyncedFunderRef = useRef<FunderSelectionData | null | undefined>(undefined);
   useEffect(() => {
-    const handleBlockUpdate = (e: Event) => {
-      const customEvent = e as CustomEvent<{ blockType: string; moduleName: string; data: any }>;
-      if (customEvent.detail?.blockType === 'funder_selection' && customEvent.detail?.data) {
-        console.log('[FunderSelection] Received nbs-block-updated event, applying data directly');
-        const dbData = customEvent.detail.data as FunderSelectionData;
-        if (dbData.questionnaire) {
-          setAnswers(dbData.questionnaire as QuestionnaireAnswers);
-        }
-        const savedPlan = dbData.fundingPlan;
-        if (savedPlan && savedPlan.status === 'confirmed' && fundsData) {
-          const nowFundExists = savedPlan.selectedFunderNow && fundsData.funds.some((f: any) => f.id === savedPlan.selectedFunderNow);
-          const nextFundExists = !savedPlan.selectedFunderNext || fundsData.funds.some((f: any) => f.id === savedPlan.selectedFunderNext);
-          if (nowFundExists && nextFundExists) {
-            skipAutoSaveRef.current = true;
-            setSelectedNowFundId(savedPlan.selectedFunderNow);
-            setSelectedNextFundId(savedPlan.selectedFunderNext || null);
-            setTimeout(() => { skipAutoSaveRef.current = false; }, 100);
-          }
-        }
+    const dbData = context?.funderSelection;
+    if (!dbData || dbData === lastSyncedFunderRef.current) return;
+    lastSyncedFunderRef.current = dbData;
+    if (dbData.questionnaire) {
+      setAnswers(dbData.questionnaire as QuestionnaireAnswers);
+    }
+    const savedPlan = dbData.fundingPlan;
+    if (savedPlan && savedPlan.status === 'confirmed' && fundsData) {
+      const nowFundExists = savedPlan.selectedFunderNow && fundsData.funds.some((f: any) => f.id === savedPlan.selectedFunderNow);
+      const nextFundExists = !savedPlan.selectedFunderNext || fundsData.funds.some((f: any) => f.id === savedPlan.selectedFunderNext);
+      if (nowFundExists && nextFundExists) {
+        skipAutoSaveRef.current = true;
+        setSelectedNowFundId(savedPlan.selectedFunderNow);
+        setSelectedNextFundId(savedPlan.selectedFunderNext || null);
+        setTimeout(() => { skipAutoSaveRef.current = false; }, 100);
       }
-    };
-    window.addEventListener('nbs-block-updated', handleBlockUpdate);
-    return () => window.removeEventListener('nbs-block-updated', handleBlockUpdate);
-  }, [fundsData]);
+    }
+  }, [context?.funderSelection, fundsData]);
 
   // Persist navigation state using dedicated hook (completely separate from domain data)
   // This is more elegant and robust - navigation never touches the module data/DB

--- a/client/src/core/pages/impact-model.tsx
+++ b/client/src/core/pages/impact-model.tsx
@@ -2688,18 +2688,16 @@ export default function ImpactModelPage() {
     updateNavigationState({ currentStep: newStepIndex });
   }, [currentStep, navigationRestored, dataHydrated, updateNavigationState]);
 
+  // React to external updates to impactModel (agent/ChatDrawer).
+  // Skip self-writes by remembering the last slice reference we applied.
+  const lastSyncedImpactRef = useRef<ImpactModelData | null | undefined>(undefined);
   useEffect(() => {
-    const handleBlockUpdate = (e: Event) => {
-      const customEvent = e as CustomEvent<{ blockType: string; moduleName: string; data: unknown }>;
-      if (customEvent.detail?.blockType === 'impact_model' && customEvent.detail?.data) {
-        console.log('[ImpactModel] Received nbs-block-updated event, applying data directly');
-        const freshData = normalizeRawData(customEvent.detail.data as Record<string, unknown>);
-        setLocalData(freshData);
-      }
-    };
-    window.addEventListener('nbs-block-updated', handleBlockUpdate);
-    return () => window.removeEventListener('nbs-block-updated', handleBlockUpdate);
-  }, [normalizeRawData]);
+    const dbData = context?.impactModel;
+    if (!dbData || dbData === lastSyncedImpactRef.current) return;
+    lastSyncedImpactRef.current = dbData;
+    const freshData = normalizeRawData(dbData as unknown as Record<string, unknown>);
+    setLocalData(freshData);
+  }, [context?.impactModel, normalizeRawData]);
 
   const handleUpdate = (updates: Partial<ImpactModelData>) => {
     const updated = { ...localData, ...updates, status: 'DRAFT' as const };

--- a/client/src/core/pages/project-operations.tsx
+++ b/client/src/core/pages/project-operations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, Link } from 'wouter';
 import { ArrowLeft, Check, Building2, Users, ClipboardList, DollarSign, AlertTriangle, FileText, Copy, ChevronDown, ChevronUp, Plus, Trash2, GripVertical, Sparkles, ExternalLink, Info, Lightbulb, Eye, EyeOff, Loader2 } from 'lucide-react';
 import { useNavigationPersistence } from '@/core/hooks/useNavigationPersistence';
@@ -450,7 +450,7 @@ export default function ProjectOperationsPage() {
   const { toast } = useToast();
   const { isSampleMode, sampleActions } = useSampleData();
   const { isSampleRoute, routePrefix } = useSampleRoute();
-  const { loadContext, updateModule } = useProjectContext();
+  const { loadContext, updateModule, context } = useProjectContext();
 
   // Separate navigation persistence from domain data
   const { 
@@ -503,21 +503,19 @@ export default function ProjectOperationsPage() {
     updateNavigationState({ currentStep });
   }, [currentStep, navigationRestored, updateNavigationState]);
 
-  // Listen for agent block updates
+  // React to external updates to operations (agent/ChatDrawer).
+  // ChatDrawer writes through updateModule, which updates context AND localStorage;
+  // we read back through getStoredOMData to preserve the existing hydration path.
+  const lastSyncedOperationsRef = useRef<unknown>(undefined);
   useEffect(() => {
-    const handleBlockUpdate = (event: Event) => {
-      const customEvent = event as CustomEvent;
-      if (customEvent.detail?.blockType === 'operations') {
-        console.log('[Operations] Received nbs-block-updated event, re-hydrating...');
-        const stored = getStoredOMData(projectId || '');
-        if (stored) {
-          setOMData(stored);
-        }
-      }
-    };
-    window.addEventListener('nbs-block-updated', handleBlockUpdate);
-    return () => window.removeEventListener('nbs-block-updated', handleBlockUpdate);
-  }, [projectId]);
+    const slice = context?.operations;
+    if (!slice || slice === lastSyncedOperationsRef.current) return;
+    lastSyncedOperationsRef.current = slice;
+    const stored = getStoredOMData(projectId || '');
+    if (stored) {
+      setOMData(stored);
+    }
+  }, [context?.operations, projectId]);
 
   useEffect(() => {
     if (projectId && omData) {

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -463,27 +463,22 @@ export default function SiteExplorerPage() {
     });
   }, [selectedZone, navigationRestored, updateNavigationState]);
 
+  // React to external updates to siteExplorer (agent/ChatDrawer).
+  const lastSyncedSiteExplorerRef = useRef<unknown>(undefined);
   useEffect(() => {
-    const handleBlockUpdate = (event: Event) => {
-      const customEvent = event as CustomEvent<{ blockType: string; moduleName: string; data: any }>;
-      if (customEvent.detail?.blockType === 'site_explorer') {
-        console.log('[SiteExplorer] Received nbs-block-updated event, applying data directly');
-        const data = customEvent.detail.data;
-        if (data?.selectedZones) {
-          const portfolios: Record<string, SelectedIntervention[]> = {};
-          data.selectedZones.forEach((zone: any) => {
-            if (typeof zone === 'object' && zone.interventionPortfolio && zone.interventionPortfolio.length > 0) {
-              portfolios[zone.zoneId] = zone.interventionPortfolio;
-            }
-          });
-          console.log('[SiteExplorer] Applied portfolios from event:', Object.keys(portfolios));
-          setZonePortfolios(portfolios);
+    const data = context?.siteExplorer;
+    if (!data || data === lastSyncedSiteExplorerRef.current) return;
+    lastSyncedSiteExplorerRef.current = data;
+    if (data.selectedZones) {
+      const portfolios: Record<string, SelectedIntervention[]> = {};
+      data.selectedZones.forEach((zone: any) => {
+        if (typeof zone === 'object' && zone.interventionPortfolio && zone.interventionPortfolio.length > 0) {
+          portfolios[zone.zoneId] = zone.interventionPortfolio;
         }
-      }
-    };
-    window.addEventListener('nbs-block-updated', handleBlockUpdate);
-    return () => window.removeEventListener('nbs-block-updated', handleBlockUpdate);
-  }, []);
+      });
+      setZonePortfolios(portfolios);
+    }
+  }, [context?.siteExplorer]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary

Fixes the visible UI jitter on **funder selection** (and the other project module pages) where state rapidly oscillates during load, especially after the ChatDrawer side-panel is active. Also closes the ping-pong between the agent panel and the page it's docked to.

### Root cause

\`updateModule\` in \`project-context.tsx\` was a \`useCallback\` whose dep array included \`context\` itself. Every context update changed its reference. Pages that listed \`updateModule\` (or derivative callbacks) in their effect deps therefore re-fired those effects on every render, which called \`updateModule\` again → setState → re-render → re-fire → loop.

The ChatDrawer added a second failure mode: after writing via \`updateModule\`, it dispatched a \`nbs-block-updated\` custom event, which each page listened to and used to set local state. That bridge was redundant with shared context and produced duplicate re-renders.

### Changes

- \`contexts/project-context.tsx\`
  - Mirror the latest \`context\` in a ref so \`updateModule\`, \`saveContext\`, and the new \`scheduleDbSync\` can have stable \`[]\`-ish deps and no longer re-create on every state change.
  - Add a per-module debounce (400ms) with a generation counter for the DB sync, so a late response can't clobber a newer local edit.
  - Clear timers on unmount.
- \`components/agent/ChatDrawer.tsx\`
  - Remove the \`window.dispatchEvent('nbs-block-updated', ...)\` call. \`updateModule\` already propagates through shared context, so subscribed pages re-render automatically when the chatbot changes data.
- 5 pages (\`funder-selection\`, \`impact-model\`, \`site-explorer\`, \`project-operations\`, \`business-model\`)
  - Replace each \`window.addEventListener('nbs-block-updated', ...)\` with a \`useEffect\` that watches the relevant context slice.
  - Guard against self-writes via a \`lastSynced…Ref\` — the effect only applies data when the slice reference changes from the one the page last saw.

## Test plan

- [ ] Open funder selection page and watch render/console — no repeated \`[AutoSave]\` / \`[Hydration]\` log floods on mount.
- [ ] Open ChatDrawer on funder selection, ask the agent to change the selected funder; the page updates without visible flicker and without a second DB write within 500ms.
- [ ] Repeat on impact-model, site-explorer, project-operations, business-model.
- [ ] Refresh each page and confirm selections rehydrate correctly from DB.
- [ ] No new ESLint \`react-hooks/exhaustive-deps\` warnings introduced in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)