### PR TITLE
fix: / is always reachable — only ?role= query param skips the gate

### DIFF
--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -63,9 +63,16 @@ export default function RoleSelectionPage() {
 
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
 
-  // If role is already set, skip the gate.
+  // Only auto-skip the gate when the user arrived via a deep-link like
+  // `?role=cbo`. A persisted role in localStorage is NOT a reason to
+  // redirect — if the user navigated to `/` explicitly they almost always
+  // want the gate (to switch role, start over, or just see the landing).
+  // RoleProvider already hydrated role from the query param before we got
+  // here, so this just decides whether to honor the redirect this one time.
   useEffect(() => {
-    if (role) {
+    if (typeof window === 'undefined') return;
+    const hasDeepLinkedRole = new URLSearchParams(window.location.search).has('role');
+    if (hasDeepLinkedRole && role) {
       setLocation(ROLE_CONFIGS[role].entryRoute);
     }
   }, [role, setLocation]);


### PR DESCRIPTION
## Symptom

You reported: visiting \`/\` still redirects into Login (or wherever your last role went); can't get back to the landing page to switch roles.

## Root cause

Mirror of the trap I fixed in #120. On \`/\`, \`role-selection.tsx\` had a \`useEffect\` that auto-redirects to \`ROLE_CONFIGS[role].entryRoute\` whenever a role is set. Since role persists in localStorage, once you picked any role you could never see the landing again — every visit to \`/\` bounced you, with no way to switch except manually clearing localStorage.

## Fix

Only auto-skip the gate when \`?role=\` is **currently in the URL query** (the deep-link case). A persisted-only role no longer triggers a redirect.

\`\`\`ts
// Before
useEffect(() => {
  if (role) setLocation(ROLE_CONFIGS[role].entryRoute);
}, [role, setLocation]);

// After
useEffect(() => {
  const hasDeepLinkedRole = new URLSearchParams(window.location.search).has('role');
  if (hasDeepLinkedRole && role) {
    setLocation(ROLE_CONFIGS[role].entryRoute);
  }
}, [role, setLocation]);
\`\`\`

Persistence is still useful — downstream pages (project page banners, module labels, funder filter) read from localStorage just like before. It's just that \`/\` itself no longer hides because of it.

## Test plan

- [ ] With any persisted role, visit \`/\` → you now see the 3-card landing. Picking a different card switches role cleanly.
- [ ] Deep-link \`/?role=cbo\` still works: you bypass the gate and land in the CBO flow.
- [ ] After following a deep-link, \`/\` by itself (no query) now shows the gate again so you can switch.
- [ ] Fresh incognito \`/\` still works (no role set → gate shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)