### PR TITLE
docs: document the persisted-state swap loop anti-pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,18 @@ Layer definitions (with value encodings) live in `shared/geospatial-layers.ts`. 
 
 ## Lessons Learned
 
+### Persisted-state swap loop (useNavigationPersistence)
+
+**Symptom**: a module page jittering at ~125 renders/sec — two state values (one local, one inside `savedNavState`) alternate true↔false on every React commit.
+
+**Cause**: a restoration effect with `[navigationRestored, savedNavState]` deps that reads from `savedNavState` into local state, paired with a write-back effect that pushes local state into `savedNavState`. Once the two sides disagree by one value, each commit makes them swap.
+
+**Fix**: restoration MUST be one-shot. Use a `useRef(false)` latch that flips to `true` after the first apply; subsequent savedNavState changes are ignored for reads (writes continue as normal). See the JSDoc on `client/src/core/hooks/useNavigationPersistence.ts` for the exact pattern.
+
+**Also watch for** any effect that has `savedNavState` in its deps and calls `loadContext` / `setContext` — its reference churn cascades through every context subscriber (same class of loop, longer chain). The questionnaire-hydration effect in funder-selection hit this.
+
+Fixed across all 5 module pages in PRs #114, #115.
+
 ### Replit Sync
 
 Replit tracks the default branch (`main`). If you create a PR targeting a different branch, merged changes won't appear in Replit. Always verify the base branch before creating PRs.

--- a/client/src/core/hooks/useNavigationPersistence.ts
+++ b/client/src/core/hooks/useNavigationPersistence.ts
@@ -8,6 +8,46 @@ export interface NavigationState {
   additionalState?: Record<string, unknown>;
 }
 
+/**
+ * Navigation persistence — remembers per-module UI state across reloads via localStorage.
+ *
+ * ⚠️ Anti-pattern to avoid: "persisted-state swap loop"
+ * ----------------------------------------------------
+ * Do NOT drive local component state FROM `navigationState` on every change.
+ * If you also have a write-back effect that pushes local state INTO
+ * `navigationState` (the usual pairing), the two effects will alternate
+ * values on every commit — ~125 renders/sec, visible UI flicker.
+ *
+ *   ❌ // runs on every savedNavState reference change → loops with write-back
+ *   useEffect(() => {
+ *     if (navigationRestored && savedNavState) {
+ *       setCurrentStep(savedNavState.currentStep ?? 0);
+ *       setFoo(savedNavState.additionalState?.foo);
+ *     }
+ *   }, [navigationRestored, savedNavState]);
+ *
+ *   ✅ // restore ONCE when persistence finishes loading; latch with a ref
+ *   const navRestoreAppliedRef = useRef(false);
+ *   useEffect(() => {
+ *     if (!navigationRestored || navRestoreAppliedRef.current) return;
+ *     navRestoreAppliedRef.current = true;
+ *     if (savedNavState) {
+ *       setCurrentStep(savedNavState.currentStep ?? 0);
+ *       setFoo(savedNavState.additionalState?.foo);
+ *     }
+ *   }, [navigationRestored, savedNavState]);
+ *
+ * After the one-shot restore, local state is the source of truth; the
+ * persisted store becomes write-only for the rest of the session.
+ *
+ * Also applies to any effect that **reads** from `navigationState` in its
+ * deps (e.g. an effect that calls `loadContext` gated on `savedNavState`).
+ * Reference churn on every write-back cascades through `setContext` and
+ * triggers every context subscriber — same class of loop, longer chain.
+ *
+ * Seen in: NBS funder-selection, April 2026. Fixed in PRs #114, #115.
+ */
+
 interface UseNavigationPersistenceOptions {
   projectId: string | undefined;
   moduleName: string;


### PR DESCRIPTION
## Summary

Two docs so the bug fixed in #114/#115 doesn't get reintroduced:

1. **JSDoc on \`useNavigationPersistence\`** — warning block at the top of the hook with a ❌/✅ side-by-side, the broader warning about any effect reading \`navigationState\` in its deps (e.g. a \`loadContext\` gated on \`savedNavState\`), and a pointer to PRs #114/#115.
2. **\`CLAUDE.md\` 'Lessons Learned' entry** — short description so future Claude sessions pick it up automatically from project context.

## Test plan

- [ ] \`npm run build\` clean (verified).
- [ ] Nothing else changes — docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)