### PR TITLE
fix: wrap cohort route handlers so DB errors don't crash the server

### DIFF
--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,5 +1,5 @@
-import type { Express, Request, Response } from 'express';
-import { eq, and } from 'drizzle-orm';
+import type { Express, Request, Response, RequestHandler } from 'express';
+import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import {
@@ -14,6 +14,20 @@ import {
 // a 10-CBO pilot where the only attacker is a coordinator's WhatsApp typo.
 const slug = () => nanoid(24);
 
+// Wrap async handlers so a thrown DB error becomes a 500 response instead of
+// an unhandled promise rejection that crashes the Node process. (Node 20
+// terminates on unhandled rejections by default; without this, a missing
+// table or a transient DB hiccup takes the whole server down.)
+const wrap = (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler => async (req, res, next) => {
+  try {
+    await fn(req, res);
+  } catch (err: any) {
+    console.error('[cohort] handler error', err);
+    if (res.headersSent) return next(err);
+    res.status(500).json({ error: err?.message || 'internal error', code: err?.code });
+  }
+};
+
 async function findCohortByCoordinatorSlug(coordinatorSlug: string) {
   const [c] = await db.select().from(cohorts).where(eq(cohorts.coordinatorSlug, coordinatorSlug)).limit(1);
   return c;
@@ -26,7 +40,7 @@ async function findMemberBySlug(memberSlug: string) {
 
 export function registerCohortRoutes(app: Express): void {
   // Create cohort
-  app.post('/api/cohort', async (req: Request, res: Response) => {
+  app.post('/api/cohort', wrap(async (req, res) => {
     const { name } = req.body ?? {};
     const coordinatorSlug = slug();
     const [created] = await db.insert(cohorts).values({
@@ -35,23 +49,23 @@ export function registerCohortRoutes(app: Express): void {
       settings: { workshops: DEFAULT_WORKSHOPS },
     }).returning();
     res.json({ cohort: created });
-  });
+  }));
 
   // Read cohort + members
-  app.get('/api/cohort/:coordinatorSlug', async (req: Request, res: Response) => {
+  app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     res.json({ cohort, members });
-  });
+  }));
 
   // Invite a CBO
-  app.post('/api/cohort/:coordinatorSlug/invite', async (req: Request, res: Response) => {
+  app.post('/api/cohort/:coordinatorSlug/invite', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const { orgName, neighborhood, role, origin } = req.body ?? {};
-    if (!orgName) return res.status(400).json({ error: 'orgName required' });
+    if (!orgName) { res.status(400).json({ error: 'orgName required' }); return; }
 
     const memberSlug = slug();
     const [member] = await db.insert(cohortMembers).values({
@@ -64,15 +78,15 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: [1],
     }).returning();
     res.json({ member });
-  });
+  }));
 
   // Update workshops
-  app.patch('/api/cohort/:coordinatorSlug/workshops', async (req: Request, res: Response) => {
+  app.patch('/api/cohort/:coordinatorSlug/workshops', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const incoming = req.body?.workshops;
-    if (!Array.isArray(incoming)) return res.status(400).json({ error: 'workshops must be an array' });
+    if (!Array.isArray(incoming)) { res.status(400).json({ error: 'workshops must be an array' }); return; }
 
     const workshops: WorkshopConfig[] = incoming.map((w: any) => ({
       name: String(w.name ?? ''),
@@ -82,16 +96,16 @@ export function registerCohortRoutes(app: Express): void {
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true });
-  });
+  }));
 
   // Unlock a phase — for one member, multiple members, or 'all'
-  app.patch('/api/cohort/:coordinatorSlug/unlock', async (req: Request, res: Response) => {
+  app.patch('/api/cohort/:coordinatorSlug/unlock', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const { memberIds, phase } = req.body ?? {};
     const phaseNum = Number(phase);
-    if (!phaseNum || phaseNum < 1 || phaseNum > 7) return res.status(400).json({ error: 'invalid phase' });
+    if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
 
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     const targets = memberIds === 'all'
@@ -105,12 +119,12 @@ export function registerCohortRoutes(app: Express): void {
       await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
     }
     res.json({ ok: true, updated: targets.length });
-  });
+  }));
 
   // Member-facing read (no auth beyond knowing the slug)
-  app.get('/api/cbo-member/:memberSlug', async (req: Request, res: Response) => {
+  app.get('/api/cbo-member/:memberSlug', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) return res.status(404).json({ error: 'member not found' });
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
     res.json({
       id: member.id,
       orgName: member.orgName,
@@ -118,12 +132,12 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: member.unlockedPhases ?? [1],
       cboStateId: member.cboStateId,
     });
-  });
+  }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.
-  app.patch('/api/cbo-member/:memberSlug/snapshot', async (req: Request, res: Response) => {
+  app.patch('/api/cbo-member/:memberSlug/snapshot', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) return res.status(404).json({ error: 'member not found' });
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
 
     const {
       phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
@@ -140,5 +154,5 @@ export function registerCohortRoutes(app: Express): void {
       snapshotUpdatedAt: new Date(),
     }).where(eq(cohortMembers.id, member.id));
     res.json({ ok: true });
-  });
+  }));
 }


### PR DESCRIPTION
## Summary

A missing table (before `npm run db:push` runs) or any transient DB error inside the new cohort async handlers was bubbling up as an unhandled promise rejection. Node 20 terminates the process on unhandled rejections by default, so the entire Express server died and every subsequent request — including pre-existing routes like `/api/sample/init` — returned 502 from the Replit proxy.

Tracked it down from a real workspace log: `error: relation "cohorts" does not exist` thrown from `/api/cohort` POST → process exit → every route 502s.

Wraps every handler in `cohortRoutes.ts` with a small `wrap()` helper that catches and returns `500 { error, code }`. PG error codes (like `42P01` for missing relation) now surface in the response so the browser shows what's wrong instead of a generic 502.

## Why this is a separate PR

Per the new-PR-per-change rule. Originally pushed onto #130 by mistake; reverted there and reopened here against `feat/orchestrator-foundation` as base.

## Test plan

- [ ] Without running `npm run db:push` first → hit `POST /api/cohort` → expect `500 { error: "relation \"cohorts\" does not exist", code: "42P01" }`, server stays up
- [ ] Run `npm run db:push` → hit `POST /api/cohort` again → expect `200` with new cohort

🤖 Generated with [Claude Code](https://claude.com/claude-code)