### PR TITLE
feat(phase-0): role/audience architecture contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@ shared/
 
 ## Key Architecture Patterns
 
+### Role / Audience Architecture
+
+The app serves three audiences: **city** governments, **community-based organizations** (CBOs), and **orchestrators** that coordinate CBOs. Role is a cross-cutting parameter read from a single `ROLE_CONFIGS` record in `shared/roles.ts` — NOT a component-level conditional.
+
+**Rule**: if you find yourself writing `if (role === 'cbo') { … } else { … }` in a component, stop and push the variation into `RoleConfig` instead. Likewise, don't fork files per role (no `cboFunderSelection.tsx`, no `cbo-funds.json`) — parameterize the shared one.
+
+See **`docs/ROLE-ARCHITECTURE.md`** for the contract, the `RoleConfig` shape, right/wrong examples, and the phased migration plan. See also `docs/modular-agent-architecture.md` for how agent skills (orthogonal to roles) get unified.
+
 ### Dual Mode: Sample vs API
 
 The app runs in two modes controlled by `SampleDataContext`:

--- a/docs/ROLE-ARCHITECTURE.md
+++ b/docs/ROLE-ARCHITECTURE.md
@@ -1,0 +1,174 @@
+# Role / Audience Architecture
+
+Status: contract established (Phase 0). Consumers being migrated in Phase 1.
+
+## Why this document exists
+
+The app serves multiple audiences — city governments, community-based organizations (CBOs), and organizations that coordinate CBOs ("orchestrators" such as Villa Flores). Each audience needs a different framing of the same underlying NBS project-preparation flow:
+
+- Different primary goal (concept note for financing vs CBO maturity profile vs portfolio overview).
+- Different funder universe (MDB loans vs small grants).
+- Different module visibility (cities care about operating models and revenue stacks; CBOs mostly don't).
+- Different entry path (OAuth + city picker vs direct-to-sample CBO demo).
+
+We are **one product**, not three. Forking components / services / knowledge trees per audience would compound the same dedup problem already called out for agent skills in `docs/modular-agent-architecture.md`.
+
+## The rule
+
+> **Role is a cross-cutting parameter, not a code fork.**
+>
+> Behavior that varies by role lives in *config/data* — specifically in `shared/roles.ts` via `ROLE_CONFIGS[role]`. Components, agents, module pages, knowledge files, and tools are written **once** and parameterized by role.
+>
+> If you are about to write `if (role === 'cbo') <ComponentA /> else <ComponentB />`, stop and make it `<Component config={useRoleConfig()} />`.
+> If you are about to add a `cityFunderSelection.tsx` alongside a `cboFunderSelection.tsx`, stop — extend `climate-funds.json` with an `audience` tag instead.
+
+### Right way / wrong way
+
+```tsx
+// ❌ WRONG — role becomes a component-level conditional
+function ProjectPageCTA() {
+  const { role } = useRoleContext();
+  if (role === 'city') return <Button href="/concept-note">Generate Concept Note</Button>;
+  if (role === 'cbo')  return <Button href="/cbo-profile">Start CBO Profile</Button>;
+  return null;
+}
+
+// ✅ RIGHT — role drives config; component is parameterized
+function ProjectPageCTA() {
+  const config = useRoleConfig();
+  return (
+    <Button href={config.primaryCta.route}>
+      {t(config.primaryCta.labelKey)}
+    </Button>
+  );
+}
+```
+
+```ts
+// ❌ WRONG — two datasets, drift guaranteed
+import cityFunds from './city-funds.json';
+import cboFunds from './cbo-funds.json';
+const funds = role === 'cbo' ? cboFunds : cityFunds;
+
+// ✅ RIGHT — one dataset with an audience tag
+import funds from './climate-funds.json';
+const config = ROLE_CONFIGS[role];
+const eligible = funds.filter(f =>
+  f.audience.some(a => config.funders.audience.includes(a))
+);
+```
+
+### Legitimate exceptions
+
+Not every audience variation is a component conditional. Some are **genuinely different screens**:
+
+- The orchestrator portfolio page is a dashboard, not a project page. It legitimately lives at a different route with a different top-level layout.
+- The city landing flow starts on `/cities`; the CBO demo goes straight to `sample-ada-1`.
+
+Even in those cases, shared primitives should still be reused: cards, badges, progress meters, the agent drawer. The line is at **page/screen composition**, not at primitive components.
+
+## Relationship to `docs/modular-agent-architecture.md`
+
+Roles and skills are **orthogonal**:
+
+| Concept | What it answers | Source of truth | Examples |
+|--------|-----------------|-----------------|----------|
+| **Role** | Who is the user? | `shared/roles.ts` → `ROLE_CONFIGS` | `city`, `cbo`, `orchestrator` |
+| **Skill** | What is the agent doing right now? | `server/skills/*.skill.ts` (future; see the skill doc) | `concept-note`, `cbo-profile`, future `feasibility-study` |
+
+A role *picks a primary skill* via `RoleConfig.agent.skillId`, but a role is not a skill:
+- A city user using the concept-note skill is different from a CBO user browsing a concept note — same skill, different framing.
+- A future "feasibility study" skill could be available to both cities and CBOs.
+- The orchestrator role maps to a future `portfolio` skill that doesn't exist yet.
+
+**When in doubt**: if the variation is in "what the agent does," it belongs in the skill definition. If it's in "how the rest of the app is framed around the user," it belongs in the role config.
+
+## The contract
+
+See `shared/roles.ts` for the authoritative TypeScript. Summary:
+
+```ts
+interface RoleConfig {
+  id: AudienceRole;
+  label:  { en: string; pt: string };
+  tagline:{ en: string; pt: string };
+  entryRoute: string;           // where to go from the landing page
+  bypassAuth: boolean;          // CBO demo can skip auth
+  visibleModules: ModuleKey[];  // which cards show on the project page
+  primaryCta: { route: string; labelKey: string };
+  agent: { skillId: SkillKey };
+  funders: {
+    audience: FunderAudience[];                 // which funds are eligible
+    questionnaireSteps: FunderQuestionnaireStepKey[];
+    rankingWeights: Record<string, number>;
+  };
+}
+
+const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = { city, cbo, orchestrator };
+```
+
+## Where role gets set
+
+1. **URL query param `?role=cbo`** — wins if present. Shareable deep-links use this.
+2. **`localStorage.nbs_user_role`** — persisted across sessions after first selection.
+3. **Landing page** (`/` when role is unset) — user picks via a 3-card chooser, we set both localStorage and URL.
+
+A single `RoleProvider` (Phase 1) hydrates the role from (1) → (2) → fallback to `null` (show the gate).
+
+## File-layout conventions
+
+| Where | What lives there |
+|-------|------------------|
+| `shared/roles.ts` | `AudienceRole`, `RoleConfig`, `ROLE_CONFIGS`, `parseRole()` |
+| `client/src/core/contexts/role-context.tsx` | `RoleProvider`, `useRoleContext()`, `useRoleConfig()` (Phase 1) |
+| `client/src/core/pages/role-selection.tsx` | Landing page with 3-card chooser (Phase 1) |
+| `client/src/core/pages/orchestrator-landing.tsx` | Phase-1 "coming soon" stub |
+| `client/public/sample-data/climate-funds.json` | Funds carry `audience: FunderAudience[]` |
+| `client/src/core/locales/{en,pt}.json` | All role-facing strings |
+
+## Migration plan
+
+### Phase 0 — this PR (contract only, no behavior change)
+
+- `shared/roles.ts` scaffold with stubbed `ROLE_CONFIGS`.
+- This doc.
+- Pointer from `CLAUDE.md`.
+
+### Phase 1 — Villa Flores MVP
+
+Ship the CBO path end-to-end using `ROLE_CONFIGS`. Every role-dependent call site reads from config.
+
+- `RoleProvider` + `useRoleConfig()`.
+- Landing page + orchestrator stub.
+- Project page: CTA and module visibility driven by config.
+- Funder-selection: filter by `config.funders.audience`; restrict questionnaire to `config.funders.questionnaireSteps`.
+- `climate-funds.json`: add `audience` tag to every fund; add CBO-relevant grants (Teia da Sociobiodiversidade, Fundo Casa RS, GEF SGP, Petrobras NBS Urbano) in the same file.
+- `conceptNoteAgent` / `cboAgent` stay as-is — their URLs are referenced via `config.primaryCta.route`.
+
+### Phase 2 — agent framework unification
+
+Follow `docs/modular-agent-architecture.md` exactly. `config.agent.skillId` starts pointing at real skill definitions instead of current forked services. Old agent routes become shims and are eventually deleted.
+
+### Phase 3 — orchestrator
+
+Real portfolio view + `portfolio` skill. Orchestrator's `RoleConfig` fields fill in; the same `useRoleConfig()` consumers work unchanged.
+
+## Success criteria
+
+- [ ] A new role-dependent behavior is added by editing `ROLE_CONFIGS` — zero new `if (role === …)` conditionals at call sites.
+- [ ] Adding a new audience (e.g., academic researcher) is a ~1-file change: add an entry to `ROLE_CONFIGS`, add an entry on the landing page.
+- [ ] A reviewer can reject any PR that forks a component per role by pointing at this doc.
+- [ ] No parallel `cityX.ts` + `cboX.ts` files introduced after Phase 1.
+
+## Anti-patterns to watch for in code review
+
+- `if (role === 'city')` or `role === 'cbo'` checks in components. Push the variation into `RoleConfig`.
+- New `*.json` data files keyed by role. Use tags / filters on a single file instead.
+- New pages/routes whose name includes a role (`cbo-*.tsx`). The orchestrator dashboard is a legitimate exception because it's a different screen; most other cases aren't.
+- Duplicated helpers (e.g., `rankFundsForCity` + `rankFundsForCbo`). Parameterize the helper with the role's config fields.
+
+## Related
+
+- `docs/modular-agent-architecture.md` — skill-level modularity (agent engine, micro-apps, knowledge base).
+- `docs/callback-stability-patterns.md` — hydration / callback anti-patterns that interact with context.
+- `client/src/core/hooks/useNavigationPersistence.ts` — JSDoc explains the persisted-state swap loop, a nearby concern that applies to any role-aware persistence we add.

--- a/shared/roles.ts
+++ b/shared/roles.ts
@@ -1,0 +1,225 @@
+/**
+ * Role / Audience Architecture — see docs/ROLE-ARCHITECTURE.md
+ *
+ * A `role` is the audience persona of the current user. It is a cross-cutting
+ * parameter that varies the app's behavior: which modules are visible, which
+ * agent skill is primary, which funders are eligible, etc.
+ *
+ * Roles are distinct from **skills** (see docs/modular-agent-architecture.md).
+ * A skill is what the agent does (e.g. `concept-note`, `cbo-profile`).
+ * A role picks which skill is primary and how the rest of the app is framed.
+ *
+ * This file is the single source of truth for role-dependent behavior.
+ * Consumers MUST read from `ROLE_CONFIGS[role]` rather than branching on the
+ * role string in their own code.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AudienceRole = 'city' | 'cbo' | 'orchestrator';
+
+/**
+ * Keys for the project-preparation modules that appear on the project page.
+ * Extend when a new module is added.
+ */
+export type ModuleKey =
+  | 'funderSelection'
+  | 'siteExplorer'
+  | 'impactModel'
+  | 'operations'
+  | 'businessModel';
+
+/**
+ * Funder audience tag used on entries in `client/public/sample-data/climate-funds.json`
+ * and for filtering in the funder-selection module.
+ */
+export type FunderAudience = 'city' | 'cbo' | 'both';
+
+/**
+ * Questionnaire step IDs in funder-selection. Kept as a string literal union
+ * so `RoleConfig` can declare which subset of steps applies per role without
+ * pulling in the component code.
+ */
+export type FunderQuestionnaireStepKey =
+  | 'projectReadiness'
+  | 'politicalAlignment'
+  | 'financingNeeds'
+  | 'institutionalSetup';
+
+/**
+ * Skill IDs from the agent framework (see docs/modular-agent-architecture.md).
+ * Until skills are extracted, these map 1:1 to the current agent services
+ * (`conceptNoteAgent.ts`, `cboAgent.ts`). The `portfolio` skill is a phase-3
+ * placeholder for the orchestrator view and does NOT exist yet.
+ */
+export type SkillKey = 'concept-note' | 'cbo-profile' | 'portfolio';
+
+/**
+ * The contract every consumer reads from. Changes to this shape are
+ * architecture changes — discuss in PR before extending.
+ */
+export interface RoleConfig {
+  /** Role identifier. */
+  id: AudienceRole;
+  /** Display labels (shown on the landing page, header, etc.). */
+  label: { en: string; pt: string };
+  /** One-line description for the landing-page card. */
+  tagline: { en: string; pt: string };
+  /** Where to route after the role is chosen. */
+  entryRoute: string;
+  /**
+   * If true, this role can use sample data without authenticating (CBO demo).
+   * Phase 1 uses this for CBO; phase-3 orchestrator likely flips to false.
+   */
+  bypassAuth: boolean;
+  /** Which project modules appear on the project page, in order. */
+  visibleModules: ModuleKey[];
+  /** Hero call-to-action on the project page (Concept Note vs CBO Profile vs …). */
+  primaryCta: {
+    /** Route to navigate to (sample-prefix is applied by caller if needed). */
+    route: string;
+    /** i18n key for the button label. */
+    labelKey: string;
+  };
+  /** Which agent skill this role's primary CTA opens. */
+  agent: {
+    skillId: SkillKey;
+  };
+  /** How the funder-selection module behaves for this role. */
+  funders: {
+    /** Values to accept when filtering `climate-funds.json[].audience`. */
+    audience: FunderAudience[];
+    /** Subset of questionnaire steps shown. */
+    questionnaireSteps: FunderQuestionnaireStepKey[];
+    /**
+     * Ranking weights applied on top of base fund ranking. Empty object means
+     * use defaults. Concrete weights will land in phase 1.
+     */
+    rankingWeights: Record<string, number>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ROLE_CONFIGS — populated in Phase 1
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase 0 scaffold. Fields marked `// TODO phase-1` are intentionally empty
+ * or placeholder — they will be filled in as each module is role-enabled.
+ * Consumers should NOT branch on `role === 'city'`; they should read the
+ * relevant field from `ROLE_CONFIGS[role]`.
+ */
+export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
+  city: {
+    id: 'city',
+    label: { en: 'City', pt: 'Cidade' },
+    tagline: {
+      en: 'I work for a city government preparing a climate project.',
+      pt: 'Trabalho em um governo municipal preparando um projeto climático.',
+    },
+    entryRoute: '/cities', // existing city selection flow
+    bypassAuth: false,
+    visibleModules: [
+      'funderSelection',
+      'siteExplorer',
+      'impactModel',
+      'operations',
+      'businessModel',
+    ],
+    primaryCta: {
+      route: '/concept-note', // TODO phase-1: confirm sample-prefix handling
+      labelKey: 'project.primaryCta.city', // TODO phase-1: add to locales
+    },
+    agent: { skillId: 'concept-note' },
+    funders: {
+      audience: ['city', 'both'],
+      questionnaireSteps: [
+        'projectReadiness',
+        'politicalAlignment',
+        'financingNeeds',
+        'institutionalSetup',
+      ],
+      rankingWeights: {}, // defaults
+    },
+  },
+
+  cbo: {
+    id: 'cbo',
+    label: {
+      en: 'Community-Based Organization',
+      pt: 'Organização de Base Comunitária',
+    },
+    tagline: {
+      en: 'We are a community organization building or running a nature-based project.',
+      pt: 'Somos uma organização comunitária construindo ou mantendo um projeto de base natural.',
+    },
+    entryRoute: '/sample/project/sample-ada-1', // direct into NBS sample
+    bypassAuth: true,
+    visibleModules: [
+      // TODO phase-1: confirm which modules make sense; operations + businessModel
+      // are likely out-of-scope for CBO MVP.
+      'funderSelection',
+      'siteExplorer',
+      'impactModel',
+    ],
+    primaryCta: {
+      route: '/cbo-profile',
+      labelKey: 'project.primaryCta.cbo', // TODO phase-1: add to locales
+    },
+    agent: { skillId: 'cbo-profile' },
+    funders: {
+      audience: ['cbo', 'both'],
+      questionnaireSteps: [
+        // TODO phase-1: confirm with Villa Flores which questionnaire steps
+        // are meaningful for a CBO. politicalAlignment + institutionalSetup
+        // are probably out.
+        'projectReadiness',
+        'financingNeeds',
+      ],
+      rankingWeights: {}, // TODO phase-1: prioritize grants, small ticket size
+    },
+  },
+
+  orchestrator: {
+    id: 'orchestrator',
+    label: {
+      en: 'Orchestrator',
+      pt: 'Organização Articuladora',
+    },
+    tagline: {
+      en: 'I coordinate several community organizations implementing nature-based projects.',
+      pt: 'Coordeno várias organizações comunitárias implementando projetos de base natural.',
+    },
+    entryRoute: '/orchestrator', // phase-1 ships a "coming soon" stub here
+    bypassAuth: true,
+    // Phase 3 — real portfolio view. Listed empty until then; the stub page
+    // ignores this field.
+    visibleModules: [],
+    primaryCta: {
+      route: '/orchestrator', // stub self-route
+      labelKey: 'project.primaryCta.orchestrator', // TODO phase-3
+    },
+    agent: { skillId: 'portfolio' }, // phase-3 skill, not yet implemented
+    funders: {
+      // Orchestrators likely want a union view — defer until phase 3.
+      audience: ['city', 'cbo', 'both'],
+      questionnaireSteps: [],
+      rankingWeights: {},
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow an unknown string (e.g. a URL query param) to a valid AudienceRole.
+ * Returns `null` if the value isn't a known role.
+ */
+export function parseRole(raw: unknown): AudienceRole | null {
+  if (raw === 'city' || raw === 'cbo' || raw === 'orchestrator') return raw;
+  return null;
+}


### PR DESCRIPTION
## Summary

Phase 0 of the role-architecture work — establishes the contract Villa Flores MVP (Phase 1) will build on. **No runtime behavior changes** in this PR; purely docs + scaffold.

## What's in here

- **\`shared/roles.ts\`** (225 lines) — \`AudienceRole\` type, \`RoleConfig\` interface, and a \`ROLE_CONFIGS\` record stubbed out for \`city\`, \`cbo\`, and \`orchestrator\`. Every role-dependent behavior the app will need (visible modules, primary CTA, funder audience filter, agent skill pointer, i18n labels) is a field on \`RoleConfig\` — so consumers read config instead of branching on role strings.

- **\`docs/ROLE-ARCHITECTURE.md\`** (174 lines) — the rule, right/wrong code examples, the relationship to \`docs/modular-agent-architecture.md\` (roles and skills are **orthogonal** — a role picks a skill), file-layout conventions, the 0→3 migration plan, and anti-patterns to catch in review.

- **\`CLAUDE.md\`** — new entry under 'Key Architecture Patterns' pointing to both architecture docs so future contributors (and future Claude sessions) see the contract before writing role-dependent code.

## The rule this codifies

> Role is a cross-cutting parameter, not a code fork. Behavior that varies by role lives in \`ROLE_CONFIGS[role]\`. Components, agents, module pages, knowledge files, and tools are written once and parameterized by role. If you're about to write \`if (role === 'cbo') <A /> else <B />\`, push the variation into \`RoleConfig\` instead.

## Phase plan (for reviewer context)

- **Phase 0** (this PR): contract only.
- **Phase 1**: Villa Flores MVP — \`RoleProvider\`, landing page, CBO path end-to-end, funder-selection branching. Every branch point reads \`ROLE_CONFIGS\`.
- **Phase 2**: agent-framework unification, following the existing \`docs/modular-agent-architecture.md\`. \`RoleConfig.agent.skillId\` starts pointing at real skill definitions; current forked agent services collapse.
- **Phase 3**: orchestrator portfolio view + \`portfolio\` skill.

## How I'd like review to go

- Sanity-check the \`RoleConfig\` shape — especially whether the \`funders\` subshape is expressive enough (audience filter + questionnaire steps + ranking weights). Phase 1 is where this becomes load-bearing.
- Confirm the \`city\`/\`cbo\`/\`orchestrator\` tagline copy (EN + PT) is acceptable as a starting point for the landing-page cards. Easy to change later.
- Flag any file-layout convention in \`ROLE-ARCHITECTURE.md\` that conflicts with existing repo conventions I missed.

## Test plan

- [ ] \`npm run build\` clean (verified).
- [ ] \`npx tsc --noEmit\` — no new errors in \`shared/roles.ts\` (verified).
- [ ] Nothing imports \`ROLE_CONFIGS\` yet — it's dormant scaffold. No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)