### PR TITLE
feat: orchestrator foundation — cohorts, invites, phase unlocks

### DIFF
--- a/client/src/core/contexts/sample-cohort.ts
+++ b/client/src/core/contexts/sample-cohort.ts
@@ -1,0 +1,120 @@
+// Sample cohort + members for `/orchestrator` when no real coordinator slug is
+// present (stakeholder demos, first-visit walkthrough). Same shape as the
+// server-backed cohort so the page renders a single code path.
+
+import type { Cohort, CohortMember } from '@shared/cohort-schema';
+import { DEFAULT_WORKSHOPS } from '@shared/cohort-schema';
+
+const now = new Date();
+const daysAgo = (d: number) => new Date(now.getTime() - d * 86400000);
+
+export const SAMPLE_COHORT: Cohort = {
+  id: 'sample-cohort',
+  coordinatorSlug: 'sample',
+  name: 'Vila Flores — Sample cohort',
+  settings: {
+    workshops: DEFAULT_WORKSHOPS.map((w, i) => ({
+      ...w,
+      // Seed dates: weekly Thursdays starting mid-June 2026.
+      date: new Date(2026, 5, 11 + i * 7).toISOString().slice(0, 10),
+    })),
+  },
+  createdAt: daysAgo(14),
+};
+
+type SampleMember = Omit<CohortMember, 'snapshotUpdatedAt' | 'invitedAt' | 'startedAt'> & {
+  snapshotUpdatedAt: Date | null;
+  invitedAt: Date | null;
+  startedAt: Date | null;
+  /** UI-only: latitude / longitude for the map marker. */
+  coords?: [number, number] | null;
+  /** UI-only: bilingual display name for the demo. */
+  displayName?: { en: string; pt: string };
+};
+
+export const SAMPLE_MEMBERS: SampleMember[] = [
+  {
+    id: 'horta-cascata',
+    cohortId: SAMPLE_COHORT.id,
+    memberSlug: 'sample-horta-cascata',
+    cboStateId: null,
+    orgName: 'Horta Comunitária Cascata',
+    displayName: { en: 'Horta Comunitária Cascata', pt: 'Horta Comunitária Cascata' },
+    neighborhood: 'Cascata',
+    role: 'priority',
+    origin: 'cohort',
+    unlockedPhases: [1, 2, 3, 4],
+    invitedAt: daysAgo(14),
+    startedAt: daysAgo(12),
+    snapshotPhase: 4,
+    snapshotSectionsComplete: 4,
+    snapshotMaturityScore: 15,
+    snapshotFlagsMet: 3,
+    snapshotIntervention: 'bioswales',
+    snapshotUpdatedAt: daysAgo(2),
+    coords: [-30.115, -51.178],
+  },
+  {
+    id: 'arquipelago-verde',
+    cohortId: SAMPLE_COHORT.id,
+    memberSlug: 'sample-arquipelago-verde',
+    cboStateId: null,
+    orgName: 'Coletivo Arquipélago Verde',
+    displayName: { en: 'Coletivo Arquipélago Verde', pt: 'Coletivo Arquipélago Verde' },
+    neighborhood: 'Arquipélago',
+    role: 'priority',
+    origin: 'cohort',
+    unlockedPhases: [1, 2, 3],
+    invitedAt: daysAgo(14),
+    startedAt: daysAgo(10),
+    snapshotPhase: 3,
+    snapshotSectionsComplete: 2,
+    snapshotMaturityScore: 8,
+    snapshotFlagsMet: 2,
+    snapshotIntervention: 'wetlands',
+    snapshotUpdatedAt: daysAgo(7),
+    coords: [-29.993, -51.263],
+  },
+  {
+    id: 'bosque-humaita',
+    cohortId: SAMPLE_COHORT.id,
+    memberSlug: 'sample-bosque-humaita',
+    cboStateId: null,
+    orgName: 'Agentes do Bosque Humaitá',
+    displayName: { en: 'Agentes do Bosque Humaitá', pt: 'Agentes do Bosque Humaitá' },
+    neighborhood: 'Humaitá',
+    role: 'priority',
+    origin: 'cohort',
+    unlockedPhases: [1, 2, 3, 4, 5],
+    invitedAt: daysAgo(14),
+    startedAt: daysAgo(13),
+    snapshotPhase: 5,
+    snapshotSectionsComplete: 7,
+    snapshotMaturityScore: 22,
+    snapshotFlagsMet: 5,
+    snapshotIntervention: 'urban-forests',
+    snapshotUpdatedAt: daysAgo(1),
+    coords: [-29.995, -51.195],
+  },
+  {
+    id: 'restinga-nova',
+    cohortId: SAMPLE_COHORT.id,
+    memberSlug: 'sample-restinga-nova',
+    cboStateId: null,
+    orgName: 'Coletivo Restinga Nova',
+    displayName: { en: 'Coletivo Restinga Nova', pt: 'Coletivo Restinga Nova' },
+    neighborhood: 'Restinga',
+    role: 'priority',
+    origin: 'cohort',
+    unlockedPhases: [1],
+    invitedAt: daysAgo(7),
+    startedAt: null,
+    snapshotPhase: 1,
+    snapshotSectionsComplete: 0,
+    snapshotMaturityScore: 0,
+    snapshotFlagsMet: 0,
+    snapshotIntervention: null,
+    snapshotUpdatedAt: null,
+    coords: null,
+  },
+];

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -1,0 +1,138 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { Cohort, CohortMember, WorkshopConfig } from '@shared/cohort-schema';
+import { SAMPLE_COHORT, SAMPLE_MEMBERS } from '@/core/contexts/sample-cohort';
+
+const STORAGE_KEY = 'oef.cohortSlug';
+
+export type CohortMode = 'sample' | 'live';
+
+export interface UseCohortResult {
+  mode: CohortMode;
+  loading: boolean;
+  cohort: Cohort | null;
+  members: CohortMember[];
+  coordinatorSlug: string | null;
+  refresh: () => Promise<void>;
+  createCohort: (name: string) => Promise<void>;
+  loadCohort: (slug: string) => Promise<void>;
+  invite: (params: { orgName: string; neighborhood?: string; role?: 'priority' | 'alternate' }) => Promise<CohortMember | null>;
+  unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
+  saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
+}
+
+function readSlug(): string | null {
+  try { return localStorage.getItem(STORAGE_KEY); } catch { return null; }
+}
+function writeSlug(slug: string | null) {
+  try {
+    if (slug) localStorage.setItem(STORAGE_KEY, slug);
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}
+
+export function useCohort(): UseCohortResult {
+  // URL param `?coord=<slug>` overrides whatever's in localStorage so a
+  // coordinator can switch devices by pasting their link.
+  const [coordinatorSlug, setCoordinatorSlug] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    const fromUrl = new URLSearchParams(window.location.search).get('coord');
+    if (fromUrl) {
+      writeSlug(fromUrl);
+      return fromUrl;
+    }
+    return readSlug();
+  });
+  const [cohort, setCohort] = useState<Cohort | null>(null);
+  const [members, setMembers] = useState<CohortMember[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const mode: CohortMode = coordinatorSlug ? 'live' : 'sample';
+
+  const fetchCohort = useCallback(async (slug: string) => {
+    setLoading(true);
+    try {
+      const r = await fetch(`/api/cohort/${slug}`);
+      if (!r.ok) {
+        if (r.status === 404) {
+          // Slug is dead — reset to sample mode.
+          writeSlug(null);
+          setCoordinatorSlug(null);
+        }
+        return;
+      }
+      const data = await r.json();
+      setCohort(data.cohort);
+      setMembers(data.members ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (coordinatorSlug) {
+      fetchCohort(coordinatorSlug);
+    } else {
+      setCohort(SAMPLE_COHORT);
+      setMembers(SAMPLE_MEMBERS as unknown as CohortMember[]);
+    }
+  }, [coordinatorSlug, fetchCohort]);
+
+  const refresh = useCallback(async () => {
+    if (coordinatorSlug) await fetchCohort(coordinatorSlug);
+  }, [coordinatorSlug, fetchCohort]);
+
+  const createCohort = useCallback(async (name: string) => {
+    const r = await fetch('/api/cohort', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!r.ok) throw new Error('failed to create cohort');
+    const { cohort } = await r.json();
+    writeSlug(cohort.coordinatorSlug);
+    setCoordinatorSlug(cohort.coordinatorSlug);
+  }, []);
+
+  const loadCohort = useCallback(async (slug: string) => {
+    writeSlug(slug);
+    setCoordinatorSlug(slug);
+  }, []);
+
+  const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, role }) => {
+    if (!coordinatorSlug) return null;
+    const r = await fetch(`/api/cohort/${coordinatorSlug}/invite`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgName, neighborhood, role }),
+    });
+    if (!r.ok) return null;
+    const { member } = await r.json();
+    await refresh();
+    return member;
+  }, [coordinatorSlug, refresh]);
+
+  const unlockPhase = useCallback(async (memberIds: string[] | 'all', phase: number) => {
+    if (!coordinatorSlug) return;
+    await fetch(`/api/cohort/${coordinatorSlug}/unlock`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ memberIds, phase }),
+    });
+    await refresh();
+  }, [coordinatorSlug, refresh]);
+
+  const saveWorkshops = useCallback(async (workshops: WorkshopConfig[]) => {
+    if (!coordinatorSlug) return;
+    await fetch(`/api/cohort/${coordinatorSlug}/workshops`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workshops }),
+    });
+    await refresh();
+  }, [coordinatorSlug, refresh]);
+
+  return {
+    mode, loading, cohort, members, coordinatorSlug,
+    refresh, createCohort, loadCohort, invite, unlockPhase, saveWorkshops,
+  };
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -178,6 +178,35 @@ export default function CboProfilePage() {
   const [highlightedSections, setHighlightedSections] = useState<string[]>([]);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
+  // Cohort membership: if `?cbo=<memberSlug>` is in the URL, this CBO is part
+  // of a coordinator-managed cohort and the coordinator gates phase access.
+  const [memberSlug, setMemberSlug] = useState<string | null>(null);
+  const [unlockedPhases, setUnlockedPhases] = useState<number[]>([1, 2, 3, 4, 5]); // ungated by default
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const slug = params.get('cbo');
+    if (!slug) return;
+    setMemberSlug(slug);
+    fetch(`/api/cbo-member/${slug}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.unlockedPhases) setUnlockedPhases(data.unlockedPhases); })
+      .catch(() => {});
+    // Re-fetch on focus so coordinator unlocks propagate without a hard reload.
+    const onFocus = () => {
+      fetch(`/api/cbo-member/${slug}`)
+        .then(r => r.ok ? r.json() : null)
+        .then(data => { if (data?.unlockedPhases) setUnlockedPhases(data.unlockedPhases); })
+        .catch(() => {});
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
+
+  const isPhaseUnlocked = useCallback(
+    (phase: number) => unlockedPhases.includes(phase),
+    [unlockedPhases]
+  );
+
   // Hide Replit chat widget on this page
   useEffect(() => {
     const style = document.createElement('style');
@@ -319,9 +348,28 @@ export default function CboProfilePage() {
         break;
       case 'phase_change':
         setState(prev => prev ? { ...prev, phase: event.phase } : prev);
+        if (memberSlug) {
+          fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ phase: event.phase, cboStateId: cboId }),
+          }).catch(() => {});
+        }
         break;
       case 'maturity_update':
         setState(prev => prev ? { ...prev, maturityScores: event.scores, totalMaturityScore: event.total, priorityFlags: event.flags } : prev);
+        if (memberSlug) {
+          // Count filled sections from current state for the snapshot.
+          fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              maturityScore: event.total,
+              flagsMet: (event.flags || []).filter((f: PriorityFlag) => f.met).length,
+              cboStateId: cboId,
+            }),
+          }).catch(() => {});
+        }
         break;
       case 'ask_user': {
         const spatialKeywords = /\b(zone|zona|area|área|site|sítio|where|onde|map|mapa|location|local|bairro)\b/i;
@@ -482,9 +530,25 @@ export default function CboProfilePage() {
                     const sectionFilled = sectionId && state.sections[sectionId as CboSectionId] && Object.keys(state.sections[sectionId as CboSectionId].fields).length > 0;
                     const isActive = p.phase === state.phase;
                     const isPast = p.phase < state.phase || sectionFilled;
+                    const locked = !isPhaseUnlocked(p.phase);
+                    const baseClass = `h-5 px-1.5 rounded text-[10px] font-medium transition-all ${isActive ? 'bg-green-600 text-white' : isPast ? 'bg-green-200 text-green-700' : 'bg-muted text-muted-foreground'}`;
+                    if (locked) {
+                      return (
+                        <Tooltip key={p.skip}>
+                          <TooltipTrigger asChild>
+                            <button
+                              aria-disabled
+                              className={`${baseClass} opacity-40 cursor-not-allowed`}
+                              onClick={(e) => e.preventDefault()}
+                            >🔒{p.label}</button>
+                          </TooltipTrigger>
+                          <TooltipContent>{t('cbo.phaseLocked', { defaultValue: 'Your coordinator will unlock this after the next workshop.' })}</TooltipContent>
+                        </Tooltip>
+                      );
+                    }
                     return (
                       <button key={p.skip} onClick={() => !isStreaming && sendMessage(`[SKIP TO phase:${p.skip}]`)}
-                        className={`h-5 px-1.5 rounded text-[10px] font-medium transition-all ${isActive ? 'bg-green-600 text-white' : isPast ? 'bg-green-200 text-green-700' : 'bg-muted text-muted-foreground'}`}
+                        className={baseClass}
                       >{p.label}</button>
                     );
                   })}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,14 +19,16 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Droplets, Leaf, MapPin, Mountain,
-  Network, Sparkles, Sprout, Trees, Users, Waves,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, MapPin,
+  Mountain, Network, Plus, Sparkles, Sprout, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
 import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
+import { useCohort } from '@/core/hooks/useCohort';
+import type { CohortMember, WorkshopConfig } from '@shared/cohort-schema';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -71,60 +73,42 @@ const TOTAL_SECTIONS = 7;
 const TOTAL_FLAGS = 6;
 const TOTAL_MATURITY = 27;
 
-const DEMO_PROJECTS: CboDemoProject[] = [
-  {
-    id: 'horta-cascata',
-    name: { en: 'Horta Comunitária Cascata', pt: 'Horta Comunitária Cascata' },
-    neighborhood: 'Cascata',
-    coords: [-30.115, -51.178],
-    currentPhase: 'needs',
-    sectionsComplete: 4,
-    interventionKey: 'bioswales',
-    maturityScore: 15,
-    priorityFlagsMet: 3,
-    updatedDaysAgo: 2,
-    nextActionKey: 'orchestrator.demo.nextAction.reviewNeeds',
-  },
-  {
-    id: 'arquipelago-verde',
-    name: { en: 'Coletivo Arquipélago Verde', pt: 'Coletivo Arquipélago Verde' },
-    neighborhood: 'Arquipélago',
-    coords: [-29.993, -51.263],
-    currentPhase: 'building',
-    sectionsComplete: 2,
-    interventionKey: 'wetlands',
-    maturityScore: 8,
-    priorityFlagsMet: 2,
-    updatedDaysAgo: 7,
-    nextActionKey: 'orchestrator.demo.nextAction.completeIntervention',
-  },
-  {
-    id: 'bosque-humaita',
-    name: { en: 'Agentes do Bosque Humaitá', pt: 'Agentes do Bosque Humaitá' },
-    neighborhood: 'Humaitá',
-    coords: [-29.995, -51.195],
-    currentPhase: 'results',
-    sectionsComplete: 7,
-    interventionKey: 'urban-forests',
-    maturityScore: 22,
-    priorityFlagsMet: 5,
-    updatedDaysAgo: 1,
-    nextActionKey: 'orchestrator.demo.nextAction.publishScorecard',
-  },
-  {
-    id: 'restinga-nova',
-    name: { en: 'Coletivo Restinga Nova', pt: 'Coletivo Restinga Nova' },
-    neighborhood: 'Restinga',
-    coords: null,
-    currentPhase: 'who',
-    sectionsComplete: 0,
-    interventionKey: null,
-    maturityScore: 0,
-    priorityFlagsMet: 0,
-    updatedDaysAgo: 0,
-    nextActionKey: 'orchestrator.demo.nextAction.beginProfile',
-  },
-];
+// Adapter: convert a CohortMember (server or sample) into the view-model the
+// existing card + map render from. Keeps the rendering code path single while
+// data source changes.
+const PHASE_TO_KEY: Record<number, PhaseKey> = {
+  1: 'who', 2: 'where', 3: 'building', 4: 'needs', 5: 'results',
+};
+const NEXT_ACTION_KEY: Record<number, string> = {
+  0: 'orchestrator.demo.nextAction.beginProfile',
+  1: 'orchestrator.demo.nextAction.beginProfile',
+  2: 'orchestrator.demo.nextAction.completeIntervention',
+  3: 'orchestrator.demo.nextAction.completeIntervention',
+  4: 'orchestrator.demo.nextAction.reviewNeeds',
+  5: 'orchestrator.demo.nextAction.publishScorecard',
+};
+
+function memberToView(m: CohortMember): CboDemoProject {
+  const sm = m as CohortMember & { displayName?: { en: string; pt: string }; coords?: [number, number] | null };
+  const updatedAt = m.snapshotUpdatedAt ? new Date(m.snapshotUpdatedAt) : null;
+  const daysAgo = updatedAt
+    ? Math.max(0, Math.floor((Date.now() - updatedAt.getTime()) / 86400000))
+    : 0;
+  const phaseNum = m.snapshotPhase ?? 1;
+  return {
+    id: m.id,
+    name: sm.displayName ?? { en: m.orgName, pt: m.orgName },
+    neighborhood: m.neighborhood ?? '',
+    coords: sm.coords ?? null,
+    currentPhase: PHASE_TO_KEY[phaseNum] ?? 'who',
+    sectionsComplete: m.snapshotSectionsComplete ?? 0,
+    interventionKey: (m.snapshotIntervention as InterventionKey | null) ?? null,
+    maturityScore: m.snapshotMaturityScore ?? 0,
+    priorityFlagsMet: m.snapshotFlagsMet ?? 0,
+    updatedDaysAgo: daysAgo,
+    nextActionKey: NEXT_ACTION_KEY[phaseNum] ?? NEXT_ACTION_KEY[1],
+  };
+}
 
 // Intervention → icon + tone (color family). Mirrors the landing showcase.
 const INTERVENTION_META: Record<InterventionKey, { Icon: typeof Leaf; tone: Tone }> = {
@@ -407,21 +391,106 @@ export default function OrchestratorLandingPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  const {
+    mode, cohort, members, coordinatorSlug,
+    createCohort, loadCohort, invite, unlockPhase,
+  } = useCohort();
+
+  const projects = useMemo(() => members.map(memberToView), [members]);
+  const memberById = useMemo(() => new Map(members.map(m => [m.id, m])), [members]);
+
   const stats = useMemo(() => {
-    const sitesMapped = DEMO_PROJECTS.filter(p => p.coords).length;
-    const profilesInProgress = DEMO_PROJECTS.filter(
+    const sitesMapped = projects.filter(p => p.coords).length;
+    const profilesInProgress = projects.filter(
       p => p.sectionsComplete > 0 && p.sectionsComplete < TOTAL_SECTIONS
     ).length;
-    const profilesComplete = DEMO_PROJECTS.filter(p => p.sectionsComplete === TOTAL_SECTIONS).length;
-    return { sitesMapped, profilesInProgress, profilesComplete, total: DEMO_PROJECTS.length };
-  }, []);
+    const profilesComplete = projects.filter(p => p.sectionsComplete === TOTAL_SECTIONS).length;
+    return { sitesMapped, profilesInProgress, profilesComplete, total: projects.length };
+  }, [projects]);
 
   const openProject = (p: CboDemoProject) => {
+    const member = memberById.get(p.id);
+    if (mode === 'live' && member?.memberSlug) {
+      const url = `${window.location.origin}/cbo-profile?cbo=${member.memberSlug}`;
+      navigator.clipboard?.writeText(url).catch(() => {});
+      toast({
+        title: t('orchestrator.cohort.shareLinkCopied', { defaultValue: 'Share link copied' }),
+        description: url,
+      });
+      return;
+    }
     toast({
       title: t('orchestrator.demo.toastTitle'),
       description: t('orchestrator.demo.toastBody', { project: p.name[locale] }),
     });
   };
+
+  const handleUnlockNext = async (member: CohortMember) => {
+    if (mode !== 'live') {
+      toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to enable unlocks' }) });
+      return;
+    }
+    const current = Array.isArray(member.unlockedPhases) ? member.unlockedPhases : [1];
+    const max = Math.max(0, ...current);
+    const next = Math.min(5, max + 1);
+    if (next === max) {
+      toast({ title: t('orchestrator.cohort.allUnlocked', { defaultValue: 'All phases already unlocked' }) });
+      return;
+    }
+    await unlockPhase([member.id], next);
+    toast({ title: t('orchestrator.cohort.phaseUnlocked', { defaultValue: `Phase ${next} unlocked`, phase: next }) });
+  };
+
+  const handleBulkUnlock = async (phase: number) => {
+    if (mode !== 'live') {
+      toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to enable unlocks' }) });
+      return;
+    }
+    await unlockPhase('all', phase);
+    toast({ title: t('orchestrator.cohort.bulkUnlocked', { defaultValue: `Phase ${phase} unlocked for cohort`, phase }) });
+  };
+
+  const handleInvite = async () => {
+    if (mode !== 'live') {
+      toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to invite CBOs' }) });
+      return;
+    }
+    const orgName = window.prompt(t('orchestrator.cohort.invitePromptName', { defaultValue: 'CBO name?' }));
+    if (!orgName) return;
+    const neighborhood = window.prompt(t('orchestrator.cohort.invitePromptNeighborhood', { defaultValue: 'Neighborhood? (optional)' })) || undefined;
+    const created = await invite({ orgName, neighborhood });
+    if (created) {
+      const url = `${window.location.origin}/cbo-profile?cbo=${created.memberSlug}`;
+      navigator.clipboard?.writeText(url).catch(() => {});
+      toast({
+        title: t('orchestrator.cohort.inviteCreated', { defaultValue: 'Invitation created — link copied' }),
+        description: url,
+      });
+    }
+  };
+
+  const handleCreateCohort = async () => {
+    const name = window.prompt(t('orchestrator.cohort.createPromptName', { defaultValue: 'Cohort name?' }), 'Vila Flores cohort');
+    if (!name) return;
+    await createCohort(name);
+    toast({ title: t('orchestrator.cohort.created', { defaultValue: 'Cohort created' }) });
+  };
+
+  const handleLoadCohort = async () => {
+    const slug = window.prompt(t('orchestrator.cohort.loadPromptSlug', { defaultValue: 'Paste your coordinator link or slug' }));
+    if (!slug) return;
+    const cleaned = slug.includes('/') ? slug.trim().split('/').pop()! : slug.trim();
+    await loadCohort(cleaned);
+  };
+
+  const handleCopyCoordinatorLink = () => {
+    if (!coordinatorSlug) return;
+    const url = `${window.location.origin}/orchestrator?coord=${coordinatorSlug}`;
+    navigator.clipboard?.writeText(url).catch(() => {});
+    toast({ title: t('orchestrator.cohort.coordLinkCopied', { defaultValue: 'Coordinator link copied' }) });
+  };
+
+  const workshops: WorkshopConfig[] = cohort?.settings?.workshops ?? [];
 
   return (
     <div className="min-h-screen relative bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
@@ -449,6 +518,86 @@ export default function OrchestratorLandingPage() {
       </header>
 
       <main className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
+        {/* Cohort header — mode banner + actions */}
+        <div className="mb-6 rounded-xl border border-foreground/10 bg-card/60 px-4 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <span className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border ${
+                mode === 'live'
+                  ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300'
+                  : 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300'
+              }`}>
+                {mode === 'live'
+                  ? t('orchestrator.cohort.modeLive', { defaultValue: 'Live cohort' })
+                  : t('orchestrator.cohort.modeSample', { defaultValue: 'Sample mode' })}
+              </span>
+              <span className="text-sm font-medium tracking-tight">{cohort?.name ?? '—'}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {mode === 'live' ? (
+                <>
+                  <Button size="sm" variant="outline" onClick={handleCopyCoordinatorLink} data-testid="button-copy-coord-link">
+                    <Copy className="w-3.5 h-3.5 mr-1.5" />
+                    {t('orchestrator.cohort.copyCoordLink', { defaultValue: 'My link' })}
+                  </Button>
+                  <Button size="sm" onClick={handleInvite} data-testid="button-invite-cbo">
+                    <Plus className="w-3.5 h-3.5 mr-1.5" />
+                    {t('orchestrator.cohort.invite', { defaultValue: 'Invite CBO' })}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button size="sm" variant="outline" onClick={handleLoadCohort} data-testid="button-load-cohort">
+                    {t('orchestrator.cohort.loadExisting', { defaultValue: 'Load existing' })}
+                  </Button>
+                  <Button size="sm" onClick={handleCreateCohort} data-testid="button-create-cohort">
+                    <Plus className="w-3.5 h-3.5 mr-1.5" />
+                    {t('orchestrator.cohort.create', { defaultValue: 'Create cohort' })}
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Workshop cadence strip */}
+          {workshops.length > 0 && (
+            <div className="mt-3 pt-3 border-t border-foreground/5">
+              <div className="flex items-center justify-between mb-2">
+                <BodySmall className="text-muted-foreground uppercase tracking-wide text-[10px]">
+                  {t('orchestrator.cohort.workshops', { defaultValue: 'Workshop cadence' })}
+                </BodySmall>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {workshops.map((w, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 rounded-lg border border-foreground/10 bg-background px-2.5 py-1.5"
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-[11px] font-medium leading-tight">{w.name}</span>
+                      <span className="text-[10px] text-muted-foreground leading-tight">
+                        {w.date ?? t('orchestrator.cohort.noDate', { defaultValue: 'no date' })}
+                        {' · '}
+                        {t('orchestrator.cohort.unlocksPhase', { defaultValue: 'unlocks P{{phase}}', phase: w.unlocksPhase })}
+                      </span>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-[10px]"
+                      onClick={() => handleBulkUnlock(w.unlocksPhase)}
+                      data-testid={`button-bulk-unlock-${i}`}
+                    >
+                      <Unlock className="w-3 h-3 mr-1" />
+                      {t('orchestrator.cohort.unlockForCohort', { defaultValue: 'Unlock for cohort' })}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
         {/* Co-design ribbon */}
         <motion.div
           initial={{ opacity: 0, y: -8 }}
@@ -510,7 +659,7 @@ export default function OrchestratorLandingPage() {
           {/* Map column — ~60% on desktop */}
           <div className="md:flex-[3] md:min-h-[640px]">
             <MapPanel
-              projects={DEMO_PROJECTS}
+              projects={projects}
               selectedId={selectedId}
               onSelect={setSelectedId}
             />
@@ -518,22 +667,49 @@ export default function OrchestratorLandingPage() {
 
           {/* Card list column — ~40%, independently scrollable */}
           <div className="md:flex-[2] md:max-h-[640px] md:overflow-y-auto pr-1 space-y-3">
-            {DEMO_PROJECTS.map((p, i) => (
-              <motion.div
-                key={p.id}
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: 0.15 + i * 0.06 }}
-              >
-                <ProjectCard
-                  project={p}
-                  locale={locale}
-                  selected={selectedId === p.id}
-                  onHover={setSelectedId}
-                  onOpen={openProject}
-                />
-              </motion.div>
-            ))}
+            {projects.map((p, i) => {
+              const member = memberById.get(p.id);
+              const maxUnlocked = Math.max(0, ...(member?.unlockedPhases ?? [1]));
+              const canUnlockNext = maxUnlocked < 5;
+              return (
+                <motion.div
+                  key={p.id}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: 0.15 + i * 0.06 }}
+                >
+                  <ProjectCard
+                    project={p}
+                    locale={locale}
+                    selected={selectedId === p.id}
+                    onHover={setSelectedId}
+                    onOpen={openProject}
+                  />
+                  {member && (
+                    <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <Unlock className="w-3 h-3" />
+                        {t('orchestrator.cohort.unlockedThrough', {
+                          defaultValue: `Unlocked through Phase ${maxUnlocked}`,
+                          phase: maxUnlocked,
+                        })}
+                      </span>
+                      {canUnlockNext && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          onClick={(e) => { e.stopPropagation(); handleUnlockNext(member); }}
+                          data-testid={`button-unlock-next-${p.id}`}
+                        >
+                          {t('orchestrator.cohort.unlockNext', { defaultValue: 'Unlock next phase' })}
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })}
           </div>
         </div>
 

--- a/knowledge/runs/2026-05-14-cougar-backlog-refresh/backlog.md
+++ b/knowledge/runs/2026-05-14-cougar-backlog-refresh/backlog.md
@@ -1,0 +1,136 @@
+# COUGAR Platform Backlog — Refresh, 2026-05-14
+
+Consolidates the April 16 Vila Flores demo backlog (`../2026-04-16-villa-flores-demo/backlog.md`) with new context from the April 21 internal alignment, the April 29 OEF internal check-in, the May 5 PxG↔OEF biweekly, and a fresh round of ideas surfaced by Vila Flores between meetings.
+
+**Use this file** as the working backlog. The April 16 file is preserved as history — references below use the same P-IDs so we don't lose continuity.
+
+---
+
+## What changed since April 16
+
+1. **Convening series launches week-of June 8** (second week of June, avoids the Brazilian holiday). The platform must be **active from day one of convening** — not as a follow-on tool (decision, May 5 PxG biweekly).
+2. **Dedicated Vila Flores platform refinement session scheduled for the week of May 18–20** with Julia (VF coordinator) — last working window to finalize tool requirements + onboarding flow before convening.
+3. **Stakeholder showcase tour week of May 25 → June 1** (Regenera, Innovation Office, MAMM/SMAMUS, possibly Secretary of Planning). Demo will be in **Portuguese**, customized per stakeholder, with Julia attending at least one session. AR leads slide consolidation; JVP trains AR on the demo.
+4. **Two-stage pipeline workflow formalized**: Stage 1 = PxG/Vila Flores first filter (eligibility + maturity, ~10 priority + 10 alternate orgs by mid-June). Stage 2 = NBS Project Builder readiness/bankability assessment. NBS expert (PxG hire) sources additional projects outside the 10-org cohort. Final selection is **human** — platform supports decision-making, doesn't make decisions.
+5. **November 2026 = hard milestone** for QCF €50K catalytic deployment.
+6. **Three Pyxera framework misalignments still outstanding** (to resolve May 21): (a) Vila Flores not listed as Project Builder user in PxG↔VF contract, (b) "platform" terminology conflates NBS Project Builder with Transition Fund Studio, (c) "municipal feedback loop" framing is too passive vs OEF's intended co-design.
+7. **Pyxera restructuring**: Kami Taylor replaces Fernanda Scur as day-to-day ops lead; FS pivots to network mobilization + VF convening support.
+
+## Critical-path summary
+
+| Window | What ships | Owner |
+|---|---|---|
+| **By May 20** | P-8, P-1, P-4, P-22, P-7 ready for the VF refinement session. Demo polish for the showcase tour. | JVP |
+| **By May 25** | Stakeholder-customized demo flows (P-23). AR trained on demo. | JVP + AR |
+| **By June 8** | Coordinator gating (P-8), invite/share flow (P-14), territory scorecard MVP (P-6), profile-progress (P-22), impact calc v1 (P-24). Platform usable end-to-end by the 10-org cohort. | JVP |
+| **By mid-July** | Phase A of funding-overlay (P-10), public org registry MVP (P-11 lite), richer intervention cards (P-15), adaptive recipe tuned to Palafita (P-16). | JVP |
+| **By November** | Bankability assessment loop with BWB; QCF deployment-ready. | JVP + BWB |
+
+---
+
+## New items (added 2026-05-14)
+
+### P-23. Stakeholder-segmented demo flows
+**Source**: May 5 PxG biweekly (Fernanda + Ana). Stakeholder showcase tour is one platform, multiple audiences: Innovation Office (community + innovation framing), MAMM/SMAMUS (regulatory + city-territory framing), Regenera (state fund alignment), Secretary of Planning (portfolio + bankability framing). Each lands differently.
+
+Define 3–4 saved demo entry points that pre-load the relevant view (risk map for SMAMUS; orchestrator+CBO flow for Innovation; portfolio aggregation + funding-overlay placeholder for Planning) and skip the cold-start setup. Add a presenter-mode that hides scaffolding.
+
+**Acceptance**: from a single URL or sample switcher, the presenter picks the audience → the platform opens on the right view with sample data already loaded; ≤2 clicks to the headline screen.
+
+### P-24. Automatic impact calculation by selected area *(your idea #4)*
+**Source**: April 16 transcript (Joaquin 41:42 *"since you selected this site, we know that the impact of what you will do would be this"*) + your message 2026-05-14.
+
+When a CBO selects an intervention site + an intervention type, auto-compute estimated impact ranges from the 250m risk grid + intervention library (typical effect sizes per `knowledge/_interventions/*.md`). Examples: m² of canopy added → flood-peak reduction %; permeable area → infiltration capacity; tree count → cooling Δ°C. Report as bounded ranges, not point estimates, with the assumptions visible.
+
+This is the *funder-facing* artifact: feeds the concept note's impact section and the territory scorecard (P-6).
+
+**Acceptance**: after Phase 3a (intervention selection), the right-side panel shows "Estimated impact" with 2–4 indicators (flood/heat/canopy/people-served), each with a source + uncertainty range. Reproducible from the intervention library.
+
+### P-25. Risk-area × planned-investment "uncovered territory" view *(your idea #1)*
+**Source**: Julia (April 16) + your message 2026-05-14. **Note**: this is a refinement of P-10, not a new item — but framing matters. The original P-10 acceptance is the *overlay*; this expands it to an explicit **gap map**: a derived layer that highlights neighborhoods where risk is high *and* planned investment is low/zero. That's the layer Vila Flores wants to weaponize for the Innovation Office conversation: *"these are the territories nobody is funding."*
+
+Merge into P-10 Phase A acceptance criteria.
+
+**Acceptance**: in P-10 Phase A, the bairro-detail panel includes a "Coverage gap score" = f(risk, planned R$/capita). A separate map toggle "Show uncovered territory" shades only bairros where gap-score ≥ threshold.
+
+### P-26. Educational territory scorecard (printable, didactic format) *(your idea #5)*
+**Source**: Julia (April 16, 40:43) + your message 2026-05-14. **Refines P-6**, not new. The original P-6 acceptance was a coordinator-facing report. This adds a **second output**: an educational, plain-language version organizations can hand to their leadership / community members. Less data, more narrative; designed for a non-technical reader.
+
+**Acceptance**: P-6 generates two artifacts from the same data — (a) coordinator scorecard (existing P-6 acceptance), (b) community-facing 1-pager with simple icons, plain-language risk explanations, and the org's planned interventions framed as "your contribution." Both export to PDF.
+
+### P-27. NBS expert + Bankers-Without-Boundaries handoff surface
+**Source**: April 29 internal + May 5 PxG biweekly. The platform now needs to receive projects sourced by the PxG-hired NBS expert (outside the 10-org cohort) for readiness assessment, and to hand finalized projects to BWB for bankability. Today nothing in the UI handles either.
+
+Lightweight v1: a "submit external project" entry point (for the NBS expert, possibly a different role) that fills the same CBO schema; and a "ready for bankability review" status that surfaces the project to BWB-role users with the readiness scoring + gap list. Defer multi-tenant auth (still Phase 3 per ROLE-ARCHITECTURE.md) — for the pilot, use share-link gating + a status field.
+
+**Acceptance**: NBS-expert can drop a project via a single-page intake (or upload a doc the agent extracts from); orchestrator sees it alongside CBO-sourced projects with an `origin` chip. A BWB-ready filter exists in the orchestrator view.
+
+---
+
+## Status of April 16 items (re-prioritized for June convening)
+
+### Must-ship for June 8 convening
+
+- **P-8 — Workshop-phased unlock** *(your idea #2)*. Confirmed in April 16 + May 5 meetings as the *workflow primitive* that ties platform progress to workshop cadence. Highest sequencing priority — convening series can't run without it.
+- **P-4 — Profile persistence UX clarity**. Trivial. Ship.
+- **P-22 — Profile-completion progress indicator**. Trivial. Ship.
+- **P-1 — Risk-aware site selection during Phase 2**. UI surfacing on data we already have. Needed for the May 25 stakeholder demos.
+- **P-14 — Coordinator invitation / sharing link**. Convening cohort can't self-onboard without this.
+- **P-7 — Mobile optimization for CBO flow**. Palafita coordinators will use phones — gating user experience.
+- **P-12 — Public vs private land filter on interventions** *(your idea #3)*. Cheap. Ship.
+- **P-6 — Territory scorecard auto-generation** (now P-6 + P-26). MVP version for the coordinator; community-facing variant can follow.
+- **P-24 — Automatic impact calculation v1** *(your idea #4, new)*. Even rough ranges raise the credibility of the demo for SMAMUS + Planning audiences.
+- **P-23 — Stakeholder-segmented demo flows** (new). Required for the May 25 → June 1 tour.
+
+### Ship by mid-July (Phase A of pipeline assessment)
+
+- **P-10 — Planned-funding overlay × risk** *(your idea #1, refined by P-25)*. **The single highest-leverage feature** per April 16. Phase A only: POA Futura earmarks × risk × uncovered-territory layer. The April 16 backlog already has the source PDFs archived in `raw/`.
+- **P-11 — Public organization registry (lite)**. SEO catalog of participating CBOs. The shared component library (`@oef/components`) should make this fast.
+- **P-15 — Richer intervention info cards**. Material for SMAMUS / city-engineering audiences.
+- **P-16 — Adaptive question tuning from VF workshop goals**. Wait for Antônia's workshop agenda; then update the cboAgent recipe.
+- **P-13 — "Already doing" vs "Potential" filter**. Useful once CBOs are filling profiles in week 1 of convening.
+- **P-9 — Dual-mode map (management + public)**. Pre-req for P-11 public registry.
+- **P-21 — Sector-based platform segmentation** (Community / Government / Funding). Drives info architecture once P-10 + P-11 land.
+
+### Q3 / portfolio phase
+
+- **P-27 — NBS expert + BWB handoff surface** (new). Needed before September when the PxG NBS expert starts producing project leads outside the cohort.
+- **P-17 — Pyxera scanning-criteria ingestion**. Now blocked on resolving the framework alignment (May 21 meeting) — the criteria list Andrew shared in April is the input.
+- **P-5 — Territory diagnosis beyond climate** (poverty rate, schools, healthcare overlays). Becomes important when stakeholder conversations turn from risk to equity.
+
+### Park (research only, no work this quarter)
+
+- **P-18 HubSPOA overlap research** — defer; if Innovation Office references HubSPOA in the May 25 meeting, revisit.
+- **P-19 Koalizone / PoaHabitat / PontosdeCultura UX study** — light week of work, pair with P-11 design.
+- **P-20 Pontos de Cultura registry schema** — informs P-11.
+
+---
+
+## Open coordination questions (need PxG / VF answers)
+
+1. **Vila Flores user role** in the PxG↔VF contract — must be resolved May 21 before we onboard Julia onto the platform. Without it, who is paying for VF's time on the platform?
+2. **Workshop agenda + goals** from Antônia (was due "end of next week" per April 16; check status). Required to tune the cboAgent recipe (P-16) and to lock the unlock cadence (P-8).
+3. **NBS expert job posting date** (mid-May target per May 5). Affects when P-27 needs to be ready.
+4. **POA Futura / FUNRIGS territorial data** — Julia mentioned the city has the data; need a written hand-off so we can stop scraping the PDFs for P-10.
+5. **Public-view publication rights** — for P-9/P-11, who signs off that an organization's profile can be public? Default: coordinator (Vila Flores) with per-org opt-out, but confirm with Antônia.
+
+---
+
+## Out of scope (explicit non-goals, captured to avoid re-litigation)
+
+- **Real orchestrator backend / multi-tenant auth** — still Phase 3 per `docs/ROLE-ARCHITECTURE.md`. For the June pilot, share-link gating + role config are enough.
+- **Automated portfolio selection** — confirmed April 29 + May 5: humans (VF + OEF + BWB) make the call; the platform supports the decision with scoring/readiness, doesn't replace it.
+- **Community-owned fund design** — explicitly deferred until pipeline + financing needs are identified (MW response to FS, April 29). "Cart before the horse."
+- **Engagement + narrative-deck work** — tracked in the Pyxera harmonized framework document + meeting notes, not here.
+
+## Sources
+
+- `_meetings/2026-04-08-cougar---vila-flores-open-earth-foundation.md` (initial framing)
+- `_meetings/2026-04-16-cougar---vila-flores-oef.md` (P-1 through P-22 feature surface)
+- `_meetings/2026-04-21-cougar-internal-alignment.md` (stakeholder strategy)
+- `_meetings/2026-04-29-cougar-biweekly-oef-internal-check-in.md` (framework misalignments, Transition Studio scope, two-stage pipeline)
+- `_meetings/2026-04-30-cougar-pxg-oef-biweekly.md` (PxG framework v1)
+- `_meetings/2026-05-05-cougar-pxg-oef-biweekly.md` (timelines, NBS expert, convening week, May 18–20 VF session, May 25 stakeholder tour)
+- `knowledge/runs/2026-04-16-villa-flores-demo/backlog.md` (P-1..P-22 detailed acceptance)
+- `knowledge/runs/2026-04-16-villa-flores-demo/raw/poa-futura-revista.pdf` (P-10 data source)
+- `knowledge/runs/2026-04-16-villa-flores-demo/raw/plano-rio-grande-investimentos.pdf` (P-10 data source)

--- a/knowledge/runs/2026-05-14-cougar-backlog-refresh/foundation-block-plan.md
+++ b/knowledge/runs/2026-05-14-cougar-backlog-refresh/foundation-block-plan.md
@@ -1,0 +1,126 @@
+# Plan: Orchestrator Foundation Block (O-14 + O-1 + O-2 + O-4)
+
+Target: ship by 2026-05-20, ahead of Julia (Vila Flores) refinement session.
+
+## Summary
+
+Replace the hardcoded `DEMO_PROJECTS` array with a server-backed cohort that the coordinator can grow (invite CBOs by share-link) and gate (per-CBO + bulk phase unlocks). Workshop cadence is a UI strip driven by a cohort settings blob; the data layer holds only `unlockedPhases: number[]` per CBO. Sample mode keeps working for the May 25 stakeholder demos.
+
+## Decisions
+
+- **Persistence**: Neon/Postgres via Drizzle. New `cohort` + `cohort_member` tables. Slug-as-secret auth (no login).
+- **Workshop model**: phase locks at data layer; workshops live in a `cohort.settings.workshops` JSON blob. Schema doesn't change when workshop dates shift.
+- **Granularity**: phase-level locks (5 phases). Matches `phase` field already on `CBO_SECTIONS`.
+- **CBO profile state**: stays agent-driven for now. CBO page **pushes a snapshot** (phase, sectionsComplete, maturityScore, flagsMet) to the server on each agent event so the orchestrator can read summaries. Profile content itself doesn't move to DB in this block.
+- **Sample mode**: when no coordinator slug is present, `useCohort()` returns the existing `DEMO_PROJECTS` in the same shape. No code paths diverge in the page.
+
+## Data model
+
+```ts
+// server/schema.ts (additions)
+
+cohort {
+  id              uuid PK
+  coordinatorSlug text unique (long random)
+  name            text
+  createdAt       timestamp
+  settings        jsonb        // { workshops: [{name, date, unlocksPhase}], ... }
+}
+
+cohortMember {
+  id              uuid PK
+  cohortId        uuid FK → cohort
+  memberSlug      text unique  (long random; goes in CBO share link)
+  orgName         text
+  neighborhood    text
+  role            enum('priority','alternate')   // O-5 lives here later
+  origin          enum('cohort','external')      // O-6 lives here later
+  unlockedPhases  jsonb        // number[] — defaults to [1]
+  invitedAt       timestamp
+  startedAt       timestamp nullable
+  // inlined snapshot (cheap to update; orchestrator reads):
+  snapshotPhase            int     nullable
+  snapshotSectionsComplete int     nullable
+  snapshotMaturityScore    int     nullable
+  snapshotFlagsMet         int     nullable
+  snapshotIntervention     text    nullable
+  snapshotUpdatedAt        timestamp nullable
+}
+```
+
+No FK to a `user` table — slug-secret only. When Phase-3 auth lands, `coordinatorSlug` is replaced with a real session.
+
+## Endpoints
+
+```
+POST   /api/cohort                                  → create cohort, return coordinatorSlug
+GET    /api/cohort/:coordinatorSlug                 → cohort + members + snapshots
+POST   /api/cohort/:coordinatorSlug/invite          → {orgName, neighborhood, role?} → memberSlug
+PATCH  /api/cohort/:coordinatorSlug/workshops       → {workshops: [...]} → settings update
+PATCH  /api/cohort/:coordinatorSlug/unlock          → {memberIds: string[]|'all', phase: number}
+GET    /api/cbo/:memberSlug                         → { unlockedPhases, identity }
+PATCH  /api/cbo/:memberSlug/snapshot                → CBO pushes profile summary
+```
+
+6 endpoints. All slug-checked; no other auth.
+
+## Implementation steps
+
+1. [ ] **Schema + migration** — `server/schema.ts`, `npm run db:push`. ~30 min.
+2. [ ] **Endpoints** — `server/routes/cohortRoutes.ts` + register in `server/routes.ts`. ~3 h. Slug generation uses `nanoid(24)`. Zod validation on bodies.
+3. [ ] **`useCohort()` hook** — `client/src/core/hooks/useCohort.ts`. Reads coordinator slug from localStorage (`oef.cohortSlug`); sample-mode shim returns `DEMO_PROJECTS` shape. React-Query for caching + invalidation. ~1.5 h.
+4. [ ] **Orchestrator page rewire** — `orchestrator-landing.tsx`:
+   - First-load CTA: "Create cohort" (POST) or "Load existing" (paste slug). After creation, slug stored in localStorage.
+   - Replace `DEMO_PROJECTS` source with `useCohort()`.
+   - Add "Invite a CBO" button → dialog → POST invite → show share link + "Copy invitation message" (WhatsApp-formatted template).
+   - Per-card "Unlock next phase" button → PATCH unlock with single memberId.
+   - Workshop cadence strip at the top: renders from `cohort.settings.workshops`; each workshop has its date (editable) and a "Unlock Phase X for cohort" bulk button → PATCH unlock with `memberIds: 'all'`.
+   - Sample-mode path: page renders identical UI with seed data; invite/unlock actions show "Sample mode — sign up to enable."
+   ~4 h.
+5. [ ] **CBO profile gating** — `cbo-profile.tsx`:
+   - On mount: if `?cbo=<slug>` in URL, fetch `/api/cbo/:slug` → store `unlockedPhases` in state.
+   - Phase-strip (line 471): locked phases render with a lock icon + tooltip ("Your coordinator will unlock this after Workshop 2"). Click is a no-op.
+   - `[SKIP TO phase:X]` send: client-side guard refuses if `X` not in `unlockedPhases`.
+   - On `phase_change` / `maturity_update`: also `PATCH /api/cbo/:slug/snapshot` with the relevant fields.
+   ~2 h.
+6. [ ] **Agent-side guard (server)** — `server/services/cboAgent.ts`: when handling a `[SKIP TO phase:X]`, look up the member's `unlockedPhases`; if not unlocked, respond with a polite refusal instead of advancing. Belt-and-suspenders for the client-side check. ~30 min.
+7. [ ] **i18n** — add EN/PT keys for: invite dialog, share message template, lock tooltips, workshop strip labels, sample-mode banner. ~30 min.
+8. [ ] **Seed a default cohort for sample mode** — `client/src/core/contexts/sample-data-context.tsx` or new `sample-cohort.ts`. Use today's `DEMO_PROJECTS` content, just re-shaped. ~30 min.
+
+**Total estimated effort**: ~12 h focused work. Comfortably fits May 14 → 20.
+
+## Files touched
+
+- New: `server/routes/cohortRoutes.ts`, `client/src/core/hooks/useCohort.ts`, `client/src/core/contexts/sample-cohort.ts`
+- Modified: `server/schema.ts`, `server/routes.ts`, `server/services/cboAgent.ts`, `client/src/core/pages/orchestrator-landing.tsx`, `client/src/core/pages/cbo-profile.tsx`, `client/src/core/locales/{en,pt}.json`
+
+## Risks & mitigations
+
+- **Risk**: slug leaks to wrong CBO via shared-screen / WhatsApp forwarding.
+  **Mitigation**: pilot scale (10 CBOs, all known to Julia). For Phase 3, real auth.
+- **Risk**: server-side `[SKIP TO phase]` enforcement requires touching the agent; might be brittle.
+  **Mitigation**: client-side guard is enough for pilot; flag agent-side as P1 follow-up.
+- **Risk**: snapshots get out of sync if a CBO clears localStorage mid-flow.
+  **Mitigation**: on next agent message, snapshot re-pushes current state; eventual consistency.
+- **Risk**: sample mode rots because we forget to update the seed when shapes change.
+  **Mitigation**: TypeScript: seed and `useCohort` return the same type. Compiler catches drift.
+- **Risk**: coordinator loses their slug if browser localStorage is cleared.
+  **Mitigation**: "Copy my coordinator link" button surfaced prominently after cohort creation. JVP records it in the VF Notion page on Julia's behalf.
+
+## Success criteria
+
+- [ ] Coordinator creates a cohort from `/orchestrator` and invites 10 named CBOs via share-link
+- [ ] Each CBO opens their link, sees their identity, lands on Phase 1; Phases 2–5 visibly locked with explanation
+- [ ] Coordinator clicks "Unlock Phase 2 for cohort" → on a CBO's next agent message, Phase 2 unlocks
+- [ ] Orchestrator shows each CBO's current phase, sections complete, maturity score, last-updated time — driven by snapshots, not hardcoded
+- [ ] Per-CBO "Unlock next phase" override works for stragglers
+- [ ] `/orchestrator` with no slug still renders the DEMO_PROJECTS-equivalent sample view for stakeholder demos
+- [ ] Julia can run through the full cohort lifecycle in the May 20 refinement session
+
+## Out of scope for this block (parked)
+
+- Status pill (O-3), external-origin chip (O-6), alternates UX (O-5), territory report action (O-7) — next block.
+- Map intelligence (O-8 / O-9 / O-10 / O-11) — separate block.
+- Sector tabs (O-12) and public toggle (O-13) — later in the quarter.
+- Replacing the agent's in-memory profile state with DB-backed state — not needed for the foundation; only the *summary* moves to DB.
+- Multi-coordinator support — single coordinator (Julia) for the pilot.

--- a/knowledge/runs/2026-05-14-cougar-backlog-refresh/orchestrator-page-backlog.md
+++ b/knowledge/runs/2026-05-14-cougar-backlog-refresh/orchestrator-page-backlog.md
@@ -1,0 +1,159 @@
+# Orchestrator Page Backlog — 2026-05-14
+
+Scope: items that ship as changes to `/orchestrator` (`client/src/core/pages/orchestrator-landing.tsx`). Everything else stays in the broader backlog (`./backlog.md`).
+
+## What Vila Flores said the coordinator view is *for*
+
+Three jobs, in their words:
+
+1. **Manage the cohort** — "see what they've done so far, have they actually completed their sections, have they shared the information, have they chosen a site or not" (JVP 8:30).
+2. **Recruit proactively** — "this is the map of Porto Alegre, these are the highest-risk neighborhoods, this is where I recommend you go find more organizations" (JVP 11:04).
+3. **Coordinate with the city** — "show the amount of money planned to be invested in specific parts of the city, which parts are not covered yet, cross that with the risk areas" (Julia 13:46); "how the platform will be divided in these sectors — community projects, government projects, who fills the platform" (Antônia 30:50).
+
+Today's page does (1) well-ish. Doesn't do (2) or (3) at all. The gap is what this backlog closes.
+
+## Layout direction
+
+Today: 60% map + 40% cards.
+
+Proposed evolution: top-level **sector tabs** (Community / Government / Funding), each with the same split-screen shell but different map layers + right-rail content. Plus a thin **convening-cadence header strip** (workshop dates → which phase each unlocks).
+
+That structure is what most items below assume.
+
+---
+
+## Items
+
+### O-1. Phase-unlock controls on each CBO card
+**Source**: Ana 42:04. *"Functionality for communities locked until the orchestrator review and liberate — okay, you're ready for the next phase."*
+**What to add**: "Unlock next phase" button on each card; CBO sees grayed sections with a "Coordinator will unlock after Workshop 2" tooltip on their side. Bulk action in the cohort header (see O-2). Default state on invite: Phase 1 unlocked, Phases 2–5 locked.
+**Today**: nothing — CBOs can skip to any phase via the strip in `cbo-profile.tsx:471`.
+**Acceptance**: per-card "Unlock Phase 2 (Where we work)" action; persisted; CBO page enforces the lock visually and in the agent flow.
+
+### O-2. Bulk-unlock action tied to workshop cadence
+**Source**: April 16 + workshop-cadence framing throughout.
+**What to add**: a "Workshops" strip at the top of the page — "Workshop 1 · May 28 ✓ · Phase 1 unlocked" / "Workshop 2 · June 5 → Unlock Phase 2 for all". Coordinator clicks once per workshop; cohort moves together. Per-CBO override (O-1) handles stragglers.
+**Today**: no concept of "workshop" in the data model.
+**Acceptance**: cadence strip lists 5–6 workshops with dates; each has a one-click bulk unlock; per-CBO state still wins if explicitly set.
+
+### O-3. CBO status pill (drafting / in-review / ready-for-bankability / submitted)
+**Source**: April 29 (MW + JVP) — *"humans make selection, platform supports."* PxG: 10 priority + 10 alternate cohort, then handoff to BWB.
+**What to add**: a 4-state status pill on each card the coordinator can advance manually; filterable in the cohort list.
+**Today**: only `currentPhase` + `sectionsComplete`. No notion of "ready to hand off."
+**Acceptance**: pill on each card; "Advance status" menu (drafting → coordinator-review → ready-for-bankability → submitted); list filter by status.
+
+### O-4. Invite-a-CBO flow + share link
+**Source**: Antônia 1:03:15. *"Share this with three or four more people coordinating Palafita."*
+**What to add**: "Invite CBO" button in the page header → form for org name + neighborhood → generates a share-link slug. New card appears in the cohort once the invited org opens the link and starts their profile.
+**Today**: hardcoded DEMO_PROJECTS, no mechanism to add a CBO.
+**Acceptance**: coordinator can add a CBO from the page; share URL works; new card shows the link state ("Invited · not yet started") until profile begins.
+
+### O-5. Alternates list (10 priority + 10 alternate)
+**Source**: May 5 PxG biweekly — *"10 priority + 10 alternate organizations with justification, criteria assessment, recommended themes."*
+**What to add**: a "Cohort" / "Alternates" split inside the right rail (or a tab). Alternates have the same card shape but visually de-emphasized. "Promote to cohort" action swaps an alternate up when a priority CBO drops out.
+**Today**: flat list of 4 demo CBOs.
+**Acceptance**: two grouped lists with a clear visual hierarchy; promote/demote actions; status preserved on swap.
+
+### O-6. External-origin chip (NBS expert pipeline)
+**Source**: April 29 + May 5 — PxG-hired NBS expert sources projects *outside* the 10-org cohort.
+**What to add**: an `origin: cohort | external` field on each project; small chip on the card and a filter ("Show external projects from NBS expert"). External projects skip O-2's workshop unlock cadence — they come in already at later phases.
+**Today**: implicit assumption that everything is CBO-cohort-sourced.
+**Acceptance**: chip visible; filter works; external projects don't get auto-locked by O-1/O-2.
+
+### O-7. Generate territory report (PDF) action per card
+**Source**: Julia 40:43 — *"your territory in this moment looks like this, like a scorecard you can offer for even the leadership and for us."*
+**What to add**: per-card action "Generate territory report" → opens the scorecard preview → "Download PDF" with coordinator + community variants (the community variant is plain-language).
+**Today**: nothing.
+**Acceptance**: button on card; preview page; both PDFs export.
+
+### O-8. Highest-risk-neighborhoods layer toggle on the map
+**Source**: JVP 11:04 — *"these are the highest-risk neighborhoods, this is where I recommend you go find more organizations."*
+**What to add**: layer toggle in the map's top-right; choropleth shading of bairro polygons by composite risk score. Hover a bairro → top hazard + population in risk area. Data already exists in `geospatial-data` repo + 250m grid.
+**Today**: blank map with CartoDB Positron tiles + markers.
+**Acceptance**: toggle works; hover tooltips show risk + pop; can coexist with markers.
+
+### O-9. Planned-funding × risk overlay + "uncovered territory" gap map
+**Source**: Julia 13:46 + Antônia 19:05 — *"the amount of money planned to be invested in specific parts of the city, which parts are not covered yet."* **The single strongest-signal product ask from April 16.**
+**What to add**: second layer toggle showing POA Futura earmarks by bairro (we already have `raw/poa-futura-revista.pdf` archived). Click a bairro → list of earmarked investments. Third toggle "Uncovered territory" shades only bairros where risk ≥ threshold AND planned R$/capita ≤ threshold.
+**Today**: no funding data anywhere in the UI.
+**Acceptance**: Phase A only — static POA Futura mapping + risk-overlap gap layer. Click for line-item list.
+
+### O-10. Territory-diagnosis side panel on bairro click
+**Source**: Julia 44:32 — *"diagnosis of the territory on health, education… like a scorecard offer for the leadership."*
+**What to add**: click a bairro on the map → right-rail flips to a "Territory profile" panel: population, poverty rate, informal-settlement %, schools, parks, top risks. IBGE + OSM data already in repo.
+**Today**: bairros are non-clickable.
+**Acceptance**: click → panel; panel has a "Recruit here" call-to-action (kicks off O-4 pre-filled with the bairro).
+
+### O-11. Resilience-concept filter chips
+**Source**: Julia 15:38 — *"labels on the concept of resilience — drainage, NBS, housing, sanitation, social services, cultural, transport."*
+**What to add**: chip row above the map (or above the right rail): drainage / NBS / housing / sanitation / social / cultural / transport. Filters both map markers and the cohort list. Coordinator can mark each CBO with one or more concepts.
+**Today**: no tagging.
+**Acceptance**: chip filter; CBO tagging UI in the card; persists.
+
+### O-12. Sector segmentation (top-level tabs)
+**Source**: Antônia 30:50 — *"how the platform will be divided in these sectors, like the community projects portfolio is one sector, government projects, who is going to fill the platform."*
+**What to add**: three top-level tabs: **Community projects** (today's view) / **Government projects** (POA Futura + FUNRIGS earmarks) / **Funding opportunities** (active and closing funds). Same split-screen shell per tab; map layers + right-rail content differ.
+**Today**: only "Community projects" exists implicitly.
+**Acceptance**: three working tabs; each loads its own data shape; map state survives tab switch where appropriate.
+
+### O-13. Per-CBO "Show publicly" toggle
+**Source**: Julia 12:40 — *"is it possible that this map has an online version open for everyone to see?"* + Antônia 20:00 referencing the Pontos de Cultura federal catalog.
+**What to add**: per-card toggle "List in public registry." Feeds a downstream `/public/vila-flores` surface (out of scope for this backlog — see P-9 / P-11 in the parent backlog). Coordinator controls visibility per org.
+**Today**: nothing.
+**Acceptance**: toggle persists; off by default; rendering of the public view itself is parent-backlog work.
+
+### O-14. Replace `DEMO_PROJECTS` with persistence-backed cohort
+**Source**: implicit. June pilot has 10 real CBOs filling profiles; today's page reads a hardcoded array.
+**What to add**: cohort list reads from the same persistence layer the CBO profile writes to (localStorage in sample mode, DB in API mode). CBO profile updates → orchestrator cohort reflects them on next visit.
+**Today**: 4 hardcoded projects.
+**Acceptance**: orchestrator + CBO profile share state; sample mode + API mode both work; new CBOs from O-4 appear without code changes.
+
+---
+
+## Suggested build order (May 14 → June 8)
+
+Tied to the two real deadlines:
+
+**By May 20 — VF refinement session with Julia**:
+- **O-14** (persistence wiring — foundation for everything else)
+- **O-1** (per-card phase unlock)
+- **O-2** (workshop cadence header + bulk unlock)
+- **O-4** (invite flow + share link)
+
+That gives Julia a working coordinator surface to react to.
+
+**By May 25 — stakeholder showcase tour**:
+- **O-8** (risk neighborhoods layer — visible win for SMAMUS / Innovation Office audience)
+- **O-11** (concept filter — gives Innovation Office their "innovation" framing)
+- **O-9 Phase A** (POA Futura overlay — gives Secretary of Planning the "uncovered territory" framing) — if time permits
+
+**By June 8 — convening series launch**:
+- **O-3** (status pill — needed once cohort is real)
+- **O-6** (external-origin chip — NBS expert ramps up mid-June)
+- **O-7** (territory report — community-facing scorecard for first workshop)
+- **O-10** (bairro click → territory panel) — supports recruitment between workshops
+
+**Post-June, July:**
+- **O-5** (alternates list — kicks in if a priority CBO drops)
+- **O-9 Phase B** (FUNRIGS + MDBs)
+- **O-12** (sector tabs — once Government + Funding views have content)
+- **O-13** (public toggle — once a public-view surface exists)
+
+---
+
+## Out of scope for this backlog
+
+- The public-facing surface itself (`/public/...`) — that's parent backlog P-9 / P-11.
+- Multi-coordinator support (Antônia 1:03:15 — *"share with 3-4 more Palafita coordinators"*). For the pilot, single-coordinator (Julia) is fine. Multi-coordinator = Phase 3 multi-tenant auth.
+- Bankability scoring logic — lives in `cbo-schema.ts` / agent, not on this page. This page just shows the result.
+- Replacing the chat-based CBO flow — coordinator stays on `/orchestrator`, CBOs stay on `/cbo-profile`.
+
+## Sources
+
+- `_meetings/2026-04-08-cougar---vila-flores-open-earth-foundation.md`
+- `_meetings/2026-04-16-cougar---vila-flores-oef.md` (most asks above)
+- `_meetings/2026-04-29-cougar-biweekly-oef-internal-check-in.md` (status pill, external pipeline)
+- `_meetings/2026-05-05-cougar-pxg-oef-biweekly.md` (alternates, NBS expert timing)
+- `knowledge/runs/2026-04-16-villa-flores-demo/backlog.md` (P-1..P-22)
+- `./backlog.md` (parent backlog, P-23..P-27)
+- `client/src/core/pages/orchestrator-landing.tsx` (current state)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -63,6 +63,7 @@ import type { LayerType } from '../shared/geospatial-schema';
 import { registerAgentRoutes } from './routes/agentRoutes';
 import { registerConceptNoteRoutes } from './routes/conceptNoteRoutes';
 import { registerCboRoutes } from './routes/cboRoutes';
+import { registerCohortRoutes } from './routes/cohortRoutes';
 import { registerUploadRoutes } from './routes/uploadRoutes';
 import { registerTileProxyRoutes } from './routes/tileProxyRoutes';
 import { registerKnowledgeRoutes } from './routes/knowledgeRoutes';
@@ -1993,6 +1994,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerKnowledgeRoutes(app);
   registerConceptNoteRoutes(app);
   registerCboRoutes(app);
+  registerCohortRoutes(app);
   registerUploadRoutes(app);
   registerTileProxyRoutes(app);
   registerOverpassRoutes(app);

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,0 +1,144 @@
+import type { Express, Request, Response } from 'express';
+import { eq, and } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { db } from '../db';
+import {
+  cohorts,
+  cohortMembers,
+  DEFAULT_WORKSHOPS,
+  type CohortSettings,
+  type WorkshopConfig,
+} from '@shared/cohort-schema';
+
+// Slug-as-secret: 24 chars of url-safe nanoid. ~143 bits of entropy; fine for
+// a 10-CBO pilot where the only attacker is a coordinator's WhatsApp typo.
+const slug = () => nanoid(24);
+
+async function findCohortByCoordinatorSlug(coordinatorSlug: string) {
+  const [c] = await db.select().from(cohorts).where(eq(cohorts.coordinatorSlug, coordinatorSlug)).limit(1);
+  return c;
+}
+
+async function findMemberBySlug(memberSlug: string) {
+  const [m] = await db.select().from(cohortMembers).where(eq(cohortMembers.memberSlug, memberSlug)).limit(1);
+  return m;
+}
+
+export function registerCohortRoutes(app: Express): void {
+  // Create cohort
+  app.post('/api/cohort', async (req: Request, res: Response) => {
+    const { name } = req.body ?? {};
+    const coordinatorSlug = slug();
+    const [created] = await db.insert(cohorts).values({
+      coordinatorSlug,
+      name: name || 'Untitled cohort',
+      settings: { workshops: DEFAULT_WORKSHOPS },
+    }).returning();
+    res.json({ cohort: created });
+  });
+
+  // Read cohort + members
+  app.get('/api/cohort/:coordinatorSlug', async (req: Request, res: Response) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    res.json({ cohort, members });
+  });
+
+  // Invite a CBO
+  app.post('/api/cohort/:coordinatorSlug/invite', async (req: Request, res: Response) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+
+    const { orgName, neighborhood, role, origin } = req.body ?? {};
+    if (!orgName) return res.status(400).json({ error: 'orgName required' });
+
+    const memberSlug = slug();
+    const [member] = await db.insert(cohortMembers).values({
+      cohortId: cohort.id,
+      memberSlug,
+      orgName,
+      neighborhood: neighborhood || null,
+      role: role === 'alternate' ? 'alternate' : 'priority',
+      origin: origin === 'external' ? 'external' : 'cohort',
+      unlockedPhases: [1],
+    }).returning();
+    res.json({ member });
+  });
+
+  // Update workshops
+  app.patch('/api/cohort/:coordinatorSlug/workshops', async (req: Request, res: Response) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+
+    const incoming = req.body?.workshops;
+    if (!Array.isArray(incoming)) return res.status(400).json({ error: 'workshops must be an array' });
+
+    const workshops: WorkshopConfig[] = incoming.map((w: any) => ({
+      name: String(w.name ?? ''),
+      date: w.date ? String(w.date) : null,
+      unlocksPhase: Number(w.unlocksPhase) || 1,
+    }));
+    const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
+    await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
+    res.json({ ok: true });
+  });
+
+  // Unlock a phase — for one member, multiple members, or 'all'
+  app.patch('/api/cohort/:coordinatorSlug/unlock', async (req: Request, res: Response) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+
+    const { memberIds, phase } = req.body ?? {};
+    const phaseNum = Number(phase);
+    if (!phaseNum || phaseNum < 1 || phaseNum > 7) return res.status(400).json({ error: 'invalid phase' });
+
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const targets = memberIds === 'all'
+      ? members
+      : members.filter(m => Array.isArray(memberIds) && memberIds.includes(m.id));
+
+    for (const m of targets) {
+      const current = Array.isArray(m.unlockedPhases) ? m.unlockedPhases : [1];
+      if (current.includes(phaseNum)) continue;
+      const next = [...current, phaseNum].sort((a, b) => a - b);
+      await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
+    }
+    res.json({ ok: true, updated: targets.length });
+  });
+
+  // Member-facing read (no auth beyond knowing the slug)
+  app.get('/api/cbo-member/:memberSlug', async (req: Request, res: Response) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) return res.status(404).json({ error: 'member not found' });
+    res.json({
+      id: member.id,
+      orgName: member.orgName,
+      neighborhood: member.neighborhood,
+      unlockedPhases: member.unlockedPhases ?? [1],
+      cboStateId: member.cboStateId,
+    });
+  });
+
+  // CBO pushes a snapshot of its current progress so the orchestrator can show it.
+  app.patch('/api/cbo-member/:memberSlug/snapshot', async (req: Request, res: Response) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) return res.status(404).json({ error: 'member not found' });
+
+    const {
+      phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
+    } = req.body ?? {};
+
+    await db.update(cohortMembers).set({
+      cboStateId: cboStateId ?? member.cboStateId ?? null,
+      startedAt: member.startedAt ?? new Date(),
+      snapshotPhase: typeof phase === 'number' ? phase : member.snapshotPhase,
+      snapshotSectionsComplete: typeof sectionsComplete === 'number' ? sectionsComplete : member.snapshotSectionsComplete,
+      snapshotMaturityScore: typeof maturityScore === 'number' ? maturityScore : member.snapshotMaturityScore,
+      snapshotFlagsMet: typeof flagsMet === 'number' ? flagsMet : member.snapshotFlagsMet,
+      snapshotIntervention: typeof intervention === 'string' ? intervention : member.snapshotIntervention,
+      snapshotUpdatedAt: new Date(),
+    }).where(eq(cohortMembers.id, member.id));
+    res.json({ ok: true });
+  });
+}

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -1,0 +1,62 @@
+// Cohort schema — orchestrator-managed groups of CBOs (Vila Flores pilot).
+// Slug-as-secret auth: coordinator has one slug, each invited CBO has another.
+// Workshop cadence lives in `cohort.settings` JSON; data layer holds only
+// `unlockedPhases` per member. See knowledge/runs/2026-05-14-cougar-backlog-refresh/
+// foundation-block-plan.md for the full design.
+
+import { sql } from 'drizzle-orm';
+import { pgTable, text, varchar, jsonb, timestamp, integer } from 'drizzle-orm/pg-core';
+
+export type WorkshopConfig = {
+  name: string;       // "Workshop 1"
+  date: string | null; // ISO date or null if unscheduled
+  unlocksPhase: number; // which CBO phase this workshop unlocks (1..5)
+};
+
+export type CohortSettings = {
+  workshops: WorkshopConfig[];
+};
+
+export const cohorts = pgTable('cohorts', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  coordinatorSlug: text('coordinator_slug').notNull().unique(),
+  name: text('name').notNull(),
+  settings: jsonb('settings').$type<CohortSettings>().default({ workshops: [] }),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const cohortMembers = pgTable('cohort_members', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  cohortId: varchar('cohort_id').notNull(),
+  memberSlug: text('member_slug').notNull().unique(),
+  // CBO state ID — links to the file-backed CBO profile (`knowledge/runs/cbo-<id>/`)
+  cboStateId: text('cbo_state_id'),
+  orgName: text('org_name').notNull(),
+  neighborhood: text('neighborhood'),
+  role: text('role').$type<'priority' | 'alternate'>().default('priority'),
+  origin: text('origin').$type<'cohort' | 'external'>().default('cohort'),
+  unlockedPhases: jsonb('unlocked_phases').$type<number[]>().default([1]),
+  invitedAt: timestamp('invited_at').defaultNow(),
+  startedAt: timestamp('started_at'),
+  // Inlined snapshot — orchestrator reads from these; CBO page pushes updates.
+  snapshotPhase: integer('snapshot_phase'),
+  snapshotSectionsComplete: integer('snapshot_sections_complete'),
+  snapshotMaturityScore: integer('snapshot_maturity_score'),
+  snapshotFlagsMet: integer('snapshot_flags_met'),
+  snapshotIntervention: text('snapshot_intervention'),
+  snapshotUpdatedAt: timestamp('snapshot_updated_at'),
+});
+
+export type Cohort = typeof cohorts.$inferSelect;
+export type CohortMember = typeof cohortMembers.$inferSelect;
+
+// Default workshops seed — Vila Flores 6-meeting convening series.
+// W6 is the wrap-up; doesn't unlock new content (unlocksPhase = 5 = no-op).
+export const DEFAULT_WORKSHOPS: WorkshopConfig[] = [
+  { name: 'Workshop 1 — Who We Are', date: null, unlocksPhase: 1 },
+  { name: 'Workshop 2 — Where We Work', date: null, unlocksPhase: 2 },
+  { name: 'Workshop 3 — What We Build', date: null, unlocksPhase: 3 },
+  { name: 'Workshop 4 — What We Need', date: null, unlocksPhase: 4 },
+  { name: 'Workshop 5 — Results & Evidence', date: null, unlocksPhase: 5 },
+  { name: 'Workshop 6 — Wrap-up & Review', date: null, unlocksPhase: 5 },
+];

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -7,3 +7,4 @@ export * from './block-schemas';
 export * from './sample-constants';
 export * from './models/chat';
 export * from './knowledge-schema';
+export * from './cohort-schema';


### PR DESCRIPTION
## Summary

Replaces hardcoded `DEMO_PROJECTS` on `/orchestrator` with a server-backed cohort the coordinator can grow (invite CBOs) and gate (per-CBO + bulk phase unlocks tied to the workshop cadence). Ships **O-14 + O-1 + O-2 + O-4** from the orchestrator-page backlog as one coherent foundation block.

Targets the **May 20 Vila Flores refinement session** with Julia, ahead of the **June 8 convening series launch**.

## What's in

- **2 new Drizzle tables** (`cohorts`, `cohort_members`) — slug-as-secret auth, no login. Coordinator and each CBO have separate slugs.
- **7 endpoints** under `/api/cohort` and `/api/cbo-member` (create, read, invite, workshops, unlock, member-read, snapshot-push).
- **`useCohort()` hook** with sample-mode fallback that reshapes `DEMO_PROJECTS` into the same `CohortMember` shape — single render path, no branching in the page.
- **Orchestrator page**: cohort header bar (mode banner + Invite / Create / Load / Copy-my-link), workshop cadence strip seeded with the 6-meeting Vila Flores series, per-card "Unlock next phase" action, per-workshop "Unlock for cohort" bulk action.
- **CBO profile**: reads `?cbo=<memberSlug>`, fetches `unlockedPhases`, renders locked phases with a 🔒 + tooltip, pushes phase + maturity snapshots so the orchestrator reflects progress without polling. Re-fetches unlock state on window focus so coordinator changes propagate.

## Out of scope (parked for next blocks)

- O-3 status pill, O-5 alternates list, O-6 external-origin chip, O-7 territory report — next block.
- Map intelligence (O-8 through O-11) — separate block.
- Sector tabs (O-12), public toggle (O-13) — later in the quarter.
- Server-side enforcement of `[SKIP TO phase:X]` — client-side guard only for the pilot; flagged P1 follow-up.

## Plan & backlog

- `knowledge/runs/2026-05-14-cougar-backlog-refresh/foundation-block-plan.md` — full /refine output for this PR
- `knowledge/runs/2026-05-14-cougar-backlog-refresh/orchestrator-page-backlog.md` — the 14-item page-scoped backlog this block is the first slice of
- `knowledge/runs/2026-05-14-cougar-backlog-refresh/backlog.md` — parent backlog refresh consolidating April 21 / April 29 / May 5 meetings

## Test plan

- [ ] `npm run db:push` on Replit deployment — confirm `cohorts` + `cohort_members` tables created
- [ ] Visit `/orchestrator` with no slug → sample mode renders today's 4-CBO demo unchanged (May 25 stakeholder tour path)
- [ ] Click "Create cohort" → coordinator slug stored in localStorage → page re-renders in live mode with empty members
- [ ] "Invite CBO" → enter name + neighborhood → share link copied to clipboard
- [ ] Open invited link in incognito → `/cbo-profile?cbo=<slug>` → only Phase 1 unlocked, Phases 2–5 show 🔒 with tooltip
- [ ] Coordinator clicks "Unlock for cohort" on Workshop 2 row → switch to invited tab, refocus window → Phase 2 unlocks
- [ ] CBO advances a phase → orchestrator card reflects new phase + section count on next refresh
- [ ] "Copy my link" → paste into a fresh browser → cohort loads via `?coord=<slug>` URL param

🤖 Generated with [Claude Code](https://claude.com/claude-code)