### PR TITLE
polish(cbo): premium welcome + friendly progress + mobile layout (rebased)

### DIFF
--- a/client/src/core/components/cbo/CboProgress.tsx
+++ b/client/src/core/components/cbo/CboProgress.tsx
@@ -1,0 +1,139 @@
+import { useTranslation } from 'react-i18next';
+import { Check, Lock } from 'lucide-react';
+import {
+  Popover, PopoverContent, PopoverTrigger,
+} from '@/core/components/ui/popover';
+import type { WorkshopConfig } from '@shared/cohort-schema';
+
+// ---------------------------------------------------------------------------
+// CboProgress — friendly progress display that replaces the
+// `1 · 2 · 3a · 3b · 3c · 4 · 5` developer strip with a calm five-segment bar
+// + a "Section X of 5" caption. Locked segments are tappable on mobile and
+// open a Popover explaining when the coordinator will unlock them.
+// ---------------------------------------------------------------------------
+
+type Phase = { num: 1 | 2 | 3 | 4 | 5; key: string };
+
+const PHASES: Phase[] = [
+  { num: 1, key: 'who' },
+  { num: 2, key: 'where' },
+  { num: 3, key: 'building' },
+  { num: 4, key: 'needs' },
+  { num: 5, key: 'results' },
+];
+
+export function CboProgress({
+  currentPhase,
+  unlockedPhases,
+  workshops,
+  onJumpToPhase,
+}: {
+  /** Numeric phase 1..5 (we collapse sub-phases 3a/b/c into 3). */
+  currentPhase: number;
+  unlockedPhases: number[];
+  workshops: WorkshopConfig[];
+  /** Called when the user taps an unlocked phase segment to navigate there. */
+  onJumpToPhase: (phaseNum: number) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const currentLabel = t(`cbo.progress.phase.${PHASES[Math.max(0, Math.min(4, currentPhase - 1))].key}`, {
+    defaultValue: {
+      who: 'Who you are',
+      where: 'Where you work',
+      building: 'What you build',
+      needs: 'What you need',
+      results: 'Results & evidence',
+    }[PHASES[Math.max(0, Math.min(4, currentPhase - 1))].key],
+  });
+
+  return (
+    <div className="space-y-1.5">
+      {/* Caption row */}
+      <div className="flex items-center justify-between gap-2 text-[11px]">
+        <span className="text-muted-foreground">
+          {t('cbo.progress.sectionOf', {
+            defaultValue: `Section ${currentPhase} of 5`,
+            current: currentPhase,
+            total: 5,
+          })}
+          {' · '}
+          <span className="text-foreground/85 font-medium">{currentLabel}</span>
+        </span>
+      </div>
+
+      {/* Segments */}
+      <div className="flex items-center gap-1">
+        {PHASES.map((p) => {
+          const isCompleted = p.num < currentPhase;
+          const isActive = p.num === currentPhase;
+          const isUnlocked = unlockedPhases.includes(p.num);
+          const segmentLabel = t(`cbo.progress.phase.${p.key}`, {
+            defaultValue: {
+              who: 'Who you are',
+              where: 'Where you work',
+              building: 'What you build',
+              needs: 'What you need',
+              results: 'Results & evidence',
+            }[p.key],
+          });
+
+          // Color tokens — emerald gradient ⇒ muted ⇒ locked.
+          const bg =
+            isCompleted ? 'bg-emerald-500'
+            : isActive ? 'bg-emerald-400'
+            : isUnlocked ? 'bg-foreground/15'
+            : 'bg-foreground/8';
+          const ring = isActive ? 'ring-2 ring-emerald-500/30' : '';
+
+          if (!isUnlocked) {
+            const workshop = workshops.find(w => w.unlocksPhase === p.num);
+            const workshopDate = workshop?.date
+              ? new Date(workshop.date).toLocaleDateString(isPt ? 'pt-BR' : 'en-US', { weekday: 'long', day: 'numeric', month: 'short' })
+              : null;
+            return (
+              <Popover key={p.num}>
+                <PopoverTrigger asChild>
+                  <button
+                    className={`flex-1 h-1.5 rounded-full ${bg} relative group cursor-help`}
+                    aria-label={`Phase ${p.num} locked`}
+                    data-testid={`cbo-progress-locked-${p.num}`}
+                  >
+                    <Lock className="absolute -top-3 left-1/2 -translate-x-1/2 w-2.5 h-2.5 text-foreground/30" strokeWidth={2.5} />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent side="top" align="center" className="w-[260px] text-xs">
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground/90">{segmentLabel}</p>
+                    <p className="text-muted-foreground">
+                      {workshop
+                        ? t('cbo.progress.lockedWithWorkshop', {
+                            defaultValue: `Opens after ${workshop.name}${workshopDate ? ` · ${workshopDate}` : ''}`,
+                            workshop: workshop.name,
+                            date: workshopDate ?? '',
+                          })
+                        : t('cbo.progress.lockedNoWorkshop', { defaultValue: 'Your coordinator will open this section.' })}
+                    </p>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            );
+          }
+
+          return (
+            <button
+              key={p.num}
+              className={`flex-1 h-1.5 rounded-full ${bg} ${ring} transition-all hover:opacity-80 ${isCompleted ? 'flex items-center justify-center' : ''}`}
+              onClick={() => onJumpToPhase(p.num)}
+              aria-label={`Go to phase ${p.num} (${segmentLabel})`}
+              data-testid={`cbo-progress-unlocked-${p.num}`}
+              title={segmentLabel}
+            >
+              {isCompleted && <Check className="w-2 h-2 text-white" strokeWidth={3} />}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -1,0 +1,169 @@
+import { useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
+import { Calendar, Clock, Leaf, Sprout } from 'lucide-react';
+import { Button } from '@/core/components/ui/button';
+import type { WorkshopConfig } from '@shared/cohort-schema';
+
+// ---------------------------------------------------------------------------
+// CBO welcome screen — the first thing a community leader sees after tapping
+// the invite link from WhatsApp. Aims to feel calm, considered, in their
+// language. No platform chrome, no chat yet. One job: build confidence and
+// invite them to start.
+// ---------------------------------------------------------------------------
+export function CboWelcome({
+  orgName,
+  neighborhood,
+  cohortName,
+  nextWorkshop,
+  unlockedPhases,
+  onStart,
+  onResume,
+  hasExistingProgress,
+}: {
+  orgName: string;
+  neighborhood: string | null;
+  cohortName: string | null;
+  nextWorkshop: WorkshopConfig | null;
+  unlockedPhases: number[];
+  onStart: () => void;
+  onResume: () => void;
+  hasExistingProgress: boolean;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const phasesUnlockedCount = unlockedPhases.length;
+
+  const workshopDateLabel = nextWorkshop?.date
+    ? new Date(nextWorkshop.date).toLocaleDateString(isPt ? 'pt-BR' : 'en-US', {
+        weekday: 'long', day: 'numeric', month: 'long',
+      })
+    : null;
+
+  return (
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
+      {/* Top bar — quiet brand mark, no other chrome */}
+      <header className="px-5 sm:px-8 py-5 flex items-center gap-2 text-emerald-700 dark:text-emerald-400">
+        <Leaf className="w-4 h-4" strokeWidth={1.75} />
+        <span className="text-xs font-medium uppercase tracking-[0.18em]">
+          {t('cbo.welcome.brand', { defaultValue: 'COUGAR · Vila Flores' })}
+        </span>
+      </header>
+
+      {/* Hero */}
+      <main className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full px-5 sm:px-8 py-8">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+          className="space-y-7"
+        >
+          {/* Greeting */}
+          <div className="space-y-2">
+            <p className="text-sm text-emerald-700/80 dark:text-emerald-300/80 font-medium">
+              {t('cbo.welcome.greeting', { defaultValue: 'Olá,' })}
+            </p>
+            <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight text-foreground">
+              {orgName}
+            </h1>
+            {neighborhood && (
+              <p className="text-sm text-muted-foreground">
+                {t('cbo.welcome.neighborhood', { defaultValue: 'from {{n}}', n: neighborhood })}
+              </p>
+            )}
+          </div>
+
+          {/* The invitation framing */}
+          <div className="space-y-3 text-foreground/85 leading-relaxed">
+            <p className="text-base">
+              {t('cbo.welcome.invitationLead', {
+                defaultValue: cohortName
+                  ? `You've been invited to the ${cohortName} platform — a quiet space to share what your organization does, where you work, and what you need to move your project forward.`
+                  : "You've been invited to a quiet space to share what your organization does, where you work, and what you need to move your project forward.",
+                cohort: cohortName ?? '',
+              })}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {t('cbo.welcome.invitationFraming', {
+                defaultValue: "We'll build this together, one part at a time. Each section opens after the workshop where we cover it.",
+              })}
+            </p>
+          </div>
+
+          {/* Next workshop card */}
+          {nextWorkshop && (
+            <motion.div
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15 }}
+              className="rounded-xl border border-emerald-200/60 bg-white/70 dark:border-emerald-900/40 dark:bg-emerald-950/30 px-4 py-3 backdrop-blur-sm"
+            >
+              <p className="text-[10px] uppercase tracking-wider text-emerald-700/70 dark:text-emerald-400/70 font-semibold mb-1.5">
+                {t('cbo.welcome.nextWorkshopLabel', { defaultValue: 'Next workshop' })}
+              </p>
+              <p className="text-sm font-medium text-foreground/90">{nextWorkshop.name}</p>
+              {workshopDateLabel && (
+                <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Calendar className="w-3 h-3" />
+                  {workshopDateLabel}
+                </p>
+              )}
+            </motion.div>
+          )}
+
+          {/* Section preview — what we'll do */}
+          <div className="space-y-1.5">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+              {t('cbo.welcome.whatWeWillDoLabel', { defaultValue: "What we'll do together" })}
+            </p>
+            <ol className="space-y-1.5">
+              {[
+                { label: t('cbo.welcome.step1', { defaultValue: 'Who you are' }), unlocked: unlockedPhases.includes(1) },
+                { label: t('cbo.welcome.step2', { defaultValue: 'Where you work' }), unlocked: unlockedPhases.includes(2) },
+                { label: t('cbo.welcome.step3', { defaultValue: 'What you build' }), unlocked: unlockedPhases.includes(3) },
+                { label: t('cbo.welcome.step4', { defaultValue: 'What you need' }), unlocked: unlockedPhases.includes(4) },
+                { label: t('cbo.welcome.step5', { defaultValue: 'Results & evidence' }), unlocked: unlockedPhases.includes(5) },
+              ].map((s, i) => (
+                <li key={i} className="flex items-center gap-2.5 text-sm">
+                  <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${s.unlocked ? 'bg-emerald-500' : 'bg-foreground/15'}`} />
+                  <span className={s.unlocked ? 'text-foreground/85' : 'text-muted-foreground/60'}>{s.label}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          {/* CTA */}
+          <div className="pt-2 space-y-2">
+            <Button
+              size="lg"
+              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white rounded-full h-12 text-base font-medium shadow-sm"
+              onClick={hasExistingProgress ? onResume : onStart}
+              data-testid="button-cbo-welcome-cta"
+            >
+              {hasExistingProgress
+                ? t('cbo.welcome.ctaResume', { defaultValue: 'Continue where I left off' })
+                : t('cbo.welcome.ctaStart', { defaultValue: 'Start' })}
+            </Button>
+            {hasExistingProgress && (
+              <button
+                className="w-full text-xs text-muted-foreground hover:text-foreground/80 py-1.5"
+                onClick={onStart}
+              >
+                {t('cbo.welcome.ctaStartOver', { defaultValue: 'Or start over' })}
+              </button>
+            )}
+            <p className="flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground/70 pt-1">
+              <Clock className="w-3 h-3" />
+              {t('cbo.welcome.timeEstimate', { defaultValue: 'About 20 min total, across the workshops. Saves automatically.' })}
+            </p>
+          </div>
+        </motion.div>
+
+        {/* Soft footer */}
+        <p className="mt-12 flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground/60">
+          <Sprout className="w-3 h-3" />
+          {t('cbo.welcome.footer', { defaultValue: 'Open Earth Foundation · COUGAR pilot' })}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -1,0 +1,386 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Copy, Link as LinkIcon, MessageCircle, Plus, Users } from 'lucide-react';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from '@/core/components/ui/dialog';
+import { Button } from '@/core/components/ui/button';
+import { Input } from '@/core/components/ui/input';
+
+// ---------------------------------------------------------------------------
+// CreateCohortDialog — replaces window.prompt for "Create cohort"
+// ---------------------------------------------------------------------------
+export function CreateCohortDialog({
+  open, onOpenChange, onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (name: string) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [name, setName] = useState('Vila Flores cohort');
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    if (!name.trim()) return;
+    setBusy(true);
+    try { await onSubmit(name.trim()); onOpenChange(false); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Plus className="w-4 h-4" />
+            {t('orchestrator.cohort.createTitle', { defaultValue: 'Create cohort' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.createDesc', {
+              defaultValue: 'A cohort holds the CBOs you coordinate through one convening cycle. You\'ll get a private link to come back to.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1.5 py-2">
+          <label className="text-xs font-medium text-foreground/80">
+            {t('orchestrator.cohort.cohortName', { defaultValue: 'Cohort name' })}
+          </label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Vila Flores cohort"
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+            data-testid="input-cohort-name"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button onClick={submit} disabled={busy || !name.trim()} data-testid="button-confirm-create-cohort">
+            {busy
+              ? t('common.working', { defaultValue: 'Working…' })
+              : t('orchestrator.cohort.create', { defaultValue: 'Create cohort' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LoadCohortDialog — paste a coordinator link/slug to load an existing cohort
+// ---------------------------------------------------------------------------
+export function LoadCohortDialog({
+  open, onOpenChange, onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (slug: string) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    const cleaned = value.trim().includes('=')
+      ? value.trim().split('=').pop()!
+      : value.trim().includes('/')
+        ? value.trim().split('/').pop()!
+        : value.trim();
+    if (!cleaned) return;
+    setBusy(true);
+    try { await onSubmit(cleaned); onOpenChange(false); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <LinkIcon className="w-4 h-4" />
+            {t('orchestrator.cohort.loadTitle', { defaultValue: 'Load existing cohort' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.loadDesc', {
+              defaultValue: 'Paste your coordinator link or slug. Use this to return to your cohort from a new browser or device.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1.5 py-2">
+          <label className="text-xs font-medium text-foreground/80">
+            {t('orchestrator.cohort.coordLinkOrSlug', { defaultValue: 'Coordinator link or slug' })}
+          </label>
+          <Input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="https://…/orchestrator?coord=… or just the slug"
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+            data-testid="input-coord-slug"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button onClick={submit} disabled={busy || !value.trim()} data-testid="button-confirm-load-cohort">
+            {busy
+              ? t('common.working', { defaultValue: 'Working…' })
+              : t('orchestrator.cohort.load', { defaultValue: 'Load' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InviteCboDialog — single form for org name + neighborhood + role
+// ---------------------------------------------------------------------------
+export function InviteCboDialog({
+  open, onOpenChange, onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => Promise<{ memberSlug: string; orgName: string } | null>;
+}) {
+  const { t } = useTranslation();
+  const [orgName, setOrgName] = useState('');
+  const [neighborhood, setNeighborhood] = useState('');
+  const [role, setRole] = useState<'priority' | 'alternate'>('priority');
+  const [busy, setBusy] = useState(false);
+
+  // Reset form on close so the next open starts fresh.
+  useEffect(() => {
+    if (!open) {
+      setOrgName('');
+      setNeighborhood('');
+      setRole('priority');
+    }
+  }, [open]);
+
+  const submit = async () => {
+    if (!orgName.trim() || busy) return;
+    setBusy(true);
+    try {
+      const result = await onSubmit({
+        orgName: orgName.trim(),
+        neighborhood: neighborhood.trim() || undefined,
+        role,
+      });
+      if (result) onOpenChange(false);
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Users className="w-4 h-4" />
+            {t('orchestrator.cohort.inviteTitle', { defaultValue: 'Invite a CBO' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.inviteDesc', {
+              defaultValue: 'Adds a CBO to your cohort and generates a private link you can share. The CBO starts with Phase 1 unlocked.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.orgName', { defaultValue: 'Organization name' })}
+              <span className="text-red-600 ml-0.5">*</span>
+            </label>
+            <Input
+              value={orgName}
+              onChange={(e) => setOrgName(e.target.value)}
+              placeholder="Horta Comunitária Cascata"
+              autoFocus
+              data-testid="input-org-name"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.neighborhood', { defaultValue: 'Neighborhood (optional)' })}
+            </label>
+            <Input
+              value={neighborhood}
+              onChange={(e) => setNeighborhood(e.target.value)}
+              placeholder="Cascata"
+              onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+              data-testid="input-neighborhood"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.role', { defaultValue: 'Role in cohort' })}
+            </label>
+            <div className="flex gap-1.5">
+              {(['priority', 'alternate'] as const).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setRole(r)}
+                  className={`flex-1 text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                    role === r
+                      ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200'
+                      : 'border-foreground/10 bg-background text-foreground/70 hover:bg-foreground/5'
+                  }`}
+                  data-testid={`button-role-${r}`}
+                >
+                  {r === 'priority'
+                    ? t('orchestrator.cohort.rolePriority', { defaultValue: 'Priority' })
+                    : t('orchestrator.cohort.roleAlternate', { defaultValue: 'Alternate' })}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button onClick={submit} disabled={busy || !orgName.trim()} data-testid="button-confirm-invite">
+            {busy
+              ? t('common.working', { defaultValue: 'Working…' })
+              : t('orchestrator.cohort.inviteAndCopy', { defaultValue: 'Invite & get link' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ShareLinkDialog — generic "share this link" dialog with copy + WhatsApp
+//   - Used after an invite (audience: a CBO contact)
+//   - Used for "My link" (audience: the coordinator themselves)
+// ---------------------------------------------------------------------------
+type ShareLinkContext =
+  | { kind: 'cbo'; orgName: string }
+  | { kind: 'coordinator'; cohortName: string };
+
+export function ShareLinkDialog({
+  open, onOpenChange, url, context,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  url: string;
+  context: ShareLinkContext | null;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedMessage, setCopiedMessage] = useState(false);
+
+  // Reset copy state when dialog reopens with a new URL.
+  useEffect(() => {
+    if (open) { setCopiedLink(false); setCopiedMessage(false); }
+  }, [open, url]);
+
+  const whatsappMessage = (() => {
+    if (!context) return url;
+    if (context.kind === 'cbo') {
+      // CBO-facing greeting. Default to Portuguese for the Brazilian audience;
+      // English fallback for the demo.
+      return isPt
+        ? `Olá! 👋\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${context.orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
+        : `Hi! 👋\n\nHere's the COUGAR / Vila Flores platform link for *${context.orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
+    }
+    // Coordinator-facing — short, just for their own notes
+    return isPt
+      ? `Meu link de coordenador — ${context.cohortName}:\n${url}\n\n⚠️ Guarde este link. É a forma de voltar ao cohort em outro navegador.`
+      : `My coordinator link — ${context.cohortName}:\n${url}\n\n⚠️ Save this link. It's how you get back to the cohort from another browser.`;
+  })();
+
+  const copy = async (text: string, setCopied: (v: boolean) => void) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  };
+
+  const isCoordinatorContext = context?.kind === 'coordinator';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <LinkIcon className="w-4 h-4" />
+            {isCoordinatorContext
+              ? t('orchestrator.cohort.coordLinkTitle', { defaultValue: 'Your coordinator link' })
+              : t('orchestrator.cohort.cboLinkTitle', { defaultValue: 'Invitation ready' })}
+          </DialogTitle>
+          <DialogDescription>
+            {isCoordinatorContext
+              ? t('orchestrator.cohort.coordLinkDesc', {
+                  defaultValue: 'Save this somewhere safe. It\'s the only way back to this cohort if you switch browsers or clear cookies.',
+                })
+              : context?.kind === 'cbo'
+                ? t('orchestrator.cohort.cboLinkDesc', {
+                    defaultValue: 'Share this link with {{org}}. They\'ll land on the chat with Phase 1 unlocked.',
+                    org: context.orgName,
+                  })
+                : ''}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          {/* URL preview */}
+          <div className="rounded-md border border-foreground/10 bg-muted/50 px-3 py-2 break-all text-xs font-mono text-foreground/80">
+            {url}
+          </div>
+
+          {/* Actions */}
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant="outline"
+              onClick={() => copy(url, setCopiedLink)}
+              data-testid="button-copy-link"
+            >
+              {copiedLink ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <Copy className="w-3.5 h-3.5 mr-1.5" />}
+              {copiedLink
+                ? t('common.copied', { defaultValue: 'Copied!' })
+                : t('orchestrator.cohort.copyLink', { defaultValue: 'Copy link' })}
+            </Button>
+            <Button
+              onClick={() => copy(whatsappMessage, setCopiedMessage)}
+              data-testid="button-copy-message"
+            >
+              {copiedMessage ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <MessageCircle className="w-3.5 h-3.5 mr-1.5" />}
+              {copiedMessage
+                ? t('common.copied', { defaultValue: 'Copied!' })
+                : t('orchestrator.cohort.copyMessage', { defaultValue: 'Copy WhatsApp message' })}
+            </Button>
+          </div>
+
+          {/* Message preview */}
+          {context && (
+            <details className="text-xs text-muted-foreground">
+              <summary className="cursor-pointer select-none hover:text-foreground/80">
+                {t('orchestrator.cohort.previewMessage', { defaultValue: 'Preview message' })}
+              </summary>
+              <pre className="mt-2 whitespace-pre-wrap rounded-md border border-foreground/10 bg-muted/30 px-3 py-2 text-[11px] leading-relaxed font-sans">
+                {whatsappMessage}
+              </pre>
+            </details>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>
+            {t('common.done', { defaultValue: 'Done' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -181,22 +181,22 @@ export default function CboProfilePage() {
   // Cohort membership: if `?cbo=<memberSlug>` is in the URL, this CBO is part
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
+  const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
   const [unlockedPhases, setUnlockedPhases] = useState<number[]>([1, 2, 3, 4, 5]); // ungated by default
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const slug = params.get('cbo');
     if (!slug) return;
     setMemberSlug(slug);
-    fetch(`/api/cbo-member/${slug}`)
-      .then(r => r.ok ? r.json() : null)
-      .then(data => { if (data?.unlockedPhases) setUnlockedPhases(data.unlockedPhases); })
-      .catch(() => {});
+    const applyMember = (data: any) => {
+      if (!data) return;
+      if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
+      if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
+    };
+    fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
     // Re-fetch on focus so coordinator unlocks propagate without a hard reload.
     const onFocus = () => {
-      fetch(`/api/cbo-member/${slug}`)
-        .then(r => r.ok ? r.json() : null)
-        .then(data => { if (data?.unlockedPhases) setUnlockedPhases(data.unlockedPhases); })
-        .catch(() => {});
+      fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
     };
     window.addEventListener('focus', onFocus);
     return () => window.removeEventListener('focus', onFocus);
@@ -562,6 +562,30 @@ export default function CboProfilePage() {
               <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.startOver')}</TooltipContent></Tooltip>
             </div>
           </div>
+
+          {/* Cohort welcome banner — only when arrived via ?cbo=<slug> */}
+          {memberInfo && (
+            <div className="px-3 py-2 border-b bg-emerald-50/60 dark:bg-emerald-950/20">
+              <div className="flex items-center gap-2">
+                <Leaf className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+                <p className="text-xs leading-tight">
+                  <span className="text-muted-foreground">
+                    {t('cbo.cohortWelcomePrefix', { defaultValue: 'Welcome,' })}
+                  </span>{' '}
+                  <span className="font-semibold">{memberInfo.orgName}</span>
+                  {memberInfo.neighborhood && (
+                    <span className="text-muted-foreground"> · {memberInfo.neighborhood}</span>
+                  )}
+                </p>
+                <span className="ml-auto text-[10px] text-muted-foreground">
+                  {t('cbo.cohortPhasesUnlocked', {
+                    defaultValue: 'Phases unlocked: {{phases}}',
+                    phases: unlockedPhases.join(', '),
+                  })}
+                </span>
+              </div>
+            </div>
+          )}
 
           <div className="flex-1 overflow-y-auto p-4 space-y-3">
             {messages.length === 0 && state.phase === 0 && (

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -29,6 +29,9 @@ import {
   FileText, Loader2, RotateCcw, Star, Leaf,
   Check, Circle, AlertCircle, Pencil,
 } from 'lucide-react';
+import { CboWelcome } from '@/core/components/cbo/CboWelcome';
+import { CboProgress } from '@/core/components/cbo/CboProgress';
+import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
 const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
@@ -182,7 +185,14 @@ export default function CboProfilePage() {
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
+  const [cohortName, setCohortName] = useState<string | null>(null);
+  const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
+  const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
   const [unlockedPhases, setUnlockedPhases] = useState<number[]>([1, 2, 3, 4, 5]); // ungated by default
+  // When arriving via ?cbo=<slug>, render the premium welcome screen until
+  // the user taps Start / Continue. Flipped to true once member-fetch lands.
+  const [welcomeMode, setWelcomeMode] = useState(false);
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const slug = params.get('cbo');
@@ -192,8 +202,17 @@ export default function CboProfilePage() {
       if (!data) return;
       if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
+      if (data.cohort?.name) setCohortName(data.cohort.name);
+      if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
+      setNextWorkshop(data.nextWorkshop ?? null);
     };
-    fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
+    fetch(`/api/cbo-member/${slug}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        applyMember(data);
+        if (data) setWelcomeMode(true);
+      })
+      .catch(() => {});
     // Re-fetch on focus so coordinator unlocks propagate without a hard reload.
     const onFocus = () => {
       fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
@@ -481,6 +500,17 @@ export default function CboProfilePage() {
     setCboId(data.cboId); setState(data.state); saveId(data.cboId);
   }, [cboId]);
 
+  // Kick off the agent chat with the standard intake prompt. Hidden from the
+  // visible message stream — the agent's first response is what the user sees.
+  // Called from the welcome screen's "Start" button (cohort CBOs) and from
+  // the inline empty-state button (standalone visitors).
+  const kickoffChat = useCallback(() => {
+    const text = lang === 'pt'
+      ? "Iniciar o perfil de intervenção comunitária para Porto Alegre. Use o fluxo /cbo-intervention. Sempre use a ferramenta ask_user para perguntas de múltipla escolha. Na primeira mensagem, mencione que o usuário pode enviar documentos existentes (propostas, relatórios, planos, fotos) no chat a qualquer momento — você vai extrair as informações e preencher as seções automaticamente."
+      : "Start the CBO intervention profile for Porto Alegre. Use the /cbo-intervention skill flow. Always use the ask_user tool for multiple-choice questions. In your first message, mention that the user can drop existing documents (proposals, reports, plans, photos) into the chat at any time — you'll extract info and auto-fill sections.";
+    sendMessage(text, true);
+  }, [lang, sendMessage]);
+
   // File drop handler
   const { isDragging, isUploading, dragHandlers } = useFileDrop({
     sessionId: cboId,
@@ -494,12 +524,32 @@ export default function CboProfilePage() {
 
   if (!state) return <div className="flex items-center justify-center h-screen"><Loader2 className="w-8 h-8 animate-spin text-muted-foreground" /></div>;
 
+  // Cohort welcome screen — only when the user arrived via an invite and
+  // hasn't dismissed the welcome. Replaces the entire chrome with a calm,
+  // single-CTA first-impression. Tapping Start (or Continue) flips
+  // welcomeMode off and reveals the chat.
+  if (welcomeMode && memberInfo) {
+    const hasExistingProgress = messages.length > 0 || (state?.phase ?? 0) > 0;
+    return (
+      <CboWelcome
+        orgName={memberInfo.orgName}
+        neighborhood={memberInfo.neighborhood}
+        cohortName={cohortName}
+        nextWorkshop={nextWorkshop}
+        unlockedPhases={unlockedPhases}
+        hasExistingProgress={hasExistingProgress}
+        onStart={() => { setWelcomeMode(false); if (!hasExistingProgress) kickoffChat(); }}
+        onResume={() => setWelcomeMode(false)}
+      />
+    );
+  }
+
   return (
     <div className="h-screen flex flex-col bg-background">
       <Header />
       <div className="flex flex-1 min-h-0">
-        {/* LEFT: Chat */}
-        <div className="w-1/2 border-r flex flex-col relative" {...dragHandlers}>
+        {/* LEFT: Chat — full width on mobile, half on md+ */}
+        <div className="w-full md:w-1/2 md:border-r flex flex-col relative" {...dragHandlers}>
           {isDragging && (
             <div className="absolute inset-0 z-50 bg-green-500/10 border-2 border-dashed border-green-500 rounded-lg flex items-center justify-center backdrop-blur-sm">
               <div className="text-center">
@@ -509,51 +559,33 @@ export default function CboProfilePage() {
               </div>
             </div>
           )}
-          <div className="p-3 border-b bg-background flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link href="/sample/project/sample-ada-1"><Button variant="ghost" size="sm" className="h-7 px-2"><ArrowLeft className="w-4 h-4" /></Button></Link>
-              <div>
-                <h2 className="text-sm font-semibold flex items-center gap-1.5"><Leaf className="w-4 h-4 text-green-600" /> {t('cbo.title')}</h2>
-                <div className="flex items-center gap-1 mt-0.5">
-                  {[
-                    { label: '1', phase: 1, skip: '1' },
-                    { label: '2', phase: 2, skip: '2' },
-                    { label: '3a', phase: 3, skip: '3a' },
-                    { label: '3b', phase: 3, skip: '3b' },
-                    { label: '3c', phase: 3, skip: '3c' },
-                    { label: '4', phase: 4, skip: '4' },
-                    { label: '5', phase: 5, skip: '5' },
-                  ].map(p => {
-                    // Determine if this sub-phase is active or completed
-                    const sectionMap: Record<string, string> = { '1': 'org_profile', '2': 'intervention_site', '3a': 'intervention_type', '3b': 'impact_monitoring', '3c': 'operations_sustain', '4': 'needs_assessment', '5': 'results_evidence' };
-                    const sectionId = sectionMap[p.skip];
-                    const sectionFilled = sectionId && state.sections[sectionId as CboSectionId] && Object.keys(state.sections[sectionId as CboSectionId].fields).length > 0;
-                    const isActive = p.phase === state.phase;
-                    const isPast = p.phase < state.phase || sectionFilled;
-                    const locked = !isPhaseUnlocked(p.phase);
-                    const baseClass = `h-5 px-1.5 rounded text-[10px] font-medium transition-all ${isActive ? 'bg-green-600 text-white' : isPast ? 'bg-green-200 text-green-700' : 'bg-muted text-muted-foreground'}`;
-                    if (locked) {
-                      return (
-                        <Tooltip key={p.skip}>
-                          <TooltipTrigger asChild>
-                            <button
-                              aria-disabled
-                              className={`${baseClass} opacity-40 cursor-not-allowed`}
-                              onClick={(e) => e.preventDefault()}
-                            >🔒{p.label}</button>
-                          </TooltipTrigger>
-                          <TooltipContent>{t('cbo.phaseLocked', { defaultValue: 'Your coordinator will unlock this after the next workshop.' })}</TooltipContent>
-                        </Tooltip>
-                      );
-                    }
-                    return (
-                      <button key={p.skip} onClick={() => !isStreaming && sendMessage(`[SKIP TO phase:${p.skip}]`)}
-                        className={baseClass}
-                      >{p.label}</button>
-                    );
-                  })}
-                  <span className="text-[10px] text-muted-foreground ml-1">{filledCount}/7</span>
-                  {state.totalMaturityScore > 0 && <Badge variant="outline" className="text-[10px] h-4 ml-1">{state.totalMaturityScore}/27</Badge>}
+          <div className="px-4 py-3 border-b bg-background flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Link href="/sample/project/sample-ada-1"><Button variant="ghost" size="sm" className="h-7 px-2 shrink-0"><ArrowLeft className="w-4 h-4" /></Button></Link>
+              <div className="min-w-0 flex-1">
+                {memberInfo ? (
+                  <h2 className="text-sm font-semibold tracking-tight truncate">
+                    {memberInfo.orgName}
+                    {memberInfo.neighborhood && (
+                      <span className="ml-1.5 text-xs text-muted-foreground font-normal">· {memberInfo.neighborhood}</span>
+                    )}
+                  </h2>
+                ) : (
+                  <h2 className="text-sm font-semibold flex items-center gap-1.5">
+                    <Leaf className="w-4 h-4 text-green-600" /> {t('cbo.title')}
+                  </h2>
+                )}
+                <div className="mt-2">
+                  <CboProgress
+                    currentPhase={Math.max(1, Math.min(5, state.phase || 1))}
+                    unlockedPhases={unlockedPhases}
+                    workshops={workshops}
+                    onJumpToPhase={(p) => {
+                      if (isStreaming) return;
+                      const skip = p === 3 ? '3a' : String(p);
+                      sendMessage(`[SKIP TO phase:${skip}]`);
+                    }}
+                  />
                 </div>
               </div>
             </div>
@@ -563,41 +595,18 @@ export default function CboProfilePage() {
             </div>
           </div>
 
-          {/* Cohort welcome banner — only when arrived via ?cbo=<slug> */}
-          {memberInfo && (
-            <div className="px-3 py-2 border-b bg-emerald-50/60 dark:bg-emerald-950/20">
-              <div className="flex items-center gap-2">
-                <Leaf className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400 shrink-0" />
-                <p className="text-xs leading-tight">
-                  <span className="text-muted-foreground">
-                    {t('cbo.cohortWelcomePrefix', { defaultValue: 'Welcome,' })}
-                  </span>{' '}
-                  <span className="font-semibold">{memberInfo.orgName}</span>
-                  {memberInfo.neighborhood && (
-                    <span className="text-muted-foreground"> · {memberInfo.neighborhood}</span>
-                  )}
-                </p>
-                <span className="ml-auto text-[10px] text-muted-foreground">
-                  {t('cbo.cohortPhasesUnlocked', {
-                    defaultValue: 'Phases unlocked: {{phases}}',
-                    phases: unlockedPhases.join(', '),
-                  })}
-                </span>
-              </div>
-            </div>
-          )}
-
           <div className="flex-1 overflow-y-auto p-4 space-y-3">
             {messages.length === 0 && state.phase === 0 && (
-              <div className="text-center text-muted-foreground py-8">
-                <Leaf className="w-12 h-12 mx-auto mb-3 text-green-500" />
-                <p className="text-lg mb-2">{t('cbo.welcomeTitle')}</p>
-                <p className="text-sm mb-4">{t('cbo.welcomeSubtitle')}</p>
-                <Button className="bg-green-600 hover:bg-green-700" onClick={() => sendMessage(lang === 'pt'
-                  ? "Iniciar o perfil de intervenção comunitária para Porto Alegre. Use o fluxo /cbo-intervention. Sempre use a ferramenta ask_user para perguntas de múltipla escolha. Na primeira mensagem, mencione que o usuário pode enviar documentos existentes (propostas, relatórios, planos, fotos) no chat a qualquer momento — você vai extrair as informações e preencher as seções automaticamente."
-                  : "Start the CBO intervention profile for Porto Alegre. Use the /cbo-intervention skill flow. Always use the ask_user tool for multiple-choice questions. In your first message, mention that the user can drop existing documents (proposals, reports, plans, photos) into the chat at any time — you'll extract info and auto-fill sections.",
-                  true // hide system prompt from chat
-                )}>
+              <div className="text-center text-muted-foreground py-10 max-w-sm mx-auto">
+                <div className="inline-flex w-14 h-14 rounded-full bg-emerald-50 dark:bg-emerald-950/40 items-center justify-center mb-4">
+                  <Leaf className="w-6 h-6 text-emerald-600 dark:text-emerald-300" />
+                </div>
+                <h3 className="text-xl font-semibold tracking-tight text-foreground mb-1.5">{t('cbo.welcomeTitle')}</h3>
+                <p className="text-sm leading-relaxed mb-5">{t('cbo.welcomeSubtitle')}</p>
+                <Button
+                  className="bg-emerald-600 hover:bg-emerald-700 rounded-full px-6 h-10"
+                  onClick={kickoffChat}
+                >
                   {t('cbo.startProfile')}
                 </Button>
               </div>
@@ -717,7 +726,7 @@ export default function CboProfilePage() {
         </div>
 
         {/* RIGHT: Document / Map / Scorecard */}
-        <div className="w-1/2 flex flex-col bg-muted/30">
+        <div className="hidden md:flex w-1/2 flex-col bg-muted/30">
           <div className="border-b bg-background">
             <div className="px-4 pt-3 pb-0">
               <h2 className="text-base font-semibold">{state.orgName || t('cbo.interventionProfile')}</h2>

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -143,27 +143,58 @@ const BAND_CHIP: Record<ReturnType<typeof maturityBand>, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Map panel — CartoDB Positron tiles, one marker per CBO with coords.
-// Selected state is driven by `selectedId`; clicks and mouseovers call
-// `onSelect`, which the parent also uses to sync card hover highlighting.
+// Risk layer styling — neighborhood choropleth keyed by priorityScore from
+// `porto-alegre-neighborhood-zones.json`. Bands are derived from the
+// distribution in that file (scores ~0..2.5+); colors progress from green to
+// red so the eye lands first on the urgent recruitment targets.
+// ---------------------------------------------------------------------------
+type RiskLayers = {
+  hotspots: boolean;     // composite_hotspot raster tiles
+  recruitZones: boolean; // bairro choropleth by priorityScore
+};
+
+const PRIORITY_BANDS: Array<{ max: number; fill: string; label: string }> = [
+  { max: 0.5, fill: '#86efac', label: 'low' },        // emerald-300
+  { max: 1.0, fill: '#fde68a', label: 'medium' },     // amber-200
+  { max: 1.5, fill: '#fb923c', label: 'high' },       // orange-400
+  { max: Infinity, fill: '#ef4444', label: 'very high' }, // red-500
+];
+
+function priorityFill(score: number): string {
+  for (const band of PRIORITY_BANDS) if (score <= band.max) return band.fill;
+  return PRIORITY_BANDS[PRIORITY_BANDS.length - 1].fill;
+}
+
+// ---------------------------------------------------------------------------
+// Map panel — CartoDB Positron base + CBO markers + toggleable risk overlays
+// (composite hotspot raster, bairro choropleth). Selected state synced with
+// the right-rail cards via `selectedId` / `onSelect`.
 // ---------------------------------------------------------------------------
 function MapPanel({
   projects,
   selectedId,
   onSelect,
+  layers,
+  onBairroClick,
 }: {
   projects: CboDemoProject[];
   selectedId: string | null;
   onSelect: (id: string | null) => void;
+  layers: RiskLayers;
+  onBairroClick: (info: { name: string; primaryHazard: string; population: number; priorityScore: number }) => void;
 }) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const markersRef = useRef<Map<string, L.Marker>>(new Map());
+  const hotspotsLayerRef = useRef<L.TileLayer | null>(null);
+  const recruitLayerRef = useRef<L.GeoJSON | null>(null);
+  const neighborhoodCacheRef = useRef<any>(null);
 
-  // Keep a ref to the latest onSelect so we don't re-create the map when the
-  // parent's callback identity changes.
+  // Stable refs for callbacks so adding/removing layers doesn't remount the map.
   const onSelectRef = useRef(onSelect);
   useEffect(() => { onSelectRef.current = onSelect; }, [onSelect]);
+  const onBairroClickRef = useRef(onBairroClick);
+  useEffect(() => { onBairroClickRef.current = onBairroClick; }, [onBairroClick]);
 
   // Mount the map once.
   useEffect(() => {
@@ -215,6 +246,8 @@ function MapPanel({
       map.remove();
       mapInstanceRef.current = null;
       markersRef.current.clear();
+      hotspotsLayerRef.current = null;
+      recruitLayerRef.current = null;
     };
     // Intentionally run once; projects is stable demo data.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -229,9 +262,145 @@ function MapPanel({
     });
   }, [selectedId]);
 
+  // Toggle the hotspot raster layer.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    if (layers.hotspots && !hotspotsLayerRef.current) {
+      hotspotsLayerRef.current = L.tileLayer('/tiles/composite_hotspot/{z}/{x}/{y}.png', {
+        opacity: 0.65,
+        maxNativeZoom: 14,
+        attribution: 'OEF risk grid (250m)',
+      }).addTo(map);
+    } else if (!layers.hotspots && hotspotsLayerRef.current) {
+      map.removeLayer(hotspotsLayerRef.current);
+      hotspotsLayerRef.current = null;
+    }
+  }, [layers.hotspots]);
+
+  // Toggle the bairro choropleth (priorityScore). GeoJSON loaded lazily +
+  // cached in a ref so repeat toggles are instant.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    let cancelled = false;
+
+    if (layers.recruitZones && !recruitLayerRef.current) {
+      const buildLayer = (fc: any) => {
+        if (!mapInstanceRef.current || cancelled) return;
+        const layer = L.geoJSON(fc, {
+          style: (feat: any) => ({
+            color: '#ffffff',
+            weight: 1,
+            opacity: 0.85,
+            fillColor: priorityFill(feat?.properties?.priorityScore ?? 0),
+            fillOpacity: 0.5,
+          }),
+          onEachFeature: (feat: any, lyr: L.Layer) => {
+            const p = feat.properties || {};
+            const name: string = p.neighbourhoodName || 'Unknown';
+            const hazard: string = (p.primaryHazard || '').toString();
+            const pop: number = Math.round(p.populationTotal || 0);
+            const score: number = +p.priorityScore || 0;
+            const tipHtml = `<b>${name}</b><br/>${hazard ? hazard.toLowerCase() + ' risk · ' : ''}${pop.toLocaleString()} people<br/>priority ${score.toFixed(2)}`;
+            (lyr as L.Path).bindTooltip(tipHtml, { direction: 'top', className: 'orch-marker-tip', sticky: true });
+            lyr.on('click', () => onBairroClickRef.current({ name, primaryHazard: hazard, population: pop, priorityScore: score }));
+            lyr.on('mouseover', () => (lyr as L.Path).setStyle({ weight: 2.5, color: '#0f172a' }));
+            lyr.on('mouseout', () => (lyr as L.Path).setStyle({ weight: 1, color: '#ffffff' }));
+          },
+        });
+        layer.addTo(mapInstanceRef.current);
+        // Send the choropleth underneath the CBO markers so cards stay clickable.
+        layer.bringToBack();
+        recruitLayerRef.current = layer;
+      };
+
+      if (neighborhoodCacheRef.current) {
+        buildLayer(neighborhoodCacheRef.current);
+      } else {
+        fetch('/sample-data/porto-alegre-neighborhood-zones.json')
+          .then(r => r.ok ? r.json() : null)
+          .then(data => {
+            if (cancelled || !data?.geoJson) return;
+            neighborhoodCacheRef.current = data.geoJson;
+            buildLayer(data.geoJson);
+          })
+          .catch(() => {});
+      }
+    } else if (!layers.recruitZones && recruitLayerRef.current) {
+      map.removeLayer(recruitLayerRef.current);
+      recruitLayerRef.current = null;
+    }
+
+    return () => { cancelled = true; };
+  }, [layers.recruitZones]);
+
   return (
     <div className="relative h-[420px] md:h-full w-full overflow-hidden rounded-xl border border-foreground/10 bg-muted">
       <div ref={mapRef} className="absolute inset-0" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layer controls — small overlay top-right of the map. Toggles each risk
+// overlay; expands to show a band legend when the choropleth is on.
+// ---------------------------------------------------------------------------
+function MapLayerControls({
+  layers,
+  onChange,
+}: {
+  layers: RiskLayers;
+  onChange: (next: RiskLayers) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="absolute top-3 right-3 z-[400] rounded-lg border border-foreground/10 bg-background/90 backdrop-blur-sm px-3 py-2.5 shadow-md text-xs space-y-1.5 w-[200px]">
+      <div className="font-medium text-foreground/80 uppercase tracking-wide text-[10px]">
+        {t('orchestrator.map.riskOverlays', { defaultValue: 'Risk overlays' })}
+      </div>
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={layers.recruitZones}
+          onChange={(e) => onChange({ ...layers, recruitZones: e.target.checked })}
+          className="h-3.5 w-3.5 accent-red-500"
+          data-testid="toggle-recruit-zones"
+        />
+        <span className="text-foreground/90">
+          {t('orchestrator.map.recruitZones', { defaultValue: 'Recruit zones (bairros)' })}
+        </span>
+      </label>
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={layers.hotspots}
+          onChange={(e) => onChange({ ...layers, hotspots: e.target.checked })}
+          className="h-3.5 w-3.5 accent-amber-500"
+          data-testid="toggle-hotspots"
+        />
+        <span className="text-foreground/90">
+          {t('orchestrator.map.hotspots', { defaultValue: 'Hazard hotspots (250m)' })}
+        </span>
+      </label>
+
+      {layers.recruitZones && (
+        <div className="pt-1.5 mt-1 border-t border-foreground/5 space-y-0.5">
+          <div className="text-[9px] uppercase tracking-wide text-muted-foreground">
+            {t('orchestrator.map.priorityScore', { defaultValue: 'Priority score' })}
+          </div>
+          {PRIORITY_BANDS.map((b, i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded-sm" style={{ background: b.fill }} />
+              <span className="text-[10px] text-muted-foreground">
+                {i === 0 ? `≤ ${b.max.toFixed(1)}` :
+                 i === PRIORITY_BANDS.length - 1 ? `> ${PRIORITY_BANDS[i - 1].max.toFixed(1)}` :
+                 `${PRIORITY_BANDS[i - 1].max.toFixed(1)} – ${b.max.toFixed(1)}`}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -390,6 +559,30 @@ export default function OrchestratorLandingPage() {
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [riskLayers, setRiskLayers] = useState<RiskLayers>({ hotspots: false, recruitZones: false });
+
+  const handleBairroClick = (info: { name: string; primaryHazard: string; population: number; priorityScore: number }) => {
+    // For this PR: surface a toast describing the bairro. The follow-up PR
+    // (once #132's invite dialog is on main) wires this into a pre-filled
+    // "Invite a CBO" flow so the recruit zone → invitation step is one click.
+    const hazardLabel = info.primaryHazard
+      ? t(`orchestrator.map.hazard.${info.primaryHazard.toLowerCase()}`, {
+          defaultValue: info.primaryHazard.toLowerCase().replace(/_/g, ' + '),
+        })
+      : '';
+    toast({
+      title: t('orchestrator.map.recruitFrom', {
+        defaultValue: 'Recruit from {{name}}',
+        name: info.name,
+      }),
+      description: t('orchestrator.map.recruitDesc', {
+        defaultValue: '{{hazard}} risk · {{pop}} people · priority {{score}}',
+        hazard: hazardLabel || 'mixed',
+        pop: info.population.toLocaleString(),
+        score: info.priorityScore.toFixed(2),
+      }),
+    });
+  };
 
   const {
     mode, cohort, members, coordinatorSlug,
@@ -658,11 +851,16 @@ export default function OrchestratorLandingPage() {
         <div className="flex flex-col md:flex-row gap-4 md:gap-6 md:items-stretch">
           {/* Map column — ~60% on desktop */}
           <div className="md:flex-[3] md:min-h-[640px]">
-            <MapPanel
-              projects={projects}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
-            />
+            <div className="relative h-[420px] md:h-full w-full">
+              <MapPanel
+                projects={projects}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+                layers={riskLayers}
+                onBairroClick={handleBairroClick}
+              />
+              <MapLayerControls layers={riskLayers} onChange={setRiskLayers} />
+            </div>
           </div>
 
           {/* Card list column — ~40%, independently scrollable */}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -29,6 +29,12 @@ import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
 import { useCohort } from '@/core/hooks/useCohort';
 import type { CohortMember, WorkshopConfig } from '@shared/cohort-schema';
+import {
+  CreateCohortDialog,
+  LoadCohortDialog,
+  InviteCboDialog,
+  ShareLinkDialog,
+} from '@/core/components/orchestrator/CohortDialogs';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -408,15 +414,31 @@ export default function OrchestratorLandingPage() {
     return { sitesMapped, profilesInProgress, profilesComplete, total: projects.length };
   }, [projects]);
 
+  // Dialog state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [loadOpen, setLoadOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string>('');
+  const [shareContext, setShareContext] = useState<
+    | { kind: 'cbo'; orgName: string }
+    | { kind: 'coordinator'; cohortName: string }
+    | null
+  >(null);
+
+  const openShare = (url: string, ctx: typeof shareContext) => {
+    setShareUrl(url);
+    setShareContext(ctx);
+    setShareOpen(true);
+  };
+
   const openProject = (p: CboDemoProject) => {
     const member = memberById.get(p.id);
     if (mode === 'live' && member?.memberSlug) {
-      const url = `${window.location.origin}/cbo-profile?cbo=${member.memberSlug}`;
-      navigator.clipboard?.writeText(url).catch(() => {});
-      toast({
-        title: t('orchestrator.cohort.shareLinkCopied', { defaultValue: 'Share link copied' }),
-        description: url,
-      });
+      openShare(
+        `${window.location.origin}/cbo-profile?cbo=${member.memberSlug}`,
+        { kind: 'cbo', orgName: member.orgName }
+      );
       return;
     }
     toast({
@@ -450,44 +472,43 @@ export default function OrchestratorLandingPage() {
     toast({ title: t('orchestrator.cohort.bulkUnlocked', { defaultValue: `Phase ${phase} unlocked for cohort`, phase }) });
   };
 
-  const handleInvite = async () => {
+  const handleInviteOpen = () => {
     if (mode !== 'live') {
       toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to invite CBOs' }) });
       return;
     }
-    const orgName = window.prompt(t('orchestrator.cohort.invitePromptName', { defaultValue: 'CBO name?' }));
-    if (!orgName) return;
-    const neighborhood = window.prompt(t('orchestrator.cohort.invitePromptNeighborhood', { defaultValue: 'Neighborhood? (optional)' })) || undefined;
-    const created = await invite({ orgName, neighborhood });
-    if (created) {
-      const url = `${window.location.origin}/cbo-profile?cbo=${created.memberSlug}`;
-      navigator.clipboard?.writeText(url).catch(() => {});
-      toast({
-        title: t('orchestrator.cohort.inviteCreated', { defaultValue: 'Invitation created — link copied' }),
-        description: url,
-      });
-    }
+    setInviteOpen(true);
   };
 
-  const handleCreateCohort = async () => {
-    const name = window.prompt(t('orchestrator.cohort.createPromptName', { defaultValue: 'Cohort name?' }), 'Vila Flores cohort');
-    if (!name) return;
+  const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => {
+    const created = await invite(params);
+    if (!created) {
+      toast({ title: t('orchestrator.cohort.inviteFailed', { defaultValue: 'Could not create invitation' }) });
+      return null;
+    }
+    // Open the share dialog with the new CBO link.
+    openShare(
+      `${window.location.origin}/cbo-profile?cbo=${created.memberSlug}`,
+      { kind: 'cbo', orgName: created.orgName }
+    );
+    return { memberSlug: created.memberSlug, orgName: created.orgName };
+  };
+
+  const handleCreateSubmit = async (name: string) => {
     await createCohort(name);
     toast({ title: t('orchestrator.cohort.created', { defaultValue: 'Cohort created' }) });
   };
 
-  const handleLoadCohort = async () => {
-    const slug = window.prompt(t('orchestrator.cohort.loadPromptSlug', { defaultValue: 'Paste your coordinator link or slug' }));
-    if (!slug) return;
-    const cleaned = slug.includes('/') ? slug.trim().split('/').pop()! : slug.trim();
-    await loadCohort(cleaned);
+  const handleLoadSubmit = async (slug: string) => {
+    await loadCohort(slug);
   };
 
   const handleCopyCoordinatorLink = () => {
-    if (!coordinatorSlug) return;
-    const url = `${window.location.origin}/orchestrator?coord=${coordinatorSlug}`;
-    navigator.clipboard?.writeText(url).catch(() => {});
-    toast({ title: t('orchestrator.cohort.coordLinkCopied', { defaultValue: 'Coordinator link copied' }) });
+    if (!coordinatorSlug || !cohort) return;
+    openShare(
+      `${window.location.origin}/orchestrator?coord=${coordinatorSlug}`,
+      { kind: 'coordinator', cohortName: cohort.name }
+    );
   };
 
   const workshops: WorkshopConfig[] = cohort?.settings?.workshops ?? [];
@@ -540,17 +561,17 @@ export default function OrchestratorLandingPage() {
                     <Copy className="w-3.5 h-3.5 mr-1.5" />
                     {t('orchestrator.cohort.copyCoordLink', { defaultValue: 'My link' })}
                   </Button>
-                  <Button size="sm" onClick={handleInvite} data-testid="button-invite-cbo">
+                  <Button size="sm" onClick={handleInviteOpen} data-testid="button-invite-cbo">
                     <Plus className="w-3.5 h-3.5 mr-1.5" />
                     {t('orchestrator.cohort.invite', { defaultValue: 'Invite CBO' })}
                   </Button>
                 </>
               ) : (
                 <>
-                  <Button size="sm" variant="outline" onClick={handleLoadCohort} data-testid="button-load-cohort">
+                  <Button size="sm" variant="outline" onClick={() => setLoadOpen(true)} data-testid="button-load-cohort">
                     {t('orchestrator.cohort.loadExisting', { defaultValue: 'Load existing' })}
                   </Button>
-                  <Button size="sm" onClick={handleCreateCohort} data-testid="button-create-cohort">
+                  <Button size="sm" onClick={() => setCreateOpen(true)} data-testid="button-create-cohort">
                     <Plus className="w-3.5 h-3.5 mr-1.5" />
                     {t('orchestrator.cohort.create', { defaultValue: 'Create cohort' })}
                   </Button>
@@ -732,6 +753,12 @@ export default function OrchestratorLandingPage() {
           </BodySmall>
         </motion.div>
       </main>
+
+      {/* Cohort flow dialogs */}
+      <CreateCohortDialog open={createOpen} onOpenChange={setCreateOpen} onSubmit={handleCreateSubmit} />
+      <LoadCohortDialog open={loadOpen} onOpenChange={setLoadOpen} onSubmit={handleLoadSubmit} />
+      <InviteCboDialog open={inviteOpen} onOpenChange={setInviteOpen} onSubmit={handleInviteSubmit} />
+      <ShareLinkDialog open={shareOpen} onOpenChange={setShareOpen} url={shareUrl} context={shareContext} />
     </div>
   );
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -26,32 +26,48 @@
         "floodParks": {
           "name": "Floodable Parks",
           "description": "Public green spaces designed to store stormwater during heavy rain and return to use afterwards.",
-          "hazards": ["Flood"]
+          "hazards": [
+            "Flood"
+          ]
         },
         "bioswales": {
           "name": "Bioswales & Rain Gardens",
           "description": "Vegetated channels and small depressions that slow runoff, filter pollutants, and recharge groundwater.",
-          "hazards": ["Flood", "Water quality"]
+          "hazards": [
+            "Flood",
+            "Water quality"
+          ]
         },
         "urbanForests": {
           "name": "Urban Forests",
           "description": "Dense tree canopy that cools neighborhoods, improves air quality, and creates habitat for wildlife.",
-          "hazards": ["Heat", "Air quality"]
+          "hazards": [
+            "Heat",
+            "Air quality"
+          ]
         },
         "greenCorridors": {
           "name": "Green Corridors",
           "description": "Connected strips of vegetation that link parks and rivers, giving people and wildlife a cooler, greener path.",
-          "hazards": ["Heat", "Biodiversity"]
+          "hazards": [
+            "Heat",
+            "Biodiversity"
+          ]
         },
         "wetlands": {
           "name": "Wetland Restoration",
           "description": "Rehabilitated wetlands that buffer floods, filter water, sequester carbon, and anchor biodiversity.",
-          "hazards": ["Flood", "Biodiversity"]
+          "hazards": [
+            "Flood",
+            "Biodiversity"
+          ]
         },
         "slopeStabilize": {
           "name": "Slope Stabilization",
           "description": "Living walls, terraces, and deep-rooted plantings that reduce landslide risk on steep urban slopes.",
-          "hazards": ["Landslide"]
+          "hazards": [
+            "Landslide"
+          ]
         }
       }
     }
@@ -82,34 +98,34 @@
       "updatedAgo_one": "Updated {{count}} day ago",
       "updatedAgo_other": "Updated {{count}} days ago",
       "phase": {
-        "who":        "Phase 1 — Who We Are",
-        "where":      "Phase 2 — Where We Work",
-        "building":   "Phase 3a — What We're Building",
-        "impact":     "Phase 3b — Expected Impact",
+        "who": "Phase 1 — Who We Are",
+        "where": "Phase 2 — Where We Work",
+        "building": "Phase 3a — What We're Building",
+        "impact": "Phase 3b — Expected Impact",
         "operations": "Phase 3c — Ops & Sustainability",
-        "needs":      "Phase 4 — What We Need",
-        "results":    "Phase 5 — Results & Evidence"
+        "needs": "Phase 4 — What We Need",
+        "results": "Phase 5 — Results & Evidence"
       },
       "intervention": {
-        "notChosen":             "Intervention not yet chosen",
-        "bioswales":             "Bioswales & Rain Gardens",
-        "flood-parks":           "Floodable Parks",
-        "urban-forests":         "Urban Forests",
-        "green-corridors":       "Green Corridors",
-        "wetlands":              "Wetland Restoration",
-        "slope-stabilization":   "Slope Stabilization"
+        "notChosen": "Intervention not yet chosen",
+        "bioswales": "Bioswales & Rain Gardens",
+        "flood-parks": "Floodable Parks",
+        "urban-forests": "Urban Forests",
+        "green-corridors": "Green Corridors",
+        "wetlands": "Wetland Restoration",
+        "slope-stabilization": "Slope Stabilization"
       },
       "maturityBand": {
-        "emerging":   "Emerging",
+        "emerging": "Emerging",
         "developing": "Developing",
-        "building":   "Building",
-        "mature":     "Mature"
+        "building": "Building",
+        "mature": "Mature"
       },
       "nextAction": {
-        "reviewNeeds":           "Review Phase 4 — What We Need",
-        "completeIntervention":  "Finish choosing an intervention (Phase 3a)",
-        "publishScorecard":      "Publish maturity scorecard to funders",
-        "beginProfile":          "Begin Phase 1 — Who We Are"
+        "reviewNeeds": "Review Phase 4 — What We Need",
+        "completeIntervention": "Finish choosing an intervention (Phase 3a)",
+        "publishScorecard": "Publish maturity scorecard to funders",
+        "beginProfile": "Begin Phase 1 — Who We Are"
       },
       "toastTitle": "Prototype view",
       "toastBody": "In Phase 3, clicking here would open {{project}}'s workspace.",
@@ -628,7 +644,6 @@
     "minorContour": "Minor Contour",
     "selectCategory": "Select Intervention Category",
     "selectedInterventions": "Selected Interventions",
-    "saveInterventions": "Save Interventions",
     "clickToSelect": "Click to select interventions",
     "moreDetails": "More details",
     "scale": "Scale",
@@ -893,11 +908,7 @@
       "VANDALISM": "Vandalism",
       "PESTS_DISEASE": "Pests/Disease"
     },
-    "riskLevel": {
-      "LOW": "Low",
-      "MEDIUM": "Medium",
-      "HIGH": "High"
-    },
+    "riskLevel": "Risk Level",
     "mitigationPlaceholder": "Describe mitigation measures...",
     "noMitigation": "No mitigation defined",
     "readinessGate": "Readiness Gate",
@@ -1052,12 +1063,10 @@
     "miroPromptDesc": "Diagram prompt for Miro",
     "miroPromptCopied": "Miro prompt copied to clipboard",
     "conceptNoteDesc": "Formatted for concept notes",
-    "notAssigned": "Not assigned",
     "operatingModelLabel": "Operating Model",
     "operatorLabel": "Operator",
     "verifierLabel": "Verifier",
-    "communityRoleLabel": "Community Role",
-    "riskLevel": "Risk Level"
+    "communityRoleLabel": "Community Role"
   },
   "bm": {
     "pageTitle": "Business Model",
@@ -1805,7 +1814,41 @@
       "operations_sustain": "3c. Operations & Sustainability",
       "needs_assessment": "4. What We Need",
       "results_evidence": "5. Results & Evidence"
-    }
+    },
+    "welcome": {
+      "brand": "COUGAR · Vila Flores",
+      "greeting": "Hi,",
+      "neighborhood": "from {{n}}",
+      "invitationLead": "You've been invited to the {{cohort}} platform — a quiet space to share what your organization does, where you work, and what you need to move your project forward.",
+      "invitationFraming": "We'll build this together, one part at a time. Each section opens after the workshop where we cover it.",
+      "nextWorkshopLabel": "Next workshop",
+      "whatWeWillDoLabel": "What we'll do together",
+      "step1": "Who you are",
+      "step2": "Where you work",
+      "step3": "What you build",
+      "step4": "What you need",
+      "step5": "Results & evidence",
+      "ctaStart": "Start",
+      "ctaResume": "Continue where I left off",
+      "ctaStartOver": "Or start over",
+      "timeEstimate": "About 20 min total, across the workshops. Saves automatically.",
+      "footer": "Open Earth Foundation · COUGAR pilot"
+    },
+    "progress": {
+      "sectionOf": "Section {{current}} of {{total}}",
+      "phase": {
+        "who": "Who you are",
+        "where": "Where you work",
+        "building": "What you build",
+        "needs": "What you need",
+        "results": "Results & evidence"
+      },
+      "lockedWithWorkshop": "Opens after {{workshop}}{{date}}",
+      "lockedNoWorkshop": "Your coordinator will open this section."
+    },
+    "cohortWelcomePrefix": "Welcome,",
+    "cohortPhasesUnlocked": "Sections open: {{phases}}",
+    "phaseLocked": "Your coordinator will unlock this after the next workshop."
   },
   "mapMicroapp": {
     "layers": "Layers",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -26,32 +26,48 @@
         "floodParks": {
           "name": "Parques Alagáveis",
           "description": "Áreas verdes públicas que armazenam águas pluviais em chuvas intensas e voltam ao uso comum depois.",
-          "hazards": ["Inundação"]
+          "hazards": [
+            "Inundação"
+          ]
         },
         "bioswales": {
           "name": "Biovaletas e Jardins de Chuva",
           "description": "Canais e depressões vegetados que retardam o escoamento, filtram poluentes e recarregam o lençol.",
-          "hazards": ["Inundação", "Qualidade da água"]
+          "hazards": [
+            "Inundação",
+            "Qualidade da água"
+          ]
         },
         "urbanForests": {
           "name": "Florestas Urbanas",
           "description": "Copa arbórea densa que refresca bairros, melhora a qualidade do ar e cria habitat para fauna.",
-          "hazards": ["Calor", "Qualidade do ar"]
+          "hazards": [
+            "Calor",
+            "Qualidade do ar"
+          ]
         },
         "greenCorridors": {
           "name": "Corredores Verdes",
           "description": "Faixas conectadas de vegetação que ligam parques e rios, criando caminhos mais frescos e vivos.",
-          "hazards": ["Calor", "Biodiversidade"]
+          "hazards": [
+            "Calor",
+            "Biodiversidade"
+          ]
         },
         "wetlands": {
           "name": "Recuperação de Banhados",
           "description": "Áreas úmidas recuperadas que amortecem enchentes, filtram água, sequestram carbono e ancoram biodiversidade.",
-          "hazards": ["Inundação", "Biodiversidade"]
+          "hazards": [
+            "Inundação",
+            "Biodiversidade"
+          ]
         },
         "slopeStabilize": {
           "name": "Estabilização de Encostas",
           "description": "Muros vivos, terraços e plantios de raízes profundas que reduzem risco de deslizamentos em encostas urbanas.",
-          "hazards": ["Deslizamento"]
+          "hazards": [
+            "Deslizamento"
+          ]
         }
       }
     }
@@ -82,34 +98,34 @@
       "updatedAgo_one": "Atualizado há {{count}} dia",
       "updatedAgo_other": "Atualizado há {{count}} dias",
       "phase": {
-        "who":        "Fase 1 — Quem Somos",
-        "where":      "Fase 2 — Onde Atuamos",
-        "building":   "Fase 3a — O Que Construímos",
-        "impact":     "Fase 3b — Impacto Esperado",
+        "who": "Fase 1 — Quem Somos",
+        "where": "Fase 2 — Onde Atuamos",
+        "building": "Fase 3a — O Que Construímos",
+        "impact": "Fase 3b — Impacto Esperado",
         "operations": "Fase 3c — Operação e Sustentabilidade",
-        "needs":      "Fase 4 — O Que Precisamos",
-        "results":    "Fase 5 — Resultados e Evidências"
+        "needs": "Fase 4 — O Que Precisamos",
+        "results": "Fase 5 — Resultados e Evidências"
       },
       "intervention": {
-        "notChosen":             "Intervenção ainda não escolhida",
-        "bioswales":             "Biovaletas e Jardins de Chuva",
-        "flood-parks":           "Parques Alagáveis",
-        "urban-forests":         "Florestas Urbanas",
-        "green-corridors":       "Corredores Verdes",
-        "wetlands":              "Recuperação de Banhados",
-        "slope-stabilization":   "Estabilização de Encostas"
+        "notChosen": "Intervenção ainda não escolhida",
+        "bioswales": "Biovaletas e Jardins de Chuva",
+        "flood-parks": "Parques Alagáveis",
+        "urban-forests": "Florestas Urbanas",
+        "green-corridors": "Corredores Verdes",
+        "wetlands": "Recuperação de Banhados",
+        "slope-stabilization": "Estabilização de Encostas"
       },
       "maturityBand": {
-        "emerging":   "Inicial",
+        "emerging": "Inicial",
         "developing": "Em desenvolvimento",
-        "building":   "Em consolidação",
-        "mature":     "Consolidado"
+        "building": "Em consolidação",
+        "mature": "Consolidado"
       },
       "nextAction": {
-        "reviewNeeds":           "Revisar a Fase 4 — O Que Precisamos",
-        "completeIntervention":  "Concluir a escolha de intervenção (Fase 3a)",
-        "publishScorecard":      "Publicar o placar de maturidade para financiadores",
-        "beginProfile":          "Começar a Fase 1 — Quem Somos"
+        "reviewNeeds": "Revisar a Fase 4 — O Que Precisamos",
+        "completeIntervention": "Concluir a escolha de intervenção (Fase 3a)",
+        "publishScorecard": "Publicar o placar de maturidade para financiadores",
+        "beginProfile": "Começar a Fase 1 — Quem Somos"
       },
       "toastTitle": "Visão protótipo",
       "toastBody": "Na Fase 3, clicar aqui abriria o espaço de {{project}}.",
@@ -621,7 +637,6 @@
     "minorContour": "Contorno Secundário",
     "selectCategory": "Selecionar Categoria de Intervenção",
     "selectedInterventions": "Intervenções Selecionadas",
-    "saveInterventions": "Salvar Intervenções",
     "clickToSelect": "Clique para selecionar intervenções",
     "moreDetails": "Mais detalhes",
     "scale": "Escala",
@@ -883,11 +898,7 @@
       "VANDALISM": "Vandalismo",
       "PESTS_DISEASE": "Pragas/Doenças"
     },
-    "riskLevel": {
-      "LOW": "Baixo",
-      "MEDIUM": "Médio",
-      "HIGH": "Alto"
-    },
+    "riskLevel": "Nível de Risco",
     "mitigationPlaceholder": "Descreva medidas de mitigação...",
     "noMitigation": "Sem mitigação definida",
     "readinessGate": "Portal de Prontidão",
@@ -1040,12 +1051,10 @@
     "miroPromptDesc": "Prompt de diagrama para Miro",
     "miroPromptCopied": "Prompt Miro copiado para a área de transferência",
     "conceptNoteDesc": "Formatado para notas conceituais",
-    "notAssigned": "Não atribuído",
     "operatingModelLabel": "Modelo Operacional",
     "operatorLabel": "Operador",
     "verifierLabel": "Verificador",
-    "communityRoleLabel": "Função da Comunidade",
-    "riskLevel": "Nível de Risco"
+    "communityRoleLabel": "Função da Comunidade"
   },
   "bm": {
     "pageTitle": "Modelo de Negócio",
@@ -1784,7 +1793,41 @@
       "operations_sustain": "3c. Operação e Sustentabilidade",
       "needs_assessment": "4. O Que Precisamos",
       "results_evidence": "5. Resultados e Evidências"
-    }
+    },
+    "welcome": {
+      "brand": "COUGAR · Vila Flores",
+      "greeting": "Olá,",
+      "neighborhood": "de {{n}}",
+      "invitationLead": "Você foi convidado(a) para a plataforma do {{cohort}} — um espaço tranquilo para contar o que a sua organização faz, onde trabalha, e do que precisa para tirar o seu projeto do papel.",
+      "invitationFraming": "Vamos construir isso juntos, uma parte de cada vez. Cada seção abre depois do encontro em que tratamos do tema.",
+      "nextWorkshopLabel": "Próximo encontro",
+      "whatWeWillDoLabel": "O que vamos fazer juntos",
+      "step1": "Quem somos",
+      "step2": "Onde trabalhamos",
+      "step3": "O que construímos",
+      "step4": "O que precisamos",
+      "step5": "Resultados e evidências",
+      "ctaStart": "Começar",
+      "ctaResume": "Continuar de onde parei",
+      "ctaStartOver": "Ou começar do zero",
+      "timeEstimate": "Cerca de 20 min no total, ao longo dos encontros. Salva sozinho.",
+      "footer": "Open Earth Foundation · Piloto COUGAR"
+    },
+    "progress": {
+      "sectionOf": "Seção {{current}} de {{total}}",
+      "phase": {
+        "who": "Quem somos",
+        "where": "Onde trabalhamos",
+        "building": "O que construímos",
+        "needs": "O que precisamos",
+        "results": "Resultados e evidências"
+      },
+      "lockedWithWorkshop": "Abre depois do {{workshop}}{{date,select, ?\\` · ${date}\\`:\\`\\`}}",
+      "lockedNoWorkshop": "Seu coordenador vai abrir esta seção."
+    },
+    "cohortWelcomePrefix": "Bem-vindo(a),",
+    "cohortPhasesUnlocked": "Seções abertas: {{phases}}",
+    "phaseLocked": "Seu coordenador vai abrir esta seção depois do próximo encontro."
   },
   "mapMicroapp": {
     "layers": "Camadas",

--- a/knowledge/runs/2026-05-14-cougar-backlog-refresh/end-to-end-ux-review.md
+++ b/knowledge/runs/2026-05-14-cougar-backlog-refresh/end-to-end-ux-review.md
@@ -1,0 +1,98 @@
+# End-to-end UX review — Vila Flores pilot (2026-05-14)
+
+Walking the platform from the eyes of the two real users for the June 8 convening:
+- **Julia / Antônia** (coordinators) on a laptop, mid-workshop
+- **Sandra** (composite: a CBO leader at e.g. Horta Cascata) on her **phone**, between workshops, on patchy mobile data
+
+Goal: catch what's too technical, what's friction-heavy, what'll embarrass us in front of stakeholders on May 25, before we keep shipping features.
+
+## Critical issues
+
+### 1. The CBO page does not work on a phone
+**Severity: blocker for June 8.**
+
+`client/src/core/pages/cbo-profile.tsx` hardcodes `w-1/2 border-r` on both the chat panel (line 502) and the document panel (line 696). On a 375px-wide iPhone viewport that's two 180-pixel columns side-by-side — the chat is unusable, the document is unreadable. Julia said April 16: *"the technological tools sometimes are a problem for the communities — we have to think about something accessible for them."* Sandra opens her WhatsApp link, sees this, closes the tab.
+
+**Fix**: collapse to single-column on `sm` and below; surface a "see my profile" sheet/drawer for the right panel. ~2h.
+
+### 2. CBO sees a developer's progress UI, not their own
+The chat header (line 519+) shows `1 · 2 · 3a · 3b · 3c · 4 · 5 · 0/7` plus a maturity score chip `0/27`. This is the schema. For Sandra it's gibberish.
+
+**Fix**: replace the strip with a friendly progress chunk — *"You're 30% done. 3 sections complete. Next up: where you work."* Keep the schema strip behind a developer-mode toggle (or just remove from prod). The 🔒 we added means "locked" but adjacent to `3a · 3b · 3c · 4 · 5` is more confusing, not less. ~2h.
+
+### 3. Tooltips don't exist on touchscreens
+The locked-phase 🔒 button uses `<Tooltip>` (TooltipContent) to explain *"Your coordinator will unlock this after the next workshop."* That tooltip only fires on hover, which doesn't exist on phones. Sandra taps the lock and nothing happens.
+
+**Fix**: tap on locked phase opens a small bottom sheet / popover explaining the lock + showing the next workshop date pulled from the cohort settings. ~1h.
+
+## Significant friction
+
+### 4. The invite loop is 10× manual
+Julia has to: open dialog → type name → type bairro → submit → share dialog → click "Copy WhatsApp message" → switch to WhatsApp → find the CBO contact → paste → send → return to platform → open dialog → … × 10. On a workshop day with limited time this becomes the bottleneck.
+
+**Fixes** (small to large):
+- **Bulk invite** — paste a list, one per line (`Org name, Bairro`), creates all at once, shows a copyable summary block
+- **`wa.me` deep-link** — instead of copy-to-clipboard, open `https://wa.me/?text=<encoded>` directly. WhatsApp opens with the message pre-filled; pick the contact, send.
+- **QR code** at the top of the workshop deck — CBOs scan it with their phone; lands on a self-service "enter your org name" screen → no per-CBO invite at all
+
+The QR route is the most aligned to how Vila Flores actually runs workshops (people in a room, projector behind Antônia). Worth prototyping for the June 8 first workshop.
+
+### 5. Cohort recovery is fragile
+"My link" + localStorage is the only path back. If Julia clears cookies, switches laptops, or her browser nukes localStorage, the cohort is unreachable. The slug is a 24-char random string — not memorable, not shareable verbally.
+
+**Fixes**:
+- On cohort creation, **email** the coordinator link to a Julia-provided address. Stick a tiny "send to email" button next to "My link".
+- Alternatively: generate a 3-word slug (`forest-river-bairro`) instead of nanoid — easier to type, easier to write on a sticky note. Slightly less entropy, fine for pilot scale.
+
+### 6. The CBO has no idea when the next workshop is
+The coordinator sees the cadence strip on `/orchestrator`. The CBO sees nothing. *"Coordinator will unlock this after the next workshop"* (tooltip text) — but **when**? Sandra doesn't know if that's tomorrow, next month, or never.
+
+**Fix**: pull `cohort.settings.workshops` into the welcome banner. *"Phase 2 opens after Workshop 2 — Wed June 11."* The CBO page already fetches the member; one extra field (cohort settings) on the `/api/cbo-member/:slug` response. ~30 min.
+
+### 7. The agent throws the user into the deep end
+The CBO welcome screen says *"Start your community profile"* and the agent immediately asks structured questions. Sandra hasn't been told *what NBS is*, *why this matters*, or *how long it will take*. Julia at the demo: *"the communities are completely apart from this process — they're used to dealing with food, recycling, not NBS."*
+
+**Fix**: a 3-screen intro before the chat (skippable): (1) "Why we're doing this" — one paragraph + one image, (2) "What we'll ask" — 5 phase pills with one line each, (3) "How long" — *"about 20 min across the workshops, save and come back anytime."* Buttons: **Get started** / **I've done this before, skip**. ~3h.
+
+### 8. The role-picker at `/` is a footgun
+Julia visits `/orchestrator/?coord=…` — fine. Antônia (a coordinator herself, but not the cohort owner) visits `/` accidentally — sees City / CBO / Orchestrator cards. Picks CBO → starts a *new, standalone* CBO profile not tied to any cohort. Now she's in two parallel sessions.
+
+**Fix**: when the URL has `?cbo=<slug>` or `?coord=<slug>`, bypass the role gate entirely (already done). But add a fallback: if there's a coordinatorSlug in localStorage but no URL param, the "Orchestrator" card auto-resumes. Same for memberSlug → CBO card. ~30 min.
+
+## Cosmetic but visible
+
+### 9. Sample mode is sparse
+4 hardcoded CBOs, all roughly stuck in early phases except `bosque-humaita` which is at phase 5. For a Secretary-of-Planning stakeholder demo this looks toy-like. The cadence shows future dates (`2026-06-11` etc.) which is fine but the unlock buttons in sample mode just toast "Create a cohort to enable" — that's an explicit dead-end.
+
+**Fix**: add 6 more sample CBOs (10 total, matching the priority cohort scale), distribute them across all 5 phases with realistic maturity scores. Make the unlock buttons in sample mode visually *open* the next phase in the sample data temporarily (no server call) so the demo flow shows the unlock animation. ~2h.
+
+### 10. "Switch role" on the orchestrator header
+Top-right corner has `← Back to role selection`. For Julia, this is a permanent footgun — one wrong click and she's at the role picker losing context.
+
+**Fix**: when in live mode (coordinator slug present), replace "Switch role" with a small avatar / cohort-name pill that opens a popover with *Sign out of this cohort* + *Open a different cohort* (which routes through the LoadCohortDialog). ~1h.
+
+### 11. PT-default for the Brazilian audience
+The role-selection page, the headers, the orchestrator chrome — all default to English until the user clicks the language picker. The audience is Portuguese-first.
+
+**Fix**: detect `navigator.language` on first load. If `pt-*` → set i18n to `pt`. Persist the choice. ~30 min.
+
+### 12. "Phase" is engineering language
+Throughout: *Phase 1*, *Phase 2*, *Phases unlocked*. The Portuguese term *Fase* works but in Vila Flores' workshop framing these are *workshops* (Encontros). Better: *Encontro 1 — Quem Somos*, *Encontro 2 — Onde Trabalhamos*. Pull from `cohort.settings.workshops` so the data already knows the names. Coordinator's user-facing labels match her workshop deck. ~1h once the data is plumbed.
+
+## Suggested priority order before June 8
+
+| When | What | Why |
+|---|---|---|
+| **This week** | (1) CBO page mobile layout, (2) friendly progress chunk, (3) tap-popover on locked phases | Without these the CBO experience is broken on phones, period |
+| **Next week** | (4) `wa.me` deep-link + bulk invite, (6) next-workshop date in welcome banner, (7) 3-screen intro | The CBO-side friction that costs us drop-offs in week 1 of convening |
+| **Before May 25 demo** | (9) richer sample mode, (10) less footgun-y header, (11) PT default, (12) "Encontro" naming | These ship the stakeholder-tour polish |
+| **Nice to have** | (5) email cohort link / 3-word slug, QR code workshop flow | If time permits |
+
+**Total estimated**: ~15–20h of focused work. Realistic for the May 14–June 8 window.
+
+## What I'm not suggesting
+
+- Reworking the chat / agent flow itself — that's content + agent-prompt work, not UX
+- Adding new platform features (territory report, status pill, sector tabs) — already on the backlog, lower priority than fixing what we have
+- Real auth — defer to Phase 3 per the existing scope
+- Multi-coordinator support — single Julia for the pilot is fine

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -121,16 +121,30 @@ export function registerCohortRoutes(app: Express): void {
     res.json({ ok: true, updated: targets.length });
   }));
 
-  // Member-facing read (no auth beyond knowing the slug)
+  // Member-facing read (no auth beyond knowing the slug). Also returns the
+  // cohort's workshop cadence so the CBO welcome page can show *which*
+  // workshop will unlock their next phase, and when.
   app.get('/api/cbo-member/:memberSlug', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    const [cohort] = await db.select().from(cohorts).where(eq(cohorts.id, member.cohortId)).limit(1);
+    const workshops = (cohort?.settings as CohortSettings | null)?.workshops ?? [];
+
+    const unlocked = (member.unlockedPhases as number[] | null) ?? [1];
+    const maxUnlocked = Math.max(0, ...unlocked);
+    const nextPhase = maxUnlocked + 1;
+    const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
+
     res.json({
       id: member.id,
       orgName: member.orgName,
       neighborhood: member.neighborhood,
-      unlockedPhases: member.unlockedPhases ?? [1],
+      unlockedPhases: unlocked,
       cboStateId: member.cboStateId,
+      cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
+      workshops,
+      nextWorkshop,
     });
   }));
 

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,5 +1,5 @@
-import type { Express, Request, Response } from 'express';
-import { eq, and } from 'drizzle-orm';
+import type { Express, Request, Response, RequestHandler } from 'express';
+import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import {
@@ -14,6 +14,20 @@ import {
 // a 10-CBO pilot where the only attacker is a coordinator's WhatsApp typo.
 const slug = () => nanoid(24);
 
+// Wrap async handlers so a thrown DB error becomes a 500 response instead of
+// an unhandled promise rejection that crashes the Node process. (Node 20
+// terminates on unhandled rejections by default; without this, a missing
+// table or a transient DB hiccup takes the whole server down.)
+const wrap = (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler => async (req, res, next) => {
+  try {
+    await fn(req, res);
+  } catch (err: any) {
+    console.error('[cohort] handler error', err);
+    if (res.headersSent) return next(err);
+    res.status(500).json({ error: err?.message || 'internal error', code: err?.code });
+  }
+};
+
 async function findCohortByCoordinatorSlug(coordinatorSlug: string) {
   const [c] = await db.select().from(cohorts).where(eq(cohorts.coordinatorSlug, coordinatorSlug)).limit(1);
   return c;
@@ -26,7 +40,7 @@ async function findMemberBySlug(memberSlug: string) {
 
 export function registerCohortRoutes(app: Express): void {
   // Create cohort
-  app.post('/api/cohort', async (req: Request, res: Response) => {
+  app.post('/api/cohort', wrap(async (req, res) => {
     const { name } = req.body ?? {};
     const coordinatorSlug = slug();
     const [created] = await db.insert(cohorts).values({
@@ -35,23 +49,23 @@ export function registerCohortRoutes(app: Express): void {
       settings: { workshops: DEFAULT_WORKSHOPS },
     }).returning();
     res.json({ cohort: created });
-  });
+  }));
 
   // Read cohort + members
-  app.get('/api/cohort/:coordinatorSlug', async (req: Request, res: Response) => {
+  app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     res.json({ cohort, members });
-  });
+  }));
 
   // Invite a CBO
-  app.post('/api/cohort/:coordinatorSlug/invite', async (req: Request, res: Response) => {
+  app.post('/api/cohort/:coordinatorSlug/invite', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const { orgName, neighborhood, role, origin } = req.body ?? {};
-    if (!orgName) return res.status(400).json({ error: 'orgName required' });
+    if (!orgName) { res.status(400).json({ error: 'orgName required' }); return; }
 
     const memberSlug = slug();
     const [member] = await db.insert(cohortMembers).values({
@@ -64,15 +78,15 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: [1],
     }).returning();
     res.json({ member });
-  });
+  }));
 
   // Update workshops
-  app.patch('/api/cohort/:coordinatorSlug/workshops', async (req: Request, res: Response) => {
+  app.patch('/api/cohort/:coordinatorSlug/workshops', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const incoming = req.body?.workshops;
-    if (!Array.isArray(incoming)) return res.status(400).json({ error: 'workshops must be an array' });
+    if (!Array.isArray(incoming)) { res.status(400).json({ error: 'workshops must be an array' }); return; }
 
     const workshops: WorkshopConfig[] = incoming.map((w: any) => ({
       name: String(w.name ?? ''),
@@ -82,16 +96,16 @@ export function registerCohortRoutes(app: Express): void {
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true });
-  });
+  }));
 
   // Unlock a phase — for one member, multiple members, or 'all'
-  app.patch('/api/cohort/:coordinatorSlug/unlock', async (req: Request, res: Response) => {
+  app.patch('/api/cohort/:coordinatorSlug/unlock', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
     const { memberIds, phase } = req.body ?? {};
     const phaseNum = Number(phase);
-    if (!phaseNum || phaseNum < 1 || phaseNum > 7) return res.status(400).json({ error: 'invalid phase' });
+    if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
 
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     const targets = memberIds === 'all'
@@ -105,12 +119,12 @@ export function registerCohortRoutes(app: Express): void {
       await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
     }
     res.json({ ok: true, updated: targets.length });
-  });
+  }));
 
   // Member-facing read (no auth beyond knowing the slug)
-  app.get('/api/cbo-member/:memberSlug', async (req: Request, res: Response) => {
+  app.get('/api/cbo-member/:memberSlug', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) return res.status(404).json({ error: 'member not found' });
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
     res.json({
       id: member.id,
       orgName: member.orgName,
@@ -118,12 +132,12 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: member.unlockedPhases ?? [1],
       cboStateId: member.cboStateId,
     });
-  });
+  }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.
-  app.patch('/api/cbo-member/:memberSlug/snapshot', async (req: Request, res: Response) => {
+  app.patch('/api/cbo-member/:memberSlug/snapshot', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) return res.status(404).json({ error: 'member not found' });
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
 
     const {
       phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
@@ -140,5 +154,5 @@ export function registerCohortRoutes(app: Express): void {
       snapshotUpdatedAt: new Date(),
     }).where(eq(cohortMembers.id, member.id));
     res.json({ ok: true });
-  });
+  }));
 }

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,5 +1,5 @@
-import type { Express, Request, Response, RequestHandler } from 'express';
-import { eq } from 'drizzle-orm';
+import type { Express, Request, Response } from 'express';
+import { eq, and } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import {
@@ -14,20 +14,6 @@ import {
 // a 10-CBO pilot where the only attacker is a coordinator's WhatsApp typo.
 const slug = () => nanoid(24);
 
-// Wrap async handlers so a thrown DB error becomes a 500 response instead of
-// an unhandled promise rejection that crashes the Node process. (Node 20
-// terminates on unhandled rejections by default; without this, a missing
-// table or a transient DB hiccup takes the whole server down.)
-const wrap = (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler => async (req, res, next) => {
-  try {
-    await fn(req, res);
-  } catch (err: any) {
-    console.error('[cohort] handler error', err);
-    if (res.headersSent) return next(err);
-    res.status(500).json({ error: err?.message || 'internal error', code: err?.code });
-  }
-};
-
 async function findCohortByCoordinatorSlug(coordinatorSlug: string) {
   const [c] = await db.select().from(cohorts).where(eq(cohorts.coordinatorSlug, coordinatorSlug)).limit(1);
   return c;
@@ -40,7 +26,7 @@ async function findMemberBySlug(memberSlug: string) {
 
 export function registerCohortRoutes(app: Express): void {
   // Create cohort
-  app.post('/api/cohort', wrap(async (req, res) => {
+  app.post('/api/cohort', async (req: Request, res: Response) => {
     const { name } = req.body ?? {};
     const coordinatorSlug = slug();
     const [created] = await db.insert(cohorts).values({
@@ -49,23 +35,23 @@ export function registerCohortRoutes(app: Express): void {
       settings: { workshops: DEFAULT_WORKSHOPS },
     }).returning();
     res.json({ cohort: created });
-  }));
+  });
 
   // Read cohort + members
-  app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
+  app.get('/api/cohort/:coordinatorSlug', async (req: Request, res: Response) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     res.json({ cohort, members });
-  }));
+  });
 
   // Invite a CBO
-  app.post('/api/cohort/:coordinatorSlug/invite', wrap(async (req, res) => {
+  app.post('/api/cohort/:coordinatorSlug/invite', async (req: Request, res: Response) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
 
     const { orgName, neighborhood, role, origin } = req.body ?? {};
-    if (!orgName) { res.status(400).json({ error: 'orgName required' }); return; }
+    if (!orgName) return res.status(400).json({ error: 'orgName required' });
 
     const memberSlug = slug();
     const [member] = await db.insert(cohortMembers).values({
@@ -78,15 +64,15 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: [1],
     }).returning();
     res.json({ member });
-  }));
+  });
 
   // Update workshops
-  app.patch('/api/cohort/:coordinatorSlug/workshops', wrap(async (req, res) => {
+  app.patch('/api/cohort/:coordinatorSlug/workshops', async (req: Request, res: Response) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
 
     const incoming = req.body?.workshops;
-    if (!Array.isArray(incoming)) { res.status(400).json({ error: 'workshops must be an array' }); return; }
+    if (!Array.isArray(incoming)) return res.status(400).json({ error: 'workshops must be an array' });
 
     const workshops: WorkshopConfig[] = incoming.map((w: any) => ({
       name: String(w.name ?? ''),
@@ -96,16 +82,16 @@ export function registerCohortRoutes(app: Express): void {
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true });
-  }));
+  });
 
   // Unlock a phase — for one member, multiple members, or 'all'
-  app.patch('/api/cohort/:coordinatorSlug/unlock', wrap(async (req, res) => {
+  app.patch('/api/cohort/:coordinatorSlug/unlock', async (req: Request, res: Response) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
-    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    if (!cohort) return res.status(404).json({ error: 'cohort not found' });
 
     const { memberIds, phase } = req.body ?? {};
     const phaseNum = Number(phase);
-    if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
+    if (!phaseNum || phaseNum < 1 || phaseNum > 7) return res.status(400).json({ error: 'invalid phase' });
 
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     const targets = memberIds === 'all'
@@ -119,12 +105,12 @@ export function registerCohortRoutes(app: Express): void {
       await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
     }
     res.json({ ok: true, updated: targets.length });
-  }));
+  });
 
   // Member-facing read (no auth beyond knowing the slug)
-  app.get('/api/cbo-member/:memberSlug', wrap(async (req, res) => {
+  app.get('/api/cbo-member/:memberSlug', async (req: Request, res: Response) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    if (!member) return res.status(404).json({ error: 'member not found' });
     res.json({
       id: member.id,
       orgName: member.orgName,
@@ -132,12 +118,12 @@ export function registerCohortRoutes(app: Express): void {
       unlockedPhases: member.unlockedPhases ?? [1],
       cboStateId: member.cboStateId,
     });
-  }));
+  });
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.
-  app.patch('/api/cbo-member/:memberSlug/snapshot', wrap(async (req, res) => {
+  app.patch('/api/cbo-member/:memberSlug/snapshot', async (req: Request, res: Response) => {
     const member = await findMemberBySlug(req.params.memberSlug);
-    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    if (!member) return res.status(404).json({ error: 'member not found' });
 
     const {
       phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
@@ -154,5 +140,5 @@ export function registerCohortRoutes(app: Express): void {
       snapshotUpdatedAt: new Date(),
     }).where(eq(cohortMembers.id, member.id));
     res.json({ ok: true });
-  }));
+  });
 }


### PR DESCRIPTION
## Summary

**Replaces #134** — that PR had merge conflicts after #131/#132/#133 merged into the foundation branch. This PR is the same change, rebased onto the current `main` so it applies cleanly.

End-to-end UX review of the platform from the eyes of Vila Flores' real users surfaced three blockers for an invited CBO on a phone (the dominant context for the June 8 convening). This PR fixes all three with a considered first-impression rebuild.

Full review at `knowledge/runs/2026-05-14-cougar-backlog-refresh/end-to-end-ux-review.md`.

## The three issues

1. **Page was broken on mobile.** `cbo-profile.tsx` used `w-1/2 border-r` on both panels with no responsive overrides. On a 375px iPhone viewport that's two ~180px columns — unusable.
2. **The progress header was the schema.** `1 · 2 · 3a · 3b · 3c · 4 · 5 · 0/7 · 0/27` is useful to engineers, gibberish to a community leader.
3. **Locked phases relied on Tooltip.** Tooltips don't fire on touch. Tap the 🔒 → nothing.

## What ships

### New `CboWelcome.tsx` — premium first-impression
Full-screen calm welcome shown the first time a member arrives via `?cbo=<slug>`:
- Org name in display typography
- Soft emerald gradient surface
- One primary CTA (**Começar** / **Start**)
- Next-workshop card with date + name pulled from `cohort.settings.workshops`
- 5-step preview so the user knows what's coming
- Detects existing progress → offers "Continue where I left off" instead

### New `CboProgress.tsx` — friendly progress
- "Section 3 of 5 · What you build"
- 5-segment bar; completed segments carry a checkmark
- Locked segments use Popover (works on touch): *"Opens after Workshop 4 · Wednesday, July 2."*

### `cbo-profile.tsx`
- Mobile-first: chat full width on mobile, desktop unchanged
- Header shows org name + bairro for cohort CBOs
- Removed the duplicate welcome banner from #132 (CboWelcome supersedes it)
- Standalone empty state rebuilt with the same calm language

### `GET /api/cbo-member/:slug`
Returns `cohort.name`, `workshops[]`, and `nextWorkshop` (the workshop whose `unlocksPhase` matches the user's first locked phase). Wrapped in the `wrap()` helper from #131.

### `locales/{en,pt}.json`
Full Portuguese translations for every new key.

## Test plan

- [ ] Open `/cbo-profile?cbo=<test-slug>` on iPhone-sized viewport → welcome screen renders, fits cleanly, no horizontal scroll
- [ ] Tap **Start** → chat begins, welcome dismisses
- [ ] Visit again with existing progress → welcome shows "Continue where I left off"
- [ ] Tap a locked progress segment → Popover with workshop name + date
- [ ] Switch browser to pt-BR locale → entire welcome in Portuguese

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)