### PR TITLE
fix: sweep nav-restore latch to 2 remaining pages + strip JitterDebug

### DIFF
--- a/client/src/core/contexts/project-context.tsx
+++ b/client/src/core/contexts/project-context.tsx
@@ -897,14 +897,6 @@ export function ProjectContextProvider({ children }: { children: ReactNode }) {
     const current = contextRef.current;
     if (!current) return;
 
-    // [JitterDebug] Log every updateModule call with caller stack.
-    const stack = new Error().stack?.split('\n').slice(2, 6).join(' | ') ?? '(no stack)';
-    const summary = module === 'funderSelection'
-      ? `selectedFunderNow=${(data as unknown as { fundingPlan?: { selectedFunderNow?: string | null } } | null)?.fundingPlan?.selectedFunderNow ?? '(n/a)'} status=${(data as unknown as { status?: string } | null)?.status ?? '(n/a)'}`
-      : '';
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] updateModule(${module}) ${summary} skipDb=${options?.skipDbSync ?? false} caller: ${stack}`);
-
     const updated: ProjectContextData = {
       ...current,
       [module]: data,

--- a/client/src/core/pages/business-model.tsx
+++ b/client/src/core/pages/business-model.tsx
@@ -502,9 +502,14 @@ export default function BusinessModelPage() {
   const stakeholders = SAMPLE_STAKEHOLDERS;
   const hazards = ['FLOOD', 'HEAT', 'LANDSLIDE'];
 
-  // Restore navigation from dedicated hook
+  // Restore navigation ONCE when persistence finishes loading. After that,
+  // local state owns currentStep — re-reading savedNavState on every write
+  // creates a swap loop with the write-back effect below (see PR #114).
+  const navRestoreAppliedRef = useRef(false);
   useEffect(() => {
-    if (navigationRestored && savedNavState) {
+    if (!navigationRestored || navRestoreAppliedRef.current) return;
+    navRestoreAppliedRef.current = true;
+    if (savedNavState) {
       setCurrentStep(savedNavState.currentStep ?? 0);
     }
   }, [navigationRestored, savedNavState]);

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -612,67 +612,6 @@ export default function FunderSelectionPage() {
   const [hydrationComplete, setHydrationComplete] = useState(false);
   const skipAutoSaveRef = useRef(false);
 
-  // ==========================================================================
-  // [JitterDebug] Instrumentation — temporary. Grep console for `[JitterDebug]`.
-  // Remove this block once the root cause is identified.
-  // ==========================================================================
-  const jitterRenderCountRef = useRef(0);
-  jitterRenderCountRef.current += 1;
-  const jitterRenderId = jitterRenderCountRef.current;
-  if (typeof window !== 'undefined') {
-    const w = window as unknown as { __jitterCounters?: Record<string, { count: number; firstAt: number; lastAt: number }> };
-    w.__jitterCounters = w.__jitterCounters ?? {};
-    const bucketKey = `render:FunderSelectionPage:${Math.floor(Date.now() / 1000)}`;
-    const bucket = w.__jitterCounters[bucketKey] ?? { count: 0, firstAt: Date.now(), lastAt: Date.now() };
-    bucket.count += 1;
-    bucket.lastAt = Date.now();
-    w.__jitterCounters[bucketKey] = bucket;
-    if (bucket.count === 5) {
-      // eslint-disable-next-line no-console
-      console.warn(`[JitterDebug] ⚠ FunderSelectionPage rendered ${bucket.count}+ times in 1s — jitter candidate. See window.__jitterCounters.`);
-    }
-  }
-  // eslint-disable-next-line no-console
-  console.log(`[JitterDebug] render #${jitterRenderId} t=${Date.now() % 100000} fundingPlanConfirmed=${fundingPlanConfirmed} selectedNowFundId=${selectedNowFundId} selectedNextFundId=${selectedNextFundId} hydrationComplete=${hydrationComplete} showResults=${showResults} currentStep=${currentStep} navigationRestored=${navigationRestored}`);
-
-  useEffect(() => {
-    const t = Date.now();
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] 🟢 FunderSelectionPage MOUNT at t=${t}`);
-    return () => {
-      // eslint-disable-next-line no-console
-      console.log(`[JitterDebug] 🔴 FunderSelectionPage UNMOUNT at t=${Date.now()} (lived ${Date.now() - t}ms)`);
-    };
-  }, []);
-
-  const jitterPrevRef = useRef<Record<string, unknown>>({});
-  useEffect(() => {
-    const current: Record<string, unknown> = {
-      fundingPlanConfirmed,
-      selectedNowFundId,
-      selectedNextFundId,
-      hydrationComplete,
-      showResults,
-      currentStep,
-      showDecisionStep,
-      hasSavedToContext,
-      navigationRestored,
-      'context.funderSelection.fundingPlan.selectedFunderNow': context?.funderSelection?.fundingPlan?.selectedFunderNow ?? null,
-      'context.funderSelection.status': context?.funderSelection?.status ?? null,
-      'savedNavState.additionalState.fundingPlanConfirmed': (savedNavState?.additionalState as { fundingPlanConfirmed?: boolean } | undefined)?.fundingPlanConfirmed ?? null,
-    };
-    const prev = jitterPrevRef.current;
-    for (const key of Object.keys(current)) {
-      if (!(key in prev)) continue; // first render, seed only
-      if (prev[key] !== current[key]) {
-        // eslint-disable-next-line no-console
-        console.log(`[JitterDebug] Δ ${key}: ${JSON.stringify(prev[key])} → ${JSON.stringify(current[key])} (render #${jitterRenderId})`);
-      }
-    }
-    jitterPrevRef.current = current;
-  });
-  // ==========================================================================
-
   const action = (isSampleMode || isSampleRoute)
     ? sampleActions.find(a => a.id === projectId)
     : null;
@@ -689,8 +628,6 @@ export default function FunderSelectionPage() {
   // every write creates a swap loop with the write-back effect below.
   const navRestoreAppliedRef = useRef(false);
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:navRestore FIRE navRestored=${navigationRestored} applied=${navRestoreAppliedRef.current} savedNavState=${JSON.stringify(savedNavState)}`);
     if (!navigationRestored || navRestoreAppliedRef.current) return;
     navRestoreAppliedRef.current = true;
     if (savedNavState) {
@@ -746,11 +683,9 @@ export default function FunderSelectionPage() {
     if (!projectId || !fundsData) return;
     const dbProjectId = (isSampleMode || isSampleRoute) ? 'sample-porto-alegre-project' : projectId;
     const dataOnly = options?.dataOnly ?? false;
-    // eslint-disable-next-line no-console
     console.log('[Hydration] Starting fetch from DB, projectId:', dbProjectId, 'dataOnly:', dataOnly);
-    // eslint-disable-next-line no-console
-    console.log('[JitterDebug] hydrateFromDB CALLED. Stack:\n' + (new Error().stack?.split('\n').slice(2, 8).join('\n') ?? '(no stack)'));
-    
+
+
     fetch(`/api/projects/${dbProjectId}/blocks/funder_selection`)
       .then(res => res.ok ? res.json() : null)
       .then(result => {
@@ -802,8 +737,6 @@ export default function FunderSelectionPage() {
 
   // Hydrate funding plan selection state from DATABASE directly (not localStorage)
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:hydrateGate FIRE projectId=${projectId} fundsData=${!!fundsData} hydrationComplete=${hydrationComplete}`);
     if (projectId && fundsData && !hydrationComplete) {
       hydrateFromDB();
     }
@@ -814,13 +747,8 @@ export default function FunderSelectionPage() {
   const lastSyncedFunderRef = useRef<FunderSelectionData | null | undefined>(undefined);
   useEffect(() => {
     const dbData = context?.funderSelection;
-    const sameRef = dbData === lastSyncedFunderRef.current;
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:ctxWatcher FIRE hasData=${!!dbData} sameRef=${sameRef} newSelectedFunderNow=${dbData?.fundingPlan?.selectedFunderNow ?? null}`);
-    if (!dbData || sameRef) return;
+    if (!dbData || dbData === lastSyncedFunderRef.current) return;
     lastSyncedFunderRef.current = dbData;
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] ctxWatcher APPLYING questionnaire + funder IDs from context`);
     if (dbData.questionnaire) {
       setAnswers(dbData.questionnaire as QuestionnaireAnswers);
     }
@@ -856,8 +784,6 @@ export default function FunderSelectionPage() {
   const [lastSavedSelection, setLastSavedSelection] = useState<{ now: string | null; next: string | null } | null>(null);
   
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:autoSaveSelection FIRE hydrationComplete=${hydrationComplete} skipAutoSave=${skipAutoSaveRef.current} selNow=${selectedNowFundId} selNext=${selectedNextFundId} lastSaved=${JSON.stringify(lastSavedSelection)}`);
     // Skip during hydration or before hydration complete
     if (!hydrationComplete || skipAutoSaveRef.current) return;
     if (!projectId || !fundsData) return;
@@ -936,16 +862,12 @@ export default function FunderSelectionPage() {
   
   useEffect(() => {
     const answersKey = JSON.stringify(answers);
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:answersChanged FIRE changed=${!!lastSavedAnswers && answersKey !== lastSavedAnswers}`);
     if (lastSavedAnswers && answersKey !== lastSavedAnswers) {
       setHasSavedToContext(false);
     }
   }, [answers, lastSavedAnswers]);
 
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(`[JitterDebug] effect:readyBlockSave FIRE computedResults=${!!computedResults} hasSavedToContext=${hasSavedToContext} fundingPlanConfirmed=${fundingPlanConfirmed} hydrationComplete=${hydrationComplete} skipAutoSave=${skipAutoSaveRef.current}`);
     // Wait for hydration to complete before auto-saving to avoid overwriting confirmed data
     // Also check the ref as a synchronous guard against race conditions
     if (computedResults && projectId && !hasSavedToContext && !fundingPlanConfirmed && hydrationComplete && !skipAutoSaveRef.current) {

--- a/client/src/core/pages/project-operations.tsx
+++ b/client/src/core/pages/project-operations.tsx
@@ -476,9 +476,14 @@ export default function ProjectOperationsPage() {
   
   const allStakeholders = [...SAMPLE_STAKEHOLDERS, ...(omData?.customStakeholders || [])];
 
-  // Restore navigation from dedicated hook
+  // Restore navigation ONCE when persistence finishes loading. After that,
+  // local state owns currentStep — re-reading savedNavState on every write
+  // creates a swap loop with the write-back effect below (see PR #114).
+  const navRestoreAppliedRef = useRef(false);
   useEffect(() => {
-    if (navigationRestored && savedNavState) {
+    if (!navigationRestored || navRestoreAppliedRef.current) return;
+    navRestoreAppliedRef.current = true;
+    if (savedNavState) {
       setCurrentStep(savedNavState.currentStep ?? 0);
     }
   }, [navigationRestored, savedNavState]);


### PR DESCRIPTION
## Summary

Follow-up to #114 (which fixed funder-selection). Two actions:

1. **Apply the same \`navRestoreAppliedRef\` latch** to the two other module pages whose restoration effect had the same preconditions for the swap loop.
2. **Strip the \`[JitterDebug]\` instrumentation** from funder-selection and project-context — its job is done.

## Sweep findings

| Page | Status | Action |
|---|---|---|
| funder-selection | fixed in #114 | — |
| project-operations | same bug, not yet observed | ✅ latch added |
| business-model | same bug, not yet observed | ✅ latch added |
| impact-model | **already safe** | — |
| site-explorer | **already safe** | — |

**Why impact-model is safe**: its restoration effect's deps are \`[navigationRestored, dataHydrated]\` (both latch-once booleans); \`savedNavState\` is only read via closure, so changes don't re-fire the effect.

**Why site-explorer is safe**: destructures \`savedNavState\` but never reads it.

## Instrumentation removal

All \`[JitterDebug]\` traces removed:
- Render counter, mount/unmount logs, per-variable Δ tracker (funder-selection).
- \`effect:*\` FIRE logs in all five effect sites (funder-selection).
- \`hydrateFromDB\` caller-stack log (funder-selection).
- \`updateModule\` caller-stack log (project-context).

## Test plan

- [ ] \`npm run build\` clean (verified).
- [ ] Funder-selection console is quiet — no \`[JitterDebug]\` lines, normal \`[Hydration]\` / \`[AutoSave]\` logs only.
- [ ] Project-operations and business-model: navigate in/out, refresh; \`currentStep\` rehydrates correctly on reload.
- [ ] No new render storms on any of the 5 module pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)