### PR TITLE
feat: Villa Flores demo-prep — orchestrator preview, PT default, NBS showcase, 'preliminary' grant badge

### DIFF
--- a/client/public/sample-data/climate-funds.json
+++ b/client/public/sample-data/climate-funds.json
@@ -363,7 +363,8 @@
       "supportsGrants": true,
       "audience": [
         "cbo"
-      ]
+      ],
+      "needsValidation": true
     },
     {
       "id": "fundo-casa-rs",
@@ -403,7 +404,8 @@
       "supportsGrants": true,
       "audience": [
         "cbo"
-      ]
+      ],
+      "needsValidation": true
     },
     {
       "id": "gef-sgp",
@@ -444,7 +446,8 @@
       "supportsGrants": true,
       "audience": [
         "cbo"
-      ]
+      ],
+      "needsValidation": true
     },
     {
       "id": "periferias-verdes",
@@ -485,7 +488,8 @@
       "supportsGrants": true,
       "audience": [
         "cbo"
-      ]
+      ],
+      "needsValidation": true
     },
     {
       "id": "petrobras-nbs-urbano",
@@ -526,7 +530,8 @@
       "supportsGrants": true,
       "audience": [
         "both"
-      ]
+      ],
+      "needsValidation": true
     }
   ],
   "pathways": {

--- a/client/src/core/pages/funder-selection.tsx
+++ b/client/src/core/pages/funder-selection.tsx
@@ -50,6 +50,12 @@ interface Fund {
    * Missing audience is treated as `['city']` for backward compatibility.
    */
   audience?: Array<'city' | 'cbo' | 'both'>;
+  /**
+   * When true, the catalog entry is our first-pass estimate and hasn't been
+   * validated by someone with domain knowledge. The UI shows a 'Preliminary'
+   * badge on cards for these funds so demo participants know to redline.
+   */
+  needsValidation?: boolean;
 }
 
 interface Pathway {
@@ -1689,13 +1695,23 @@ export default function FunderSelectionPage() {
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div>
-                          <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-2 flex-wrap">
                             <Badge variant="outline">#{index + 1}</Badge>
                             <h4 className="font-medium">{fund.name}</h4>
                             {isSelected && (
                               <Badge className="bg-green-600">
                                 <Check className="h-3 w-3 mr-1" />
                                 {t('funderSelection.decision.selected')}
+                              </Badge>
+                            )}
+                            {fund.needsValidation && (
+                              <Badge
+                                variant="outline"
+                                className="border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+                                title={t('funderSelection.results.preliminaryHint')}
+                              >
+                                <AlertTriangle className="h-3 w-3 mr-1" />
+                                {t('funderSelection.results.preliminaryBadge')}
                               </Badge>
                             )}
                           </div>

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -1,50 +1,301 @@
 /**
- * Orchestrator "coming soon" stub (Phase 1).
+ * Orchestrator portfolio preview (Phase 1, demo-grade).
  *
- * The real portfolio view is Phase 3. This page is what role=orchestrator
- * lands on for now — honest placeholder with a way to switch role.
+ * A visual prototype of what role=orchestrator would look like once Phase 3
+ * lands. All data here is hardcoded — the point is to give Villa Flores and
+ * other coordinators something concrete to react to. Clicking a card shows
+ * a toast instead of navigating; the banner makes it clear this is an
+ * early design, not production.
  *
- * See docs/ROLE-ARCHITECTURE.md.
+ * See docs/ROLE-ARCHITECTURE.md. Replace the demo cards + any hardcoded
+ * copy with real data when Phase 3 materializes.
  */
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Network } from 'lucide-react';
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft, ArrowRight, Clock, Compass, Droplets, Leaf, MapPin, Sparkles, Trees, Users,
+} from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
 import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
+import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
 
+type CboProject = {
+  id: string;
+  name: { en: string; pt: string };
+  neighborhood: string;
+  interventionType: 'garden' | 'wetland' | 'forest';
+  phaseKey: 'profile_partial' | 'profile_complete' | 'seeking_funding' | 'funded' | 'implementing';
+  phaseProgress: number; // 0..100
+  fundingSecured: number;
+  fundingSought: number;
+  currency: 'BRL';
+  nextActionKey: string;
+  updatedDaysAgo: number;
+};
+
+const DEMO_PROJECTS: CboProject[] = [
+  {
+    id: 'horta-cascata',
+    name: { en: 'Horta Comunitária Cascata', pt: 'Horta Comunitária Cascata' },
+    neighborhood: 'Cascata',
+    interventionType: 'garden',
+    phaseKey: 'seeking_funding',
+    phaseProgress: 80,
+    fundingSecured: 40_000,
+    fundingSought: 150_000,
+    currency: 'BRL',
+    nextActionKey: 'orchestrator.demo.nextAction.applyTeia',
+    updatedDaysAgo: 2,
+  },
+  {
+    id: 'arquipelago-verde',
+    name: { en: 'Coletivo Arquipélago Verde', pt: 'Coletivo Arquipélago Verde' },
+    neighborhood: 'Arquipélago',
+    interventionType: 'wetland',
+    phaseKey: 'profile_partial',
+    phaseProgress: 40,
+    fundingSecured: 15_000,
+    fundingSought: 60_000,
+    currency: 'BRL',
+    nextActionKey: 'orchestrator.demo.nextAction.completePhase3',
+    updatedDaysAgo: 7,
+  },
+  {
+    id: 'bosque-humaita',
+    name: { en: 'Agentes do Bosque Humaitá', pt: 'Agentes do Bosque Humaitá' },
+    neighborhood: 'Humaitá',
+    interventionType: 'forest',
+    phaseKey: 'profile_complete',
+    phaseProgress: 95,
+    fundingSecured: 0,
+    fundingSought: 80_000,
+    currency: 'BRL',
+    nextActionKey: 'orchestrator.demo.nextAction.applyFundoCasa',
+    updatedDaysAgo: 1,
+  },
+];
+
+const INTERVENTION_ICON: Record<CboProject['interventionType'], typeof Leaf> = {
+  garden: Leaf,
+  wetland: Droplets,
+  forest: Trees,
+};
+const INTERVENTION_TONE: Record<CboProject['interventionType'], { bubble: string; fg: string }> = {
+  garden:  { bubble: 'bg-emerald-50 dark:bg-emerald-950/40', fg: 'text-emerald-600 dark:text-emerald-300' },
+  wetland: { bubble: 'bg-sky-50 dark:bg-sky-950/40',         fg: 'text-sky-600 dark:text-sky-300' },
+  forest:  { bubble: 'bg-amber-50 dark:bg-amber-950/40',     fg: 'text-amber-600 dark:text-amber-300' },
+};
+const PHASE_STYLE: Record<CboProject['phaseKey'], { label: string; chip: string }> = {
+  profile_partial:  { label: 'orchestrator.demo.phase.profilePartial',  chip: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
+  profile_complete: { label: 'orchestrator.demo.phase.profileComplete', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800' },
+  seeking_funding:  { label: 'orchestrator.demo.phase.seekingFunding',  chip: 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800' },
+  funded:           { label: 'orchestrator.demo.phase.funded',          chip: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800' },
+  implementing:     { label: 'orchestrator.demo.phase.implementing',    chip: 'bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950/40 dark:text-violet-300 dark:border-violet-800' },
+};
+
+function formatBRL(v: number): string {
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(v);
+}
+
 export default function OrchestratorLandingPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const switchRole = useResetRole();
+  const { toast } = useToast();
+  const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+
+  const totalSecured = DEMO_PROJECTS.reduce((s, p) => s + p.fundingSecured, 0);
+  const totalSought = DEMO_PROJECTS.reduce((s, p) => s + p.fundingSought, 0);
+
+  const openProject = (p: CboProject) => {
+    toast({
+      title: t('orchestrator.demo.toastTitle'),
+      description: t('orchestrator.demo.toastBody', { project: p.name[locale] }),
+    });
+  };
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 py-12 bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
-      <div className="w-full max-w-xl">
-        <Card>
-          <CardContent className="p-10 text-center">
-            <div className="mx-auto w-14 h-14 rounded-xl bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300 flex items-center justify-center mb-6">
-              <Network className="w-7 h-7" strokeWidth={1.75} />
+    <div className="min-h-screen relative bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
+      {/* Header */}
+      <header className="relative z-10 px-6 sm:px-10 py-6 border-b border-foreground/5 bg-background/40 backdrop-blur-sm">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-amber-50 dark:bg-amber-950/40 text-amber-600 dark:text-amber-300 flex items-center justify-center">
+              <Compass className="w-5 h-5" strokeWidth={1.75} />
             </div>
-            <TitleLarge className="mb-3" data-testid="text-orchestrator-title">
-              {t('orchestrator.title')}
-            </TitleLarge>
-            <BodyMedium className="text-muted-foreground mb-2">
-              {t('orchestrator.subtitle')}
-            </BodyMedium>
-            <BodySmall className="text-muted-foreground mb-8">
-              {t('orchestrator.status')}
+            <div>
+              <BodySmall className="text-muted-foreground uppercase tracking-wide text-[11px]">
+                {t('orchestrator.demo.headerEyebrow')}
+              </BodySmall>
+              <TitleLarge className="!text-lg tracking-tight">{t('orchestrator.demo.headerTitle')}</TitleLarge>
+            </div>
+          </div>
+          <Button variant="ghost" size="sm" onClick={switchRole} data-testid="button-orchestrator-switch-role">
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            {t('orchestrator.switchRole')}
+          </Button>
+        </div>
+      </header>
+
+      <main className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 py-10 sm:py-12">
+        {/* Co-design ribbon */}
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 flex items-start gap-3 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 px-4 py-3"
+        >
+          <Sparkles className="w-4 h-4 text-amber-600 dark:text-amber-300 mt-0.5 shrink-0" />
+          <div className="flex-1">
+            <BodySmall className="text-amber-900 dark:text-amber-200 font-medium">
+              {t('orchestrator.demo.codesignBannerTitle')}
             </BodySmall>
-            <Button
-              variant="outline"
-              onClick={switchRole}
-              data-testid="button-orchestrator-switch-role"
+            <BodySmall className="text-amber-900/80 dark:text-amber-200/80 mt-0.5 text-xs">
+              {t('orchestrator.demo.codesignBannerBody')}
+            </BodySmall>
+          </div>
+        </motion.div>
+
+        {/* Aggregate stats */}
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10"
+          initial="hidden"
+          animate="show"
+          variants={{ hidden: {}, show: { transition: { staggerChildren: 0.08, delayChildren: 0.1 } } }}
+        >
+          {[
+            { label: t('orchestrator.demo.stats.activeProjects'), value: String(DEMO_PROJECTS.length) },
+            { label: t('orchestrator.demo.stats.totalSecured'),   value: formatBRL(totalSecured) },
+            { label: t('orchestrator.demo.stats.totalSought'),    value: formatBRL(totalSought) },
+          ].map((s, i) => (
+            <motion.div
+              key={i}
+              variants={{ hidden: { opacity: 0, y: 8 }, show: { opacity: 1, y: 0, transition: { duration: 0.4 } } }}
             >
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              {t('orchestrator.switchRole')}
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
+              <Card>
+                <CardContent className="p-5">
+                  <BodySmall className="text-muted-foreground uppercase tracking-wide text-[11px] mb-1">
+                    {s.label}
+                  </BodySmall>
+                  <div className="text-2xl font-semibold tracking-tight">{s.value}</div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </motion.div>
+
+        {/* Section heading */}
+        <div className="flex items-center justify-between mb-5">
+          <div>
+            <TitleLarge className="!text-xl tracking-tight mb-0.5">
+              {t('orchestrator.demo.portfolioTitle')}
+            </TitleLarge>
+            <BodySmall className="text-muted-foreground">
+              {t('orchestrator.demo.portfolioSubtitle')}
+            </BodySmall>
+          </div>
+        </div>
+
+        {/* Project cards */}
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+          initial="hidden"
+          animate="show"
+          variants={{ hidden: {}, show: { transition: { staggerChildren: 0.08, delayChildren: 0.3 } } }}
+        >
+          {DEMO_PROJECTS.map(p => {
+            const Icon = INTERVENTION_ICON[p.interventionType];
+            const tone = INTERVENTION_TONE[p.interventionType];
+            const phase = PHASE_STYLE[p.phaseKey];
+            const pct = p.fundingSought > 0 ? Math.round((p.fundingSecured / p.fundingSought) * 100) : 0;
+            return (
+              <motion.button
+                key={p.id}
+                onClick={() => openProject(p)}
+                className="group text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 rounded-xl"
+                variants={{ hidden: { opacity: 0, y: 12 }, show: { opacity: 1, y: 0, transition: { duration: 0.4 } } }}
+                whileHover={{ y: -4 }}
+                whileTap={{ scale: 0.985 }}
+                transition={{ type: 'spring', stiffness: 260, damping: 22 }}
+                data-testid={`card-orchestrator-project-${p.id}`}
+              >
+                <Card className="h-full transition-shadow duration-300 group-hover:shadow-xl group-hover:shadow-foreground/5">
+                  <CardContent className="p-5 flex flex-col h-full">
+                    {/* Top row: icon + name + phase chip */}
+                    <div className="flex items-start gap-3 mb-3">
+                      <div className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${tone.bubble} ${tone.fg}`}>
+                        <Icon className="w-5 h-5" strokeWidth={1.75} />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="text-sm font-semibold tracking-tight truncate">{p.name[locale]}</h3>
+                        <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
+                          <MapPin className="w-3 h-3" />
+                          <span>{p.neighborhood}</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Phase */}
+                    <div className="mb-4">
+                      <span className={`inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border ${phase.chip}`}>
+                        {t(phase.label)}
+                      </span>
+                    </div>
+
+                    {/* Funding progress */}
+                    <div className="mb-4">
+                      <div className="flex items-center justify-between text-xs mb-1.5">
+                        <span className="text-muted-foreground">{t('orchestrator.demo.funding')}</span>
+                        <span className="font-medium text-foreground/80">
+                          {formatBRL(p.fundingSecured)} / {formatBRL(p.fundingSought)}
+                        </span>
+                      </div>
+                      <div className="h-1.5 rounded-full bg-foreground/5 overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    {/* Next action + updated */}
+                    <div className="mt-auto pt-3 border-t border-foreground/5 space-y-1.5">
+                      <div className="flex items-center gap-2 text-xs">
+                        <ArrowRight className="w-3 h-3 text-foreground/50" />
+                        <span className="text-foreground/80">{t(p.nextActionKey)}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Clock className="w-3 h-3" />
+                        <span>{t('orchestrator.demo.updatedAgo', { count: p.updatedDaysAgo })}</span>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </motion.button>
+            );
+          })}
+        </motion.div>
+
+        {/* Feedback prompt */}
+        <motion.div
+          className="mt-10 rounded-xl border border-dashed border-foreground/15 bg-card/40 p-6 text-center"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-foreground/5 mb-3">
+            <Users className="w-4 h-4 text-foreground/60" />
+          </div>
+          <TitleLarge className="!text-base tracking-tight mb-1">
+            {t('orchestrator.demo.feedbackTitle')}
+          </TitleLarge>
+          <BodySmall className="text-muted-foreground max-w-xl mx-auto">
+            {t('orchestrator.demo.feedbackBody')}
+          </BodySmall>
+        </motion.div>
+      </main>
     </div>
   );
 }

--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -13,7 +13,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'wouter';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
-import { ArrowRight, Building2, Check, Network, Sparkles, Users } from 'lucide-react';
+import { ArrowRight, Building2, Check, Droplets, Leaf, Mountain, Network, Sparkles, Sprout, Trees, Users, Waves } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useRoleContext } from '@/core/contexts/role-context';
@@ -33,6 +33,33 @@ type RolePresentation = {
     glowVia: string;
     corner: string;
   };
+};
+
+// NBS typology showcase — the educational strip below the role cards. Derived
+// from the intervention types referenced in server/services/cboAgent.ts and
+// the sample-data interventions. Copy is deliberately compact; the grid is
+// scannable, not a full catalog.
+type NbsTypology = {
+  key: string;
+  Icon: typeof Building2;
+  /** primary hazard for icon color accent */
+  tone: 'flood' | 'heat' | 'landslide' | 'biodiversity';
+};
+
+const NBS_TYPOLOGIES: NbsTypology[] = [
+  { key: 'floodParks',     Icon: Droplets, tone: 'flood' },
+  { key: 'bioswales',      Icon: Leaf,     tone: 'flood' },
+  { key: 'urbanForests',   Icon: Trees,    tone: 'heat' },
+  { key: 'greenCorridors', Icon: Sprout,   tone: 'biodiversity' },
+  { key: 'wetlands',       Icon: Waves,    tone: 'flood' },
+  { key: 'slopeStabilize', Icon: Mountain, tone: 'landslide' },
+];
+
+const TONE_STYLES: Record<NbsTypology['tone'], { bubble: string; fg: string; chip: string }> = {
+  flood:        { bubble: 'bg-sky-50 dark:bg-sky-950/40',       fg: 'text-sky-600 dark:text-sky-300',       chip: 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800' },
+  heat:         { bubble: 'bg-amber-50 dark:bg-amber-950/40',   fg: 'text-amber-600 dark:text-amber-300',   chip: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
+  landslide:    { bubble: 'bg-orange-50 dark:bg-orange-950/40', fg: 'text-orange-600 dark:text-orange-300', chip: 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/40 dark:text-orange-300 dark:border-orange-800' },
+  biodiversity: { bubble: 'bg-emerald-50 dark:bg-emerald-950/40', fg: 'text-emerald-600 dark:text-emerald-300', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800' },
 };
 
 const PRESENTATIONS: RolePresentation[] = [
@@ -104,6 +131,12 @@ export default function RoleSelectionPage() {
     // a bypass-auth role (CBO demo) enables sample data; picking an
     // auth-requiring role (City) clears any sticky CBO sample mode.
     setSampleMode(config.bypassAuth);
+    // Auto-switch to Portuguese for the CBO path — our primary CBO audience
+    // is Brazilian. City / Orchestrator keep whatever the user picked on the
+    // landing. Users can always override via the EN/PT pill.
+    if (next === 'cbo' && !i18n.language?.startsWith('pt')) {
+      i18n.changeLanguage('pt');
+    }
     // Pre-initiate any sample projects this role's entryRoute lands on
     // directly — otherwise the project page sees an un-initiated id and
     // renders "project not found" on the first click.
@@ -270,6 +303,80 @@ export default function RoleSelectionPage() {
           </motion.div>
         </div>
       </main>
+
+      {/* NBS typology showcase — scroll-down educational strip */}
+      <section className="relative z-10 border-t border-foreground/5 bg-background/50 backdrop-blur-sm">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-14 sm:py-20">
+          <motion.div
+            className="text-center mb-10 sm:mb-12"
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-80px' }}
+            transition={{ duration: 0.5 }}
+          >
+            <BodySmall className="uppercase tracking-[0.2em] text-muted-foreground mb-3">
+              {t('roleSelection.showcase.eyebrow')}
+            </BodySmall>
+            <TitleLarge className="!text-2xl sm:!text-3xl tracking-tight mb-3">
+              {t('roleSelection.showcase.title')}
+            </TitleLarge>
+            <BodyMedium className="text-muted-foreground max-w-2xl mx-auto">
+              {t('roleSelection.showcase.subtitle')}
+            </BodyMedium>
+          </motion.div>
+
+          <motion.div
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, margin: '-60px' }}
+            variants={{
+              hidden: {},
+              show: { transition: { staggerChildren: 0.05 } },
+            }}
+          >
+            {NBS_TYPOLOGIES.map(({ key, Icon, tone }) => {
+              const toneStyle = TONE_STYLES[tone];
+              const hazards = t(`roleSelection.showcase.typologies.${key}.hazards`, { returnObjects: true }) as string[];
+              return (
+                <motion.div
+                  key={key}
+                  variants={{
+                    hidden: { opacity: 0, y: 12 },
+                    show:   { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
+                  }}
+                >
+                  <div className="group h-full rounded-xl border border-foreground/10 bg-card/60 p-5 hover:border-foreground/20 hover:bg-card transition-all duration-300">
+                    <div className="flex items-start gap-4">
+                      <div className={`shrink-0 w-11 h-11 rounded-lg flex items-center justify-center ${toneStyle.bubble} ${toneStyle.fg} transition-transform duration-300 group-hover:scale-105`}>
+                        <Icon className="w-5 h-5" strokeWidth={1.75} />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="text-sm font-semibold tracking-tight mb-1">
+                          {t(`roleSelection.showcase.typologies.${key}.name`)}
+                        </h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed mb-3">
+                          {t(`roleSelection.showcase.typologies.${key}.description`)}
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {Array.isArray(hazards) && hazards.map((h, i) => (
+                            <span
+                              key={i}
+                              className={`inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border ${toneStyle.chip}`}
+                            >
+                              {h}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </motion.div>
+        </div>
+      </section>
 
       {/* Footer */}
       <footer className="relative z-10 border-t border-foreground/5 py-6 px-6 sm:px-10 bg-background/40 backdrop-blur-sm">

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -16,13 +16,82 @@
     "helper": "You can switch roles any time — everything you do is saved locally.",
     "footer": "A tool by Open Earth Foundation",
     "footerLink": "openearth.org",
-    "changeRole": "Switch role"
+    "changeRole": "Switch role",
+    "showcase": {
+      "eyebrow": "Nature-based solutions",
+      "title": "The toolkit we help you design around.",
+      "subtitle": "Every project you build here draws on a catalog of interventions tuned to Brazilian cities and community contexts.",
+      "typologies": {
+        "floodParks": {
+          "name": "Floodable Parks",
+          "description": "Public green spaces designed to store stormwater during heavy rain and return to use afterwards.",
+          "hazards": ["Flood"]
+        },
+        "bioswales": {
+          "name": "Bioswales & Rain Gardens",
+          "description": "Vegetated channels and small depressions that slow runoff, filter pollutants, and recharge groundwater.",
+          "hazards": ["Flood", "Water quality"]
+        },
+        "urbanForests": {
+          "name": "Urban Forests",
+          "description": "Dense tree canopy that cools neighborhoods, improves air quality, and creates habitat for wildlife.",
+          "hazards": ["Heat", "Air quality"]
+        },
+        "greenCorridors": {
+          "name": "Green Corridors",
+          "description": "Connected strips of vegetation that link parks and rivers, giving people and wildlife a cooler, greener path.",
+          "hazards": ["Heat", "Biodiversity"]
+        },
+        "wetlands": {
+          "name": "Wetland Restoration",
+          "description": "Rehabilitated wetlands that buffer floods, filter water, sequester carbon, and anchor biodiversity.",
+          "hazards": ["Flood", "Biodiversity"]
+        },
+        "slopeStabilize": {
+          "name": "Slope Stabilization",
+          "description": "Living walls, terraces, and deep-rooted plantings that reduce landslide risk on steep urban slopes.",
+          "hazards": ["Landslide"]
+        }
+      }
+    }
   },
   "orchestrator": {
     "title": "Orchestrator view — coming soon",
     "subtitle": "You'll be able to coordinate a portfolio of community-based projects here: see their status, aggregate impact, and shepherd them through funding cycles.",
     "status": "We're designing this with partners now. Want early access? Reach out to the team.",
-    "switchRole": "Back to role selection"
+    "switchRole": "Back to role selection",
+    "demo": {
+      "headerEyebrow": "Coordinator view",
+      "headerTitle": "Community projects portfolio",
+      "codesignBannerTitle": "Early prototype — help us design this.",
+      "codesignBannerBody": "The three projects below are illustrative. Tell us what's missing, what's useless, and what a real coordinator view should show.",
+      "stats": {
+        "activeProjects": "Active projects",
+        "totalSecured": "Funding secured",
+        "totalSought": "Total pipeline"
+      },
+      "portfolioTitle": "Community projects",
+      "portfolioSubtitle": "Each card represents a CBO you'd coordinate. Click one to preview how you'd open its workspace.",
+      "funding": "Funding",
+      "updatedAgo_one": "Updated {{count}} day ago",
+      "updatedAgo_other": "Updated {{count}} days ago",
+      "phase": {
+        "profilePartial": "Profile in progress",
+        "profileComplete": "Profile complete",
+        "seekingFunding": "Seeking funding",
+        "funded": "Funded",
+        "implementing": "Implementing"
+      },
+      "nextAction": {
+        "applyTeia": "Apply to the next Teia da Sociobiodiversidade call",
+        "completePhase3": "Complete Phase 3 of the CBO profile",
+        "applyFundoCasa": "Apply to Fundo Casa Reconstruir RS"
+      },
+      "toastTitle": "Prototype view",
+      "toastBody": "In Phase 3, clicking here would open {{project}}'s workspace.",
+      "feedbackTitle": "What would you want to see here?",
+      "feedbackBody": "This page is deliberately sparse. Tell us which metrics, alerts, or actions a coordinator would actually use day to day — that's what we'll build next."
+    }
   },
   "citySelection": {
     "title": "Select a City",
@@ -419,6 +488,8 @@
       "sovereignRequired": "This fund requires federal/sovereign approval"
     },
     "results": {
+      "preliminaryBadge": "Preliminary",
+      "preliminaryHint": "These amounts and dates are our best estimates — your feedback updates the catalog.",
       "recommendedPathway": "Recommended Funding Pathway",
       "whatThisMeans": "What this type of funding is",
       "whyThisFits": "Why this fits your project",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -16,13 +16,82 @@
     "helper": "Você pode trocar de perfil a qualquer momento — tudo fica salvo localmente.",
     "footer": "Uma ferramenta da Open Earth Foundation",
     "footerLink": "openearth.org",
-    "changeRole": "Trocar perfil"
+    "changeRole": "Trocar perfil",
+    "showcase": {
+      "eyebrow": "Soluções baseadas na natureza",
+      "title": "O repertório que usamos para desenhar seu projeto.",
+      "subtitle": "Cada projeto que você constrói aqui parte de um catálogo de intervenções adaptado a cidades brasileiras e organizações comunitárias.",
+      "typologies": {
+        "floodParks": {
+          "name": "Parques Alagáveis",
+          "description": "Áreas verdes públicas que armazenam águas pluviais em chuvas intensas e voltam ao uso comum depois.",
+          "hazards": ["Inundação"]
+        },
+        "bioswales": {
+          "name": "Biovaletas e Jardins de Chuva",
+          "description": "Canais e depressões vegetados que retardam o escoamento, filtram poluentes e recarregam o lençol.",
+          "hazards": ["Inundação", "Qualidade da água"]
+        },
+        "urbanForests": {
+          "name": "Florestas Urbanas",
+          "description": "Copa arbórea densa que refresca bairros, melhora a qualidade do ar e cria habitat para fauna.",
+          "hazards": ["Calor", "Qualidade do ar"]
+        },
+        "greenCorridors": {
+          "name": "Corredores Verdes",
+          "description": "Faixas conectadas de vegetação que ligam parques e rios, criando caminhos mais frescos e vivos.",
+          "hazards": ["Calor", "Biodiversidade"]
+        },
+        "wetlands": {
+          "name": "Recuperação de Banhados",
+          "description": "Áreas úmidas recuperadas que amortecem enchentes, filtram água, sequestram carbono e ancoram biodiversidade.",
+          "hazards": ["Inundação", "Biodiversidade"]
+        },
+        "slopeStabilize": {
+          "name": "Estabilização de Encostas",
+          "description": "Muros vivos, terraços e plantios de raízes profundas que reduzem risco de deslizamentos em encostas urbanas.",
+          "hazards": ["Deslizamento"]
+        }
+      }
+    }
   },
   "orchestrator": {
     "title": "Visão da organização articuladora — em breve",
     "subtitle": "Você poderá coordenar um portfólio de projetos comunitários aqui: acompanhar o status, ver o impacto agregado e orientá-los nos ciclos de financiamento.",
     "status": "Estamos desenhando isso junto com parceiros. Quer acesso antecipado? Entre em contato com a equipe.",
-    "switchRole": "Voltar para seleção de perfil"
+    "switchRole": "Voltar para seleção de perfil",
+    "demo": {
+      "headerEyebrow": "Visão da articuladora",
+      "headerTitle": "Portfólio de projetos comunitários",
+      "codesignBannerTitle": "Protótipo inicial — ajude a desenhar essa visão.",
+      "codesignBannerBody": "Os três projetos abaixo são ilustrativos. Diga o que está faltando, o que não é útil e o que uma articuladora realmente precisaria ver aqui.",
+      "stats": {
+        "activeProjects": "Projetos ativos",
+        "totalSecured": "Financiamento garantido",
+        "totalSought": "Pipeline total"
+      },
+      "portfolioTitle": "Projetos comunitários",
+      "portfolioSubtitle": "Cada card é uma OBC que você coordenaria. Clique em um para pré-visualizar como abriria o espaço de trabalho dela.",
+      "funding": "Financiamento",
+      "updatedAgo_one": "Atualizado há {{count}} dia",
+      "updatedAgo_other": "Atualizado há {{count}} dias",
+      "phase": {
+        "profilePartial": "Perfil em andamento",
+        "profileComplete": "Perfil completo",
+        "seekingFunding": "Buscando financiamento",
+        "funded": "Financiado",
+        "implementing": "Em implementação"
+      },
+      "nextAction": {
+        "applyTeia": "Submeter ao próximo edital Teia da Sociobiodiversidade",
+        "completePhase3": "Completar a Fase 3 do perfil da OBC",
+        "applyFundoCasa": "Submeter ao Fundo Casa Reconstruir RS"
+      },
+      "toastTitle": "Visão protótipo",
+      "toastBody": "Na Fase 3, clicar aqui abriria o espaço de {{project}}.",
+      "feedbackTitle": "O que você gostaria de ver aqui?",
+      "feedbackBody": "Essa página é propositalmente enxuta. Nos conte quais métricas, alertas ou ações uma articuladora realmente usaria no dia a dia — é isso que vamos construir a seguir."
+    }
   },
   "citySelection": {
     "title": "Selecione uma Cidade",
@@ -412,6 +481,8 @@
       "advanced": "Avançado"
     },
     "results": {
+      "preliminaryBadge": "Preliminar",
+      "preliminaryHint": "Os valores e prazos são estimativas iniciais — sua validação atualiza o catálogo.",
       "recommendedPathway": "Caminho de Financiamento Recomendado",
       "whatThisMeans": "O que este tipo de financiamento significa",
       "whyThisFits": "Por que isso se encaixa no seu projeto",


### PR DESCRIPTION
## Four-part bundle for the Villa Flores co-design demo tomorrow

Deliberately 'honest prototype', not polished pitch. Every new surface invites feedback rather than asserting completeness.

## 1. Orchestrator portfolio preview

Replaces the 'coming soon' stub with a visual prototype of what role=orchestrator would look like once Phase 3 lands. All data hardcoded.

- 3 demo CBOs tied to Porto Alegre neighborhoods for continuity with the rest of the sample:
  - **Horta Comunitária Cascata** (garden, seeking funding, R$40k/R$150k)
  - **Coletivo Arquipélago Verde** (wetland, profile in progress, R$15k/R$60k)
  - **Agentes do Bosque Humaitá** (forest, profile complete, R$0/R$80k)
- Each card: phase badge, funding progress bar, next action, days-since-update.
- Click a card → toast: *"In Phase 3, clicking here would open {{project}}'s workspace."* No fake navigation.
- Aggregate stat strip: active projects, total secured, total pipeline.
- **Co-design ribbon at top**: *"Early prototype — help us design this."*
- **'What would you want to see here?' placeholder at bottom** — explicit open-ended ask.
- Header has 'switch role' escape hatch.

## 2. PT-default when CBO is picked

\`role-selection.tsx \→ choose('cbo')\` now also \`i18n.changeLanguage('pt')\` if the user isn't already on a PT locale. Villa Flores is Brazilian; shouldn't have to toggle the pill first. Users can still override. City/Orchestrator don't auto-switch.

## 3. NBS showcase on the landing page

Scroll-down educational strip below the role cards. Makes the tool feel grounded before the user has committed.

- 6 typology cards in a 3×2 grid: Floodable Parks, Bioswales & Rain Gardens, Urban Forests, Green Corridors, Wetland Restoration, Slope Stabilization.
- Each: icon, name (EN/PT), ~2-line description, hazard tag chips.
- Color-coded by primary hazard: blue=flood, amber=heat, emerald=biodiversity, orange=landslide.
- Stays **below the fold** so the role decision isn't diluted; only on scroll.
- Entry animation via framer-motion + whileInView so it feels alive when you scroll to it.

## 4. 'Preliminary' badge on the 5 CBO grants

- \`Fund.needsValidation?: boolean\` added to the interface.
- 5 CBO grants (Teia da Sociobiodiversidade, Fundo Casa RS, GEF SGP, Periferias Verdes, Petrobras NBS Urbano) marked \`needsValidation: true\` in \`climate-funds.json\`.
- Fund recommendation cards render an amber 'Preliminary' chip with AlertTriangle icon + tooltip: *"These amounts and dates are our best estimates — your feedback updates the catalog."*
- Primes the room to redline the catalog during the demo — the main validation we want out of tomorrow per the \`/refine\`.

## Explicitly NOT in this PR

- Pre-filled CBO questionnaire — for co-design, watching Villa Flores fill it themselves is the signal.
- Renaming Porto Alegre → Villa Flores everywhere — Villa Flores actually works in Porto Alegre, so the neighborhood names are familiar.
- Site-Explorer / Impact Model / Operations / Business Model CBO tailoring — better informed by their reaction.
- Real orchestrator data model — Phase 3.

## Test plan for tomorrow

- [ ] Clear localStorage. \`/\` → scroll down, see the NBS typology grid; looks coherent at mobile + desktop.
- [ ] Pick **CBO** → language auto-flips to PT; lands on Porto Alegre project with demo banner.
- [ ] Open Funding & Grants → 2-step questionnaire, fill with plausible answers → recommendations show CBO funds, with the 5 new entries visually marked 'Preliminar'.
- [ ] Go back to \`/\` → pick **Articuladora** → orchestrator portfolio renders: 3 cards, stat strip, co-design banner, feedback prompt at bottom. Click a card → toast fires.
- [ ] Pick City path → OAuth landing unchanged. English stays English.
- [ ] Switch-role links work from all three surfaces (Login, CBO demo banner, Orchestrator header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)