### PR TITLE
feat(invite): WhatsApp deep-link + bulk-paste invite mode

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -1,12 +1,27 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Copy, Link as LinkIcon, MessageCircle, Plus, Users } from 'lucide-react';
+import { Check, Copy, ExternalLink, Link as LinkIcon, MessageCircle, Plus, Send, Users } from 'lucide-react';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter,
   DialogHeader, DialogTitle,
 } from '@/core/components/ui/dialog';
 import { Button } from '@/core/components/ui/button';
 import { Input } from '@/core/components/ui/input';
+
+// ---------------------------------------------------------------------------
+// Greeting templates — shared between ShareLinkDialog and bulk summary so the
+// CBO-facing message is consistent everywhere.
+// ---------------------------------------------------------------------------
+export function cboGreetingMessage(orgName: string, url: string, isPt: boolean): string {
+  return isPt
+    ? `Olá! 👋\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
+    : `Hi! 👋\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
+}
+
+export function whatsappDeepLink(message: string, phone?: string): string {
+  const text = encodeURIComponent(message);
+  return phone ? `https://wa.me/${phone}?text=${text}` : `https://wa.me/?text=${text}`;
+}
 
 // ---------------------------------------------------------------------------
 // CreateCohortDialog — replaces window.prompt for "Create cohort"
@@ -140,86 +155,229 @@ export function LoadCohortDialog({
 }
 
 // ---------------------------------------------------------------------------
-// InviteCboDialog — single form for org name + neighborhood + role
+// InviteCboDialog — Single (one CBO at a time) or Bulk (paste a list) modes.
+// Bulk is the typical workshop-day flow: Julia comes in with a list of 10
+// orgs, pastes them, hits invite, gets a summary of links to send out.
 // ---------------------------------------------------------------------------
+
+export type BulkInviteResult = {
+  memberSlug: string;
+  orgName: string;
+  neighborhood?: string;
+};
+
+/** Parse a textarea of "Org name, neighborhood" lines into a structured list. */
+export function parseBulkInviteText(text: string): Array<{ orgName: string; neighborhood?: string }> {
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [name, ...rest] = line.split(',');
+      const orgName = name.trim();
+      const neighborhood = rest.join(',').trim() || undefined;
+      return { orgName, neighborhood };
+    })
+    .filter(p => p.orgName.length > 0);
+}
+
 export function InviteCboDialog({
-  open, onOpenChange, onSubmit,
+  open, onOpenChange, onSubmit, onSingleSuccess, onBulkComplete,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Pure invite — no side effects. Called once per CBO in either mode. */
   onSubmit: (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => Promise<{ memberSlug: string; orgName: string } | null>;
+  /** Called after a successful single-mode invite — parent typically opens
+      the ShareLinkDialog for that CBO. NOT called in bulk mode. */
+  onSingleSuccess?: (result: { memberSlug: string; orgName: string }) => void;
+  /** Called once after a Bulk submission completes — parent typically opens
+      the BulkInviteSummaryDialog with these results. */
+  onBulkComplete?: (results: BulkInviteResult[]) => void;
 }) {
   const { t } = useTranslation();
+  const [mode, setMode] = useState<'single' | 'bulk'>('single');
   const [orgName, setOrgName] = useState('');
   const [neighborhood, setNeighborhood] = useState('');
   const [role, setRole] = useState<'priority' | 'alternate'>('priority');
+  const [bulkText, setBulkText] = useState('');
+  const [bulkProgress, setBulkProgress] = useState<{ done: number; total: number } | null>(null);
   const [busy, setBusy] = useState(false);
 
   // Reset form on close so the next open starts fresh.
   useEffect(() => {
     if (!open) {
+      setMode('single');
       setOrgName('');
       setNeighborhood('');
       setRole('priority');
+      setBulkText('');
+      setBulkProgress(null);
     }
   }, [open]);
 
+  const parsed = useMemo(() => parseBulkInviteText(bulkText), [bulkText]);
+
   const submit = async () => {
-    if (!orgName.trim() || busy) return;
+    if (busy) return;
+
+    if (mode === 'single') {
+      if (!orgName.trim()) return;
+      setBusy(true);
+      try {
+        const result = await onSubmit({
+          orgName: orgName.trim(),
+          neighborhood: neighborhood.trim() || undefined,
+          role,
+        });
+        if (result) {
+          onOpenChange(false);
+          onSingleSuccess?.(result);
+        }
+      } finally { setBusy(false); }
+      return;
+    }
+
+    // Bulk: invite each row sequentially so the server isn't overwhelmed and
+    // the coordinator gets a steady progress count.
+    if (parsed.length === 0) return;
     setBusy(true);
+    setBulkProgress({ done: 0, total: parsed.length });
+    const results: BulkInviteResult[] = [];
     try {
-      const result = await onSubmit({
-        orgName: orgName.trim(),
-        neighborhood: neighborhood.trim() || undefined,
-        role,
-      });
-      if (result) onOpenChange(false);
-    } finally { setBusy(false); }
+      for (let i = 0; i < parsed.length; i++) {
+        const p = parsed[i];
+        const r = await onSubmit({ orgName: p.orgName, neighborhood: p.neighborhood, role });
+        if (r) results.push({ memberSlug: r.memberSlug, orgName: r.orgName, neighborhood: p.neighborhood });
+        setBulkProgress({ done: i + 1, total: parsed.length });
+      }
+      onBulkComplete?.(results);
+      onOpenChange(false);
+    } finally {
+      setBusy(false);
+      setBulkProgress(null);
+    }
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className="sm:max-w-[520px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Users className="w-4 h-4" />
-            {t('orchestrator.cohort.inviteTitle', { defaultValue: 'Invite a CBO' })}
+            {mode === 'bulk'
+              ? t('orchestrator.cohort.inviteTitleBulk', { defaultValue: 'Invite CBOs in bulk' })
+              : t('orchestrator.cohort.inviteTitle', { defaultValue: 'Invite a CBO' })}
           </DialogTitle>
           <DialogDescription>
-            {t('orchestrator.cohort.inviteDesc', {
-              defaultValue: 'Adds a CBO to your cohort and generates a private link you can share. The CBO starts with Phase 1 unlocked.',
-            })}
+            {mode === 'bulk'
+              ? t('orchestrator.cohort.inviteDescBulk', {
+                  defaultValue: 'Paste your CBO list — one per line, optionally with a neighborhood after a comma. Each one gets a private link.',
+                })
+              : t('orchestrator.cohort.inviteDesc', {
+                  defaultValue: 'Adds a CBO to your cohort and generates a private link you can share. The CBO starts with Phase 1 unlocked.',
+                })}
           </DialogDescription>
         </DialogHeader>
+
+        {/* Mode toggle — segmented control */}
+        <div className="flex p-0.5 rounded-md border border-foreground/10 bg-muted/40 text-xs">
+          {(['single', 'bulk'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={`flex-1 px-3 py-1.5 rounded transition-colors ${
+                mode === m
+                  ? 'bg-background text-foreground shadow-sm font-medium'
+                  : 'text-muted-foreground hover:text-foreground/80'
+              }`}
+              data-testid={`invite-mode-${m}`}
+            >
+              {m === 'single'
+                ? t('orchestrator.cohort.inviteModeSingle', { defaultValue: 'One at a time' })
+                : t('orchestrator.cohort.inviteModeBulk', { defaultValue: 'Paste a list' })}
+            </button>
+          ))}
+        </div>
         <div className="space-y-3 py-2">
+          {mode === 'single' ? (
+            <>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-foreground/80">
+                  {t('orchestrator.cohort.orgName', { defaultValue: 'Organization name' })}
+                  <span className="text-red-600 ml-0.5">*</span>
+                </label>
+                <Input
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                  placeholder="Horta Comunitária Cascata"
+                  autoFocus
+                  data-testid="input-org-name"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-foreground/80">
+                  {t('orchestrator.cohort.neighborhood', { defaultValue: 'Neighborhood (optional)' })}
+                </label>
+                <Input
+                  value={neighborhood}
+                  onChange={(e) => setNeighborhood(e.target.value)}
+                  placeholder="Cascata"
+                  onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+                  data-testid="input-neighborhood"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground/80">
+                {t('orchestrator.cohort.bulkList', { defaultValue: 'CBO list' })}
+                <span className="text-red-600 ml-0.5">*</span>
+                <span className="ml-2 text-[10px] font-normal text-muted-foreground">
+                  {t('orchestrator.cohort.bulkListHint', { defaultValue: 'One per line · `Org name, Neighborhood`' })}
+                </span>
+              </label>
+              <textarea
+                value={bulkText}
+                onChange={(e) => setBulkText(e.target.value)}
+                placeholder={`Horta Comunitária Cascata, Cascata\nColetivo Arquipélago Verde, Arquipélago\nAgentes do Bosque Humaitá, Humaitá\n…`}
+                rows={8}
+                autoFocus
+                className="w-full text-sm px-3 py-2 rounded-md border border-foreground/15 bg-background font-mono text-[12px] leading-relaxed focus:outline-none focus:ring-2 focus:ring-emerald-300/40"
+                data-testid="input-bulk-text"
+              />
+              <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                <span>
+                  {bulkProgress
+                    ? t('orchestrator.cohort.bulkProgress', {
+                        defaultValue: 'Inviting {{done}} of {{total}}…',
+                        done: bulkProgress.done,
+                        total: bulkProgress.total,
+                      })
+                    : t('orchestrator.cohort.bulkParsedCount', {
+                        defaultValue: '{{n}} ready to invite',
+                        n: parsed.length,
+                      })}
+                </span>
+                {parsed.length > 0 && !bulkProgress && (
+                  <span className="text-[10px] text-muted-foreground/70">
+                    {parsed
+                      .slice(0, 3)
+                      .map(p => p.neighborhood ? `${p.orgName} · ${p.neighborhood}` : p.orgName)
+                      .join(' · ')}
+                    {parsed.length > 3 ? ` … +${parsed.length - 3}` : ''}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-foreground/80">
-              {t('orchestrator.cohort.orgName', { defaultValue: 'Organization name' })}
-              <span className="text-red-600 ml-0.5">*</span>
-            </label>
-            <Input
-              value={orgName}
-              onChange={(e) => setOrgName(e.target.value)}
-              placeholder="Horta Comunitária Cascata"
-              autoFocus
-              data-testid="input-org-name"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-foreground/80">
-              {t('orchestrator.cohort.neighborhood', { defaultValue: 'Neighborhood (optional)' })}
-            </label>
-            <Input
-              value={neighborhood}
-              onChange={(e) => setNeighborhood(e.target.value)}
-              placeholder="Cascata"
-              onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
-              data-testid="input-neighborhood"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-foreground/80">
-              {t('orchestrator.cohort.role', { defaultValue: 'Role in cohort' })}
+              {mode === 'bulk'
+                ? t('orchestrator.cohort.roleAll', { defaultValue: 'Role (applies to all)' })
+                : t('orchestrator.cohort.role', { defaultValue: 'Role in cohort' })}
             </label>
             <div className="flex gap-1.5">
               {(['priority', 'alternate'] as const).map((r) => (
@@ -242,14 +400,144 @@ export function InviteCboDialog({
             </div>
           </div>
         </div>
+
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
             {t('common.cancel', { defaultValue: 'Cancel' })}
           </Button>
-          <Button onClick={submit} disabled={busy || !orgName.trim()} data-testid="button-confirm-invite">
+          <Button
+            onClick={submit}
+            disabled={
+              busy
+              || (mode === 'single' && !orgName.trim())
+              || (mode === 'bulk' && parsed.length === 0)
+            }
+            data-testid="button-confirm-invite"
+          >
             {busy
               ? t('common.working', { defaultValue: 'Working…' })
-              : t('orchestrator.cohort.inviteAndCopy', { defaultValue: 'Invite & get link' })}
+              : mode === 'bulk'
+                ? t('orchestrator.cohort.inviteAll', { defaultValue: 'Invite {{n}}', n: parsed.length })
+                : t('orchestrator.cohort.inviteAndCopy', { defaultValue: 'Invite & get link' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BulkInviteSummaryDialog — shown after bulk invite completes. Lists every
+// new CBO with two single-tap actions per row: Open WhatsApp (wa.me deep-
+// link with the greeting pre-filled) and Copy link. A "Copy all" master
+// action at the top stuffs every link into a single clipboard block.
+// ---------------------------------------------------------------------------
+export function BulkInviteSummaryDialog({
+  open, onOpenChange, invitations, origin,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  invitations: BulkInviteResult[];
+  /** window.location.origin from the caller — kept as a prop so this component is testable. */
+  origin: string;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const [copiedAll, setCopiedAll] = useState(false);
+  const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+
+  useEffect(() => { if (open) { setCopiedAll(false); setCopiedIdx(null); } }, [open]);
+
+  if (!open) return null;
+
+  const buildUrl = (slug: string) => `${origin}/cbo-profile?cbo=${slug}`;
+  const buildMessage = (orgName: string, slug: string) =>
+    cboGreetingMessage(orgName, buildUrl(slug), isPt);
+
+  const copy = async (text: string, after: () => void) => {
+    try { await navigator.clipboard.writeText(text); after(); } catch {}
+  };
+
+  const copyAllMessages = () => {
+    const block = invitations
+      .map(inv => `— ${inv.orgName}${inv.neighborhood ? ` (${inv.neighborhood})` : ''}\n${buildMessage(inv.orgName, inv.memberSlug)}`)
+      .join('\n\n──────────\n\n');
+    copy(block, () => { setCopiedAll(true); setTimeout(() => setCopiedAll(false), 2000); });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[640px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Send className="w-4 h-4" />
+            {t('orchestrator.cohort.bulkSummaryTitle', {
+              defaultValue: '{{n}} invitations ready',
+              n: invitations.length,
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.bulkSummaryDesc', {
+              defaultValue: 'Tap "Open in WhatsApp" on each row to send the invite, or copy all messages at once.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={copyAllMessages}
+            data-testid="button-copy-all-messages"
+          >
+            {copiedAll ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <Copy className="w-3.5 h-3.5 mr-1.5" />}
+            {copiedAll
+              ? t('common.copied', { defaultValue: 'Copied!' })
+              : t('orchestrator.cohort.copyAllMessages', { defaultValue: 'Copy all messages' })}
+          </Button>
+
+          <div className="max-h-[420px] overflow-y-auto -mx-1 px-1 space-y-1.5">
+            {invitations.map((inv, i) => {
+              const url = buildUrl(inv.memberSlug);
+              const msg = buildMessage(inv.orgName, inv.memberSlug);
+              return (
+                <div
+                  key={inv.memberSlug}
+                  className="flex items-center gap-2 rounded-lg border border-foreground/10 bg-background px-3 py-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium tracking-tight truncate">{inv.orgName}</div>
+                    {inv.neighborhood && (
+                      <div className="text-[11px] text-muted-foreground truncate">{inv.neighborhood}</div>
+                    )}
+                  </div>
+                  <a
+                    href={whatsappDeepLink(msg)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-[11px] px-2.5 h-7 rounded-md bg-[#25D366] hover:bg-[#1ebd5a] text-white font-medium whitespace-nowrap"
+                    data-testid={`button-bulk-whatsapp-${i}`}
+                  >
+                    <MessageCircle className="w-3 h-3" />
+                    WhatsApp
+                  </a>
+                  <button
+                    onClick={() => copy(url, () => { setCopiedIdx(i); setTimeout(() => setCopiedIdx(c => c === i ? null : c), 2000); })}
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-foreground/10 hover:bg-muted text-muted-foreground"
+                    title={t('orchestrator.cohort.copyLink', { defaultValue: 'Copy link' })}
+                    data-testid={`button-bulk-copy-${i}`}
+                  >
+                    {copiedIdx === i ? <Check className="w-3 h-3 text-emerald-600" /> : <Copy className="w-3 h-3" />}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>
+            {t('common.done', { defaultValue: 'Done' })}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -287,11 +575,7 @@ export function ShareLinkDialog({
   const whatsappMessage = (() => {
     if (!context) return url;
     if (context.kind === 'cbo') {
-      // CBO-facing greeting. Default to Portuguese for the Brazilian audience;
-      // English fallback for the demo.
-      return isPt
-        ? `Olá! 👋\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${context.orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
-        : `Hi! 👋\n\nHere's the COUGAR / Vila Flores platform link for *${context.orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
+      return cboGreetingMessage(context.orgName, url, isPt);
     }
     // Coordinator-facing — short, just for their own notes
     return isPt
@@ -339,7 +623,24 @@ export function ShareLinkDialog({
             {url}
           </div>
 
-          {/* Actions */}
+          {/* Primary action — open WhatsApp with the message pre-filled.
+              Only shown for CBO-facing shares; coordinator-link is private. */}
+          {context?.kind === 'cbo' && (
+            <a
+              href={whatsappDeepLink(whatsappMessage)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-[#25D366] hover:bg-[#1ebd5a] text-white font-medium text-sm h-10 transition-colors"
+              data-testid="button-open-whatsapp"
+            >
+              <MessageCircle className="w-4 h-4" />
+              {t('orchestrator.cohort.openWhatsApp', { defaultValue: 'Open in WhatsApp' })}
+              <ExternalLink className="w-3 h-3 opacity-70" />
+            </a>
+          )}
+
+          {/* Secondary actions — fallbacks if wa.me doesn't work (e.g. desktop
+              without WhatsApp Web set up). */}
           <div className="grid grid-cols-2 gap-2">
             <Button
               variant="outline"
@@ -352,13 +653,14 @@ export function ShareLinkDialog({
                 : t('orchestrator.cohort.copyLink', { defaultValue: 'Copy link' })}
             </Button>
             <Button
+              variant="outline"
               onClick={() => copy(whatsappMessage, setCopiedMessage)}
               data-testid="button-copy-message"
             >
-              {copiedMessage ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <MessageCircle className="w-3.5 h-3.5 mr-1.5" />}
+              {copiedMessage ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <Copy className="w-3.5 h-3.5 mr-1.5" />}
               {copiedMessage
                 ? t('common.copied', { defaultValue: 'Copied!' })
-                : t('orchestrator.cohort.copyMessage', { defaultValue: 'Copy WhatsApp message' })}
+                : t('orchestrator.cohort.copyMessage', { defaultValue: 'Copy message' })}
             </Button>
           </div>
 

--- a/client/src/core/components/orchestrator/WorkshopCadence.tsx
+++ b/client/src/core/components/orchestrator/WorkshopCadence.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Calendar, Check, ChevronRight, Lock, Pencil, Unlock } from 'lucide-react';
+import { Button } from '@/core/components/ui/button';
+import type { WorkshopConfig } from '@shared/cohort-schema';
+
+// ---------------------------------------------------------------------------
+// WorkshopCadence — the rail of workshops on /orchestrator. Visually
+// differentiates past / current / next-up / locked workshops so the
+// coordinator knows at a glance where the cohort is and what to do next.
+//
+// Two distinct dates per workshop:
+//   - `date`     — the *scheduled* workshop date (editable any time)
+//   - `openedAt` — set the moment the coordinator clicks "Open for cohort".
+//                  This is the source of truth for state (held vs not).
+//
+// The most-recent opened workshop is Open; everything earlier is Past;
+// the next workshop is Next-up; everything after that is Locked. The
+// "Open for cohort" CTA appears only on Next-up — a single focused action.
+// ---------------------------------------------------------------------------
+
+type WorkshopState = 'past' | 'open' | 'nextUp' | 'locked';
+
+function computeState(workshops: WorkshopConfig[]): WorkshopState[] {
+  const openedIndices = workshops
+    .map((w, i) => (w.openedAt ? i : -1))
+    .filter(i => i >= 0);
+  const lastOpenedIndex = openedIndices.length ? Math.max(...openedIndices) : -1;
+
+  return workshops.map((w, i) => {
+    if (w.openedAt) return i < lastOpenedIndex ? 'past' : 'open';
+    if (i === lastOpenedIndex + 1) return 'nextUp';
+    return 'locked';
+  });
+}
+
+function formatShortDate(iso: string, locale: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' });
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inline date editor — click the date pill, edit, blur or Enter to save.
+// ---------------------------------------------------------------------------
+function DatePill({
+  value,
+  placeholder,
+  disabled,
+  emphasis,
+  onSave,
+}: {
+  value: string | null;
+  placeholder: string;
+  disabled?: boolean;
+  emphasis?: 'muted' | 'accent';
+  onSave: (next: string | null) => void;
+}) {
+  const { i18n } = useTranslation();
+  const locale = i18n.language?.startsWith('pt') ? 'pt-BR' : 'en-US';
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+  useEffect(() => { setDraft(value ?? ''); }, [value]);
+
+  const commit = () => {
+    const next = draft.trim() ? draft.trim() : null;
+    if (next !== (value ?? null)) onSave(next);
+    setEditing(false);
+  };
+
+  if (editing && !disabled) {
+    return (
+      <input
+        ref={inputRef}
+        type="date"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') { e.currentTarget.blur(); }
+          else if (e.key === 'Escape') { setDraft(value ?? ''); setEditing(false); }
+        }}
+        className="h-6 text-[11px] px-2 rounded-md border border-emerald-300 focus:ring-2 focus:ring-emerald-300/40 focus:outline-none bg-background"
+      />
+    );
+  }
+
+  const baseTone =
+    emphasis === 'accent'
+      ? 'text-emerald-700 dark:text-emerald-300 border-emerald-200/60 dark:border-emerald-900/40'
+      : 'text-muted-foreground border-foreground/10';
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => !disabled && setEditing(true)}
+      className={`group inline-flex items-center gap-1 text-[11px] px-2 h-6 rounded-md border bg-background/50 hover:bg-background ${baseTone} ${disabled ? 'cursor-default' : 'cursor-pointer'}`}
+    >
+      <Calendar className="w-3 h-3" />
+      <span>{value ? formatShortDate(value, locale) : placeholder}</span>
+      {!disabled && <Pencil className="w-2.5 h-2.5 opacity-0 group-hover:opacity-60 transition-opacity" />}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Held-on pill — non-editable indicator of when a workshop was opened.
+// Renders for Past and Open states.
+// ---------------------------------------------------------------------------
+function HeldOnPill({ openedAt }: { openedAt: string }) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language?.startsWith('pt') ? 'pt-BR' : 'en-US';
+  return (
+    <span className="inline-flex items-center gap-1 text-[11px] px-2 h-6 rounded-md border border-emerald-200/60 dark:border-emerald-900/40 bg-emerald-50/60 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300">
+      <Check className="w-3 h-3" />
+      <span>
+        {t('orchestrator.cohort.heldOn', {
+          defaultValue: 'Held {{date}}',
+          date: formatShortDate(openedAt, locale),
+        })}
+      </span>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single workshop row.
+// ---------------------------------------------------------------------------
+function WorkshopRow({
+  workshop,
+  state,
+  index,
+  disabled,
+  onOpenForCohort,
+  onUpdateDate,
+}: {
+  workshop: WorkshopConfig;
+  state: WorkshopState;
+  index: number;
+  disabled?: boolean;
+  onOpenForCohort: () => void;
+  onUpdateDate: (date: string | null) => void;
+}) {
+  const { t } = useTranslation();
+
+  // Visual treatment per state — premium, not loud.
+  const stateMeta = {
+    past: {
+      ring: 'border-foreground/8',
+      bg: 'bg-background',
+      iconBg: 'bg-emerald-100 dark:bg-emerald-950/40',
+      iconColor: 'text-emerald-700 dark:text-emerald-300',
+      Icon: Check,
+      titleClass: 'text-foreground/75',
+      pill: t('orchestrator.cohort.statePast', { defaultValue: 'Held' }),
+      pillClass: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-300 border-emerald-200/50 dark:border-emerald-900/40',
+    },
+    open: {
+      ring: 'border-emerald-300/60 dark:border-emerald-800/60 ring-2 ring-emerald-200/40 dark:ring-emerald-950/40',
+      bg: 'bg-emerald-50/50 dark:bg-emerald-950/20',
+      iconBg: 'bg-emerald-500 dark:bg-emerald-500',
+      iconColor: 'text-white',
+      Icon: Check,
+      titleClass: 'text-foreground font-semibold',
+      pill: t('orchestrator.cohort.stateOpen', { defaultValue: 'Open · today' }),
+      pillClass: 'bg-emerald-600 text-white border-emerald-700/0',
+    },
+    nextUp: {
+      ring: 'border-emerald-300 dark:border-emerald-800',
+      bg: 'bg-emerald-50/30 dark:bg-emerald-950/10',
+      iconBg: 'bg-emerald-100 dark:bg-emerald-950/40',
+      iconColor: 'text-emerald-700 dark:text-emerald-300',
+      Icon: ChevronRight,
+      titleClass: 'text-foreground font-semibold',
+      pill: t('orchestrator.cohort.stateNextUp', { defaultValue: 'Next up' }),
+      pillClass: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 border-emerald-300/60 dark:border-emerald-900/60',
+    },
+    locked: {
+      ring: 'border-foreground/8',
+      bg: 'bg-background',
+      iconBg: 'bg-foreground/5',
+      iconColor: 'text-foreground/40',
+      Icon: Lock,
+      titleClass: 'text-foreground/60',
+      pill: t('orchestrator.cohort.stateLocked', { defaultValue: 'Locked' }),
+      pillClass: 'bg-transparent text-muted-foreground border-foreground/10',
+    },
+  }[state];
+
+  const Icon = stateMeta.Icon;
+
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-xl border ${stateMeta.ring} ${stateMeta.bg} px-3 py-2.5 transition-all`}
+      data-testid={`workshop-row-${index}-${state}`}
+    >
+      {/* State icon */}
+      <div className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${stateMeta.iconBg}`}>
+        <Icon className={`w-3.5 h-3.5 ${stateMeta.iconColor}`} strokeWidth={2.5} />
+      </div>
+
+      {/* Main column */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-xs tracking-tight ${stateMeta.titleClass}`}>{workshop.name}</span>
+          <span className={`inline-flex items-center text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full border ${stateMeta.pillClass}`}>
+            {stateMeta.pill}
+          </span>
+        </div>
+        <div className="mt-1 flex items-center gap-2 flex-wrap">
+          {/* For Past / Open: show the held-on date inline; the scheduled date
+              is secondary. For Next-up / Locked: show the schedule pill so
+              coordinator can plan ahead. */}
+          {workshop.openedAt ? (
+            <HeldOnPill openedAt={workshop.openedAt} />
+          ) : (
+            <DatePill
+              value={workshop.date}
+              placeholder={
+                state === 'nextUp'
+                  ? t('orchestrator.cohort.scheduleDate', { defaultValue: 'Schedule date' })
+                  : t('orchestrator.cohort.addDate', { defaultValue: 'Add date' })
+              }
+              emphasis={state === 'nextUp' ? 'accent' : 'muted'}
+              disabled={disabled}
+              onSave={onUpdateDate}
+            />
+          )}
+          <span className="text-[10px] text-muted-foreground">
+            {t('orchestrator.cohort.unlocksPhaseLabel', {
+              defaultValue: 'Opens Phase {{phase}}',
+              phase: workshop.unlocksPhase,
+            })}
+          </span>
+        </div>
+      </div>
+
+      {/* Action column — only next-up gets the CTA */}
+      {state === 'nextUp' && (
+        <Button
+          size="sm"
+          disabled={disabled}
+          className="h-8 bg-emerald-600 hover:bg-emerald-700 text-white text-xs whitespace-nowrap"
+          onClick={onOpenForCohort}
+          data-testid={`button-open-workshop-${index}`}
+        >
+          <Unlock className="w-3 h-3 mr-1.5" />
+          {t('orchestrator.cohort.openForCohort', { defaultValue: 'Open for cohort' })}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The full rail.
+// ---------------------------------------------------------------------------
+export function WorkshopCadence({
+  workshops,
+  disabled,
+  onOpenWorkshop,
+  onUpdateWorkshops,
+}: {
+  workshops: WorkshopConfig[];
+  /** True in sample mode — actions are no-ops with a toast handled by caller. */
+  disabled?: boolean;
+  /**
+   * Coordinator clicked "Open for cohort" on `index`. Caller should: bulk-unlock
+   * the workshop's phase + persist `today` as the workshop's date (if blank).
+   */
+  onOpenWorkshop: (index: number, todayISO: string) => Promise<void>;
+  /** Caller persists the workshops array (used by inline date editor). */
+  onUpdateWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const states = useMemo(() => computeState(workshops), [workshops]);
+
+  if (workshops.length === 0) return null;
+
+  return (
+    <div className="mt-3 pt-3 border-t border-foreground/5">
+      <div className="flex items-center justify-between mb-2.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {t('orchestrator.cohort.workshops', { defaultValue: 'Workshop cadence' })}
+        </span>
+        <span className="text-[10px] text-muted-foreground">
+          {(() => {
+            const heldCount = workshops.filter(w => w.date).length;
+            return t('orchestrator.cohort.heldOf', {
+              defaultValue: '{{held}} of {{total}} held',
+              held: heldCount,
+              total: workshops.length,
+            });
+          })()}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {workshops.map((w, i) => (
+          <WorkshopRow
+            key={i}
+            workshop={w}
+            state={states[i]}
+            index={i}
+            disabled={disabled}
+            onOpenForCohort={async () => {
+              const today = new Date().toISOString().slice(0, 10);
+              await onOpenWorkshop(i, today);
+            }}
+            onUpdateDate={async (next) => {
+              const updated = workshops.map((w2, j) => (j === i ? { ...w2, date: next } : w2));
+              await onUpdateWorkshops(updated);
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/contexts/sample-cohort.ts
+++ b/client/src/core/contexts/sample-cohort.ts
@@ -13,11 +13,16 @@ export const SAMPLE_COHORT: Cohort = {
   coordinatorSlug: 'sample',
   name: 'Vila Flores — Sample cohort',
   settings: {
-    workshops: DEFAULT_WORKSHOPS.map((w, i) => ({
-      ...w,
-      // Seed dates: weekly Thursdays starting mid-June 2026.
-      date: new Date(2026, 5, 11 + i * 7).toISOString().slice(0, 10),
-    })),
+    workshops: DEFAULT_WORKSHOPS.map((w, i) => {
+      // Scheduled dates: weekly Thursdays starting mid-June 2026.
+      const date = new Date(2026, 5, 11 + i * 7).toISOString().slice(0, 10);
+      // Seed first two workshops as already-held so the stakeholder demo
+      // shows the full state spectrum (Past · Open · Next-up · Locked).
+      const openedAt = i === 0 ? daysAgo(7).toISOString().slice(0, 10)
+                     : i === 1 ? daysAgo(0).toISOString().slice(0, 10)
+                     : null;
+      return { ...w, date, openedAt };
+    }),
   },
   createdAt: daysAgo(14),
 };

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -34,6 +34,8 @@ import {
   LoadCohortDialog,
   InviteCboDialog,
   ShareLinkDialog,
+  BulkInviteSummaryDialog,
+  type BulkInviteResult,
 } from '@/core/components/orchestrator/CohortDialogs';
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 
@@ -619,6 +621,8 @@ export default function OrchestratorLandingPage() {
     | { kind: 'coordinator'; cohortName: string }
     | null
   >(null);
+  const [bulkSummaryOpen, setBulkSummaryOpen] = useState(false);
+  const [bulkInvitations, setBulkInvitations] = useState<BulkInviteResult[]>([]);
 
   const openShare = (url: string, ctx: typeof shareContext) => {
     setShareUrl(url);
@@ -711,18 +715,23 @@ export default function OrchestratorLandingPage() {
     setInviteOpen(true);
   };
 
+  // Pure: just makes the invite. The post-success share dialog is wired
+  // separately via onSingleSuccess so the bulk-invite loop doesn't trigger
+  // N share dialogs (it uses onBulkComplete instead).
   const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => {
     const created = await invite(params);
     if (!created) {
       toast({ title: t('orchestrator.cohort.inviteFailed', { defaultValue: 'Could not create invitation' }) });
       return null;
     }
-    // Open the share dialog with the new CBO link.
-    openShare(
-      `${window.location.origin}/cbo-profile?cbo=${created.memberSlug}`,
-      { kind: 'cbo', orgName: created.orgName }
-    );
     return { memberSlug: created.memberSlug, orgName: created.orgName };
+  };
+
+  const handleSingleInviteSuccess = (result: { memberSlug: string; orgName: string }) => {
+    openShare(
+      `${window.location.origin}/cbo-profile?cbo=${result.memberSlug}`,
+      { kind: 'cbo', orgName: result.orgName },
+    );
   };
 
   const handleCreateSubmit = async (name: string) => {
@@ -962,8 +971,24 @@ export default function OrchestratorLandingPage() {
       {/* Cohort flow dialogs */}
       <CreateCohortDialog open={createOpen} onOpenChange={setCreateOpen} onSubmit={handleCreateSubmit} />
       <LoadCohortDialog open={loadOpen} onOpenChange={setLoadOpen} onSubmit={handleLoadSubmit} />
-      <InviteCboDialog open={inviteOpen} onOpenChange={setInviteOpen} onSubmit={handleInviteSubmit} />
+      <InviteCboDialog
+        open={inviteOpen}
+        onOpenChange={setInviteOpen}
+        onSubmit={handleInviteSubmit}
+        onSingleSuccess={handleSingleInviteSuccess}
+        onBulkComplete={(results) => {
+          if (results.length === 0) return;
+          setBulkInvitations(results);
+          setBulkSummaryOpen(true);
+        }}
+      />
       <ShareLinkDialog open={shareOpen} onOpenChange={setShareOpen} url={shareUrl} context={shareContext} />
+      <BulkInviteSummaryDialog
+        open={bulkSummaryOpen}
+        onOpenChange={setBulkSummaryOpen}
+        invitations={bulkInvitations}
+        origin={typeof window !== 'undefined' ? window.location.origin : ''}
+      />
     </div>
   );
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -35,6 +35,7 @@ import {
   InviteCboDialog,
   ShareLinkDialog,
 } from '@/core/components/orchestrator/CohortDialogs';
+import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -592,7 +593,7 @@ export default function OrchestratorLandingPage() {
 
   const {
     mode, cohort, members, coordinatorSlug,
-    createCohort, loadCohort, invite, unlockPhase,
+    createCohort, loadCohort, invite, unlockPhase, saveWorkshops,
   } = useCohort();
 
   const projects = useMemo(() => members.map(memberToView), [members]);
@@ -663,6 +664,43 @@ export default function OrchestratorLandingPage() {
     }
     await unlockPhase('all', phase);
     toast({ title: t('orchestrator.cohort.bulkUnlocked', { defaultValue: `Phase ${phase} unlocked for cohort`, phase }) });
+  };
+
+  // Coordinator clicked "Open for cohort" on a specific workshop. Two things
+  // happen together: (1) bulk-unlock the workshop's phase for every member,
+  // (2) auto-stamp today's date into the workshop's `date` field so the
+  // cadence accumulates a real timeline as it runs. If the workshop already
+  // has a scheduled date, we respect it (no overwrite).
+  const handleOpenWorkshop = async (workshopIndex: number, todayISO: string) => {
+    if (mode !== 'live') {
+      toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to enable unlocks' }) });
+      return;
+    }
+    const workshop = (cohort?.settings as any)?.workshops?.[workshopIndex] as WorkshopConfig | undefined;
+    if (!workshop) return;
+    await unlockPhase('all', workshop.unlocksPhase);
+    // Stamp openedAt — the source of truth for state. Scheduled `date` is left
+    // alone so the coordinator can still see it (and edit it later if needed).
+    if (!workshop.openedAt) {
+      const updated: WorkshopConfig[] = ((cohort?.settings as any)?.workshops ?? []).map(
+        (w: WorkshopConfig, j: number) => (j === workshopIndex ? { ...w, openedAt: todayISO } : w),
+      );
+      await saveWorkshops(updated);
+    }
+    toast({
+      title: t('orchestrator.cohort.workshopOpened', {
+        defaultValue: `${workshop.name} opened for cohort`,
+        workshop: workshop.name,
+      }),
+    });
+  };
+
+  const handleUpdateWorkshops = async (next: WorkshopConfig[]) => {
+    if (mode !== 'live') {
+      toast({ title: t('orchestrator.cohort.sampleModeNotice', { defaultValue: 'Create a cohort to edit dates' }) });
+      return;
+    }
+    await saveWorkshops(next);
   };
 
   const handleInviteOpen = () => {
@@ -773,43 +811,12 @@ export default function OrchestratorLandingPage() {
             </div>
           </div>
 
-          {/* Workshop cadence strip */}
-          {workshops.length > 0 && (
-            <div className="mt-3 pt-3 border-t border-foreground/5">
-              <div className="flex items-center justify-between mb-2">
-                <BodySmall className="text-muted-foreground uppercase tracking-wide text-[10px]">
-                  {t('orchestrator.cohort.workshops', { defaultValue: 'Workshop cadence' })}
-                </BodySmall>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {workshops.map((w, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center gap-2 rounded-lg border border-foreground/10 bg-background px-2.5 py-1.5"
-                  >
-                    <div className="flex flex-col">
-                      <span className="text-[11px] font-medium leading-tight">{w.name}</span>
-                      <span className="text-[10px] text-muted-foreground leading-tight">
-                        {w.date ?? t('orchestrator.cohort.noDate', { defaultValue: 'no date' })}
-                        {' · '}
-                        {t('orchestrator.cohort.unlocksPhase', { defaultValue: 'unlocks P{{phase}}', phase: w.unlocksPhase })}
-                      </span>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 px-2 text-[10px]"
-                      onClick={() => handleBulkUnlock(w.unlocksPhase)}
-                      data-testid={`button-bulk-unlock-${i}`}
-                    >
-                      <Unlock className="w-3 h-3 mr-1" />
-                      {t('orchestrator.cohort.unlockForCohort', { defaultValue: 'Unlock for cohort' })}
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          <WorkshopCadence
+            workshops={workshops}
+            disabled={mode !== 'live'}
+            onOpenWorkshop={handleOpenWorkshop}
+            onUpdateWorkshops={handleUpdateWorkshops}
+          />
         </div>
 
         {/* Co-design ribbon */}

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -92,6 +92,7 @@ export function registerCohortRoutes(app: Express): void {
       name: String(w.name ?? ''),
       date: w.date ? String(w.date) : null,
       unlocksPhase: Number(w.unlocksPhase) || 1,
+      openedAt: w.openedAt ? String(w.openedAt) : null,
     }));
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -9,8 +9,10 @@ import { pgTable, text, varchar, jsonb, timestamp, integer } from 'drizzle-orm/p
 
 export type WorkshopConfig = {
   name: string;       // "Workshop 1"
-  date: string | null; // ISO date or null if unscheduled
-  unlocksPhase: number; // which CBO phase this workshop unlocks (1..5)
+  date: string | null;     // ISO date — the *scheduled* workshop date (editable by coordinator)
+  unlocksPhase: number;    // which CBO phase this workshop unlocks (1..5)
+  openedAt?: string | null; // ISO date — set the moment the coordinator clicks "Open for cohort".
+                           // Source of truth for state (held vs not). null until opened.
 };
 
 export type CohortSettings = {


### PR DESCRIPTION
## Summary

The 10-CBO invite loop was the highest-friction coordinator action: open dialog → type → submit → copy → switch to WhatsApp → find contact → paste → send → return × 10. This PR closes both legs of that loop.

### 1. WhatsApp deep-link in `ShareLinkDialog`

Adds a primary **Open in WhatsApp** CTA (CBO context only). Uses `https://wa.me/?text=<encoded>` so the greeting is pre-filled; coordinator picks the contact and sends. Mobile → opens WhatsApp app. Desktop → opens WhatsApp Web. Demotes the two existing actions to fallback outlines.

### 2. Bulk-paste mode in `InviteCboDialog`

Segmented control at top toggles **One at a time / Paste a list**. Bulk mode:

```
Horta Comunitária Cascata, Cascata
Coletivo Arquipélago Verde, Arquipélago
Agentes do Bosque Humaitá, Humaitá
…
```

- Live-parsed: "10 ready to invite · Horta Cascata · Arquipélago Verde · Bosque Humaitá … +7"
- Role chip applies to all
- Sequential submission with progress ("Inviting 4 of 10…") so the server isn't hammered

### 3. New `BulkInviteSummaryDialog`

Fires after bulk completion. One row per CBO with:
- **Open in WhatsApp** (single-tap; opens `wa.me` with that CBO's greeting)
- **Copy link**
- Master **Copy all messages** button at the top — useful when batching sends

### Plumbing

Split the share-dialog side effect out of `handleInviteSubmit`. The dialog now calls `onSingleSuccess` in single mode (parent opens share dialog) and `onBulkComplete` in bulk mode (parent opens summary dialog). The bulk loop no longer triggers N share dialogs.

## Test plan

- [ ] Single invite → ShareLinkDialog has **Open in WhatsApp** as primary action; tap → WhatsApp opens with greeting + link
- [ ] Switch to **Paste a list**, paste 3 lines → "3 ready to invite" appears; preview shows them
- [ ] Submit → progress counter ticks; on completion BulkInviteSummaryDialog opens with 3 rows
- [ ] Tap WhatsApp on row 2 → WhatsApp opens with that CBO's greeting
- [ ] Tap copy-link on row 3 → URL in clipboard, ✓ feedback
- [ ] Tap **Copy all messages** → multi-line block in clipboard, separated by `──────────`
- [ ] Sample mode → bulk button toasts "Create a cohort to enable invites" (no server hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)