### PR TITLE
feat(phase-1): role-selection landing + RoleProvider + project page branching

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,11 +6,14 @@ import { TooltipProvider } from '@/core/components/ui/tooltip';
 import { SampleDataProvider } from '@/core/contexts/sample-data-context';
 import { ProjectContextProvider } from '@/core/contexts/project-context';
 import { ChatProvider, useChatState } from '@/core/contexts/chat-context';
+import { RoleProvider } from '@/core/contexts/role-context';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // Core pages
 import Login from '@/core/pages/login';
+import RoleSelectionPage from '@/core/pages/role-selection';
+import OrchestratorLandingPage from '@/core/pages/orchestrator-landing';
 import CitySelection from '@/core/pages/city-selection';
 import ProjectPage from '@/core/pages/project';
 import SiteExplorerPage from '@/core/pages/site-explorer';
@@ -30,8 +33,9 @@ import { ChatDrawer } from '@/core/components/agent/ChatDrawer';
 function Router() {
   return (
     <Switch>
-      <Route path='/' component={Login} />
+      <Route path='/' component={RoleSelectionPage} />
       <Route path='/login' component={Login} />
+      <Route path='/orchestrator' component={OrchestratorLandingPage} />
       <Route path='/auth/callback' component={OAuthCallback} />
       <Route path='/cities' component={CitySelection} />
       <Route path='/project/:projectId' component={ProjectPage} />
@@ -96,14 +100,16 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <SampleDataProvider>
-        <ProjectContextProvider>
-          <ChatProvider>
-            <TooltipProvider>
-              <Toaster />
-              <AppLayout />
-            </TooltipProvider>
-          </ChatProvider>
-        </ProjectContextProvider>
+        <RoleProvider>
+          <ProjectContextProvider>
+            <ChatProvider>
+              <TooltipProvider>
+                <Toaster />
+                <AppLayout />
+              </TooltipProvider>
+            </ChatProvider>
+          </ProjectContextProvider>
+        </RoleProvider>
       </SampleDataProvider>
     </QueryClientProvider>
   );

--- a/client/src/core/contexts/role-context.tsx
+++ b/client/src/core/contexts/role-context.tsx
@@ -1,0 +1,86 @@
+/**
+ * RoleProvider — see docs/ROLE-ARCHITECTURE.md
+ *
+ * Hydrates the current `AudienceRole` from (in order):
+ *   1. `?role=` query param (wins if present; also persists it).
+ *   2. `localStorage.nbs_user_role` (persisted prior selection).
+ *   3. `null` — caller shows the landing-page gate.
+ *
+ * Consumers should prefer `useRoleConfig()` for config-driven UI rather
+ * than branching on the role string directly.
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  ROLE_CONFIGS,
+  parseRole,
+  type AudienceRole,
+  type RoleConfig,
+} from '@shared/roles';
+
+const STORAGE_KEY = 'nbs_user_role';
+const QUERY_PARAM = 'role';
+
+interface RoleContextValue {
+  role: AudienceRole | null;
+  setRole: (role: AudienceRole | null) => void;
+}
+
+const RoleContext = createContext<RoleContextValue | null>(null);
+
+function readInitialRole(): AudienceRole | null {
+  if (typeof window === 'undefined') return null;
+  const fromQuery = parseRole(new URLSearchParams(window.location.search).get(QUERY_PARAM));
+  if (fromQuery) {
+    // Persist so subsequent navigations keep the role even if the query param
+    // is dropped by internal routing.
+    try { window.localStorage.setItem(STORAGE_KEY, fromQuery); } catch { /* storage disabled */ }
+    return fromQuery;
+  }
+  try {
+    return parseRole(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function RoleProvider({ children }: { children: ReactNode }) {
+  const [role, setRoleState] = useState<AudienceRole | null>(() => readInitialRole());
+
+  const setRole = useCallback((next: AudienceRole | null) => {
+    setRoleState(next);
+    try {
+      if (next) window.localStorage.setItem(STORAGE_KEY, next);
+      else window.localStorage.removeItem(STORAGE_KEY);
+    } catch { /* storage disabled */ }
+  }, []);
+
+  // Re-sync from storage if another tab changes role — avoids inconsistent state.
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      setRoleState(parseRole(e.newValue));
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const value = useMemo(() => ({ role, setRole }), [role, setRole]);
+  return <RoleContext.Provider value={value}>{children}</RoleContext.Provider>;
+}
+
+export function useRoleContext(): RoleContextValue {
+  const ctx = useContext(RoleContext);
+  if (!ctx) throw new Error('useRoleContext must be used inside a RoleProvider');
+  return ctx;
+}
+
+/**
+ * Returns the active `RoleConfig`, or `null` if no role has been chosen yet.
+ * Most UI that is only rendered after a role is chosen can assert non-null
+ * (e.g. `const config = useRoleConfig()!`); the landing-page gate handles
+ * the null case.
+ */
+export function useRoleConfig(): RoleConfig | null {
+  const { role } = useRoleContext();
+  return role ? ROLE_CONFIGS[role] : null;
+}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -1,0 +1,57 @@
+/**
+ * Orchestrator "coming soon" stub (Phase 1).
+ *
+ * The real portfolio view is Phase 3. This page is what role=orchestrator
+ * lands on for now — honest placeholder with a way to switch role.
+ *
+ * See docs/ROLE-ARCHITECTURE.md.
+ */
+import { useLocation } from 'wouter';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, Network } from 'lucide-react';
+import { Card, CardContent } from '@/core/components/ui/card';
+import { Button } from '@/core/components/ui/button';
+import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
+import { useRoleContext } from '@/core/contexts/role-context';
+
+export default function OrchestratorLandingPage() {
+  const { t } = useTranslation();
+  const [, setLocation] = useLocation();
+  const { setRole } = useRoleContext();
+
+  const switchRole = () => {
+    setRole(null);
+    setLocation('/');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 py-12 bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
+      <div className="w-full max-w-xl">
+        <Card>
+          <CardContent className="p-10 text-center">
+            <div className="mx-auto w-14 h-14 rounded-xl bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300 flex items-center justify-center mb-6">
+              <Network className="w-7 h-7" strokeWidth={1.75} />
+            </div>
+            <TitleLarge className="mb-3" data-testid="text-orchestrator-title">
+              {t('orchestrator.title')}
+            </TitleLarge>
+            <BodyMedium className="text-muted-foreground mb-2">
+              {t('orchestrator.subtitle')}
+            </BodyMedium>
+            <BodySmall className="text-muted-foreground mb-8">
+              {t('orchestrator.status')}
+            </BodySmall>
+            <Button
+              variant="outline"
+              onClick={switchRole}
+              data-testid="button-orchestrator-switch-role"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              {t('orchestrator.switchRole')}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/project.tsx
+++ b/client/src/core/pages/project.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { useSampleData, SAMPLE_DATA_READINESS, DataReadinessItem } from '@/core/contexts/sample-data-context';
 import { useSampleRoute } from '@/core/hooks/useSampleRoute';
 import { useProjectContext, ProjectContextData, SelectedZone } from '@/core/contexts/project-context';
+import { useRoleConfig } from '@/core/contexts/role-context';
 import { computeReadinessScores, determinePathway } from '@/core/utils/funding-readiness';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -1752,11 +1753,18 @@ function ConceptNotePanel({ context }: { context: ProjectContextData | null }) {
 
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { isSampleMode, sampleActions, initiatedProjects, sampleCity } = useSampleData();
   const { isSampleRoute, routePrefix } = useSampleRoute();
   const { context, loadContext, migrateExistingData } = useProjectContext();
   const [contextOpen, setContextOpen] = useState(false);
+  // Role-driven framing (see docs/ROLE-ARCHITECTURE.md). `null` when the user
+  // deep-linked past the landing gate — in that case we show the legacy layout
+  // (both banners) so nothing disappears for existing demo links.
+  const roleConfig = useRoleConfig();
+  const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const showConceptBanner = !roleConfig || roleConfig.id === 'city';
+  const showCboBanner = !roleConfig || roleConfig.id === 'cbo';
 
   const { data: projectData, isLoading } = useQuery<{ project: Project }>({
     queryKey: ['/api/project', projectId],
@@ -1853,49 +1861,60 @@ export default function ProjectPage() {
             </div>
           </div>
 
-          {/* AI CONCEPT NOTE BANNER */}
-          <Link href="/concept-note">
-            <div className="group relative overflow-hidden rounded-xl border border-violet-300/40 bg-violet-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-violet-500/[0.08] hover:border-violet-400/50 hover:shadow-lg hover:shadow-violet-500/5">
-              <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-violet-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
-              <div className="absolute bottom-0 left-0 w-28 h-28 bg-gradient-to-tr from-primary/[0.06] to-transparent rounded-full translate-y-8 -translate-x-8" />
-              <div className="relative flex items-center gap-4">
-                <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-gradient-to-br from-violet-500 to-violet-700 text-white shadow-sm shadow-violet-500/20 group-hover:scale-105 transition-transform">
-                  <Sparkles className="w-5 h-5" />
-                </div>
-                <div className="flex-1">
-                  <h3 className="text-sm font-semibold text-foreground group-hover:text-violet-700 transition-colors">
-                    Create Concept Note with AI Agent
-                  </h3>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    Guided interview to build a fundable BPJP/C40 concept note — grounded in city data and evidence
-                  </p>
-                </div>
-                <ArrowRight className="w-5 h-5 text-violet-300 group-hover:text-violet-500 group-hover:translate-x-1 transition-all" />
-              </div>
+          {/* DEMO DATA BANNER (role-driven) */}
+          {roleConfig?.demoBanner && (
+            <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+              {roleConfig.demoBanner[locale]}
             </div>
-          </Link>
+          )}
 
-          {/* CBO INTERVENTION PROFILE BANNER */}
-          <Link href="/cbo-profile">
-            <div className="group relative overflow-hidden rounded-xl border border-green-300/40 bg-green-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-green-500/[0.08] hover:border-green-400/50 hover:shadow-lg hover:shadow-green-500/5">
-              <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-green-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
-              <div className="absolute bottom-0 left-0 w-28 h-28 bg-gradient-to-tr from-emerald-500/[0.06] to-transparent rounded-full translate-y-8 -translate-x-8" />
-              <div className="relative flex items-center gap-4">
-                <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-gradient-to-br from-green-500 to-emerald-700 text-white shadow-sm shadow-green-500/20 group-hover:scale-105 transition-transform">
-                  <Leaf className="w-5 h-5" />
+          {/* AI CONCEPT NOTE BANNER (city role) */}
+          {showConceptBanner && (
+            <Link href="/concept-note">
+              <div className="group relative overflow-hidden rounded-xl border border-violet-300/40 bg-violet-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-violet-500/[0.08] hover:border-violet-400/50 hover:shadow-lg hover:shadow-violet-500/5">
+                <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-violet-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
+                <div className="absolute bottom-0 left-0 w-28 h-28 bg-gradient-to-tr from-primary/[0.06] to-transparent rounded-full translate-y-8 -translate-x-8" />
+                <div className="relative flex items-center gap-4">
+                  <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-gradient-to-br from-violet-500 to-violet-700 text-white shadow-sm shadow-violet-500/20 group-hover:scale-105 transition-transform">
+                    <Sparkles className="w-5 h-5" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-foreground group-hover:text-violet-700 transition-colors">
+                      Create Concept Note with AI Agent
+                    </h3>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Guided interview to build a fundable BPJP/C40 concept note — grounded in city data and evidence
+                    </p>
+                  </div>
+                  <ArrowRight className="w-5 h-5 text-violet-300 group-hover:text-violet-500 group-hover:translate-x-1 transition-all" />
                 </div>
-                <div className="flex-1">
-                  <h3 className="text-sm font-semibold text-foreground group-hover:text-green-700 transition-colors">
-                    Document Community Intervention
-                  </h3>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    CBO/NGO intervention profile with maturity scorecard — for the COUGAR portfolio
-                  </p>
-                </div>
-                <ArrowRight className="w-5 h-5 text-green-300 group-hover:text-green-500 group-hover:translate-x-1 transition-all" />
               </div>
-            </div>
-          </Link>
+            </Link>
+          )}
+
+          {/* CBO INTERVENTION PROFILE BANNER (cbo role) */}
+          {showCboBanner && (
+            <Link href="/cbo-profile">
+              <div className="group relative overflow-hidden rounded-xl border border-green-300/40 bg-green-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-green-500/[0.08] hover:border-green-400/50 hover:shadow-lg hover:shadow-green-500/5">
+                <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-green-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
+                <div className="absolute bottom-0 left-0 w-28 h-28 bg-gradient-to-tr from-emerald-500/[0.06] to-transparent rounded-full translate-y-8 -translate-x-8" />
+                <div className="relative flex items-center gap-4">
+                  <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-gradient-to-br from-green-500 to-emerald-700 text-white shadow-sm shadow-green-500/20 group-hover:scale-105 transition-transform">
+                    <Leaf className="w-5 h-5" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-foreground group-hover:text-green-700 transition-colors">
+                      Document Community Intervention
+                    </h3>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      CBO/NGO intervention profile with maturity scorecard — for the COUGAR portfolio
+                    </p>
+                  </div>
+                  <ArrowRight className="w-5 h-5 text-green-300 group-hover:text-green-500 group-hover:translate-x-1 transition-all" />
+                </div>
+              </div>
+            </Link>
+          )}
 
           {/* PREPARE Section */}
           <div className="mb-10">
@@ -2112,7 +2131,15 @@ export default function ProjectPage() {
           </div>
         </div>
 
-        {/* AI CONCEPT NOTE BANNER */}
+        {/* DEMO DATA BANNER (role-driven) */}
+        {roleConfig?.demoBanner && (
+          <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+            {roleConfig.demoBanner[locale]}
+          </div>
+        )}
+
+        {/* AI CONCEPT NOTE BANNER (city role) */}
+        {showConceptBanner && (
         <Link href="/concept-note">
           <div className="group relative overflow-hidden rounded-xl border border-violet-300/40 bg-violet-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-violet-500/[0.08] hover:border-violet-400/50 hover:shadow-lg hover:shadow-violet-500/5">
             <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-violet-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
@@ -2133,8 +2160,10 @@ export default function ProjectPage() {
             </div>
           </div>
         </Link>
+        )}
 
-        {/* CBO INTERVENTION PROFILE BANNER */}
+        {/* CBO INTERVENTION PROFILE BANNER (cbo role) */}
+        {showCboBanner && (
         <Link href="/cbo-profile">
           <div className="group relative overflow-hidden rounded-xl border border-green-300/40 bg-green-500/[0.04] p-5 mb-8 cursor-pointer transition-all duration-300 hover:bg-green-500/[0.08] hover:border-green-400/50 hover:shadow-lg hover:shadow-green-500/5">
             <div className="absolute top-0 right-0 w-40 h-40 bg-gradient-to-bl from-green-400/[0.06] to-transparent rounded-full -translate-y-10 translate-x-10" />
@@ -2155,6 +2184,7 @@ export default function ProjectPage() {
             </div>
           </div>
         </Link>
+        )}
 
         {/* PREPARE Section */}
         <div className="mb-10">

--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -1,0 +1,207 @@
+/**
+ * Role-selection landing page (Phase 1 of role architecture).
+ *
+ * Entry point for fresh visitors: pick City / CBO / Orchestrator; we persist
+ * the choice via RoleProvider (localStorage + ?role= deep-link) and route
+ * into the role's entryRoute. If role is already set, this page redirects.
+ *
+ * See docs/ROLE-ARCHITECTURE.md.
+ */
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, Building2, Network, Users } from 'lucide-react';
+import { Card, CardContent } from '@/core/components/ui/card';
+import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
+import { useRoleContext } from '@/core/contexts/role-context';
+import { ROLE_CONFIGS, type AudienceRole } from '@shared/roles';
+import { useSampleData } from '@/core/contexts/sample-data-context';
+import { analytics } from '@/core/lib/analytics';
+
+type RolePresentation = {
+  id: AudienceRole;
+  Icon: typeof Building2;
+  /** Tailwind classes for the card's icon bubble + accent. */
+  accent: { bg: string; fg: string; ring: string };
+};
+
+const PRESENTATIONS: RolePresentation[] = [
+  {
+    id: 'city',
+    Icon: Building2,
+    accent: {
+      bg: 'bg-blue-50 dark:bg-blue-950/40',
+      fg: 'text-blue-600 dark:text-blue-300',
+      ring: 'group-hover:ring-blue-300 dark:group-hover:ring-blue-700',
+    },
+  },
+  {
+    id: 'cbo',
+    Icon: Users,
+    accent: {
+      bg: 'bg-emerald-50 dark:bg-emerald-950/40',
+      fg: 'text-emerald-600 dark:text-emerald-300',
+      ring: 'group-hover:ring-emerald-300 dark:group-hover:ring-emerald-700',
+    },
+  },
+  {
+    id: 'orchestrator',
+    Icon: Network,
+    accent: {
+      bg: 'bg-amber-50 dark:bg-amber-950/40',
+      fg: 'text-amber-600 dark:text-amber-300',
+      ring: 'group-hover:ring-amber-300 dark:group-hover:ring-amber-700',
+    },
+  },
+];
+
+export default function RoleSelectionPage() {
+  const [, setLocation] = useLocation();
+  const { role, setRole } = useRoleContext();
+  const { i18n, t } = useTranslation();
+  const { setSampleMode } = useSampleData();
+
+  const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+
+  // If role is already set, skip the gate.
+  useEffect(() => {
+    if (role) {
+      setLocation(ROLE_CONFIGS[role].entryRoute);
+    }
+  }, [role, setLocation]);
+
+  useEffect(() => {
+    analytics.navigation.pageViewed('RoleSelection');
+  }, []);
+
+  const choose = (next: AudienceRole) => {
+    setRole(next);
+    const config = ROLE_CONFIGS[next];
+    // Bypass-auth roles go through sample mode so downstream components read
+    // the right data source.
+    if (config.bypassAuth) {
+      setSampleMode(true);
+    }
+    setLocation(config.entryRoute);
+  };
+
+  return (
+    <div
+      className="min-h-screen relative flex flex-col bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950"
+    >
+      {/* Subtle decorative glow — ornament, not content */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-[500px] bg-gradient-to-b from-emerald-50/40 via-transparent to-transparent dark:from-emerald-950/10"
+      />
+
+      {/* Header strip */}
+      <header className="relative z-10 flex items-center justify-between px-6 sm:px-10 py-6">
+        <div className="flex items-center gap-3">
+          <img
+            src="/poc-icon.png"
+            alt="OEF"
+            className="w-9 h-9 rounded-lg shadow-sm"
+          />
+          <BodySmall className="font-medium tracking-wide text-muted-foreground">
+            {t('roleSelection.header')}
+          </BodySmall>
+        </div>
+        {/* Language switcher */}
+        <div className="flex items-center gap-1 text-xs font-medium">
+          <button
+            className={`px-2 py-1 rounded-md transition-colors ${locale === 'en' ? 'bg-foreground/10' : 'text-muted-foreground hover:bg-foreground/5'}`}
+            onClick={() => i18n.changeLanguage('en')}
+            data-testid="button-lang-en"
+          >
+            EN
+          </button>
+          <span className="text-muted-foreground/50">·</span>
+          <button
+            className={`px-2 py-1 rounded-md transition-colors ${locale === 'pt' ? 'bg-foreground/10' : 'text-muted-foreground hover:bg-foreground/5'}`}
+            onClick={() => i18n.changeLanguage('pt')}
+            data-testid="button-lang-pt"
+          >
+            PT
+          </button>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="relative z-10 flex-1 flex flex-col items-center justify-center px-4 sm:px-6 pb-16">
+        <div className="w-full max-w-5xl">
+          <div className="text-center mb-12 sm:mb-16">
+            <BodySmall className="uppercase tracking-[0.2em] text-muted-foreground mb-4">
+              {t('roleSelection.eyebrow')}
+            </BodySmall>
+            <TitleLarge
+              className="mb-4 !text-4xl sm:!text-5xl !leading-tight"
+              data-testid="text-landing-title"
+            >
+              {t('roleSelection.title')}
+            </TitleLarge>
+            <BodyMedium className="text-muted-foreground max-w-2xl mx-auto">
+              {t('roleSelection.subtitle')}
+            </BodyMedium>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5 sm:gap-6">
+            {PRESENTATIONS.map(({ id, Icon, accent }) => {
+              const config = ROLE_CONFIGS[id];
+              return (
+                <button
+                  key={id}
+                  onClick={() => choose(id)}
+                  className="group text-left"
+                  data-testid={`card-role-${id}`}
+                >
+                  <Card
+                    className={`h-full transition-all duration-300 ring-1 ring-transparent hover:-translate-y-1 hover:shadow-xl ${accent.ring}`}
+                  >
+                    <CardContent className="p-7 flex flex-col h-full">
+                      <div
+                        className={`w-12 h-12 rounded-xl flex items-center justify-center mb-5 ${accent.bg} ${accent.fg} transition-transform duration-300 group-hover:scale-105`}
+                      >
+                        <Icon className="w-6 h-6" strokeWidth={1.75} />
+                      </div>
+                      <TitleLarge className="mb-2 !text-xl">
+                        {config.label[locale]}
+                      </TitleLarge>
+                      <BodyMedium className="text-muted-foreground flex-1">
+                        {config.tagline[locale]}
+                      </BodyMedium>
+                      <div className="mt-6 flex items-center gap-2 text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+                        <span>{t('roleSelection.continue')}</span>
+                        <ArrowRight
+                          className="w-4 h-4 transition-transform duration-300 group-hover:translate-x-1"
+                          strokeWidth={2}
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="relative z-10 border-t border-foreground/5 py-6 px-6 sm:px-10">
+        <div className="max-w-5xl mx-auto flex items-center justify-between">
+          <BodySmall className="text-muted-foreground">
+            {t('roleSelection.footer')}
+          </BodySmall>
+          <a
+            href="https://openearth.org"
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Open Earth Foundation ↗
+          </a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -6,6 +6,20 @@
     "sampleButton": "Use Sample Data",
     "sampleButtonDescription": "Explore with sample data from Porto Alegre"
   },
+  "roleSelection": {
+    "header": "NBS Project Builder",
+    "eyebrow": "Nature-Based Solutions",
+    "title": "Let's prepare your climate project.",
+    "subtitle": "We help cities and community organizations turn nature-based solutions into investment-ready projects. Tell us who you are to get started.",
+    "continue": "Continue",
+    "footer": "A tool by Open Earth Foundation"
+  },
+  "orchestrator": {
+    "title": "Orchestrator view — coming soon",
+    "subtitle": "You'll be able to coordinate a portfolio of community-based projects here: see their status, aggregate impact, and shepherd them through funding cycles.",
+    "status": "We're designing this with partners now. Want early access? Reach out to the team.",
+    "switchRole": "Back to role selection"
+  },
   "citySelection": {
     "title": "Select a City",
     "subtitle": "Choose a city to view climate actions",
@@ -90,6 +104,11 @@
     "adaptation": "Adaptation"
   },
   "project": {
+    "primaryCta": {
+      "city": "Generate Concept Note",
+      "cbo": "Start CBO Profile",
+      "orchestrator": "Open Portfolio"
+    },
     "notFound": "Project not found",
     "siteExplorer": "Site Explorer",
     "siteExplorerDescription": "View elevation data and city boundaries on an interactive map",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -6,6 +6,20 @@
     "sampleButton": "Usar Dados de Exemplo",
     "sampleButtonDescription": "Explore com dados de exemplo de Porto Alegre"
   },
+  "roleSelection": {
+    "header": "NBS Project Builder",
+    "eyebrow": "Soluções Baseadas na Natureza",
+    "title": "Vamos preparar seu projeto climático.",
+    "subtitle": "Ajudamos cidades e organizações comunitárias a transformar soluções baseadas na natureza em projetos prontos para investimento. Conte-nos quem é você para começar.",
+    "continue": "Continuar",
+    "footer": "Uma ferramenta da Open Earth Foundation"
+  },
+  "orchestrator": {
+    "title": "Visão da organização articuladora — em breve",
+    "subtitle": "Você poderá coordenar um portfólio de projetos comunitários aqui: acompanhar o status, ver o impacto agregado e orientá-los nos ciclos de financiamento.",
+    "status": "Estamos desenhando isso junto com parceiros. Quer acesso antecipado? Entre em contato com a equipe.",
+    "switchRole": "Voltar para seleção de perfil"
+  },
   "citySelection": {
     "title": "Selecione uma Cidade",
     "subtitle": "Escolha uma cidade para ver ações climáticas",
@@ -89,6 +103,11 @@
     "adaptation": "Adaptação"
   },
   "project": {
+    "primaryCta": {
+      "city": "Gerar Nota Conceitual",
+      "cbo": "Iniciar Perfil da Organização",
+      "orchestrator": "Abrir Portfólio"
+    },
     "notFound": "Projeto não encontrado",
     "siteExplorer": "Explorador de Terreno",
     "siteExplorerDescription": "Visualize dados de elevação e limites da cidade em um mapa interativo",

--- a/shared/roles.ts
+++ b/shared/roles.ts
@@ -57,6 +57,14 @@ export type FunderQuestionnaireStepKey =
 export type SkillKey = 'concept-note' | 'cbo-profile' | 'portfolio';
 
 /**
+ * Bilingual label pair. `en` and `pt` track the app's current locale set.
+ */
+export interface LocalizedLabel {
+  en: string;
+  pt: string;
+}
+
+/**
  * The contract every consumer reads from. Changes to this shape are
  * architecture changes — discuss in PR before extending.
  */
@@ -64,9 +72,9 @@ export interface RoleConfig {
   /** Role identifier. */
   id: AudienceRole;
   /** Display labels (shown on the landing page, header, etc.). */
-  label: { en: string; pt: string };
+  label: LocalizedLabel;
   /** One-line description for the landing-page card. */
-  tagline: { en: string; pt: string };
+  tagline: LocalizedLabel;
   /** Where to route after the role is chosen. */
   entryRoute: string;
   /**
@@ -76,6 +84,12 @@ export interface RoleConfig {
   bypassAuth: boolean;
   /** Which project modules appear on the project page, in order. */
   visibleModules: ModuleKey[];
+  /**
+   * Optional per-module label override. Roles can rebrand module names without
+   * a fork — e.g. 'Funder Selection' → 'Funding & Grants' for CBOs. When a
+   * module is not in this map, the module's default label is used.
+   */
+  moduleLabels?: Partial<Record<ModuleKey, LocalizedLabel>>;
   /** Hero call-to-action on the project page (Concept Note vs CBO Profile vs …). */
   primaryCta: {
     /** Route to navigate to (sample-prefix is applied by caller if needed). */
@@ -87,6 +101,12 @@ export interface RoleConfig {
   agent: {
     skillId: SkillKey;
   };
+  /**
+   * Optional banner shown at the top of the project page. Used for the CBO
+   * demo to set expectations that the sample data belongs to Porto Alegre.
+   * `null` for roles that don't need a banner.
+   */
+  demoBanner: LocalizedLabel | null;
   /** How the funder-selection module behaves for this role. */
   funders: {
     /** Values to accept when filtering `climate-funds.json[].audience`. */
@@ -116,23 +136,24 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
     id: 'city',
     label: { en: 'City', pt: 'Cidade' },
     tagline: {
-      en: 'I work for a city government preparing a climate project.',
-      pt: 'Trabalho em um governo municipal preparando um projeto climático.',
+      en: 'City government preparing a climate project for financing.',
+      pt: 'Governo municipal preparando um projeto climático para financiamento.',
     },
-    entryRoute: '/cities', // existing city selection flow
+    entryRoute: '/login', // OAuth + sample-mode picker lives here; Login auto-redirects to /cities after auth or sample-mode toggle
     bypassAuth: false,
     visibleModules: [
-      'funderSelection',
       'siteExplorer',
       'impactModel',
+      'funderSelection',
       'operations',
       'businessModel',
     ],
     primaryCta: {
-      route: '/concept-note', // TODO phase-1: confirm sample-prefix handling
-      labelKey: 'project.primaryCta.city', // TODO phase-1: add to locales
+      route: '/concept-note',
+      labelKey: 'project.primaryCta.city',
     },
     agent: { skillId: 'concept-note' },
+    demoBanner: null,
     funders: {
       audience: ['city', 'both'],
       questionnaireSteps: [
@@ -152,33 +173,61 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
       pt: 'Organização de Base Comunitária',
     },
     tagline: {
-      en: 'We are a community organization building or running a nature-based project.',
-      pt: 'Somos uma organização comunitária construindo ou mantendo um projeto de base natural.',
+      en: 'Community group building or running a nature-based project.',
+      pt: 'Grupo comunitário construindo ou mantendo um projeto de base natural.',
     },
-    entryRoute: '/sample/project/sample-ada-1', // direct into NBS sample
+    entryRoute: '/sample/project/sample-ada-1',
     bypassAuth: true,
+    // All 5 modules visible, reordered for CBO priority: funding + impact
+    // lead (what CBOs care about most), site/operations/business-model trail.
+    // Labels are role-branded below.
     visibleModules: [
-      // TODO phase-1: confirm which modules make sense; operations + businessModel
-      // are likely out-of-scope for CBO MVP.
       'funderSelection',
-      'siteExplorer',
       'impactModel',
+      'siteExplorer',
+      'operations',
+      'businessModel',
     ],
+    moduleLabels: {
+      funderSelection: {
+        en: 'Funding & Grants',
+        pt: 'Financiamento e Editais',
+      },
+      impactModel: {
+        en: 'Our Impact',
+        pt: 'Nosso Impacto',
+      },
+      siteExplorer: {
+        en: 'Our Site',
+        pt: 'Nosso Território',
+      },
+      operations: {
+        en: 'How We Run It',
+        pt: 'Como Gerenciamos',
+      },
+      businessModel: {
+        en: 'Sustainability Model',
+        pt: 'Modelo de Sustentabilidade',
+      },
+    },
     primaryCta: {
       route: '/cbo-profile',
-      labelKey: 'project.primaryCta.cbo', // TODO phase-1: add to locales
+      labelKey: 'project.primaryCta.cbo',
     },
     agent: { skillId: 'cbo-profile' },
+    demoBanner: {
+      en: 'Demo data based on Porto Alegre. Your project content will be different.',
+      pt: 'Dados de demonstração baseados em Porto Alegre. O conteúdo do seu projeto será diferente.',
+    },
     funders: {
       audience: ['cbo', 'both'],
       questionnaireSteps: [
-        // TODO phase-1: confirm with Villa Flores which questionnaire steps
-        // are meaningful for a CBO. politicalAlignment + institutionalSetup
-        // are probably out.
+        // politicalAlignment + institutionalSetup omitted — those steps assume
+        // sovereign / MDB-style approval pathways that don't apply to CBOs.
         'projectReadiness',
         'financingNeeds',
       ],
-      rankingWeights: {}, // TODO phase-1: prioritize grants, small ticket size
+      rankingWeights: {}, // TODO phase-1b: prioritize grants, small ticket size
     },
   },
 
@@ -189,8 +238,8 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
       pt: 'Organização Articuladora',
     },
     tagline: {
-      en: 'I coordinate several community organizations implementing nature-based projects.',
-      pt: 'Coordeno várias organizações comunitárias implementando projetos de base natural.',
+      en: 'Organization coordinating several community-based projects.',
+      pt: 'Organização articulando vários projetos de base comunitária.',
     },
     entryRoute: '/orchestrator', // phase-1 ships a "coming soon" stub here
     bypassAuth: true,
@@ -198,12 +247,12 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
     // ignores this field.
     visibleModules: [],
     primaryCta: {
-      route: '/orchestrator', // stub self-route
+      route: '/orchestrator',
       labelKey: 'project.primaryCta.orchestrator', // TODO phase-3
     },
     agent: { skillId: 'portfolio' }, // phase-3 skill, not yet implemented
+    demoBanner: null,
     funders: {
-      // Orchestrators likely want a union view — defer until phase 3.
       audience: ['city', 'cbo', 'both'],
       questionnaireSteps: [],
       rankingWeights: {},


### PR DESCRIPTION
## Summary

Phase 1 of the role architecture (contract in #117 / \`docs/ROLE-ARCHITECTURE.md\`). First shippable slice — the CBO path works end-to-end via config.

## What changed

### New entry flow
- **\`/\` → 3-card role-selection landing** (City / CBO / Orchestrator) with a clean hero, language switcher, and subtle hover/lift. Modestly designed per the 'wow them, don't overbuild' direction.
- **City** → routes to existing \`/login\` (OAuth + sample-mode picker). No regression.
- **CBO** → skips auth entirely (sets sample-mode true), drops straight into \`/sample/project/sample-ada-1\`.
- **Orchestrator** → honest 'coming soon' stub at \`/orchestrator\` with a 'switch role' affordance.
- **\`?role=cbo\`** (and friends) deep-links bypass the gate and persist via localStorage.

### New files
- \`client/src/core/contexts/role-context.tsx\` — \`RoleProvider\`, \`useRoleContext\`, \`useRoleConfig\`. Cross-tab storage sync via the \`storage\` event.
- \`client/src/core/pages/role-selection.tsx\` — landing gate.
- \`client/src/core/pages/orchestrator-landing.tsx\` — phase-1 stub.

### Config (\`shared/roles.ts\`)
Decisions from the interview locked in:
- **CBO shows all 5 modules**, reordered for CBO priority (funding + impact lead), with CBO-branded labels via a new \`moduleLabels: Partial<Record<ModuleKey, LocalizedLabel>>\` field. Actual module-grid reorder (the JSX) is **deferred to Phase 1b** to keep this PR reviewable.
- Added \`demoBanner: LocalizedLabel | null\` so CBO gets 'Demo data based on Porto Alegre…' at the top of the project page.
- \`city.entryRoute\` is \`/login\` (preserves today's OAuth + Sample picker; Login auto-redirects to \`/cities\` after).

### Project page (\`project.tsx\`)
- \`useRoleConfig()\` drives: concept-note banner (city), CBO-profile banner (CBO), and the demo banner (CBO only).
- Applied in **both** render branches (sample and authenticated).
- If no role is set (deep-link past the gate) both banners show — legacy fallback.

### i18n
- Added \`roleSelection.*\`, \`orchestrator.*\`, \`project.primaryCta.*\` keys to \`en.json\` and \`pt.json\`.
- Fixed a duplicate-key issue the first cut introduced by merging \`project.primaryCta\` into the existing \`project\` block (JSON silently drops the first of two \`project\` keys otherwise).

## What's intentionally NOT in this PR

- Funder-selection role branching + \`climate-funds.json\` audience tags + CBO funds — **Phase 1b**, separate PR.
- Project page's module-card **grid reorder** for CBO — config is ready (\`moduleLabels\`, \`visibleModules\` order), JSX still renders in the original sequence. Phase 1b turns the hard-coded grid into a \`.map(visibleModules)\`.

## Proposed CBO module labels (redline if any feel off)

| Default (City) | CBO label (EN) | CBO label (PT) |
|---|---|---|
| Funder Selection | Funding & Grants | Financiamento e Editais |
| Impact Model | Our Impact | Nosso Impacto |
| Site Explorer | Our Site | Nosso Território |
| Project Operations | How We Run It | Como Gerenciamos |
| Business Model | Sustainability Model | Modelo de Sustentabilidade |

## Verification

- [x] \`npm run build\` clean.
- [x] \`npx tsc --noEmit\` clean on touched files.
- [x] Static bundle serves + contains the new strings (\`vite preview\` 200s across \`/\`, assets, sample JSON).
- [ ] **Local \`npm run dev\` blocked**: needs \`DATABASE_URL\` (Replit env). Visual review / click-through happens when you deploy this.

Things worth eyeballing once deployed:
1. Does the landing page feel right? Especially the hero copy, card hover, EN/PT switcher.
2. CBO flow: pick CBO on \`/\` → lands on the Porto Alegre project page, demo banner visible, only the green 'Document Community Intervention' banner shows (no violet concept-note banner).
3. City flow: pick City on \`/\` → existing \`/login\` screen, rest of the flow unchanged.
4. Deep-link \`/?role=cbo\` — should bypass the gate.

## Test plan

- [ ] Reload \`/\` fresh (clear localStorage first): see the 3-card landing.
- [ ] Click 'Community-Based Organization' → project page for sample-ada-1 with demo banner + only CBO banner.
- [ ] Clear storage, click 'City' → login page.
- [ ] Clear storage, click 'Orchestrator' → coming-soon stub, 'Back to role selection' returns to \`/\`.
- [ ] Visit \`/?role=cbo\` fresh → goes straight into CBO flow.
- [ ] Switch EN ↔ PT on the landing page and re-read all copy.
- [ ] Regression check: existing \`/login\`, \`/cities\`, \`/sample/cities\` flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)