### PR TITLE
fix: first-click CBO 'project not found' + role-aware project-page back button

### DIFF
--- a/client/src/core/pages/project.tsx
+++ b/client/src/core/pages/project.tsx
@@ -1766,6 +1766,9 @@ export default function ProjectPage() {
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
   const showConceptBanner = !roleConfig || roleConfig.id === 'city';
   const showCboBanner = !roleConfig || roleConfig.id === 'cbo';
+  // Role-aware back target. CBO/Orchestrator go back to the landing (they
+  // didn't come via a city selection); City keeps the existing behavior.
+  const sampleBackRoute = roleConfig?.projectBackRoute;
 
   const { data: projectData, isLoading } = useQuery<{ project: Project }>({
     queryKey: ['/api/project', projectId],
@@ -1800,7 +1803,7 @@ export default function ProjectPage() {
         <div className="min-h-screen bg-background">
           <Header />
           <div className="container mx-auto px-4 py-8">
-            <Link href={`${routePrefix}/cities`}>
+            <Link href={sampleBackRoute ?? `${routePrefix}/cities`}>
               <Button variant="ghost" className="mb-4">
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 {t('common.back')}
@@ -1816,7 +1819,7 @@ export default function ProjectPage() {
       <div className="min-h-screen bg-background">
         <Header />
         <div className="container mx-auto px-4 py-8">
-          <Link href={`${routePrefix}/city-information/${action.cityId}`}>
+          <Link href={sampleBackRoute ?? `${routePrefix}/city-information/${action.cityId}`}>
             <Button variant="ghost" className="mb-4">
               <ArrowLeft className="h-4 w-4 mr-2" />
               {t('common.back')}
@@ -2082,7 +2085,7 @@ export default function ProjectPage() {
       <div className="min-h-screen bg-background">
         <Header />
         <div className="container mx-auto px-4 py-8">
-          <Link href="/cities">
+          <Link href={sampleBackRoute ?? '/cities'}>
             <Button variant="ghost" className="mb-4">
               <ArrowLeft className="h-4 w-4 mr-2" />
               {t('common.back')}
@@ -2098,7 +2101,7 @@ export default function ProjectPage() {
     <div className="min-h-screen bg-background">
       <Header />
       <div className="container mx-auto px-4 py-8">
-        <Link href={`/city-information/${project.cityId}`}>
+        <Link href={sampleBackRoute ?? `/city-information/${project.cityId}`}>
           <Button variant="ghost" className="mb-4">
             <ArrowLeft className="h-4 w-4 mr-2" />
             {t('common.back')}

--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -78,7 +78,7 @@ export default function RoleSelectionPage() {
   const [, setLocation] = useLocation();
   const { role, setRole } = useRoleContext();
   const { i18n, t } = useTranslation();
-  const { setSampleMode } = useSampleData();
+  const { setSampleMode, initiateProject } = useSampleData();
 
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
 
@@ -104,6 +104,12 @@ export default function RoleSelectionPage() {
     // a bypass-auth role (CBO demo) enables sample data; picking an
     // auth-requiring role (City) clears any sticky CBO sample mode.
     setSampleMode(config.bypassAuth);
+    // Pre-initiate any sample projects this role's entryRoute lands on
+    // directly — otherwise the project page sees an un-initiated id and
+    // renders "project not found" on the first click.
+    if (config.seedSampleProjects) {
+      for (const id of config.seedSampleProjects) initiateProject(id);
+    }
     setLocation(config.entryRoute);
   };
 

--- a/shared/roles.ts
+++ b/shared/roles.ts
@@ -107,6 +107,22 @@ export interface RoleConfig {
    * `null` for roles that don't need a banner.
    */
   demoBanner: LocalizedLabel | null;
+  /**
+   * Sample action IDs that should be pre-initiated when this role is chosen
+   * on the landing page. Needed for roles whose entryRoute lands directly on
+   * a sample project, because the sample-data context only tracks projects
+   * that went through the city-information "Start" click (which the CBO
+   * demo bypasses). Without this, first-time CBO visitors see
+   * "project not found" until they navigate elsewhere and back.
+   */
+  seedSampleProjects?: string[];
+  /**
+   * Override for the "Back" link on the project page. City uses the default
+   * city-information route (derived from the project's cityId); CBO and
+   * Orchestrator should go back to the landing gate instead, since they
+   * didn't come through a city selection step.
+   */
+  projectBackRoute?: string;
   /** How the funder-selection module behaves for this role. */
   funders: {
     /** Values to accept when filtering `climate-funds.json[].audience`. */
@@ -219,6 +235,8 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
       en: 'Demo data based on Porto Alegre. Your project content will be different.',
       pt: 'Dados de demonstração baseados em Porto Alegre. O conteúdo do seu projeto será diferente.',
     },
+    seedSampleProjects: ['sample-ada-1'],
+    projectBackRoute: '/',
     funders: {
       audience: ['cbo', 'both'],
       questionnaireSteps: [
@@ -252,6 +270,7 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
     },
     agent: { skillId: 'portfolio' }, // phase-3 skill, not yet implemented
     demoBanner: null,
+    projectBackRoute: '/',
     funders: {
       audience: ['city', 'cbo', 'both'],
       questionnaireSteps: [],


### PR DESCRIPTION
## Both bugs from manual testing

### 1. First click on CBO shows "project not found"

Second click works. Chain:

- \`SampleDataProvider.initiatedProjects\` is only populated when a user clicks "Start Project" on the city-information page.
- The new CBO flow (#118) skips that — it lands directly on \`/sample/project/sample-ada-1\`.
- \`project.tsx:1796\` checks \`initiatedProjects.includes(projectId)\` and renders "not found" when false.
- By the time you click around and come back to CBO, something else has seeded the list (or you navigated through city-information manually).

### 2. Project-page "Back" button takes CBO users to the city view

The back link is hard-coded to \`/city-information/{cityId}\`. For a city user who came through \`/cities\` that's correct. For a CBO user who never selected a city, it dumps them into Porto Alegre's city info — wrong mental model.

## Fix — both via \`RoleConfig\` per docs/ROLE-ARCHITECTURE.md

No per-page \`if (role === 'cbo')\` conditionals. Two new config fields:

\`\`\`ts
// shared/roles.ts
interface RoleConfig {
  …
  seedSampleProjects?: string[]; // pre-initiate when role is chosen
  projectBackRoute?: string;     // overrides project-page 'Back' target
}
\`\`\`

### \`seedSampleProjects\`
- \`cbo.seedSampleProjects = ['sample-ada-1']\`
- \`role-selection.tsx\` calls \`initiateProject(id)\` for each before \`setLocation\`.
- React batches the setState calls with \`setSampleMode\` + \`setLocation\`, so the project page mounts on the first click with \`initiatedProjects\` already containing the id. No race.

### \`projectBackRoute\`
- \`cbo.projectBackRoute = '/'\`
- \`orchestrator.projectBackRoute = '/'\`
- City leaves it unset → falls through to existing \`city-information/{cityId}\` behavior.
- Applied in all four back-link sites in \`project.tsx\` (sample-mode happy path, sample-mode 404, auth happy path, auth 404).

## Test plan

- [ ] Clear localStorage. Visit \`/\` → pick CBO → lands on the Porto Alegre project **on the first click**, no "not found". Demo banner + green CBO banner visible.
- [ ] On that same page, click the "← Back" arrow at the top → goes to \`/\` (landing gate), not to city-information.
- [ ] Clear localStorage. Visit \`/\` → pick City → \`/login\` → Sample Data → \`/cities\` → pick Porto Alegre → action card → project. Click "← Back" → goes to city-information (existing behavior, unchanged).
- [ ] Orchestrator's existing "Back to role selection" still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)