### PR TITLE
chore: add [JitterDebug] instrumentation to funder-selection

### DIFF
--- a/client/src/core/contexts/project-context.tsx
+++ b/client/src/core/contexts/project-context.tsx
@@ -897,6 +897,14 @@ export function ProjectContextProvider({ children }: { children: ReactNode }) {
     const current = contextRef.current;
     if (!current) return;
 
+    // [JitterDebug] Log every updateModule call with caller stack.
+    const stack = new Error().stack?.split('\n').slice(2, 6).join(' | ') ?? '(no stack)';
+    const summary = module === 'funderSelection'
+      ? `selectedFunderNow=${(data as unknown as { fundingPlan?: { selectedFunderNow?: string | null } } | null)?.fundingPlan?.selectedFunderNow ?? '(n/a)'} status=${(data as unknown as { status?: string } | null)?.status ?? '(n/a)'}`
+      : '';
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] updateModule(${module}) ${summary} skipDb=${options?.skipDbSync ?? false} caller: ${stack}`);
+
     const updated: ProjectContextData = {
       ...current,
       [module]: data,

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -612,7 +612,68 @@ export default function FunderSelectionPage() {
   const [hydrationComplete, setHydrationComplete] = useState(false);
   const skipAutoSaveRef = useRef(false);
 
-  const action = (isSampleMode || isSampleRoute) 
+  // ==========================================================================
+  // [JitterDebug] Instrumentation — temporary. Grep console for `[JitterDebug]`.
+  // Remove this block once the root cause is identified.
+  // ==========================================================================
+  const jitterRenderCountRef = useRef(0);
+  jitterRenderCountRef.current += 1;
+  const jitterRenderId = jitterRenderCountRef.current;
+  if (typeof window !== 'undefined') {
+    const w = window as unknown as { __jitterCounters?: Record<string, { count: number; firstAt: number; lastAt: number }> };
+    w.__jitterCounters = w.__jitterCounters ?? {};
+    const bucketKey = `render:FunderSelectionPage:${Math.floor(Date.now() / 1000)}`;
+    const bucket = w.__jitterCounters[bucketKey] ?? { count: 0, firstAt: Date.now(), lastAt: Date.now() };
+    bucket.count += 1;
+    bucket.lastAt = Date.now();
+    w.__jitterCounters[bucketKey] = bucket;
+    if (bucket.count === 5) {
+      // eslint-disable-next-line no-console
+      console.warn(`[JitterDebug] ⚠ FunderSelectionPage rendered ${bucket.count}+ times in 1s — jitter candidate. See window.__jitterCounters.`);
+    }
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[JitterDebug] render #${jitterRenderId} t=${Date.now() % 100000} fundingPlanConfirmed=${fundingPlanConfirmed} selectedNowFundId=${selectedNowFundId} selectedNextFundId=${selectedNextFundId} hydrationComplete=${hydrationComplete} showResults=${showResults} currentStep=${currentStep} navigationRestored=${navigationRestored}`);
+
+  useEffect(() => {
+    const t = Date.now();
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] 🟢 FunderSelectionPage MOUNT at t=${t}`);
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log(`[JitterDebug] 🔴 FunderSelectionPage UNMOUNT at t=${Date.now()} (lived ${Date.now() - t}ms)`);
+    };
+  }, []);
+
+  const jitterPrevRef = useRef<Record<string, unknown>>({});
+  useEffect(() => {
+    const current: Record<string, unknown> = {
+      fundingPlanConfirmed,
+      selectedNowFundId,
+      selectedNextFundId,
+      hydrationComplete,
+      showResults,
+      currentStep,
+      showDecisionStep,
+      hasSavedToContext,
+      navigationRestored,
+      'context.funderSelection.fundingPlan.selectedFunderNow': context?.funderSelection?.fundingPlan?.selectedFunderNow ?? null,
+      'context.funderSelection.status': context?.funderSelection?.status ?? null,
+      'savedNavState.additionalState.fundingPlanConfirmed': (savedNavState?.additionalState as { fundingPlanConfirmed?: boolean } | undefined)?.fundingPlanConfirmed ?? null,
+    };
+    const prev = jitterPrevRef.current;
+    for (const key of Object.keys(current)) {
+      if (!(key in prev)) continue; // first render, seed only
+      if (prev[key] !== current[key]) {
+        // eslint-disable-next-line no-console
+        console.log(`[JitterDebug] Δ ${key}: ${JSON.stringify(prev[key])} → ${JSON.stringify(current[key])} (render #${jitterRenderId})`);
+      }
+    }
+    jitterPrevRef.current = current;
+  });
+  // ==========================================================================
+
+  const action = (isSampleMode || isSampleRoute)
     ? sampleActions.find(a => a.id === projectId)
     : null;
 
@@ -625,6 +686,8 @@ export default function FunderSelectionPage() {
 
   // Restore navigation state from dedicated navigation persistence (separate from domain data)
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:navRestore FIRE navRestored=${navigationRestored} savedNavState=${JSON.stringify(savedNavState)}`);
     if (navigationRestored && savedNavState) {
       setCurrentStep(savedNavState.currentStep ?? 0);
       setShowResults(savedNavState.showResults ?? false);
@@ -671,7 +734,10 @@ export default function FunderSelectionPage() {
     if (!projectId || !fundsData) return;
     const dbProjectId = (isSampleMode || isSampleRoute) ? 'sample-porto-alegre-project' : projectId;
     const dataOnly = options?.dataOnly ?? false;
+    // eslint-disable-next-line no-console
     console.log('[Hydration] Starting fetch from DB, projectId:', dbProjectId, 'dataOnly:', dataOnly);
+    // eslint-disable-next-line no-console
+    console.log('[JitterDebug] hydrateFromDB CALLED. Stack:\n' + (new Error().stack?.split('\n').slice(2, 8).join('\n') ?? '(no stack)'));
     
     fetch(`/api/projects/${dbProjectId}/blocks/funder_selection`)
       .then(res => res.ok ? res.json() : null)
@@ -724,6 +790,8 @@ export default function FunderSelectionPage() {
 
   // Hydrate funding plan selection state from DATABASE directly (not localStorage)
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:hydrateGate FIRE projectId=${projectId} fundsData=${!!fundsData} hydrationComplete=${hydrationComplete}`);
     if (projectId && fundsData && !hydrationComplete) {
       hydrateFromDB();
     }
@@ -734,8 +802,13 @@ export default function FunderSelectionPage() {
   const lastSyncedFunderRef = useRef<FunderSelectionData | null | undefined>(undefined);
   useEffect(() => {
     const dbData = context?.funderSelection;
-    if (!dbData || dbData === lastSyncedFunderRef.current) return;
+    const sameRef = dbData === lastSyncedFunderRef.current;
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:ctxWatcher FIRE hasData=${!!dbData} sameRef=${sameRef} newSelectedFunderNow=${dbData?.fundingPlan?.selectedFunderNow ?? null}`);
+    if (!dbData || sameRef) return;
     lastSyncedFunderRef.current = dbData;
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] ctxWatcher APPLYING questionnaire + funder IDs from context`);
     if (dbData.questionnaire) {
       setAnswers(dbData.questionnaire as QuestionnaireAnswers);
     }
@@ -771,6 +844,8 @@ export default function FunderSelectionPage() {
   const [lastSavedSelection, setLastSavedSelection] = useState<{ now: string | null; next: string | null } | null>(null);
   
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:autoSaveSelection FIRE hydrationComplete=${hydrationComplete} skipAutoSave=${skipAutoSaveRef.current} selNow=${selectedNowFundId} selNext=${selectedNextFundId} lastSaved=${JSON.stringify(lastSavedSelection)}`);
     // Skip during hydration or before hydration complete
     if (!hydrationComplete || skipAutoSaveRef.current) return;
     if (!projectId || !fundsData) return;
@@ -849,12 +924,16 @@ export default function FunderSelectionPage() {
   
   useEffect(() => {
     const answersKey = JSON.stringify(answers);
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:answersChanged FIRE changed=${!!lastSavedAnswers && answersKey !== lastSavedAnswers}`);
     if (lastSavedAnswers && answersKey !== lastSavedAnswers) {
       setHasSavedToContext(false);
     }
   }, [answers, lastSavedAnswers]);
 
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(`[JitterDebug] effect:readyBlockSave FIRE computedResults=${!!computedResults} hasSavedToContext=${hasSavedToContext} fundingPlanConfirmed=${fundingPlanConfirmed} hydrationComplete=${hydrationComplete} skipAutoSave=${skipAutoSaveRef.current}`);
     // Wait for hydration to complete before auto-saving to avoid overwriting confirmed data
     // Also check the ref as a synchronous guard against race conditions
     if (computedResults && projectId && !hasSavedToContext && !fundingPlanConfirmed && hydrationComplete && !skipAutoSaveRef.current) {


### PR DESCRIPTION
## Summary

Temporary, surgical browser-console logging to pinpoint the 'funding plan confirmed ↔ confirm funding plan' jitter you're still seeing after #110.

**This PR changes no behavior** — it only adds \`console.log\` calls. Safe to merge and deploy; safe to revert the moment we know what's firing.

## How to reproduce

1. Merge + deploy.
2. Open the funder-selection page, open DevTools console.
3. Filter console for \`[JitterDebug]\`.
4. Trigger the jitter (scroll, have the agent patch a funder, etc.).
5. Paste the last ~100 lines back to me.

## What to look for in the console

- \`🟢 MOUNT\` / \`🔴 UNMOUNT\` — if you see these repeatedly during a single session, the component is remounting (that'd explain the second \`hydrateFromDB\` with different data we saw in the earlier log).
- \`render #N ...\` — printed on every render. If the numbers climb by several per second while nothing visible is happening, that's the jitter.
- \`⚠ FunderSelectionPage rendered 5+ times in 1s\` — auto-emits when renders are bursty. Also peek at \`window.__jitterCounters\` for the per-second histogram.
- \`Δ fundingPlanConfirmed: false → true\` (and similar \`Δ\` lines) — tells you which state variable is toggling. If you see \`fundingPlanConfirmed\` flipping false↔true rapidly, that's the exact source of the 'confirmed ↔ confirm' UI flicker.
- \`effect:... FIRE\` — one log per effect invocation. If you see the same effect firing dozens of times per second, its deps are churning.
- \`hydrateFromDB CALLED\` with stack — catches exactly who triggered the second hydration we observed.
- \`updateModule(funderSelection) ... caller: ...\` — every write to the shared context, with caller stack. Lets us see if ChatDrawer + the page are fighting.

## Test plan

- [ ] Build succeeds (\`npm run build\` — verified locally).
- [ ] Deploy picks up the logs and nothing else breaks.
- [ ] Reproduce the jitter with DevTools open, capture console, paste back to me.
- [ ] After root cause is fixed, revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)