### PR TITLE
fix: cboAgent invalid \' escapes break Replit build

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -714,7 +714,7 @@ Ask about:
 2. **Sustainability model** — "${isPt ? 'Como vocês vão pagar pela manutenção a longo prazo?' : 'How will you fund maintenance long-term?'}"
    - Realistic options: municipal budget, community cooperative fee, productive use (food, tourism, education), grant renewal
    - Carbon credits are NOT practical for small projects — be honest
-   - "${isPt ? 'Não sei' : 'I don\\'t know'}" → walk through each model with simple examples
+   - "${isPt ? 'Não sei' : "I don't know"}" → walk through each model with simple examples
 3. **Timeline** — "${isPt ? 'Quando começou ou vai começar? Quais os marcos principais?' : 'When did it start or will it start? What are the main milestones?'}"
 
 ### Phase 4: What We Need (needs_assessment) — REFERENCE BUDGET FROM 3c
@@ -722,7 +722,7 @@ Ask about:
 **DO NOT re-ask about budget** if already discussed in Phase 3c sustainability model. Instead:
 "${isPt
   ? 'Na fase anterior, falamos sobre sustentabilidade. Agora vamos detalhar o que vocês precisam para começar ou continuar.'
-  : 'In the previous phase, we discussed sustainability. Now let\\'s detail what you need to start or continue.'}"
+  : "In the previous phase, we discussed sustainability. Now let's detail what you need to start or continue."}"
 
 Read knowledge: read_knowledge(_financing-sources/cbo-grants.md)
 


### PR DESCRIPTION
## Summary

Replit deploy was failing with:
> Syntax error in server/services/cboAgent.ts: invalid escape sequence in template string
> Build fails due to JavaScript string escape error at line 717

Two single-quoted strings inside template literals used \`'I don\\'t know'\` and \`'let\\'s detail...'\`. In a single-quoted JS string, \`\\\\\` is an escaped backslash, so the following \`'\` prematurely closes the string. esbuild bails at parse time.

I confirmed by running \`npm run build\` locally — same error at \`server/services/cboAgent.ts:717:37\` and a second one at line 725.

## Fix

Switched both strings to double quotes so the apostrophe stays bare and valid. \`npm run build\` now succeeds.

## Test plan

- [ ] \`npm run build\` completes without esbuild errors (verified locally).
- [ ] Replit deploy picks up \`main\` and ships successfully.
- [ ] CBO agent still returns the prompt string at runtime (pure text change, no logic touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)