### PR TITLE
feat: orchestrator view reshaped around the CBO diagnostic pipeline (map + diagnostic cards)

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -1,19 +1,26 @@
 /**
- * Orchestrator portfolio preview (Phase 1, demo-grade).
+ * Orchestrator portfolio preview — diagnostic-pipeline view (Phase 1 demo).
  *
- * A visual prototype of what role=orchestrator would look like once Phase 3
- * lands. All data here is hardcoded — the point is to give Villa Flores and
- * other coordinators something concrete to react to. Clicking a card shows
- * a toast instead of navigating; the banner makes it clear this is an
- * early design, not production.
+ * Shape of the view:
+ *   Left (map, ~60% on desktop)     Right (CBO cards, scrollable)
  *
- * See docs/ROLE-ARCHITECTURE.md. Replace the demo cards + any hardcoded
- * copy with real data when Phase 3 materializes.
+ * Each card surfaces where each community-based organization is in the CBO
+ * profile diagnostic (see `shared/cbo-schema.ts`): phase reached, sections
+ * complete (of 7), intervention chosen (or not), COUGAR maturity total
+ * (of 27), priority flags met (of 6). Hovering a card highlights its marker
+ * on the map; hovering a marker highlights its card. All data is hardcoded —
+ * Phase 3 will wire this to a real portfolio endpoint.
+ *
+ * See docs/ROLE-ARCHITECTURE.md.
  */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, ArrowRight, Clock, Compass, Droplets, Leaf, MapPin, Sparkles, Trees, Users,
+  ArrowLeft, Check, Clock, Compass, Droplets, Leaf, MapPin, Mountain,
+  Network, Sparkles, Sprout, Trees, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -21,94 +28,395 @@ import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
 
-type CboProject = {
+// ---------------------------------------------------------------------------
+// Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
+// coordinator. Kept local to this stub; when Phase 3 lands, the shape will
+// move to shared/ and be populated from a server endpoint.
+// ---------------------------------------------------------------------------
+
+/** CBO profile phase keys — matches the shape in shared/cbo-schema.ts. */
+type PhaseKey = 'who' | 'where' | 'building' | 'impact' | 'operations' | 'needs' | 'results';
+
+type InterventionKey =
+  | 'bioswales'
+  | 'flood-parks'
+  | 'urban-forests'
+  | 'green-corridors'
+  | 'wetlands'
+  | 'slope-stabilization';
+
+type Tone = 'flood' | 'heat' | 'landslide' | 'biodiversity';
+
+type CboDemoProject = {
   id: string;
   name: { en: string; pt: string };
   neighborhood: string;
-  interventionType: 'garden' | 'wetland' | 'forest';
-  phaseKey: 'profile_partial' | 'profile_complete' | 'seeking_funding' | 'funded' | 'implementing';
-  phaseProgress: number; // 0..100
-  fundingSecured: number;
-  fundingSought: number;
-  currency: 'BRL';
-  nextActionKey: string;
+  /** Latitude, longitude. `null` means Phase 1 — site not yet plotted. */
+  coords: [number, number] | null;
+  currentPhase: PhaseKey;
+  /** Of 7 total CBO_SECTIONS (org, site, 3a/b/c, needs, results). */
+  sectionsComplete: number;
+  /** `null` means the CBO has not chosen an intervention yet (before 3a). */
+  interventionKey: InterventionKey | null;
+  /** 0..27 — sum across 9 COUGAR maturity metrics scored 0..3. */
+  maturityScore: number;
+  /** 0..6 — priority flags met (per shared/cbo-schema.PRIORITY_FLAG_DEFINITIONS). */
+  priorityFlagsMet: number;
   updatedDaysAgo: number;
+  /** i18n key for the 'next action' line on the card. */
+  nextActionKey: string;
 };
 
-const DEMO_PROJECTS: CboProject[] = [
+const TOTAL_SECTIONS = 7;
+const TOTAL_FLAGS = 6;
+const TOTAL_MATURITY = 27;
+
+const DEMO_PROJECTS: CboDemoProject[] = [
   {
     id: 'horta-cascata',
     name: { en: 'Horta Comunitária Cascata', pt: 'Horta Comunitária Cascata' },
     neighborhood: 'Cascata',
-    interventionType: 'garden',
-    phaseKey: 'seeking_funding',
-    phaseProgress: 80,
-    fundingSecured: 40_000,
-    fundingSought: 150_000,
-    currency: 'BRL',
-    nextActionKey: 'orchestrator.demo.nextAction.applyTeia',
+    coords: [-30.115, -51.178],
+    currentPhase: 'needs',
+    sectionsComplete: 4,
+    interventionKey: 'bioswales',
+    maturityScore: 15,
+    priorityFlagsMet: 3,
     updatedDaysAgo: 2,
+    nextActionKey: 'orchestrator.demo.nextAction.reviewNeeds',
   },
   {
     id: 'arquipelago-verde',
     name: { en: 'Coletivo Arquipélago Verde', pt: 'Coletivo Arquipélago Verde' },
     neighborhood: 'Arquipélago',
-    interventionType: 'wetland',
-    phaseKey: 'profile_partial',
-    phaseProgress: 40,
-    fundingSecured: 15_000,
-    fundingSought: 60_000,
-    currency: 'BRL',
-    nextActionKey: 'orchestrator.demo.nextAction.completePhase3',
+    coords: [-29.993, -51.263],
+    currentPhase: 'building',
+    sectionsComplete: 2,
+    interventionKey: 'wetlands',
+    maturityScore: 8,
+    priorityFlagsMet: 2,
     updatedDaysAgo: 7,
+    nextActionKey: 'orchestrator.demo.nextAction.completeIntervention',
   },
   {
     id: 'bosque-humaita',
     name: { en: 'Agentes do Bosque Humaitá', pt: 'Agentes do Bosque Humaitá' },
     neighborhood: 'Humaitá',
-    interventionType: 'forest',
-    phaseKey: 'profile_complete',
-    phaseProgress: 95,
-    fundingSecured: 0,
-    fundingSought: 80_000,
-    currency: 'BRL',
-    nextActionKey: 'orchestrator.demo.nextAction.applyFundoCasa',
+    coords: [-29.995, -51.195],
+    currentPhase: 'results',
+    sectionsComplete: 7,
+    interventionKey: 'urban-forests',
+    maturityScore: 22,
+    priorityFlagsMet: 5,
     updatedDaysAgo: 1,
+    nextActionKey: 'orchestrator.demo.nextAction.publishScorecard',
+  },
+  {
+    id: 'restinga-nova',
+    name: { en: 'Coletivo Restinga Nova', pt: 'Coletivo Restinga Nova' },
+    neighborhood: 'Restinga',
+    coords: null,
+    currentPhase: 'who',
+    sectionsComplete: 0,
+    interventionKey: null,
+    maturityScore: 0,
+    priorityFlagsMet: 0,
+    updatedDaysAgo: 0,
+    nextActionKey: 'orchestrator.demo.nextAction.beginProfile',
   },
 ];
 
-const INTERVENTION_ICON: Record<CboProject['interventionType'], typeof Leaf> = {
-  garden: Leaf,
-  wetland: Droplets,
-  forest: Trees,
-};
-const INTERVENTION_TONE: Record<CboProject['interventionType'], { bubble: string; fg: string }> = {
-  garden:  { bubble: 'bg-emerald-50 dark:bg-emerald-950/40', fg: 'text-emerald-600 dark:text-emerald-300' },
-  wetland: { bubble: 'bg-sky-50 dark:bg-sky-950/40',         fg: 'text-sky-600 dark:text-sky-300' },
-  forest:  { bubble: 'bg-amber-50 dark:bg-amber-950/40',     fg: 'text-amber-600 dark:text-amber-300' },
-};
-const PHASE_STYLE: Record<CboProject['phaseKey'], { label: string; chip: string }> = {
-  profile_partial:  { label: 'orchestrator.demo.phase.profilePartial',  chip: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800' },
-  profile_complete: { label: 'orchestrator.demo.phase.profileComplete', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800' },
-  seeking_funding:  { label: 'orchestrator.demo.phase.seekingFunding',  chip: 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800' },
-  funded:           { label: 'orchestrator.demo.phase.funded',          chip: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800' },
-  implementing:     { label: 'orchestrator.demo.phase.implementing',    chip: 'bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950/40 dark:text-violet-300 dark:border-violet-800' },
+// Intervention → icon + tone (color family). Mirrors the landing showcase.
+const INTERVENTION_META: Record<InterventionKey, { Icon: typeof Leaf; tone: Tone }> = {
+  'bioswales':           { Icon: Leaf,     tone: 'flood' },
+  'flood-parks':         { Icon: Droplets, tone: 'flood' },
+  'urban-forests':       { Icon: Trees,    tone: 'heat' },
+  'green-corridors':     { Icon: Sprout,   tone: 'biodiversity' },
+  'wetlands':            { Icon: Waves,    tone: 'flood' },
+  'slope-stabilization': { Icon: Mountain, tone: 'landslide' },
 };
 
-function formatBRL(v: number): string {
-  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(v);
+const TONE_STYLES: Record<Tone, { bubble: string; fg: string; ring: string; marker: string }> = {
+  flood:        { bubble: 'bg-sky-50 dark:bg-sky-950/40',         fg: 'text-sky-600 dark:text-sky-300',         ring: 'ring-sky-400',         marker: '#0284c7' },
+  heat:         { bubble: 'bg-amber-50 dark:bg-amber-950/40',     fg: 'text-amber-600 dark:text-amber-300',     ring: 'ring-amber-400',       marker: '#d97706' },
+  landslide:    { bubble: 'bg-orange-50 dark:bg-orange-950/40',   fg: 'text-orange-600 dark:text-orange-300',   ring: 'ring-orange-400',      marker: '#ea580c' },
+  biodiversity: { bubble: 'bg-emerald-50 dark:bg-emerald-950/40', fg: 'text-emerald-600 dark:text-emerald-300', ring: 'ring-emerald-400',     marker: '#059669' },
+};
+
+// Maturity band: 0..27 → 'emerging' / 'developing' / 'building' / 'mature'
+function maturityBand(score: number): 'emerging' | 'developing' | 'building' | 'mature' {
+  if (score >= 21) return 'mature';
+  if (score >= 14) return 'building';
+  if (score >= 7)  return 'developing';
+  return 'emerging';
 }
 
+const BAND_CHIP: Record<ReturnType<typeof maturityBand>, string> = {
+  emerging:   'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-900/40 dark:text-slate-300 dark:border-slate-700',
+  developing: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800',
+  building:   'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800',
+  mature:     'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800',
+};
+
+// ---------------------------------------------------------------------------
+// Map panel — CartoDB Positron tiles, one marker per CBO with coords.
+// Selected state is driven by `selectedId`; clicks and mouseovers call
+// `onSelect`, which the parent also uses to sync card hover highlighting.
+// ---------------------------------------------------------------------------
+function MapPanel({
+  projects,
+  selectedId,
+  onSelect,
+}: {
+  projects: CboDemoProject[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markersRef = useRef<Map<string, L.Marker>>(new Map());
+
+  // Keep a ref to the latest onSelect so we don't re-create the map when the
+  // parent's callback identity changes.
+  const onSelectRef = useRef(onSelect);
+  useEffect(() => { onSelectRef.current = onSelect; }, [onSelect]);
+
+  // Mount the map once.
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+
+    const map = L.map(mapRef.current, {
+      zoomControl: true,
+      attributionControl: true,
+      scrollWheelZoom: false, // keep page scrollable — zoom via + / –
+    });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd',
+      attribution: '© <a href="https://carto.com/attributions">CARTO</a> · © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      maxZoom: 19,
+    }).addTo(map);
+
+    const mapped = projects.filter(p => p.coords);
+    if (mapped.length > 0) {
+      const bounds = L.latLngBounds(mapped.map(p => p.coords!));
+      map.fitBounds(bounds, { padding: [48, 48], maxZoom: 13 });
+    } else {
+      map.setView([-30.03, -51.22], 11); // fallback to Porto Alegre center
+    }
+
+    mapInstanceRef.current = map;
+
+    for (const p of mapped) {
+      const tone = p.interventionKey ? INTERVENTION_META[p.interventionKey].tone : 'biodiversity';
+      const color = TONE_STYLES[tone].marker;
+      const icon = L.divIcon({
+        className: 'orch-marker',
+        html: `<div class="orch-marker-inner" data-id="${p.id}" style="--m:${color}"></div>`,
+        iconSize: [24, 24],
+        iconAnchor: [12, 12],
+      });
+      const marker = L.marker(p.coords!, { icon })
+        .bindTooltip(p.name.en, { direction: 'top', offset: [0, -14], className: 'orch-marker-tip' })
+        .addTo(map);
+
+      // Defer handlers to refs so identity is stable.
+      marker.on('click',     () => onSelectRef.current(p.id));
+      marker.on('mouseover', () => onSelectRef.current(p.id));
+      marker.on('mouseout',  () => onSelectRef.current(null));
+
+      markersRef.current.set(p.id, marker);
+    }
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markersRef.current.clear();
+    };
+    // Intentionally run once; projects is stable demo data.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Drive the selected class on the marker DOM from props.
+  useEffect(() => {
+    markersRef.current.forEach((marker, id) => {
+      const el = marker.getElement();
+      if (!el) return;
+      el.classList.toggle('orch-marker-selected', id === selectedId);
+    });
+  }, [selectedId]);
+
+  return (
+    <div className="relative h-[420px] md:h-full w-full overflow-hidden rounded-xl border border-foreground/10 bg-muted">
+      <div ref={mapRef} className="absolute inset-0" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio card — replaces the old funding-oriented card.
+// ---------------------------------------------------------------------------
+function ProjectCard({
+  project,
+  locale,
+  selected,
+  onHover,
+  onOpen,
+}: {
+  project: CboDemoProject;
+  locale: 'en' | 'pt';
+  selected: boolean;
+  onHover: (id: string | null) => void;
+  onOpen: (p: CboDemoProject) => void;
+}) {
+  const { t } = useTranslation();
+  const hasIntervention = project.interventionKey !== null;
+  const tone: Tone = hasIntervention
+    ? INTERVENTION_META[project.interventionKey!].tone
+    : 'biodiversity';
+  const toneStyle = TONE_STYLES[tone];
+  const Icon = hasIntervention
+    ? INTERVENTION_META[project.interventionKey!].Icon
+    : Sprout;
+  const band = maturityBand(project.maturityScore);
+  const sectionsPct = Math.round((project.sectionsComplete / TOTAL_SECTIONS) * 100);
+
+  return (
+    <button
+      type="button"
+      className="group text-left w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 rounded-xl"
+      onMouseEnter={() => onHover(project.id)}
+      onMouseLeave={() => onHover(null)}
+      onFocus={() => onHover(project.id)}
+      onClick={() => onOpen(project)}
+      data-testid={`card-orchestrator-project-${project.id}`}
+    >
+      <Card
+        className={`transition-all duration-200 ${
+          selected ? `ring-2 ${toneStyle.ring} shadow-lg` : 'group-hover:shadow-md'
+        }`}
+      >
+        <CardContent className="p-5 space-y-4">
+          {/* Header */}
+          <div className="flex items-start gap-3">
+            <div
+              className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${toneStyle.bubble} ${toneStyle.fg}`}
+            >
+              <Icon className="w-5 h-5" strokeWidth={1.75} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-semibold tracking-tight truncate">
+                {project.name[locale]}
+              </h3>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
+                <MapPin className="w-3 h-3" />
+                <span>{project.neighborhood}</span>
+                {!project.coords && (
+                  <span className="ml-1.5 inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-full border border-foreground/15 bg-background text-foreground/60">
+                    {t('orchestrator.demo.locationPending')}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Phase + Intervention row */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border border-foreground/10 bg-foreground/5 text-foreground/75">
+              {t(`orchestrator.demo.phase.${project.currentPhase}`)}
+            </span>
+            {hasIntervention ? (
+              <span
+                className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}
+              >
+                <Icon className="w-3 h-3" strokeWidth={2} />
+                {t(`orchestrator.demo.intervention.${project.interventionKey}`)}
+              </span>
+            ) : (
+              <span className="inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full border border-dashed border-foreground/20 text-muted-foreground">
+                {t('orchestrator.demo.intervention.notChosen')}
+              </span>
+            )}
+          </div>
+
+          {/* Sections progress */}
+          <div>
+            <div className="flex items-center justify-between text-xs mb-1.5">
+              <span className="text-muted-foreground">{t('orchestrator.demo.sectionsLabel')}</span>
+              <span className="font-medium text-foreground/80">
+                {t('orchestrator.demo.sectionsCount', {
+                  done: project.sectionsComplete,
+                  total: TOTAL_SECTIONS,
+                })}
+              </span>
+            </div>
+            <div className="h-1.5 rounded-full bg-foreground/5 overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${
+                  hasIntervention ? 'bg-emerald-500' : 'bg-foreground/30'
+                }`}
+                style={{ width: `${sectionsPct}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Maturity + flags row */}
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={`inline-flex items-center text-[11px] font-semibold px-2 py-1 rounded-md border ${BAND_CHIP[band]}`}
+              title={t('orchestrator.demo.maturityTooltip')}
+            >
+              {project.maturityScore}/{TOTAL_MATURITY} · {t(`orchestrator.demo.maturityBand.${band}`)}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {t('orchestrator.demo.flagsCount', {
+                met: project.priorityFlagsMet,
+                total: TOTAL_FLAGS,
+              })}
+            </span>
+          </div>
+
+          {/* Next action + updated */}
+          <div className="pt-3 border-t border-foreground/5 space-y-1.5">
+            <div className="flex items-center gap-2 text-xs">
+              <Check className="w-3 h-3 text-foreground/50" />
+              <span className="text-foreground/80">{t(project.nextActionKey)}</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Clock className="w-3 h-3" />
+              <span>
+                {project.updatedDaysAgo === 0
+                  ? t('orchestrator.demo.updatedJust')
+                  : t('orchestrator.demo.updatedAgo', { count: project.updatedDaysAgo })}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 export default function OrchestratorLandingPage() {
   const { t, i18n } = useTranslation();
   const switchRole = useResetRole();
   const { toast } = useToast();
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
 
-  const totalSecured = DEMO_PROJECTS.reduce((s, p) => s + p.fundingSecured, 0);
-  const totalSought = DEMO_PROJECTS.reduce((s, p) => s + p.fundingSought, 0);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const openProject = (p: CboProject) => {
+  const stats = useMemo(() => {
+    const sitesMapped = DEMO_PROJECTS.filter(p => p.coords).length;
+    const profilesInProgress = DEMO_PROJECTS.filter(
+      p => p.sectionsComplete > 0 && p.sectionsComplete < TOTAL_SECTIONS
+    ).length;
+    const profilesComplete = DEMO_PROJECTS.filter(p => p.sectionsComplete === TOTAL_SECTIONS).length;
+    return { sitesMapped, profilesInProgress, profilesComplete, total: DEMO_PROJECTS.length };
+  }, []);
+
+  const openProject = (p: CboDemoProject) => {
     toast({
       title: t('orchestrator.demo.toastTitle'),
       description: t('orchestrator.demo.toastBody', { project: p.name[locale] }),
@@ -119,7 +427,7 @@ export default function OrchestratorLandingPage() {
     <div className="min-h-screen relative bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
       {/* Header */}
       <header className="relative z-10 px-6 sm:px-10 py-6 border-b border-foreground/5 bg-background/40 backdrop-blur-sm">
-        <div className="max-w-6xl mx-auto flex items-center justify-between">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-lg bg-amber-50 dark:bg-amber-950/40 text-amber-600 dark:text-amber-300 flex items-center justify-center">
               <Compass className="w-5 h-5" strokeWidth={1.75} />
@@ -128,7 +436,9 @@ export default function OrchestratorLandingPage() {
               <BodySmall className="text-muted-foreground uppercase tracking-wide text-[11px]">
                 {t('orchestrator.demo.headerEyebrow')}
               </BodySmall>
-              <TitleLarge className="!text-lg tracking-tight">{t('orchestrator.demo.headerTitle')}</TitleLarge>
+              <TitleLarge className="!text-lg tracking-tight">
+                {t('orchestrator.demo.headerTitle')}
+              </TitleLarge>
             </div>
           </div>
           <Button variant="ghost" size="sm" onClick={switchRole} data-testid="button-orchestrator-switch-role">
@@ -138,13 +448,13 @@ export default function OrchestratorLandingPage() {
         </div>
       </header>
 
-      <main className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 py-10 sm:py-12">
+      <main className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
         {/* Co-design ribbon */}
         <motion.div
           initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="mb-8 flex items-start gap-3 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 px-4 py-3"
+          className="mb-6 flex items-start gap-3 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 px-4 py-3"
         >
           <Sparkles className="w-4 h-4 text-amber-600 dark:text-amber-300 mt-0.5 shrink-0" />
           <div className="flex-1">
@@ -157,17 +467,17 @@ export default function OrchestratorLandingPage() {
           </div>
         </motion.div>
 
-        {/* Aggregate stats */}
+        {/* Aggregate stats — diagnostic pipeline */}
         <motion.div
-          className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10"
+          className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8"
           initial="hidden"
           animate="show"
           variants={{ hidden: {}, show: { transition: { staggerChildren: 0.08, delayChildren: 0.1 } } }}
         >
           {[
-            { label: t('orchestrator.demo.stats.activeProjects'), value: String(DEMO_PROJECTS.length) },
-            { label: t('orchestrator.demo.stats.totalSecured'),   value: formatBRL(totalSecured) },
-            { label: t('orchestrator.demo.stats.totalSought'),    value: formatBRL(totalSought) },
+            { label: t('orchestrator.demo.pipeline.sitesMapped'),       value: `${stats.sitesMapped} / ${stats.total}` },
+            { label: t('orchestrator.demo.pipeline.profilesInProgress'), value: `${stats.profilesInProgress} / ${stats.total}` },
+            { label: t('orchestrator.demo.pipeline.profilesComplete'),  value: `${stats.profilesComplete} / ${stats.total}` },
           ].map((s, i) => (
             <motion.div
               key={i}
@@ -186,96 +496,46 @@ export default function OrchestratorLandingPage() {
         </motion.div>
 
         {/* Section heading */}
-        <div className="flex items-center justify-between mb-5">
-          <div>
-            <TitleLarge className="!text-xl tracking-tight mb-0.5">
-              {t('orchestrator.demo.portfolioTitle')}
-            </TitleLarge>
-            <BodySmall className="text-muted-foreground">
-              {t('orchestrator.demo.portfolioSubtitle')}
-            </BodySmall>
-          </div>
+        <div className="mb-5">
+          <TitleLarge className="!text-xl tracking-tight mb-0.5">
+            {t('orchestrator.demo.portfolioTitle')}
+          </TitleLarge>
+          <BodySmall className="text-muted-foreground">
+            {t('orchestrator.demo.portfolioSubtitle')}
+          </BodySmall>
         </div>
 
-        {/* Project cards */}
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
-          initial="hidden"
-          animate="show"
-          variants={{ hidden: {}, show: { transition: { staggerChildren: 0.08, delayChildren: 0.3 } } }}
-        >
-          {DEMO_PROJECTS.map(p => {
-            const Icon = INTERVENTION_ICON[p.interventionType];
-            const tone = INTERVENTION_TONE[p.interventionType];
-            const phase = PHASE_STYLE[p.phaseKey];
-            const pct = p.fundingSought > 0 ? Math.round((p.fundingSecured / p.fundingSought) * 100) : 0;
-            return (
-              <motion.button
+        {/* Map + cards */}
+        <div className="flex flex-col md:flex-row gap-4 md:gap-6 md:items-stretch">
+          {/* Map column — ~60% on desktop */}
+          <div className="md:flex-[3] md:min-h-[640px]">
+            <MapPanel
+              projects={DEMO_PROJECTS}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          </div>
+
+          {/* Card list column — ~40%, independently scrollable */}
+          <div className="md:flex-[2] md:max-h-[640px] md:overflow-y-auto pr-1 space-y-3">
+            {DEMO_PROJECTS.map((p, i) => (
+              <motion.div
                 key={p.id}
-                onClick={() => openProject(p)}
-                className="group text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 rounded-xl"
-                variants={{ hidden: { opacity: 0, y: 12 }, show: { opacity: 1, y: 0, transition: { duration: 0.4 } } }}
-                whileHover={{ y: -4 }}
-                whileTap={{ scale: 0.985 }}
-                transition={{ type: 'spring', stiffness: 260, damping: 22 }}
-                data-testid={`card-orchestrator-project-${p.id}`}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, delay: 0.15 + i * 0.06 }}
               >
-                <Card className="h-full transition-shadow duration-300 group-hover:shadow-xl group-hover:shadow-foreground/5">
-                  <CardContent className="p-5 flex flex-col h-full">
-                    {/* Top row: icon + name + phase chip */}
-                    <div className="flex items-start gap-3 mb-3">
-                      <div className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${tone.bubble} ${tone.fg}`}>
-                        <Icon className="w-5 h-5" strokeWidth={1.75} />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <h3 className="text-sm font-semibold tracking-tight truncate">{p.name[locale]}</h3>
-                        <div className="flex items-center gap-1 text-xs text-muted-foreground mt-0.5">
-                          <MapPin className="w-3 h-3" />
-                          <span>{p.neighborhood}</span>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Phase */}
-                    <div className="mb-4">
-                      <span className={`inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border ${phase.chip}`}>
-                        {t(phase.label)}
-                      </span>
-                    </div>
-
-                    {/* Funding progress */}
-                    <div className="mb-4">
-                      <div className="flex items-center justify-between text-xs mb-1.5">
-                        <span className="text-muted-foreground">{t('orchestrator.demo.funding')}</span>
-                        <span className="font-medium text-foreground/80">
-                          {formatBRL(p.fundingSecured)} / {formatBRL(p.fundingSought)}
-                        </span>
-                      </div>
-                      <div className="h-1.5 rounded-full bg-foreground/5 overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-emerald-500 transition-all duration-500"
-                          style={{ width: `${pct}%` }}
-                        />
-                      </div>
-                    </div>
-
-                    {/* Next action + updated */}
-                    <div className="mt-auto pt-3 border-t border-foreground/5 space-y-1.5">
-                      <div className="flex items-center gap-2 text-xs">
-                        <ArrowRight className="w-3 h-3 text-foreground/50" />
-                        <span className="text-foreground/80">{t(p.nextActionKey)}</span>
-                      </div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <Clock className="w-3 h-3" />
-                        <span>{t('orchestrator.demo.updatedAgo', { count: p.updatedDaysAgo })}</span>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.button>
-            );
-          })}
-        </motion.div>
+                <ProjectCard
+                  project={p}
+                  locale={locale}
+                  selected={selectedId === p.id}
+                  onHover={setSelectedId}
+                  onOpen={openProject}
+                />
+              </motion.div>
+            ))}
+          </div>
+        </div>
 
         {/* Feedback prompt */}
         <motion.div

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -281,6 +281,35 @@
   .animate-aurora-a, .animate-aurora-b, .animate-aurora-c { animation: none; }
 }
 
+/* Orchestrator map markers. Tone color arrives via --m on the inner div,
+   set inline when the DivIcon is constructed. Selected state is driven by a
+   class toggled from React; keep transitions snappy. */
+.orch-marker { background: transparent !important; border: none !important; }
+.orch-marker-inner {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--m, #0284c7);
+  border: 3px solid #ffffff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+  transform-origin: center;
+}
+.orch-marker-selected .orch-marker-inner {
+  transform: scale(1.35);
+  box-shadow: 0 0 0 4px rgba(2, 132, 199, 0.25), 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+.orch-marker-tip {
+  background: rgba(15, 23, 42, 0.92) !important;
+  color: #fff !important;
+  border: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25) !important;
+  font-size: 11px !important;
+  padding: 4px 8px !important;
+  border-radius: 6px !important;
+}
+.orch-marker-tip::before { border-top-color: rgba(15, 23, 42, 0.92) !important; }
+
 /* Risk tile layers: smooth upscaling to fill gaps between 250m cells */
 .risk-tile-layer img {
   image-rendering: auto;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -65,33 +65,56 @@
       "headerEyebrow": "Coordinator view",
       "headerTitle": "Community projects portfolio",
       "codesignBannerTitle": "Early prototype — help us design this.",
-      "codesignBannerBody": "The three projects below are illustrative. Tell us what's missing, what's useless, and what a real coordinator view should show.",
-      "stats": {
-        "activeProjects": "Active projects",
-        "totalSecured": "Funding secured",
-        "totalSought": "Total pipeline"
+      "codesignBannerBody": "Four illustrative CBOs at different points in the diagnostic flow. Tell us what's missing, what's useless, and what a real coordinator view should show.",
+      "pipeline": {
+        "sitesMapped": "Sites mapped",
+        "profilesInProgress": "Profiles in progress",
+        "profilesComplete": "Profiles complete"
       },
       "portfolioTitle": "Community projects",
-      "portfolioSubtitle": "Each card represents a CBO you'd coordinate. Click one to preview how you'd open its workspace.",
-      "funding": "Funding",
+      "portfolioSubtitle": "Each CBO sits somewhere in the profile diagnostic. Hover a card to find its site on the map.",
+      "locationPending": "Location pending",
+      "sectionsLabel": "Sections complete",
+      "sectionsCount": "{{done}} of {{total}}",
+      "flagsCount": "{{met}} of {{total}} priority flags",
+      "maturityTooltip": "Sum of 9 COUGAR maturity metrics (0–3 each, max 27).",
+      "updatedJust": "Just started",
       "updatedAgo_one": "Updated {{count}} day ago",
       "updatedAgo_other": "Updated {{count}} days ago",
       "phase": {
-        "profilePartial": "Profile in progress",
-        "profileComplete": "Profile complete",
-        "seekingFunding": "Seeking funding",
-        "funded": "Funded",
-        "implementing": "Implementing"
+        "who":        "Phase 1 — Who We Are",
+        "where":      "Phase 2 — Where We Work",
+        "building":   "Phase 3a — What We're Building",
+        "impact":     "Phase 3b — Expected Impact",
+        "operations": "Phase 3c — Ops & Sustainability",
+        "needs":      "Phase 4 — What We Need",
+        "results":    "Phase 5 — Results & Evidence"
+      },
+      "intervention": {
+        "notChosen":             "Intervention not yet chosen",
+        "bioswales":             "Bioswales & Rain Gardens",
+        "flood-parks":           "Floodable Parks",
+        "urban-forests":         "Urban Forests",
+        "green-corridors":       "Green Corridors",
+        "wetlands":              "Wetland Restoration",
+        "slope-stabilization":   "Slope Stabilization"
+      },
+      "maturityBand": {
+        "emerging":   "Emerging",
+        "developing": "Developing",
+        "building":   "Building",
+        "mature":     "Mature"
       },
       "nextAction": {
-        "applyTeia": "Apply to the next Teia da Sociobiodiversidade call",
-        "completePhase3": "Complete Phase 3 of the CBO profile",
-        "applyFundoCasa": "Apply to Fundo Casa Reconstruir RS"
+        "reviewNeeds":           "Review Phase 4 — What We Need",
+        "completeIntervention":  "Finish choosing an intervention (Phase 3a)",
+        "publishScorecard":      "Publish maturity scorecard to funders",
+        "beginProfile":          "Begin Phase 1 — Who We Are"
       },
       "toastTitle": "Prototype view",
       "toastBody": "In Phase 3, clicking here would open {{project}}'s workspace.",
       "feedbackTitle": "What would you want to see here?",
-      "feedbackBody": "This page is deliberately sparse. Tell us which metrics, alerts, or actions a coordinator would actually use day to day — that's what we'll build next."
+      "feedbackBody": "This view is deliberately sparse. Tell us which metrics, alerts, or actions a coordinator would actually use day to day — that's what we'll build next."
     }
   },
   "citySelection": {

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -65,33 +65,56 @@
       "headerEyebrow": "Visão da articuladora",
       "headerTitle": "Portfólio de projetos comunitários",
       "codesignBannerTitle": "Protótipo inicial — ajude a desenhar essa visão.",
-      "codesignBannerBody": "Os três projetos abaixo são ilustrativos. Diga o que está faltando, o que não é útil e o que uma articuladora realmente precisaria ver aqui.",
-      "stats": {
-        "activeProjects": "Projetos ativos",
-        "totalSecured": "Financiamento garantido",
-        "totalSought": "Pipeline total"
+      "codesignBannerBody": "Quatro OBCs ilustrativas em diferentes pontos do diagnóstico. Diga o que está faltando, o que não é útil e o que uma articuladora realmente precisaria ver aqui.",
+      "pipeline": {
+        "sitesMapped": "Locais mapeados",
+        "profilesInProgress": "Perfis em andamento",
+        "profilesComplete": "Perfis completos"
       },
       "portfolioTitle": "Projetos comunitários",
-      "portfolioSubtitle": "Cada card é uma OBC que você coordenaria. Clique em um para pré-visualizar como abriria o espaço de trabalho dela.",
-      "funding": "Financiamento",
+      "portfolioSubtitle": "Cada OBC está em algum ponto do diagnóstico. Passe o mouse sobre um card para localizar o ponto no mapa.",
+      "locationPending": "Local pendente",
+      "sectionsLabel": "Seções concluídas",
+      "sectionsCount": "{{done}} de {{total}}",
+      "flagsCount": "{{met}} de {{total}} flags prioritárias",
+      "maturityTooltip": "Soma das 9 métricas de maturidade COUGAR (0–3 cada, máx. 27).",
+      "updatedJust": "Iniciado agora",
       "updatedAgo_one": "Atualizado há {{count}} dia",
       "updatedAgo_other": "Atualizado há {{count}} dias",
       "phase": {
-        "profilePartial": "Perfil em andamento",
-        "profileComplete": "Perfil completo",
-        "seekingFunding": "Buscando financiamento",
-        "funded": "Financiado",
-        "implementing": "Em implementação"
+        "who":        "Fase 1 — Quem Somos",
+        "where":      "Fase 2 — Onde Atuamos",
+        "building":   "Fase 3a — O Que Construímos",
+        "impact":     "Fase 3b — Impacto Esperado",
+        "operations": "Fase 3c — Operação e Sustentabilidade",
+        "needs":      "Fase 4 — O Que Precisamos",
+        "results":    "Fase 5 — Resultados e Evidências"
+      },
+      "intervention": {
+        "notChosen":             "Intervenção ainda não escolhida",
+        "bioswales":             "Biovaletas e Jardins de Chuva",
+        "flood-parks":           "Parques Alagáveis",
+        "urban-forests":         "Florestas Urbanas",
+        "green-corridors":       "Corredores Verdes",
+        "wetlands":              "Recuperação de Banhados",
+        "slope-stabilization":   "Estabilização de Encostas"
+      },
+      "maturityBand": {
+        "emerging":   "Inicial",
+        "developing": "Em desenvolvimento",
+        "building":   "Em consolidação",
+        "mature":     "Consolidado"
       },
       "nextAction": {
-        "applyTeia": "Submeter ao próximo edital Teia da Sociobiodiversidade",
-        "completePhase3": "Completar a Fase 3 do perfil da OBC",
-        "applyFundoCasa": "Submeter ao Fundo Casa Reconstruir RS"
+        "reviewNeeds":           "Revisar a Fase 4 — O Que Precisamos",
+        "completeIntervention":  "Concluir a escolha de intervenção (Fase 3a)",
+        "publishScorecard":      "Publicar o placar de maturidade para financiadores",
+        "beginProfile":          "Começar a Fase 1 — Quem Somos"
       },
       "toastTitle": "Visão protótipo",
       "toastBody": "Na Fase 3, clicar aqui abriria o espaço de {{project}}.",
       "feedbackTitle": "O que você gostaria de ver aqui?",
-      "feedbackBody": "Essa página é propositalmente enxuta. Nos conte quais métricas, alertas ou ações uma articuladora realmente usaria no dia a dia — é isso que vamos construir a seguir."
+      "feedbackBody": "Essa visão é propositalmente enxuta. Nos conte quais métricas, alertas ou ações uma articuladora realmente usaria no dia a dia — é isso que vamos construir a seguir."
     }
   },
   "citySelection": {


### PR DESCRIPTION
## Summary

Reshapes the orchestrator portfolio view for Villa Flores. Coordinators don't track "money raised" at this stage — they track **who in their network is doing the profile diagnostic, how far along, whether they've chosen an intervention, and their COUGAR maturity**. This PR makes the page match that mental model.

## Layout

**Desktop** — two columns:

- **Left (~60%)**: Leaflet map of the Porto Alegre area (CartoDB Positron tiles, muted neutral). Auto-fits to the CBOs that have plotted a site. Hovering a card on the right grows its marker + adds a colored ring; hovering a marker highlights the card.
- **Right (~40%)**: scrollable list of CBO cards.

**Mobile** — stacks: map on top (420px), cards below.

## What the cards show now (replacing funding fields)

From \`shared/cbo-schema.ts\` — this is the real diagnostic shape:

| Field | Source |
|---|---|
| Current phase (Phase 1..5, with 3a/b/c) | \`CBO_SECTIONS\` |
| Intervention chosen (chip with icon) or "Not yet chosen" | \`NBS_INTERVENTION_TYPES\` |
| Sections complete — "N of 7" + progress bar | \`CBO_SECTIONS.length\` |
| **Maturity** — \`N/27 · band\` (Emerging <7, Developing 7–13, Building 14–20, Mature 21–27) | \`MATURITY_METRICS\` sum |
| Priority flags met — "M of 6" | \`PRIORITY_FLAG_DEFINITIONS\` |
| Next action + last-updated | — |

Tooltip on the maturity pill explains the 9-metric sum.

## Demo data (4 CBOs — one unmapped, to show the full pipeline range)

| CBO | Phase | Intervention | Sections | Maturity |
|---|---|---|---|---|
| Horta Comunitária Cascata | **4 — What We Need** | Bioswales & Rain Gardens | 4/7 | 15/27 — Building |
| Coletivo Arquipélago Verde | **3a — What We're Building** | Wetland Restoration | 2/7 | 8/27 — Developing |
| Agentes do Bosque Humaitá | **5 — Results & Evidence** | Urban Forests | 7/7 | 22/27 — Mature |
| Coletivo Restinga Nova | **1 — Who We Are** | *Not yet chosen* | 0/7 | 0/27 — Emerging |

Restinga has \`coords: null\` → no map marker, and a **"Location pending"** badge on the card. Demonstrates the "still in Phase 1, site not plotted" state coordinators would actually see.

## Stat strip (replacing funding metrics)

- **Sites mapped**: 3 / 4
- **Profiles in progress**: 2 / 4
- **Profiles complete**: 1 / 4

## Implementation notes

- Uses **Leaflet directly** (same pattern as site-explorer). No new deps.
- Custom DivIcon markers; tone color passed via CSS variable set inline when the icon is built; selected class toggled from React via a refs map.
- MapPanel mounts once (\`[]\` deps); \`onSelect\` identity stabilized through a ref so the parent's callback re-identities don't remount the map.
- Marker CSS lives in \`client/src/index.css\` next to the landing aurora keyframes.

## i18n

Fully replaced \`orchestrator.demo.*\` in both \`en.json\` and \`pt.json\` with diagnostic-shaped keys: phase names (matching \`CBO_SECTIONS\` titles), maturity bands, intervention labels, pipeline stats, next actions.

## Test plan

- [ ] Pick **Organização Articuladora** on \`/\` → lands on the new layout: map left, 4 cards right, 3 markers, one card with "Location pending".
- [ ] Hover each card → correct marker grows + gets a colored ring; other markers stay plain.
- [ ] Hover markers on the map → the right card gets the ring.
- [ ] Toggle EN ↔ PT → all copy translates; phase names match the CBO profile page's section titles.
- [ ] Click any card → "Prototype view" toast fires (no fake nav).
- [ ] Mobile: layout stacks, map fits, cards stack below, no horizontal overflow.
- [ ] Build clean (verified).

## Out of scope (Phase 3)

- Real portfolio endpoint reading \`cbo-schema\` state from the server.
- Click → actually open a CBO's workspace (stays as toast).
- Filtering by phase / intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)