### PR TITLE
fix: /login no longer bounces users stuck in sample mode

### DIFF
--- a/client/src/core/pages/login.tsx
+++ b/client/src/core/pages/login.tsx
@@ -16,15 +16,20 @@ export default function Login() {
   const { isAuthenticated, isLoading } = useAuth();
   const { toast } = useToast();
   const { t } = useTranslation();
-  const { isSampleMode, setSampleMode } = useSampleData();
+  const { setSampleMode } = useSampleData();
 
+  // Only auto-redirect when the user is actually authenticated. We used to
+  // also auto-redirect when `isSampleMode` was true, but since sample mode
+  // persists in localStorage and can now be toggled from the role-selection
+  // landing, that auto-redirect was hijacking anyone who came back to /login
+  // intentionally (e.g. to sign in as a city after trying the CBO demo).
+  // If the user wants sample data, the "Use Sample Data" button below still
+  // sets sample mode and navigates explicitly.
   useEffect(() => {
     if (isAuthenticated) {
       setLocation('/cities');
-    } else if (isSampleMode) {
-      setLocation('/sample/cities');
     }
-  }, [isAuthenticated, isSampleMode, setLocation]);
+  }, [isAuthenticated, setLocation]);
 
   useEffect(() => {
     analytics.navigation.pageViewed('Login');

--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -77,11 +77,11 @@ export default function RoleSelectionPage() {
   const choose = (next: AudienceRole) => {
     setRole(next);
     const config = ROLE_CONFIGS[next];
-    // Bypass-auth roles go through sample mode so downstream components read
-    // the right data source.
-    if (config.bypassAuth) {
-      setSampleMode(true);
-    }
+    // Keep sample mode in sync with the chosen role's auth posture. Picking
+    // a bypass-auth role (CBO demo) enables sample data; picking an
+    // auth-requiring role (City) clears it so the user isn't stuck in a
+    // sample session from a previous CBO visit.
+    setSampleMode(config.bypassAuth);
     setLocation(config.entryRoute);
   };
 


### PR DESCRIPTION
## Symptom

You reported: visiting \`/login\` while logged out sometimes redirects away from the login screen.

## Root cause

Two-part trap introduced when Phase 1a landed (#118):

1. Picking **'Community-Based Organization'** on the new landing gate calls \`setSampleMode(true)\`, which persists \`nbs_sample_mode=true\` to localStorage.
2. The \`Login\` page has a legacy \`useEffect\` that auto-redirects to \`/sample/cities\` whenever \`isSampleMode\` is true.

Net effect: once a user has ever touched the CBO demo, sample mode sticks in localStorage forever and every future visit to \`/login\` gets hijacked, even though the user is logged out and clearly trying to sign in. Same trap would fire for anyone who clicked 'Use Sample Data' in the past — this was a latent bug that Phase 1a made much more common.

## Fix (two halves)

- **\`login.tsx\`** — \`useEffect\` now only auto-redirects when \`isAuthenticated\`. Sample mode is no longer a redirect trigger. If the user wants to enter sample, the explicit "Use Sample Data" button below still works and explicitly \`setLocation('/sample/cities')\`.

- **\`role-selection.tsx\`** — picking a role now explicitly syncs sample mode to the role's \`bypassAuth\`:
  - Pick **City** → \`setSampleMode(false)\` → any sticky CBO sample mode is cleared.
  - Pick **CBO** → \`setSampleMode(true)\` (as before).
  - Pick **Orchestrator** → \`setSampleMode(true)\` (stub doesn't hit APIs).

Together: a user who came from the CBO demo and then goes to the landing to switch to City will end up on a clean Login page with sample mode cleared.

## Test plan

- [ ] Fresh browser: \`/\` → pick CBO → you land in the Porto Alegre sample project. Then navigate to \`/login\` directly → you now SEE the Login screen (previously: bounced to \`/sample/cities\`).
- [ ] From that state, pick "Use Sample Data" on Login → still works, lands on sample cities.
- [ ] From that state, go back to \`/\` → landing gate shows. Pick City → \`/login\` shows clean (sample mode cleared). Clicking OAuth still initiates the real flow.
- [ ] Existing OAuth login path unchanged: \`/login\` → OAuth button → auth success → redirects to \`/cities\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)