### PR TITLE
fix: latch navRestore + questionnaire hydration — breaks funder-selection swap loop

### DIFF
--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -684,11 +684,16 @@ export default function FunderSelectionPage() {
       .catch(console.error);
   }, []);
 
-  // Restore navigation state from dedicated navigation persistence (separate from domain data)
+  // Restore navigation state ONCE when persistence finishes loading. After
+  // that, local state is the source of truth — re-reading savedNavState on
+  // every write creates a swap loop with the write-back effect below.
+  const navRestoreAppliedRef = useRef(false);
   useEffect(() => {
     // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:navRestore FIRE navRestored=${navigationRestored} savedNavState=${JSON.stringify(savedNavState)}`);
-    if (navigationRestored && savedNavState) {
+    console.log(`[JitterDebug] effect:navRestore FIRE navRestored=${navigationRestored} applied=${navRestoreAppliedRef.current} savedNavState=${JSON.stringify(savedNavState)}`);
+    if (!navigationRestored || navRestoreAppliedRef.current) return;
+    navRestoreAppliedRef.current = true;
+    if (savedNavState) {
       setCurrentStep(savedNavState.currentStep ?? 0);
       setShowResults(savedNavState.showResults ?? false);
       if (savedNavState.additionalState) {
@@ -699,36 +704,43 @@ export default function FunderSelectionPage() {
     }
   }, [navigationRestored, savedNavState]);
   
-  // Hydrate questionnaire from saved context (domain data only, not navigation)
+  // Hydrate questionnaire from saved context — ONCE per project. savedNavState
+  // is intentionally not in deps: it churns on every write, and loadContext
+  // here would keep calling setContext, which would churn context.funderSelection
+  // and cascade through the context watcher below.
+  const questionnaireHydratedRef = useRef<string | null>(null);
   useEffect(() => {
-    if (projectId) {
-      const existingContext = loadContext(projectId, { skipDbSync: true });
-      const savedData = existingContext?.funderSelection;
-      const savedQuestionnaire = savedData?.questionnaire as QuestionnaireAnswers | undefined;
-      
-      // Check if questionnaire was already completed (has key answers filled)
-      const isQuestionnaireComplete = savedQuestionnaire?.projectStage &&
-        savedQuestionnaire?.generatesRevenue;
-      
-      if (isQuestionnaireComplete) {
-        setAnswers(savedQuestionnaire);
-        // Only auto-show results if no navigation state was saved
-        if (!savedNavState) {
-          setShowResults(true);
-        }
-      }
-      
-      // Always auto-populate project basics from action/shared context
-      if (action) {
-        setAnswers(prev => ({
-          ...prev,
-          projectName: action.name,
-          projectDescription: action.description || '',
-          sectors: action.type === 'adaptation' ? ['nature_based', 'urban_resilience'] : ['energy', 'transport'],
-        }));
+    if (!projectId || !navigationRestored) return;
+    if (questionnaireHydratedRef.current === projectId) return;
+    questionnaireHydratedRef.current = projectId;
+
+    const existingContext = loadContext(projectId, { skipDbSync: true });
+    const savedData = existingContext?.funderSelection;
+    const savedQuestionnaire = savedData?.questionnaire as QuestionnaireAnswers | undefined;
+
+    const isQuestionnaireComplete = savedQuestionnaire?.projectStage &&
+      savedQuestionnaire?.generatesRevenue;
+
+    if (isQuestionnaireComplete) {
+      setAnswers(savedQuestionnaire);
+      // Only auto-show results if no navigation state was saved at the moment
+      // we hydrate. We snapshot savedNavState here rather than depend on it.
+      if (!savedNavState) {
+        setShowResults(true);
       }
     }
-  }, [action, projectId, savedNavState, loadContext]);
+
+    // Always auto-populate project basics from action/shared context
+    if (action) {
+      setAnswers(prev => ({
+        ...prev,
+        projectName: action.name,
+        projectDescription: action.description || '',
+        sectors: action.type === 'adaptation' ? ['nature_based', 'urban_resilience'] : ['energy', 'transport'],
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [action, projectId, navigationRestored, loadContext]);
   
   const hydrateFromDB = useCallback((options?: { dataOnly?: boolean }) => {
     if (!projectId || !fundsData) return;


### PR DESCRIPTION
## Root cause (confirmed from [JitterDebug] logs)

From your console capture:

\`\`\`
render N:   fpc=true,  savedNavState.fpc=false
render N+1: fpc=false, savedNavState.fpc=true   ← swap
render N+2: fpc=true,  savedNavState.fpc=false  ← swap back
render N+3: fpc=false, savedNavState.fpc=true   ← swap
...  (≈125 renders/sec)
\`\`\`

Classic two-effect ping-pong:

1. **navRestore** (line 627) reads \`savedNavState.additionalState.fundingPlanConfirmed\` and does \`setFundingPlanConfirmed(X)\` — fires on every savedNavState change.
2. **write effect** (line 758) pushes \`{ fundingPlanConfirmed: localFpc }\` into \`savedNavState\` — fires on every local fpc change.

Once the two sides disagree by one value, the write effect captures the local value into savedNavState **before** navRestore's \`setState\` has committed, and navRestore captures savedNavState into local state **before** the write effect has run. Next commit finds them swapped. Repeat forever.

Additional cascade source: the **questionnaire hydration effect** (line 640) had \`savedNavState\` in its deps and called \`loadContext\` → \`setContext\` on every churn, which kept churning \`context.funderSelection\` and lighting up my context-watcher too.

## Fix

Both restoration effects now run **once per project** via ref latches:

- \`navRestoreAppliedRef\` — gates navRestore to a single apply after \`navigationRestored\` flips true.
- \`questionnaireHydratedRef\` (keyed by \`projectId\`) — gates the questionnaire hydration (and its \`loadContext\` call) to a single run per project; waits for \`navigationRestored\` so savedNavState has had a chance to load from localStorage before we snapshot it.

After initial restoration, **local state is the source of truth**. savedNavState becomes write-only (the write effect keeps pushing updates to localStorage; nothing reads them back during the session).

## Verification

The [JitterDebug] instrumentation from #113 is still in place. After deploy:

1. Open funder-selection, open DevTools console.
2. Filter for \`[JitterDebug]\`.
3. Expected:
   - \`effect:navRestore FIRE ... applied=false\` once, then \`applied=true\` on the (at most) one or two follow-up fires.
   - The \`Δ fundingPlanConfirmed: true↔false\` / \`Δ savedNavState.additionalState.fundingPlanConfirmed\` lines should **stop appearing**.
   - Render counter should settle (no more 125/sec bursts, no more \`⚠ rendered 5+ times in 1s\` warnings).
4. Once verified, open a small follow-up PR to strip the \`[JitterDebug]\` block.

## Test plan

- [ ] \`npm run build\` clean (verified).
- [ ] Reload funder-selection, confirm console is quiet — share one round of logs so we can confirm.
- [ ] Agent-applied patch still updates the UI (context watcher still works).
- [ ] Edit Funding Plan → questionnaire round-trip still rehydrates on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)