### PR TITLE
feat(phase-1c): finish CBO lens — step gating, data-driven module grid (+ recover lost #119)

### DIFF
--- a/client/public/sample-data/climate-funds.json
+++ b/client/public/sample-data/climate-funds.json
@@ -9,11 +9,22 @@
       "description": "Long-term loan that helps companies upgrade factories, swap inefficient boilers, install energy-efficiency measures, or develop bio-based inputs. Finances up to 80% of costs, with fixed concessional rates and a five-year grace period.",
       "instrumentType": "loan",
       "instrumentLabel": "Direct reimbursable loan",
-      "eligibleBorrowers": ["private_corporations"],
+      "eligibleBorrowers": [
+        "private_corporations"
+      ],
       "eligibleBorrowersLabel": "Brazilian private corporations",
-      "prioritySectors": ["industrial_efficiency", "bioeconomy", "biofuels", "low_carbon_industry"],
+      "prioritySectors": [
+        "industrial_efficiency",
+        "bioeconomy",
+        "biofuels",
+        "low_carbon_industry"
+      ],
       "prioritySectorsLabel": "Industrial energy efficiency, bioeconomy, advanced biofuels, low-carbon industrial upgrades",
-      "ticketWindow": { "min": 20000000, "max": 500000000, "currency": "BRL" },
+      "ticketWindow": {
+        "min": 20000000,
+        "max": 500000000,
+        "currency": "BRL"
+      },
       "ticketWindowLabel": "R$ 20m – R$ 500m per economic group / 12 months",
       "financingShare": "Up to 80%",
       "financialCost": "6.5% p.a. financial cost + ≥ 1.3% BNDES spread",
@@ -25,7 +36,10 @@
       "requiresFeasibility": true,
       "requiresSovereignGuarantee": false,
       "supportsPreparation": false,
-      "supportsGrants": false
+      "supportsGrants": false,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "fnmc-grants",
@@ -34,11 +48,25 @@
       "description": "Non-repayable funds from Brazil's Environment Ministry for cities, states, or NGOs to prepare climate plans, pilot adaptation measures, monitoring systems, or training programs. Requires at least a 5% local counterpart.",
       "instrumentType": "grant",
       "instrumentLabel": "Non-reimbursable grant",
-      "eligibleBorrowers": ["municipality", "state_government", "public_consortia", "civil_society"],
+      "eligibleBorrowers": [
+        "municipality",
+        "state_government",
+        "public_consortia",
+        "civil_society"
+      ],
       "eligibleBorrowersLabel": "Municipal & state governments, public consortia, CSOs",
-      "prioritySectors": ["climate_studies", "adaptation_pilots", "risk_information", "nature_based_solutions"],
+      "prioritySectors": [
+        "climate_studies",
+        "adaptation_pilots",
+        "risk_information",
+        "nature_based_solutions"
+      ],
       "prioritySectorsLabel": "Climate mitigation & adaptation studies, pilots, risk information systems",
-      "ticketWindow": { "min": 2000000, "max": 20000000, "currency": "BRL" },
+      "ticketWindow": {
+        "min": 2000000,
+        "max": 20000000,
+        "currency": "BRL"
+      },
       "ticketWindowLabel": "R$ 2m – R$ 20m (set by each PAAR call)",
       "financingShare": "Grant; local counterpart ≥ 5%",
       "financialCost": "N/A (grant)",
@@ -50,7 +78,10 @@
       "requiresFeasibility": false,
       "requiresSovereignGuarantee": false,
       "supportsPreparation": true,
-      "supportsGrants": true
+      "supportsGrants": true,
+      "audience": [
+        "both"
+      ]
     },
     {
       "id": "idb-esp",
@@ -59,11 +90,25 @@
       "description": "The IDB's flagship loan for public works: BRT corridors, wastewater plants, solar parks, resilient hospitals. Needs a federal guarantee and Senate approval. Up to 25 years to repay.",
       "instrumentType": "loan",
       "instrumentLabel": "Sovereign-guaranteed investment loan",
-      "eligibleBorrowers": ["municipality", "state_government", "federal_government"],
+      "eligibleBorrowers": [
+        "municipality",
+        "state_government",
+        "federal_government"
+      ],
       "eligibleBorrowersLabel": "Federal, state or municipal governments (with sovereign guarantee)",
-      "prioritySectors": ["energy", "transport", "water_sanitation", "health", "disaster_risk_reduction"],
+      "prioritySectors": [
+        "energy",
+        "transport",
+        "water_sanitation",
+        "health",
+        "disaster_risk_reduction"
+      ],
       "prioritySectorsLabel": "Energy transition, resilient transport, water & sanitation, AFOLU, health, DRR",
-      "ticketWindow": { "min": 30000000, "max": null, "currency": "USD" },
+      "ticketWindow": {
+        "min": 30000000,
+        "max": null,
+        "currency": "USD"
+      },
       "ticketWindowLabel": "≥ US$ 30m (project-driven)",
       "financingShare": "Negotiated; typically up to 80%",
       "financialCost": "SOFR + 0.80% spread + 0.41% funding margin + 0.50% commitment fee",
@@ -75,7 +120,10 @@
       "requiresFeasibility": true,
       "requiresSovereignGuarantee": true,
       "supportsPreparation": false,
-      "supportsGrants": false
+      "supportsGrants": false,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "caf-environment",
@@ -84,11 +132,24 @@
       "description": "Sovereign or sub-sovereign loan that can be blended with grants from the GEF or the Green Climate Fund to cut interest costs. Suits large low-carbon infrastructure or conservation projects with social co-benefits.",
       "instrumentType": "loan",
       "instrumentLabel": "Sovereign / sub-sovereign loan (blended possible)",
-      "eligibleBorrowers": ["municipality", "state_government", "federal_government", "ppp_spv"],
+      "eligibleBorrowers": [
+        "municipality",
+        "state_government",
+        "federal_government",
+        "ppp_spv"
+      ],
       "eligibleBorrowersLabel": "National & sub-national governments; PPP SPVs with public guarantee",
-      "prioritySectors": ["low_carbon_infrastructure", "biodiversity", "climate_adaptation"],
+      "prioritySectors": [
+        "low_carbon_infrastructure",
+        "biodiversity",
+        "climate_adaptation"
+      ],
       "prioritySectorsLabel": "Low-carbon infrastructure, biodiversity conservation, climate adaptation",
-      "ticketWindow": { "min": 20000000, "max": 300000000, "currency": "USD" },
+      "ticketWindow": {
+        "min": 20000000,
+        "max": 300000000,
+        "currency": "USD"
+      },
       "ticketWindowLabel": "US$ 20m – US$ 300m",
       "financingShare": "Negotiated",
       "financialCost": "≈ SOFR + 1.10% (net of any grant element)",
@@ -100,7 +161,10 @@
       "requiresFeasibility": true,
       "requiresSovereignGuarantee": true,
       "supportsPreparation": false,
-      "supportsGrants": false
+      "supportsGrants": false,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "fonplata-green",
@@ -109,11 +173,25 @@
       "description": "Targets cities in the Plata Basin that need clean mobility, drainage, or urban green space. Typical tickets of US$ 20–60 million, 15-year terms, and streamlined safeguard rules.",
       "instrumentType": "loan",
       "instrumentLabel": "Sovereign / sub-sovereign infrastructure loan",
-      "eligibleBorrowers": ["municipality", "state_government", "federal_government"],
+      "eligibleBorrowers": [
+        "municipality",
+        "state_government",
+        "federal_government"
+      ],
       "eligibleBorrowersLabel": "Federal, state, municipal governments in Plata Basin",
-      "prioritySectors": ["urban_mobility", "water", "flood_control", "green_spaces", "small_hydro"],
+      "prioritySectors": [
+        "urban_mobility",
+        "water",
+        "flood_control",
+        "green_spaces",
+        "small_hydro"
+      ],
       "prioritySectorsLabel": "Urban mobility, water, flood control, green spaces, small hydro",
-      "ticketWindow": { "min": 20000000, "max": 60000000, "currency": "USD" },
+      "ticketWindow": {
+        "min": 20000000,
+        "max": 60000000,
+        "currency": "USD"
+      },
       "ticketWindowLabel": "US$ 20m – US$ 60m",
       "financingShare": "Negotiated",
       "financialCost": "SOFR + ~1.50% + 0.50% commitment fee",
@@ -125,7 +203,10 @@
       "requiresFeasibility": true,
       "requiresSovereignGuarantee": true,
       "supportsPreparation": false,
-      "supportsGrants": false
+      "supportsGrants": false,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "caixa-procidades",
@@ -134,11 +215,23 @@
       "description": "Integrated urban development funding. Finances projects to improve urban public spaces, revitalize city centers, upgrade slums, and implement smart city solutions. Low-cost loans aimed at medium-sized cities.",
       "instrumentType": "loan",
       "instrumentLabel": "Concessional loan (domestic)",
-      "eligibleBorrowers": ["municipality"],
+      "eligibleBorrowers": [
+        "municipality"
+      ],
       "eligibleBorrowersLabel": "Municipal governments (typically mid-sized cities)",
-      "prioritySectors": ["urban_revitalization", "smart_cities", "public_spaces", "social_housing", "urban_governance"],
+      "prioritySectors": [
+        "urban_revitalization",
+        "smart_cities",
+        "public_spaces",
+        "social_housing",
+        "urban_governance"
+      ],
       "prioritySectorsLabel": "Urban revitalization & smart cities – public space upgrades, social housing, lighting, urban governance tech",
-      "ticketWindow": { "min": 5000000, "max": 50000000, "currency": "BRL" },
+      "ticketWindow": {
+        "min": 5000000,
+        "max": 50000000,
+        "currency": "BRL"
+      },
       "ticketWindowLabel": "R$ 5m – R$ 50m per city project",
       "financingShare": "Up to 100% of project investment",
       "financialCost": "FGTS-subsidized interest (~6–8% p.a. in BRL)",
@@ -150,7 +243,10 @@
       "requiresFeasibility": true,
       "requiresSovereignGuarantee": false,
       "supportsPreparation": false,
-      "supportsGrants": false
+      "supportsGrants": false,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "gcf-readiness",
@@ -159,11 +255,24 @@
       "description": "Grants for developing countries to strengthen institutional capacity, develop climate policies, and prepare project pipelines. Helps cities and national entities get ready for larger GCF investments.",
       "instrumentType": "grant",
       "instrumentLabel": "Capacity building grant",
-      "eligibleBorrowers": ["municipality", "state_government", "federal_government", "national_entity"],
+      "eligibleBorrowers": [
+        "municipality",
+        "state_government",
+        "federal_government",
+        "national_entity"
+      ],
       "eligibleBorrowersLabel": "National designated authorities and accredited entities",
-      "prioritySectors": ["capacity_building", "climate_planning", "project_preparation"],
+      "prioritySectors": [
+        "capacity_building",
+        "climate_planning",
+        "project_preparation"
+      ],
       "prioritySectorsLabel": "Institutional strengthening, climate policy development, project pipeline preparation",
-      "ticketWindow": { "min": 300000, "max": 3000000, "currency": "USD" },
+      "ticketWindow": {
+        "min": 300000,
+        "max": 3000000,
+        "currency": "USD"
+      },
       "ticketWindowLabel": "US$ 300k – US$ 3m per country/entity",
       "financingShare": "100% grant",
       "financialCost": "N/A (grant)",
@@ -175,7 +284,10 @@
       "requiresFeasibility": false,
       "requiresSovereignGuarantee": false,
       "supportsPreparation": true,
-      "supportsGrants": true
+      "supportsGrants": true,
+      "audience": [
+        "city"
+      ]
     },
     {
       "id": "c40-finance-facility",
@@ -184,11 +296,19 @@
       "description": "Technical assistance to help cities develop bankable climate projects. Provides project preparation support including feasibility studies, financial structuring, and investor engagement.",
       "instrumentType": "technical_assistance",
       "instrumentLabel": "Technical assistance (free)",
-      "eligibleBorrowers": ["municipality"],
+      "eligibleBorrowers": [
+        "municipality"
+      ],
       "eligibleBorrowersLabel": "C40 member cities and partner cities",
-      "prioritySectors": ["all_climate_sectors"],
+      "prioritySectors": [
+        "all_climate_sectors"
+      ],
       "prioritySectorsLabel": "All climate sectors – buildings, transport, waste, energy, adaptation",
-      "ticketWindow": { "min": 0, "max": 1000000, "currency": "USD" },
+      "ticketWindow": {
+        "min": 0,
+        "max": 1000000,
+        "currency": "USD"
+      },
       "ticketWindowLabel": "In-kind support valued at up to US$ 1m",
       "financingShare": "100% grant (technical assistance)",
       "financialCost": "N/A (free TA)",
@@ -200,7 +320,213 @@
       "requiresFeasibility": false,
       "requiresSovereignGuarantee": false,
       "supportsPreparation": true,
-      "supportsGrants": true
+      "supportsGrants": true,
+      "audience": [
+        "city"
+      ]
+    },
+    {
+      "id": "teia-sociobio",
+      "institution": "MDA / MMA (Brazil)",
+      "name": "Teia da Sociobiodiversidade",
+      "description": "Non-reimbursable funding for community-based organizations working on sociobiodiversity value chains — riverine, quilombola, Indigenous and family-farming groups. Supports productive use of nature-based solutions, seed networks, and community stewardship.",
+      "instrumentType": "grant",
+      "instrumentLabel": "Community grant (non-reimbursable)",
+      "eligibleBorrowers": [
+        "civil_society",
+        "community_organization"
+      ],
+      "eligibleBorrowersLabel": "Community-based organizations, cooperatives, Indigenous/quilombola associations",
+      "prioritySectors": [
+        "sociobiodiversity",
+        "nature_based_solutions",
+        "food_security",
+        "community_forestry"
+      ],
+      "prioritySectorsLabel": "Sociobiodiversity value chains, community NBS, food security",
+      "ticketWindow": {
+        "min": 50000,
+        "max": 100000,
+        "currency": "BRL"
+      },
+      "ticketWindowLabel": "R$ 50k – R$ 100k per organization",
+      "financingShare": "Grant",
+      "financialCost": "N/A (grant)",
+      "tenorGrace": "Aligned to project calendar (typically 12–24 months)",
+      "safeguards": "Community approval + alignment with MDA/MMA social policy",
+      "applicationChannel": "Periodic public calls by MDA / MMA",
+      "officialLink": "https://www.gov.br/mda/pt-br",
+      "category": "grant",
+      "requiresFeasibility": false,
+      "requiresSovereignGuarantee": false,
+      "supportsPreparation": true,
+      "supportsGrants": true,
+      "audience": [
+        "cbo"
+      ]
+    },
+    {
+      "id": "fundo-casa-rs",
+      "institution": "Fundo Casa Socioambiental",
+      "name": "Fundo Casa Reconstruir RS",
+      "description": "Emergency and recovery grants for community organizations in Rio Grande do Sul affected by the 2024 floods. Funds nature-based recovery, community-led reconstruction, and climate resilience at neighborhood scale.",
+      "instrumentType": "grant",
+      "instrumentLabel": "Community grant (non-reimbursable)",
+      "eligibleBorrowers": [
+        "civil_society",
+        "community_organization"
+      ],
+      "eligibleBorrowersLabel": "CSOs and CBOs operating in Rio Grande do Sul",
+      "prioritySectors": [
+        "climate_resilience",
+        "nature_based_solutions",
+        "community_reconstruction",
+        "flood_adaptation"
+      ],
+      "prioritySectorsLabel": "Climate recovery, NBS, community-led reconstruction",
+      "ticketWindow": {
+        "min": 10000,
+        "max": 40000,
+        "currency": "BRL"
+      },
+      "ticketWindowLabel": "Up to R$ 40k per organization",
+      "financingShare": "Grant",
+      "financialCost": "N/A (grant)",
+      "tenorGrace": "6–12 months typical",
+      "safeguards": "Alignment with Fundo Casa social and environmental criteria",
+      "applicationChannel": "Fundo Casa open calls (casa.org.br)",
+      "officialLink": "https://casa.org.br",
+      "category": "grant",
+      "requiresFeasibility": false,
+      "requiresSovereignGuarantee": false,
+      "supportsPreparation": true,
+      "supportsGrants": true,
+      "audience": [
+        "cbo"
+      ]
+    },
+    {
+      "id": "gef-sgp",
+      "institution": "UNDP / GEF",
+      "name": "GEF Small Grants Programme",
+      "description": "UNDP-administered small grants for community-based environmental action. Long-running global programme (active in Brazil) funding biodiversity, climate adaptation, land degradation, and international waters projects led by CBOs and Indigenous groups.",
+      "instrumentType": "grant",
+      "instrumentLabel": "International community grant (non-reimbursable)",
+      "eligibleBorrowers": [
+        "civil_society",
+        "community_organization",
+        "indigenous_group"
+      ],
+      "eligibleBorrowersLabel": "Community-based organizations, NGOs, Indigenous/traditional community groups",
+      "prioritySectors": [
+        "biodiversity",
+        "climate_adaptation",
+        "land_degradation",
+        "nature_based_solutions"
+      ],
+      "prioritySectorsLabel": "Biodiversity, climate, land, waters — community scale",
+      "ticketWindow": {
+        "min": 25000,
+        "max": 50000,
+        "currency": "USD"
+      },
+      "ticketWindowLabel": "Up to US$ 50k per project",
+      "financingShare": "Grant; in-kind or co-financing usually required",
+      "financialCost": "N/A (grant)",
+      "tenorGrace": "12–24 months",
+      "safeguards": "GEF SGP social and environmental standards",
+      "applicationChannel": "National GEF SGP country office (UNDP Brazil)",
+      "officialLink": "https://sgp.undp.org",
+      "category": "grant",
+      "requiresFeasibility": false,
+      "requiresSovereignGuarantee": false,
+      "supportsPreparation": true,
+      "supportsGrants": true,
+      "audience": [
+        "cbo"
+      ]
+    },
+    {
+      "id": "periferias-verdes",
+      "institution": "Federal Government (Brazil)",
+      "name": "Periferias Verdes Resilientes",
+      "description": "Federal programme supporting green infrastructure in urban peripheries. Combines direct CBO grants with municipal co-financing to accelerate nature-based interventions in under-served neighborhoods.",
+      "instrumentType": "grant",
+      "instrumentLabel": "Community grant with municipal partnership",
+      "eligibleBorrowers": [
+        "civil_society",
+        "community_organization",
+        "municipality"
+      ],
+      "eligibleBorrowersLabel": "CBOs (direct) or in partnership with municipal governments",
+      "prioritySectors": [
+        "urban_greening",
+        "nature_based_solutions",
+        "climate_justice",
+        "community_health"
+      ],
+      "prioritySectorsLabel": "Urban NBS in peripheral neighborhoods, climate justice",
+      "ticketWindow": {
+        "min": 100000,
+        "max": 500000,
+        "currency": "BRL"
+      },
+      "ticketWindowLabel": "R$ 100k – R$ 500k (varies by call)",
+      "financingShare": "Grant; may require municipal partnership agreement",
+      "financialCost": "N/A (grant)",
+      "tenorGrace": "Per project schedule",
+      "safeguards": "Federal programme safeguards + community benefit plan",
+      "applicationChannel": "Federal public calls",
+      "officialLink": "https://www.gov.br",
+      "category": "grant",
+      "requiresFeasibility": false,
+      "requiresSovereignGuarantee": false,
+      "supportsPreparation": true,
+      "supportsGrants": true,
+      "audience": [
+        "cbo"
+      ]
+    },
+    {
+      "id": "petrobras-nbs-urbano",
+      "institution": "Petrobras",
+      "name": "Petrobras Socioambiental — NBS Urbano",
+      "description": "Corporate sustainability programme funding nature-based solutions in Brazilian cities. Typically accessed via consortium: CBOs partner with a municipality or a larger anchor organization to apply.",
+      "instrumentType": "grant",
+      "instrumentLabel": "Corporate sustainability grant (consortium-access)",
+      "eligibleBorrowers": [
+        "civil_society",
+        "community_organization",
+        "municipality",
+        "public_consortia"
+      ],
+      "eligibleBorrowersLabel": "CBOs in consortium with municipalities or anchor NGOs",
+      "prioritySectors": [
+        "nature_based_solutions",
+        "urban_greening",
+        "climate_resilience"
+      ],
+      "prioritySectorsLabel": "Urban NBS, climate adaptation, community stewardship",
+      "ticketWindow": {
+        "min": 250000,
+        "max": 2000000,
+        "currency": "BRL"
+      },
+      "ticketWindowLabel": "R$ 250k – R$ 2m per consortium",
+      "financingShare": "Grant; counterpart sometimes required",
+      "financialCost": "N/A (grant)",
+      "tenorGrace": "12–36 months",
+      "safeguards": "Petrobras social programme criteria + environmental plan",
+      "applicationChannel": "Petrobras Socioambiental public calls",
+      "officialLink": "https://socioambiental.petrobras.com.br",
+      "category": "grant",
+      "requiresFeasibility": false,
+      "requiresSovereignGuarantee": false,
+      "supportsPreparation": true,
+      "supportsGrants": true,
+      "audience": [
+        "both"
+      ]
     }
   ],
   "pathways": {

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useSampleData } from '@/core/contexts/sample-data-context';
 import { useSampleRoute } from '@/core/hooks/useSampleRoute';
 import { useProjectContext, FunderSelectionData, FundingPlan } from '@/core/contexts/project-context';
+import { useRoleConfig } from '@/core/contexts/role-context';
 import { useChatState } from '@/core/contexts/chat-context';
 import { Alert, AlertDescription } from '@/core/components/ui/alert';
 import { useNavigationPersistence } from '@/core/hooks/useNavigationPersistence';
@@ -43,6 +44,11 @@ interface Fund {
   requiresSovereignGuarantee: boolean;
   supportsPreparation: boolean;
   supportsGrants: boolean;
+  /**
+   * Which audiences this fund is relevant for (see shared/roles.ts).
+   * Missing audience is treated as `['city']` for backward compatibility.
+   */
+  audience?: Array<'city' | 'cbo' | 'both'>;
 }
 
 interface Pathway {
@@ -565,6 +571,9 @@ export default function FunderSelectionPage() {
   const { isSampleRoute, routePrefix } = useSampleRoute();
   const { updateModule, loadContext, context } = useProjectContext();
   const { setPageContext, openChatWithMessage } = useChatState();
+  // Role-driven audience filter. Falls back to city (legacy) if no role is set.
+  const roleConfig = useRoleConfig();
+  const funderAudience = roleConfig?.funders.audience ?? ['city', 'both'];
   
   // Separate navigation persistence from domain data to prevent race conditions
   const { 
@@ -619,8 +628,27 @@ export default function FunderSelectionPage() {
   useEffect(() => {
     fetch('/sample-data/climate-funds.json')
       .then(res => res.json())
-      .then(data => setFundsData(data))
+      .then((data: FundsData) => {
+        // Filter the fund catalog by the role's audience BEFORE anything
+        // downstream ranks/ selects — so rankFunds, hydrateFromDB, and
+        // funder existence checks all work off a role-appropriate universe.
+        // `both` always passes; missing `audience` (legacy data) defaults
+        // to city for backward compatibility.
+        const allowed = new Set(funderAudience);
+        const filtered: FundsData = {
+          ...data,
+          funds: data.funds.filter(f => {
+            const aud = f.audience ?? ['city'];
+            return aud.some(a => allowed.has(a));
+          }),
+        };
+        setFundsData(filtered);
+      })
       .catch(console.error);
+    // funderAudience derives from a stable role config; joining it into the
+    // dep array would only re-fetch when the user switches role, which is a
+    // page remount anyway.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Restore navigation state ONCE when persistence finishes loading. After

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -16,6 +16,7 @@ import { useSampleData } from '@/core/contexts/sample-data-context';
 import { useSampleRoute } from '@/core/hooks/useSampleRoute';
 import { useProjectContext, FunderSelectionData, FundingPlan } from '@/core/contexts/project-context';
 import { useRoleConfig } from '@/core/contexts/role-context';
+import type { FunderQuestionnaireStepKey } from '@shared/roles';
 import { useChatState } from '@/core/contexts/chat-context';
 import { Alert, AlertDescription } from '@/core/components/ui/alert';
 import { useNavigationPersistence } from '@/core/hooks/useNavigationPersistence';
@@ -927,12 +928,22 @@ export default function FunderSelectionPage() {
     }
   }, [computedResults, projectId, hasSavedToContext, fundingPlanConfirmed, hydrationComplete, answers, updateModule]);
 
-  const steps = [
-    { id: 'readiness', title: t('funderSelection.steps.readiness'), icon: Check },
-    { id: 'political', title: t('funderSelection.steps.political'), icon: Shield },
-    { id: 'financing', title: t('funderSelection.steps.financing'), icon: DollarSign },
-    { id: 'institutional', title: t('funderSelection.steps.institutional'), icon: Building2 },
-  ];
+  // All possible wizard steps. Step id is the stable FunderQuestionnaireStepKey
+  // so role-based filtering and the switch statements below can agree without
+  // depending on array position. useMemo keeps reference stability across
+  // renders so the page-context effect further up doesn't thrash.
+  const steps = useMemo(() => {
+    const allSteps: Array<{ id: FunderQuestionnaireStepKey; title: string; icon: typeof Check }> = [
+      { id: 'projectReadiness',    title: t('funderSelection.steps.readiness'),     icon: Check },
+      { id: 'politicalAlignment',  title: t('funderSelection.steps.political'),     icon: Shield },
+      { id: 'financingNeeds',      title: t('funderSelection.steps.financing'),     icon: DollarSign },
+      { id: 'institutionalSetup',  title: t('funderSelection.steps.institutional'), icon: Building2 },
+    ];
+    const allowed = roleConfig?.funders.questionnaireSteps;
+    if (!allowed || allowed.length === 0) return allSteps;
+    const allowedSet = new Set(allowed);
+    return allSteps.filter(s => allowedSet.has(s.id));
+  }, [t, roleConfig]);
 
   useEffect(() => {
     const stepNames = ['Project Readiness', 'Political Alignment', 'Financing Needs', 'Institutional Setup'];
@@ -1092,14 +1103,34 @@ export default function FunderSelectionPage() {
   };
 
   const canProceed = () => {
-    switch (currentStep) {
-      case 0: return answers.projectStage && answers.budgetPreparation;
-      case 1: return answers.politicalMandatePlanRefs.length > 0 && answers.politicalEndorsementLevel && answers.implementingOwnership && answers.internalAlignmentLevel && answers.politicalRiskFactors.length > 0 && answers.leadershipCommitmentConfidence;
-      case 2: return answers.generatesRevenue && answers.investmentSize;
-      case 3: return answers.fundingReceiver && answers.canTakeDebt;
-      default: return true;
+    // Dispatch on step id rather than index — roles can hide steps via
+    // `config.funders.questionnaireSteps`, which shifts indices.
+    switch (steps[currentStep]?.id) {
+      case 'projectReadiness':
+        return answers.projectStage && answers.budgetPreparation;
+      case 'politicalAlignment':
+        return answers.politicalMandatePlanRefs.length > 0
+          && answers.politicalEndorsementLevel
+          && answers.implementingOwnership
+          && answers.internalAlignmentLevel
+          && answers.politicalRiskFactors.length > 0
+          && answers.leadershipCommitmentConfidence;
+      case 'financingNeeds':
+        return answers.generatesRevenue && answers.investmentSize;
+      case 'institutionalSetup':
+        return answers.fundingReceiver && answers.canTakeDebt;
+      default:
+        return true;
     }
   };
+
+  // Clamp currentStep if the visible step list shrinks (e.g. role switched
+  // mid-flow). Stops the wizard from landing on a blank step.
+  useEffect(() => {
+    if (currentStep > steps.length - 1 && steps.length > 0) {
+      setCurrentStep(steps.length - 1);
+    }
+  }, [steps.length, currentStep]);
 
   const handleNext = () => {
     if (currentStep < steps.length - 1) {
@@ -1139,8 +1170,9 @@ export default function FunderSelectionPage() {
   };
 
   const renderStepContent = () => {
-    switch (currentStep) {
-      case 0:
+    // Dispatch on step id so role-filtered step arrays render correctly.
+    switch (steps[currentStep]?.id) {
+      case 'projectReadiness':
         return (
           <div className="space-y-6">
             <div>
@@ -1220,7 +1252,7 @@ export default function FunderSelectionPage() {
           </div>
         );
 
-      case 1:
+      case 'politicalAlignment': {
         // Political Mandate & Leadership Readiness
         const PLAN_REF_IDS = ['city_climate_plan', 'sectoral_plan', 'multi_year_investment_plan', 'national_or_state_plan', 'not_in_official_plan'];
         const ENDORSEMENT_IDS = ['written', 'informal', 'none', 'unknown'];
@@ -1342,8 +1374,9 @@ export default function FunderSelectionPage() {
             </div>
           </div>
         );
+      }
 
-      case 2:
+      case 'financingNeeds':
         return (
           <div className="space-y-6">
             <div>
@@ -1406,7 +1439,7 @@ export default function FunderSelectionPage() {
           </div>
         );
 
-      case 3:
+      case 'institutionalSetup':
         return (
           <div className="space-y-6">
             <div>

--- a/client/src/core/pages/project.tsx
+++ b/client/src/core/pages/project.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from 'wouter';
 import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type ReactElement } from 'react';
 import { ArrowLeft, Map, ArrowRight, DollarSign, Settings, Landmark, Database, ChevronRight, ChevronDown, Lightbulb, FileText, CheckCircle2, Circle, Download, Sparkles, Leaf } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
 import { Header } from '@/core/components/layout/header';
@@ -18,6 +18,7 @@ import { useSampleData, SAMPLE_DATA_READINESS, DataReadinessItem } from '@/core/
 import { useSampleRoute } from '@/core/hooks/useSampleRoute';
 import { useProjectContext, ProjectContextData, SelectedZone } from '@/core/contexts/project-context';
 import { useRoleConfig, useResetRole } from '@/core/contexts/role-context';
+import type { ModuleKey } from '@shared/roles';
 import { computeReadinessScores, determinePathway } from '@/core/utils/funding-readiness';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -1751,6 +1752,129 @@ function ConceptNotePanel({ context }: { context: ProjectContextData | null }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Module card registry — drives the PREPARE grid. Role config picks which
+// entries are visible (`config.visibleModules`) and optionally overrides
+// the default titles per role (`config.moduleLabels`).
+// ---------------------------------------------------------------------------
+type ModuleCardDef = {
+  routePath: string;
+  Icon: typeof Map;
+  bubbleBg: string;    // tailwind bg for the icon bubble
+  iconFg: string;      // tailwind text color for the icon
+  accentFg: string;    // tailwind text color for the "View →" affordance
+  titleKey: string;    // i18n key for default title
+  descriptionKey: string;
+  getData: (ctx: ProjectContextData | null) => unknown;
+  Highlight: (props: { data: any }) => ReactElement;
+};
+
+const MODULE_CARD_DEFS: Record<ModuleKey, ModuleCardDef> = {
+  funderSelection: {
+    routePath: 'funder-selection',
+    Icon: DollarSign,
+    bubbleBg: 'bg-green-500/10',
+    iconFg: 'text-green-600',
+    accentFg: 'text-green-600',
+    titleKey: 'project.funderSelection',
+    descriptionKey: 'project.funderSelectionDescription',
+    getData: ctx => ctx?.funderSelection,
+    Highlight: FunderHighlight as any,
+  },
+  siteExplorer: {
+    routePath: 'site-explorer',
+    Icon: Map,
+    bubbleBg: 'bg-primary/10',
+    iconFg: 'text-primary',
+    accentFg: 'text-primary',
+    titleKey: 'project.siteExplorer',
+    descriptionKey: 'project.siteExplorerDescription',
+    getData: ctx => ctx?.siteExplorer,
+    Highlight: SiteExplorerHighlight as any,
+  },
+  impactModel: {
+    routePath: 'impact-model',
+    Icon: Lightbulb,
+    bubbleBg: 'bg-amber-500/10',
+    iconFg: 'text-amber-600',
+    accentFg: 'text-amber-600',
+    titleKey: 'project.impactModel',
+    descriptionKey: 'project.impactModelDescription',
+    getData: ctx => ctx?.impactModel,
+    Highlight: ImpactModelHighlight as any,
+  },
+  operations: {
+    routePath: 'project-operations',
+    Icon: Settings,
+    bubbleBg: 'bg-orange-500/10',
+    iconFg: 'text-orange-600',
+    accentFg: 'text-orange-600',
+    titleKey: 'project.projectOperations',
+    descriptionKey: 'project.projectOperationsDescription',
+    getData: ctx => ctx?.operations,
+    Highlight: OperationsHighlight as any,
+  },
+  businessModel: {
+    routePath: 'business-model',
+    Icon: Landmark,
+    bubbleBg: 'bg-purple-500/10',
+    iconFg: 'text-purple-600',
+    accentFg: 'text-purple-600',
+    titleKey: 'project.businessModel',
+    descriptionKey: 'project.businessModelDescription',
+    getData: ctx => ctx?.businessModel,
+    Highlight: BusinessModelHighlight as any,
+  },
+};
+
+const DEFAULT_VISIBLE_MODULES: ModuleKey[] = [
+  'funderSelection', 'siteExplorer', 'impactModel', 'operations', 'businessModel',
+];
+
+function ModuleCard({
+  moduleKey,
+  projectId,
+  routePrefix,
+  context,
+  titleOverride,
+}: {
+  moduleKey: ModuleKey;
+  projectId: string | undefined;
+  routePrefix: string;
+  context: ProjectContextData | null;
+  titleOverride?: { en: string; pt: string };
+}) {
+  const { t, i18n } = useTranslation();
+  const def = MODULE_CARD_DEFS[moduleKey];
+  const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const title = titleOverride ? titleOverride[locale] : t(def.titleKey);
+  const Highlight = def.Highlight;
+  const Icon = def.Icon;
+  const data = def.getData(context);
+  return (
+    <Link href={`${routePrefix}/${def.routePath}/${projectId}`}>
+      <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className={`p-2 ${def.bubbleBg} rounded-lg`}>
+              <Icon className={`h-6 w-6 ${def.iconFg}`} />
+            </div>
+            <CardTitle className="text-lg">{title}</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <CardDescription>{t(def.descriptionKey)}</CardDescription>
+          <Highlight data={data as any} />
+          <div className={`flex items-center ${def.accentFg} text-sm font-medium mt-3`}>
+            {t('common.view')}
+            <ArrowRight className="h-4 w-4 ml-1" />
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
 export default function ProjectPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const { t, i18n } = useTranslation();
@@ -1935,120 +2059,16 @@ export default function ProjectPage() {
               <span className="text-sm text-muted-foreground">{t('project.sections.prepareDescription')}</span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <Link href={`${routePrefix}/funder-selection/${projectId}`}>
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-green-500/10 rounded-lg">
-                        <DollarSign className="h-6 w-6 text-green-600" />
-                      </div>
-                      <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>
-                      {t('project.funderSelectionDescription')}
-                    </CardDescription>
-                    <FunderHighlight data={context?.funderSelection} />
-                    <div className="flex items-center text-green-600 text-sm font-medium mt-3">
-                      {t('common.view')}
-                      <ArrowRight className="h-4 w-4 ml-1" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-
-              <Link href={`${routePrefix}/site-explorer/${projectId}`}>
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-primary/10 rounded-lg">
-                        <Map className="h-6 w-6 text-primary" />
-                      </div>
-                      <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>
-                      {t('project.siteExplorerDescription')}
-                    </CardDescription>
-                    <SiteExplorerHighlight data={context?.siteExplorer} />
-                    <div className="flex items-center text-primary text-sm font-medium mt-3">
-                      {t('common.view')}
-                      <ArrowRight className="h-4 w-4 ml-1" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-
-              <Link href={`${routePrefix}/impact-model/${projectId}`}>
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-amber-500/10 rounded-lg">
-                        <Lightbulb className="h-6 w-6 text-amber-600" />
-                      </div>
-                      <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>
-                      {t('project.impactModelDescription')}
-                    </CardDescription>
-                    <ImpactModelHighlight data={context?.impactModel} />
-                    <div className="flex items-center text-amber-600 text-sm font-medium mt-3">
-                      {t('common.view')}
-                      <ArrowRight className="h-4 w-4 ml-1" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-
-              <Link href={`${routePrefix}/project-operations/${projectId}`}>
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-orange-500/10 rounded-lg">
-                        <Settings className="h-6 w-6 text-orange-600" />
-                      </div>
-                      <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>
-                      {t('project.projectOperationsDescription')}
-                    </CardDescription>
-                    <OperationsHighlight data={context?.operations} />
-                    <div className="flex items-center text-orange-600 text-sm font-medium mt-3">
-                      {t('common.view')}
-                      <ArrowRight className="h-4 w-4 ml-1" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-
-              <Link href={`${routePrefix}/business-model/${projectId}`}>
-                <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-purple-500/10 rounded-lg">
-                        <Landmark className="h-6 w-6 text-purple-600" />
-                      </div>
-                      <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>
-                      {t('project.businessModelDescription')}
-                    </CardDescription>
-                    <BusinessModelHighlight data={context?.businessModel} />
-                    <div className="flex items-center text-purple-600 text-sm font-medium mt-3">
-                      {t('common.view')}
-                      <ArrowRight className="h-4 w-4 ml-1" />
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
+              {(roleConfig?.visibleModules ?? DEFAULT_VISIBLE_MODULES).map(key => (
+                <ModuleCard
+                  key={key}
+                  moduleKey={key}
+                  projectId={projectId}
+                  routePrefix={routePrefix}
+                  context={context ?? null}
+                  titleOverride={roleConfig?.moduleLabels?.[key]}
+                />
+              ))}
             </div>
           </div>
 
@@ -2145,8 +2165,16 @@ export default function ProjectPage() {
 
         {/* DEMO DATA BANNER (role-driven) */}
         {roleConfig?.demoBanner && (
-          <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
-            {roleConfig.demoBanner[locale]}
+          <div className="mb-6 flex items-center justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+            <span className="flex-1">{roleConfig.demoBanner[locale]}</span>
+            <button
+              type="button"
+              onClick={resetRole}
+              className="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-amber-900/80 dark:text-amber-200/80 hover:text-amber-900 dark:hover:text-amber-100 underline-offset-2 hover:underline transition-colors"
+              data-testid="button-demo-banner-switch-role-auth"
+            >
+              {t('roleSelection.changeRole')}
+            </button>
           </div>
         )}
 
@@ -2205,115 +2233,16 @@ export default function ProjectPage() {
             <span className="text-sm text-muted-foreground">{t('project.sections.prepareDescription')}</span>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <Link href={`/funder-selection/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-green-500/10 rounded-lg">
-                      <DollarSign className="h-6 w-6 text-green-600" />
-                    </div>
-                    <CardTitle className="text-lg">{t('project.funderSelection')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="mb-4">
-                    {t('project.funderSelectionDescription')}
-                  </CardDescription>
-                  <div className="flex items-center text-green-600 text-sm font-medium">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-
-            <Link href={`/site-explorer/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-primary/10 rounded-lg">
-                      <Map className="h-6 w-6 text-primary" />
-                    </div>
-                    <CardTitle className="text-lg">{t('project.siteExplorer')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="mb-4">
-                    {t('project.siteExplorerDescription')}
-                  </CardDescription>
-                  <div className="flex items-center text-primary text-sm font-medium">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-
-            <Link href={`/impact-model/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-amber-500/10 rounded-lg">
-                      <Lightbulb className="h-6 w-6 text-amber-600" />
-                    </div>
-                    <CardTitle className="text-lg">{t('project.impactModel')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="mb-4">
-                    {t('project.impactModelDescription')}
-                  </CardDescription>
-                  <div className="flex items-center text-amber-600 text-sm font-medium">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-
-            <Link href={`/project-operations/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-orange-500/10 rounded-lg">
-                      <Settings className="h-6 w-6 text-orange-600" />
-                    </div>
-                    <CardTitle className="text-lg">{t('project.projectOperations')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="mb-4">
-                    {t('project.projectOperationsDescription')}
-                  </CardDescription>
-                  <div className="flex items-center text-orange-600 text-sm font-medium">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-
-            <Link href={`/business-model/${projectId}`}>
-              <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-purple-500/10 rounded-lg">
-                      <Landmark className="h-6 w-6 text-purple-600" />
-                    </div>
-                    <CardTitle className="text-lg">{t('project.businessModel')}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="mb-4">
-                    {t('project.businessModelDescription')}
-                  </CardDescription>
-                  <div className="flex items-center text-purple-600 text-sm font-medium">
-                    {t('common.view')}
-                    <ArrowRight className="h-4 w-4 ml-1" />
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+            {(roleConfig?.visibleModules ?? DEFAULT_VISIBLE_MODULES).map(key => (
+              <ModuleCard
+                key={key}
+                moduleKey={key}
+                projectId={projectId}
+                routePrefix=""
+                context={context ?? null}
+                titleOverride={roleConfig?.moduleLabels?.[key]}
+              />
+            ))}
           </div>
         </div>
 


### PR DESCRIPTION
## Two commits in this PR

1. **Recover #119** — I discovered (via the stacked-PR trap my own memory file warns about) that PR #119 merged into the \`feat/role-phase1-foundation-and-landing\` branch BEFORE that branch was deleted, and its contents never reached main. That means the funder audience filter + CBO grants catalog have been missing from production this whole time. Cherry-picked \`a817bff\` back into this branch.
2. **Phase 1c** — the step gating + module-grid refactor we discussed.

## Lost-PR recovery (commit 1)

Memory file \`feedback_stacked_pr_integration.md\` literally warns:
> Stacked PRs don't auto-reach main. Always open a final integration PR from the top of the stack to main, OR verify each PR's \`baseRefName\` after merging.

I did neither. Verified today: \`gh pr view 119 --json baseRefName\` returns \`"feat/role-phase1-foundation-and-landing"\`. The Phase 1b work was stranded. Recovered via cherry-pick so the funder-selection role filter + the 5 CBO grants (Teia, Fundo Casa RS, GEF SGP, Periferias Verdes, Petrobras) finally land in production.

## Wizard step gating (\`funder-selection.tsx\`)

The funder-selection wizard dispatched on \`currentStep\` index (0..3), which breaks the moment a role hides a step.

- Step ids aligned with \`FunderQuestionnaireStepKey\` values (\`projectReadiness\` etc.).
- The steps array is a \`useMemo\` that filters itself by \`roleConfig.funders.questionnaireSteps\`. CBO → only "project readiness" + "financing needs" visible.
- \`canProceed()\` and \`renderStepContent()\` switch on \`steps[currentStep]?.id\` — filtering works without shifting indices.
- Clamp effect re-centers \`currentStep\` if the visible step list shrinks.

## Module grid → data-driven (\`project.tsx\`)

The 5-card PREPARE grid was hand-rolled JSX duplicated across two render paths (~200 lines).

- New module-scope \`MODULE_CARD_DEFS: Record<ModuleKey, ModuleCardDef>\` declares each module's route path, icon, color palette, i18n keys, and Highlight component once.
- New \`<ModuleCard moduleKey={…} titleOverride={…} />\` component renders from a def.
- Both grid sites now \`.map(roleConfig?.visibleModules ?? DEFAULT_VISIBLE_MODULES)\` → ModuleCard with optional \`titleOverride = roleConfig?.moduleLabels?.[key]\`.
- CBO flow now shows: **Funding & Grants → Our Impact → Our Site → How We Run It → Sustainability Model** (reordered + rebranded purely via config).
- Net: \`project.tsx\` shrinks ~40 lines despite the added registry. Every future module is one MODULE_CARD_DEFS entry + one ROLE_CONFIGS.visibleModules entry.

## Plus — cosmetic parity

The auth-path demo banner now also has the 'Switch role' affordance that the sample-path one got in #122. CBO only hits the sample path in practice, but symmetry in the two branches prevents regressions later.

## Test plan

- [ ] Clear localStorage. Pick **CBO** → project page shows: demo banner, green "Document Community Intervention" CTA, module grid in CBO order with CBO labels (Funding & Grants / Our Impact / Our Site / How We Run It / Sustainability Model).
- [ ] Click Funding & Grants → funder-selection wizard: only **2 steps** visible (Readiness + Financing). No political or institutional pages.
- [ ] Completing the 2 steps leads to recommendations. Recommendations only show CBO-audience funds (Teia, Fundo Casa, GEF SGP, Periferias Verdes, FNMC, Petrobras).
- [ ] Clear localStorage. Pick **City** → module grid in default order with default labels. Funder wizard: all 4 steps. Recommendations show city-audience funds only.
- [ ] Auth flow (OAuth) project page still renders its module grid correctly.
- [ ] No visual regressions on hover / active states of module cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)