### PR TITLE
docs: photo curation standard + E1/E2 design + mobile tabs spec

### DIFF
--- a/docs/photo-curation.md
+++ b/docs/photo-curation.md
@@ -1,0 +1,214 @@
+# Photo Curation Standard
+
+**Last updated**: 2026-05-15 · **Status**: active
+
+Every photograph shown on the platform must demonstrably represent the named project or place. Stock-feeling photos that "look like a community garden somewhere" are not acceptable — a community leader who knows Curitiba can spot a fake Parque Barigui, and trust drops the moment they do.
+
+## What is allowed
+
+| Source | License | Notes |
+|---|---|---|
+| **Wikimedia Commons** | CC-BY / CC-BY-SA / Public Domain | Preferred. Stable URLs, machine-readable license metadata, freely redistributable. |
+| **Prefeitura websites** (Curitiba, São Paulo, POA, Recife, BH, etc.) | Varies — check each ToS | Usually permissive for non-commercial educational use. Always attribute. |
+| **Agência Brasil** | CC-BY | Brazilian state news agency. Many photos of public works + community projects. |
+| **WRI Brasil publications** | Attribution required | NBS-specific projects already framed correctly. |
+| **Partner orgs directly** (Vila Flores, Catalytic Communities, Sustainable Favela Network) | Direct permission | Best for their own work. Get written permission before use. |
+
+## What is NOT allowed
+
+- Stock photography (Getty, Shutterstock, Unsplash without explicit project match)
+- AI-generated images
+- Photos without verifiable attribution
+- Photos labeled as one project but visually inconsistent with that project's actual look (e.g. a generic "rain garden" labeled as a specific Recife project — credibility risk)
+
+## How to attribute
+
+Every photo in `client/public/assets/*` or referenced in a manifest must record:
+
+```yaml
+- file: client/public/assets/interventions/flood-parks.jpg
+  project: "Parque Barigui"
+  city: "Curitiba, PR"
+  source: "Wikimedia Commons"
+  source_url: "https://commons.wikimedia.org/wiki/File:Parque_Barigui_-_Curitiba_DSC04494.JPG"
+  photographer: "Agrinaldo Caires Fonseca"
+  license: "CC-BY-SA-3.0"
+  verified_at: "2026-05-15"
+  verified_by: "JVP"
+```
+
+The `photoCredit` field on `caseStudies[]` in `shared/cbo-schema.ts` should be a rendering of `photographer` + `license`, e.g. *"Agrinaldo C. Fonseca · CC-BY-SA"*.
+
+## Audit of existing intervention case-study photos
+
+Six photos already shipping in `client/public/assets/interventions/`. Verdicts based on the schema labels in `shared/cbo-schema.ts:87-142` (full visual audit requires opening each JPG; this doc flags what's verified by label-vs-source-search).
+
+| File | Labeled as | Verdict | Action |
+|---|---|---|---|
+| `bioswales.jpg` | "Bioretention Rain Garden, Portland USA" | ❌ **Not Brazilian.** Schema says Portland — this is the single clearest miss. The whole intervention library is supposed to read as Brazilian. | **Replace** with a Brazilian case. Recife UFPE pilot project documented at [scielo.br](http://www.scielo.br/j/ac/a/3mKRyFjSkPdBkhdvyVGZZLL/?lang=pt); São Paulo has multiple municipal projects. Need a verified-source photo. |
+| `flood-parks.jpg` | "Parque Barigui, Curitiba" | ⚠️ **Verify against Wikimedia.** Multiple high-quality Wikimedia photos exist for this park. | **Verify or replace** with `Parque_Barigui_-_Curitiba_DSC04494.JPG` (CC-BY-SA, photographer Agrinaldo Caires Fonseca). |
+| `green-corridors.jpg` | "Parque Capibaribe, Recife" | ⚠️ **Wikimedia category exists but no canonical photo found for Capibaribe specifically.** | **Verify** — if the existing JPG looks like the Recife Capibaribe project (linear riverside park, palms, walking paths), keep + attribute. Otherwise pull from [Prefeitura do Recife photo gallery](http://meioambiente.recife.pe.gov.br/parque-capibaribe) with permission. |
+| `green-roofs.jpg` | "Fundação Cásper Líbero, São Paulo" | ⚠️ **Specific project — Av. Paulista 900, Edifício Gazeta, 700 m² Mata Atlântica green roof by botanist Ricardo Cardim.** | **Verify** — the photo should show the rooftop forest with 130 native plant species, urban Av. Paulista context. If it's a generic green roof, replace. |
+| `urban-forests.jpg` | "Rua Gonçalo de Carvalho, Porto Alegre" | ⚠️ **Very recognizable place — 500m tipuana tree tunnel.** Easy to verify visually. | **Verify** — if the JPG isn't unmistakably the green-tunnel street with cobblestones + 19th-century buildings, replace. [Wikipedia article](https://pt.wikipedia.org/wiki/Rua_Gon%C3%A7alo_de_Carvalho) has source photos. |
+| `wetland-restoration.jpg` | "DRENURBS Parque Primeiro de Maio, Belo Horizonte" | ⚠️ **Verify against Wikimedia.** | **Verify or replace** with [`Parque_Primeiro_de_Maio_01.JPG`](https://commons.wikimedia.org/wiki/File:Parque_Primeiro_de_Maio_01.JPG) (Wikimedia Commons). |
+
+**One definite replacement (`bioswales.jpg`) + five visual verifications needed before pilot launch.**
+
+## New photos to source for E2 NbsShowcaseCard
+
+Per the curriculum plan, E2's showcase cards need 3 Brazilian NBS examples. Sourced URLs below.
+
+### Card 1 — Curitiba · Parques do Barigui (NbS for flooding)
+
+- **Source**: [Wikimedia Commons — Parque Barigui DSC04494](https://commons.wikimedia.org/wiki/File:Parque_Barigui_-_Curitiba_DSC04494.JPG)
+- **Photographer**: Agrinaldo Caires Fonseca
+- **License**: CC-BY-SA-3.0
+- **Alt source**: [Category:Parks in Curitiba](https://commons.wikimedia.org/wiki/Category:Parks_in_Curitiba) — multiple Barigui photos
+- **Visual check**: should show wide-open park space with the Barigui river / lake visible; capybaras optional but iconic
+
+### Card 2 — São Paulo · Parque do Tietê (NbS for flooding + biodiversity)
+
+- **Source**: [Wikimedia Commons — Category:Parque Ecológico do Tietê](https://commons.wikimedia.org/wiki/Category:Parque_Ecol%C3%B3gico_do_Tiet%C3%AA) (613+ files)
+- **License**: varies per file — pick one that's CC-BY or PD
+- **Recommendation**: photo showing the Bandeiras do DAEE or Barragem da Penha is iconic; a wider park shot showing the riparian floodplain works for the "1.400 ha with ecological function" framing
+- **Alt source**: [Governo do Estado de SP photo gallery](https://www.saopaulo.sp.gov.br/conhecasp/parques-e-reservas-naturais/parque-ecologico-do-tiete/) — verify reuse terms
+
+### Card 3 — Porto Alegre · Várzea Lab · Vila Flores (NbS for community adaptation)
+
+- **Source**: **Direct from Vila Flores** (`contato@vilaflores.org`)
+- **License**: Direct permission for COUGAR platform use
+- **Why direct**: This is their work; they own the visuals; relationship-appropriate to ask. Antônia or Julia should provide 1-2 photos of the courtyard / rain garden / community workshops on site.
+- **Visual check**: should show the 1920s architectural complex from Rua São Carlos, the courtyard, or community workshop activity. Photos with people working in the space are ideal (warmth over architecture-only)
+- **Fallback while waiting**: gradient placeholder per the mockup. The card label says *"Foto em breve"* until Vila Flores delivers.
+
+## What we DO NOT do for `bioswales.jpg` replacement
+
+The "Bioretention Rain Garden, Portland USA" entry is clearly wrong context (the whole intervention library is meant to be Brazilian-grounded). We replace with one of:
+
+- **Recife rain-garden pilot** ([UFPE study](http://www.scielo.br/j/ac/a/3mKRyFjSkPdBkhdvyVGZZLL/?lang=pt)) — academic publication, may need permission from authors
+- **São Paulo municipal jardins de chuva program** — multiple bairros documented; check Prefeitura de SP photo gallery
+- **Fortaleza tropical rain garden pilot** ([ResearchGate paper](https://www.researchgate.net/publication/387488450)) — also research-based
+
+**Recommended path**: contact UFPE researchers or São Paulo prefeitura via direct outreach; explain the use case (community education platform); request a verified-attribution photo.
+
+Until a Brazilian-grounded photo is sourced, the bioswales card should use the gradient + emoji placeholder pattern (per the E2 mockup), not the current Portland JPG.
+
+## Process for adding new photos
+
+1. **Identify** the project (specific named place, not a category).
+2. **Search**: Wikimedia Commons → category → file pages. If not found there: Prefeitura site → photo gallery. If not found there: partner org → direct ask.
+3. **Verify** the photo visually represents the named project (e.g. Parque Barigui photos should show the actual park, ideally with recognizable landmarks).
+4. **Download** to `client/public/assets/<category>/<filename>.jpg`. Compress to ~80 KB max (web-ready).
+5. **Register** in this doc's manifest block (below) + update the `caseStudies[]` entry in `shared/cbo-schema.ts` if applicable.
+6. **Commit** the file + manifest update in the same PR.
+
+## Photo manifest (canonical list — update as photos are added)
+
+```yaml
+# As of 2026-05-15, all entries below are PROPOSED. Existing JPGs in
+# client/public/assets/interventions/ have NOT yet been verified or replaced.
+# This manifest tracks the intended state — actual files need to be downloaded
+# and audited in a follow-up commit.
+
+interventions:
+  - file: client/public/assets/interventions/flood-parks.jpg
+    project: Parque Barigui
+    city: Curitiba, PR
+    source: Wikimedia Commons
+    source_url: https://commons.wikimedia.org/wiki/File:Parque_Barigui_-_Curitiba_DSC04494.JPG
+    photographer: Agrinaldo Caires Fonseca
+    license: CC-BY-SA-3.0
+    status: proposed
+    verified_at: null
+
+  - file: client/public/assets/interventions/wetland-restoration.jpg
+    project: Parque Primeiro de Maio (DRENURBS)
+    city: Belo Horizonte, MG
+    source: Wikimedia Commons
+    source_url: https://commons.wikimedia.org/wiki/File:Parque_Primeiro_de_Maio_01.JPG
+    license: CC-BY-SA (verify on file page)
+    status: proposed
+    verified_at: null
+
+  - file: client/public/assets/interventions/urban-forests.jpg
+    project: Rua Gonçalo de Carvalho (Túnel Verde)
+    city: Porto Alegre, RS
+    source: Wikipedia (multiple photos linked from article)
+    source_url: https://pt.wikipedia.org/wiki/Rua_Gon%C3%A7alo_de_Carvalho
+    license: varies per file — must pick CC-BY/PD
+    status: needs_visual_check
+    verified_at: null
+
+  - file: client/public/assets/interventions/green-corridors.jpg
+    project: Parque Capibaribe
+    city: Recife, PE
+    source: Prefeitura do Recife (request reuse) OR Wikimedia (no canonical found)
+    source_url: http://meioambiente.recife.pe.gov.br/parque-capibaribe
+    license: needs_permission
+    status: needs_outreach
+    verified_at: null
+
+  - file: client/public/assets/interventions/green-roofs.jpg
+    project: Fundação Cásper Líbero (telhado verde 900 Av. Paulista)
+    city: São Paulo, SP
+    source: Eccaplan article (need direct photographer source)
+    source_url: https://eccaplan.com.br/conheca-o-primeiro-telhado-verde-da-avenida-paulista-em-sao-paulo/
+    license: needs_permission
+    status: needs_outreach
+    verified_at: null
+
+  - file: client/public/assets/interventions/bioswales.jpg
+    project: NEEDS_REPLACEMENT — currently labeled Portland USA
+    city: TBD (Brazilian city)
+    candidates:
+      - Recife rain-garden pilot (UFPE / scielo.br)
+      - São Paulo jardins de chuva municipal program
+      - Fortaleza tropical rain garden pilot (ResearchGate)
+    status: blocked_pending_replacement
+    verified_at: null
+
+nbs_showcase_e2:
+  - id: curitiba-barigui
+    project: Parques do Barigui
+    city: Curitiba, PR
+    file: client/public/assets/nbs/showcase/curitiba-barigui.jpg
+    source: Wikimedia Commons
+    source_url: https://commons.wikimedia.org/wiki/File:Parque_Barigui_-_Curitiba_DSC04494.JPG
+    photographer: Agrinaldo Caires Fonseca
+    license: CC-BY-SA-3.0
+    status: proposed
+
+  - id: sao-paulo-tiete
+    project: Parque Ecológico do Tietê
+    city: São Paulo, SP
+    file: client/public/assets/nbs/showcase/sao-paulo-tiete.jpg
+    source: Wikimedia Commons
+    source_url: https://commons.wikimedia.org/wiki/Category:Parque_Ecol%C3%B3gico_do_Tiet%C3%AA
+    license: varies per file (pick CC-BY/PD)
+    status: proposed_pending_file_selection
+
+  - id: vila-flores-varzea
+    project: Várzea Lab · Vila Flores
+    city: Porto Alegre, RS
+    file: client/public/assets/nbs/showcase/vila-flores-varzea.jpg
+    source: Direct from Vila Flores (contato@vilaflores.org)
+    license: direct_permission
+    status: pending_outreach
+    notes: |
+      Photo of courtyard, rain garden, or community workshop. Warmth over
+      architecture. Antônia / Julia can provide.
+```
+
+## Open action items
+
+Before pilot launch (June 11):
+
+1. **Visually audit** the 5 "needs_visual_check" interventions JPGs. Anything that doesn't clearly represent the named project gets replaced.
+2. **Replace** `bioswales.jpg` with a Brazilian rain-garden case.
+3. **Source the 3 E2 showcase cards** — Wikimedia for #1-2 is straightforward; reach out to Vila Flores for #3.
+4. **Outreach** for Prefeitura do Recife (Parque Capibaribe) + Eccaplan/Cásper Líbero (telhado verde) reuse permissions.
+5. **Add `photoSource`, `photoLicense`, `photoVerifiedAt` fields** to the case-study schema for machine-readable provenance, if not already present.
+
+## A word on tooling
+
+A tiny audit script could check that every photo referenced in `cbo-schema.ts` exists, has a non-null `photoCredit`, and matches an entry in this manifest. Worth ~30 lines of TypeScript if we end up adding photos faster than humans can review.

--- a/knowledge/runs/2026-05-14-cougar-backlog-refresh/rundown.html
+++ b/knowledge/runs/2026-05-14-cougar-backlog-refresh/rundown.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NBS Orchestrator + CBO — Build Rundown · 2026-05-14</title>
+<style>
+  :root {
+    --bg: #fafaf9;
+    --surface: #ffffff;
+    --ink: #18181b;
+    --muted: #71717a;
+    --line: rgba(0,0,0,0.08);
+    --accent: #059669;
+    --accent-soft: #ecfdf5;
+    --warn: #d97706;
+    --warn-soft: #fef3c7;
+    --info: #0284c7;
+    --info-soft: #e0f2fe;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.55; }
+  .page { max-width: 880px; margin: 0 auto; padding: 56px 32px 96px; }
+  h1 { font-size: 32px; letter-spacing: -0.02em; margin: 0 0 8px; }
+  h2 { font-size: 22px; letter-spacing: -0.01em; margin: 56px 0 18px; padding-top: 24px; border-top: 1px solid var(--line); }
+  h3 { font-size: 16px; margin: 28px 0 8px; }
+  p { margin: 0 0 12px; }
+  .lede { color: var(--muted); font-size: 16px; margin-bottom: 24px; }
+  .meta { display: flex; gap: 16px; font-size: 12px; color: var(--muted); margin-bottom: 32px; }
+  .meta span { display: inline-flex; align-items: center; gap: 4px; }
+  ul { margin: 0 0 16px; padding-left: 20px; }
+  li { margin-bottom: 6px; }
+  code { background: var(--accent-soft); color: #047857; padding: 1px 6px; border-radius: 4px; font-family: ui-monospace, "JetBrains Mono", monospace; font-size: 0.88em; }
+  .pr-grid { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 24px; }
+  @media (min-width: 720px) { .pr-grid { grid-template-columns: repeat(2, 1fr); } }
+  .pr { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px; }
+  .pr .num { font-family: ui-monospace, monospace; font-size: 11px; color: var(--muted); letter-spacing: 0.06em; }
+  .pr h4 { font-size: 14px; margin: 4px 0 6px; letter-spacing: -0.01em; }
+  .pr p { font-size: 13px; color: var(--muted); margin: 0; }
+  .pill { display: inline-block; font-size: 10px; padding: 3px 8px; border-radius: 999px; background: var(--accent-soft); color: #047857; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; vertical-align: middle; }
+  .pill.warn { background: var(--warn-soft); color: #92400e; }
+  .pill.info { background: var(--info-soft); color: #075985; }
+  /* Flow steps */
+  .flow { background: var(--surface); border: 1px solid var(--line); border-radius: 16px; padding: 8px; margin: 16px 0 32px; }
+  .step { display: grid; grid-template-columns: 40px 1fr; gap: 12px; padding: 16px; border-bottom: 1px solid var(--line); align-items: start; }
+  .step:last-child { border-bottom: 0; }
+  .step .n { width: 28px; height: 28px; border-radius: 50%; background: var(--accent-soft); color: #047857; font-weight: 600; font-size: 12px; display: flex; align-items: center; justify-content: center; }
+  .step .body h4 { margin: 0 0 4px; font-size: 14px; letter-spacing: -0.01em; }
+  .step .body p { font-size: 13px; color: var(--muted); margin: 0; }
+  .step .body p + p { margin-top: 6px; }
+  .step .body code { font-size: 11px; }
+  /* Tables */
+  table { width: 100%; border-collapse: collapse; background: var(--surface); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; margin-bottom: 24px; }
+  th, td { padding: 12px 14px; text-align: left; font-size: 13px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: #fafafa; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  tr:last-child td { border-bottom: 0; }
+  /* Wireframe-ish boxes */
+  .wire { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 20px; margin: 12px 0; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); white-space: pre-wrap; line-height: 1.7; }
+  .wire .ink { color: var(--ink); }
+  .wire .accent { color: var(--accent); font-weight: 600; }
+  .wire .muted { color: var(--muted); opacity: 0.7; }
+  /* Callouts */
+  .callout { background: var(--accent-soft); border-left: 3px solid var(--accent); padding: 12px 16px; border-radius: 0 8px 8px 0; margin: 16px 0; font-size: 13px; color: #047857; }
+  .callout.warn { background: var(--warn-soft); border-color: var(--warn); color: #92400e; }
+  .small { font-size: 12px; color: var(--muted); }
+  .kbd { font-family: ui-monospace, monospace; font-size: 11px; background: #f4f4f5; padding: 2px 6px; border-radius: 4px; border: 1px solid var(--line); }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <h1>NBS Platform — Build Rundown</h1>
+  <p class="lede">Five PRs over one day. Foundation + UX polish for the Vila Flores COUGAR pilot, June 8 convening.</p>
+  <p class="meta">
+    <span>📅 2026-05-14</span>
+    <span>🏷️ Branch stack on <code>main</code></span>
+    <span>👥 Audience: Julia (coordinator), 10 Vila Flores CBOs (community leaders)</span>
+  </p>
+
+  <h2>What landed</h2>
+
+  <div class="pr-grid">
+    <div class="pr"><div class="num">#130 · feat</div>
+      <h4>Orchestrator foundation</h4>
+      <p>Server-backed cohorts (Drizzle/Postgres), slug-secret auth, invite flow, per-phase unlocks, workshop cadence.</p>
+    </div>
+    <div class="pr"><div class="num">#131 · fix</div>
+      <h4>Handler error-wrap</h4>
+      <p>Wraps cohort routes so a DB error becomes a 500 — not an unhandled rejection that kills the Node process.</p>
+    </div>
+    <div class="pr"><div class="num">#132 · feat</div>
+      <h4>Dialog-based UX</h4>
+      <p>Replaces <code>window.prompt()</code> with proper Dialogs for Create / Load / Invite / Share. WhatsApp message template.</p>
+    </div>
+    <div class="pr"><div class="num">#133 · feat</div>
+      <h4>Risk-overlay layers</h4>
+      <p>Two map toggles on /orchestrator: recruit zones (bairro choropleth) + composite hotspot tiles.</p>
+    </div>
+    <div class="pr"><div class="num">#134 · polish</div>
+      <h4>CBO premium experience</h4>
+      <p>Welcome screen, friendly progress, mobile-first chat, Portuguese-first defaults.</p>
+    </div>
+  </div>
+
+  <p class="small">Merge <strong>#130 first</strong>; the rest auto-retarget to <code>main</code> from there.</p>
+
+  <h2>The two journeys</h2>
+
+  <h3>Julia (coordinator)</h3>
+  <div class="flow">
+    <div class="step"><div class="n">1</div><div class="body">
+      <h4>Opens <code>/orchestrator</code></h4>
+      <p>If no coordinator slug in localStorage → sample mode (Vila Flores demo cohort, 4 fake CBOs). For her real cohort: clicks <strong>Create cohort</strong>.</p>
+    </div></div>
+    <div class="step"><div class="n">2</div><div class="body">
+      <h4>Names the cohort</h4>
+      <p>Single-field Dialog, default "Vila Flores cohort", <span class="kbd">Enter</span> submits. Server creates <code>cohorts</code> row + seeds 6 workshops. Slug stored to localStorage.</p>
+    </div></div>
+    <div class="step"><div class="n">3</div><div class="body">
+      <h4>Copies "My link"</h4>
+      <p>Recovery key. Share dialog with two buttons: <strong>Copy link</strong> and <strong>Copy WhatsApp message</strong> (PT-formatted for the BR audience).</p>
+    </div></div>
+    <div class="step"><div class="n">4</div><div class="body">
+      <h4>Invites 10 CBOs</h4>
+      <p>Per CBO: name + bairro + role (priority/alternate) in one form. Server creates <code>cohort_members</code> row. Share dialog opens with the CBO link + a Portuguese WhatsApp greeting:</p>
+      <p><em>"Olá! 👋 Este é o link da plataforma do COUGAR/Vila Flores para Horta Cascata…"</em></p>
+    </div></div>
+    <div class="step"><div class="n">5</div><div class="body">
+      <h4>Tracks the cohort on the map</h4>
+      <p>Right rail = CBO cards with phase, sections done, maturity, last activity. Hover a card → marker highlights. Toggle <strong>Recruit zones</strong> → 94 bairros colored by priority score; click → toast with recruit context.</p>
+    </div></div>
+    <div class="step"><div class="n">6</div><div class="body">
+      <h4>After Workshop 2 ends</h4>
+      <p>Clicks <strong>Unlock for cohort</strong> on the Workshop 2 row. Server appends phase 2 to every member's <code>unlockedPhases</code>. CBOs see phase 2 open on next focus.</p>
+    </div></div>
+  </div>
+
+  <h3>Sandra (composite CBO leader, on her phone)</h3>
+  <div class="flow">
+    <div class="step"><div class="n">1</div><div class="body">
+      <h4>WhatsApp message lands</h4>
+      <p>Julia's pre-formatted greeting + a link. Sandra taps.</p>
+    </div></div>
+    <div class="step"><div class="n">2</div><div class="body">
+      <h4>Premium welcome screen <span class="pill">#134</span></h4>
+      <p>Org name in display type, soft emerald gradient, single CTA. Next-workshop card surfaces the date pulled from cohort settings. 5-step preview tells her what's coming.</p>
+      <p>One tap on <strong>Começar</strong> → chat begins.</p>
+    </div></div>
+    <div class="step"><div class="n">3</div><div class="body">
+      <h4>Chat flow (single-column on mobile)</h4>
+      <p>Agent guides her through Phase 1: who they are, sector, scale. Multi-choice + free-text. Profile saves automatically; she can leave and come back.</p>
+      <p>Friendly progress strip at the top: <em>"Section 1 of 5 · Who you are"</em> with 5 segments. Locked segments show 🔒.</p>
+    </div></div>
+    <div class="step"><div class="n">4</div><div class="body">
+      <h4>Tries to skip to Phase 2</h4>
+      <p>Taps the locked segment → Popover (works on touch): <em>"Opens after Workshop 2 · quarta, 11 de junho."</em></p>
+    </div></div>
+    <div class="step"><div class="n">5</div><div class="body">
+      <h4>Coordinator unlocks Phase 2</h4>
+      <p>Sandra returns to the page later (window focus) → page re-fetches; Phase 2 segment is now tappable; the popover dies. Chat continues with new questions.</p>
+    </div></div>
+    <div class="step"><div class="n">6</div><div class="body">
+      <h4>Profile state syncs back</h4>
+      <p>Every <code>phase_change</code> or <code>maturity_update</code> event pushes a snapshot to <code>PATCH /api/cbo-member/:slug/snapshot</code>. Julia's orchestrator view reflects it on her next refresh.</p>
+    </div></div>
+  </div>
+
+  <h2>The premium CBO welcome — what it looks like</h2>
+
+  <div class="wire">┌─────────────────────────────────────────┐
+│ <span class="muted">🌿  COUGAR · VILA FLORES</span>                   │
+│                                         │
+│  <span class="muted">Olá,</span>                                   │
+│  <span class="ink"><strong>Horta Comunitária Cascata</strong></span>             │
+│  <span class="muted">de Cascata</span>                              │
+│                                         │
+│  <span class="ink">Você foi convidado(a) para a plataforma</span>   │
+│  <span class="ink">do Vila Flores cohort — um espaço</span>         │
+│  <span class="ink">tranquilo para contar o que a sua</span>         │
+│  <span class="ink">organização faz, onde trabalha…</span>           │
+│                                         │
+│  ┌─ <span class="accent">PRÓXIMO ENCONTRO</span> ───────────────┐    │
+│  │ <span class="ink">Workshop 2 — Where We Work</span>           │    │
+│  │ <span class="muted">📅 quarta, 11 de junho</span>             │    │
+│  └─────────────────────────────────┘    │
+│                                         │
+│  <span class="muted">O QUE VAMOS FAZER JUNTOS</span>                │
+│  <span class="accent">●</span> <span class="ink">Quem somos</span>                          │
+│  <span class="muted">○ Onde trabalhamos</span>                     │
+│  <span class="muted">○ O que construímos</span>                    │
+│  <span class="muted">○ O que precisamos</span>                     │
+│  <span class="muted">○ Resultados e evidências</span>              │
+│                                         │
+│  ┌─────────────────────────────────┐    │
+│  │ <span class="accent"><strong>Começar</strong></span>                     │    │
+│  └─────────────────────────────────┘    │
+│  <span class="muted">⏱ Cerca de 20 min no total, salva sozinho</span>│
+└─────────────────────────────────────────┘</div>
+
+  <h2>The friendly progress strip — replaces the developer one</h2>
+
+  <p class="small">Before — the schema, useful to engineers, gibberish to a community leader:</p>
+  <div class="wire"><span class="muted">[1] [2] [3a] [3b] [3c] [4] [5]  0/7  0/27</span></div>
+
+  <p class="small">After — a calm 5-segment bar with caption + locked-state popovers that work on touch:</p>
+  <div class="wire"><span class="muted">Section 2 of 5 · </span><span class="ink"><strong>Where you work</strong></span>
+
+<span class="accent">━━━━</span> <span class="accent">━━━━</span> <span class="muted">━━━━</span> <span class="muted">🔒 ━━━━</span> <span class="muted">🔒 ━━━━</span>
+                ▲ tap any locked
+                  segment → popover
+                  "Opens after Workshop 4 ·
+                   Wednesday, July 2"</div>
+
+  <h2>Under the hood</h2>
+
+  <h3>Data model</h3>
+  <table>
+    <thead><tr><th>Table</th><th>Key fields</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>cohorts</code></td><td>id, coordinatorSlug (unique), name, settings.workshops</td><td>One row per coordinator-managed cohort. Slug = recovery key + auth.</td></tr>
+      <tr><td><code>cohort_members</code></td><td>id, cohortId, memberSlug (unique), orgName, neighborhood, role, unlockedPhases, snapshot*</td><td>One per invited CBO. Inlined snapshot keeps the orchestrator card fresh without polling.</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Endpoints</h3>
+  <table>
+    <thead><tr><th>Method · Path</th><th>What</th></tr></thead>
+    <tbody>
+      <tr><td><code>POST /api/cohort</code></td><td>Create cohort, seed 6 workshops</td></tr>
+      <tr><td><code>GET /api/cohort/:slug</code></td><td>Coordinator view: cohort + members</td></tr>
+      <tr><td><code>POST /api/cohort/:slug/invite</code></td><td>Add a member, return their slug</td></tr>
+      <tr><td><code>PATCH /api/cohort/:slug/workshops</code></td><td>Edit cadence (deferred UI)</td></tr>
+      <tr><td><code>PATCH /api/cohort/:slug/unlock</code></td><td>Per-member or bulk phase unlock</td></tr>
+      <tr><td><code>GET /api/cbo-member/:slug</code></td><td>CBO view: identity + unlockedPhases + workshops + nextWorkshop</td></tr>
+      <tr><td><code>PATCH /api/cbo-member/:slug/snapshot</code></td><td>CBO pushes profile summary on agent events</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Key components</h3>
+  <table>
+    <thead><tr><th>Path</th><th>Role</th></tr></thead>
+    <tbody>
+      <tr><td><code>shared/cohort-schema.ts</code></td><td>Drizzle tables + default workshops seed</td></tr>
+      <tr><td><code>server/routes/cohortRoutes.ts</code></td><td>7 endpoints, wrapped in try/catch <span class="pill info">#131</span></td></tr>
+      <tr><td><code>client/src/core/hooks/useCohort.ts</code></td><td>One hook, sample-mode fallback, <code>?coord=</code> URL param</td></tr>
+      <tr><td><code>client/src/core/components/orchestrator/CohortDialogs.tsx</code></td><td>Create / Load / Invite / Share dialogs <span class="pill info">#132</span></td></tr>
+      <tr><td><code>client/src/core/components/cbo/CboWelcome.tsx</code></td><td>Premium full-screen welcome <span class="pill info">#134</span></td></tr>
+      <tr><td><code>client/src/core/components/cbo/CboProgress.tsx</code></td><td>5-segment progress + Popover locks <span class="pill info">#134</span></td></tr>
+      <tr><td><code>client/src/core/pages/orchestrator-landing.tsx</code></td><td>Cohort header + cadence strip + map + risk layers</td></tr>
+      <tr><td><code>client/src/core/pages/cbo-profile.tsx</code></td><td>Welcome → chat handoff, mobile-first layout</td></tr>
+    </tbody>
+  </table>
+
+  <h2>What's next</h2>
+
+  <p>Two halves of the May 14 → June 8 window remaining:</p>
+  <ul>
+    <li><strong>This week:</strong> <code>wa.me</code> deep-link + bulk invite (10-CBO invite loop is the next friction), next-workshop hint in chat header on mobile.</li>
+    <li><strong>Before May 25 stakeholder tour:</strong> richer sample mode (10 CBOs distributed across phases, so SMAMUS/Innovation Office sees the mature state), orchestrator chrome cleanup (the amber "co-design ribbon" screams demo).</li>
+    <li><strong>Before June 8:</strong> click-bairro → prefilled invite (after #132 lands), QR-code workshop entry, "Encontro" labels instead of "Phase".</li>
+  </ul>
+
+  <p class="small" style="margin-top:48px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Generated from <code>knowledge/runs/2026-05-14-cougar-backlog-refresh/</code> · Open Earth Foundation
+  </p>
+</div>
+</body>
+</html>

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/mockup.html
@@ -1,0 +1,560 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>E1 — Quem somos · mockup walkthrough</title>
+<style>
+  :root {
+    --bg: #fafaf9;
+    --surface: #ffffff;
+    --ink: #18181b;
+    --muted: #71717a;
+    --line: rgba(0,0,0,0.08);
+    --accent: #059669;
+    --accent-soft: #ecfdf5;
+    --accent-deep: #047857;
+    --warm: #f59e0b;
+    --warm-soft: #fef3c7;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1080px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  .lede { color: var(--muted); margin: 8px 0 32px; max-width: 60ch; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 24px; padding-left: 14px; border-left: 2px solid var(--accent); }
+
+  /* Phone-style frame for the CBO surface */
+  .phone {
+    width: 380px;
+    margin: 0 auto;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 12px 36px -16px rgba(0,0,0,0.18);
+  }
+  .phone .header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--surface);
+    font-size: 11px;
+    color: var(--muted);
+  }
+  .phone .body { padding: 24px 20px; min-height: 540px; }
+
+  /* Desktop-style frame (for the orchestrator) */
+  .desktop {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--surface);
+  }
+  .desktop .chrome {
+    padding: 8px 14px;
+    background: #f4f4f5;
+    border-bottom: 1px solid var(--line);
+    font-size: 11px;
+    color: var(--muted);
+    font-family: ui-monospace, "JetBrains Mono", monospace;
+  }
+  .desktop .body { padding: 24px; }
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 480px; }
+  .split .left { padding: 20px; border-right: 1px solid var(--line); }
+  .split .right { padding: 20px; background: #fafafa; }
+
+  /* Premium welcome / preamble screen */
+  .preamble-bg {
+    background: linear-gradient(to bottom, var(--accent-soft) 0%, #ffffff 40%, var(--accent-soft) 100%);
+    padding: 32px 24px;
+    border-radius: 0;
+  }
+  .brand-mark { color: var(--accent-deep); font-weight: 600; font-size: 11px; letter-spacing: 0.16em; margin-bottom: 32px; display: flex; align-items: center; gap: 6px; }
+  .display { font-size: 24px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.2; }
+  .display .subtle { color: var(--muted); display: block; font-size: 12px; font-weight: 500; margin-bottom: 6px; letter-spacing: 0.04em; text-transform: uppercase; }
+  .body-lead { font-size: 14px; color: var(--ink); margin-top: 18px; line-height: 1.6; }
+  .body-sub { font-size: 13px; color: var(--muted); margin-top: 8px; }
+  .agenda { margin: 20px 0; padding-left: 0; list-style: none; }
+  .agenda li { padding: 6px 0; font-size: 13px; color: var(--ink); display: flex; align-items: center; gap: 10px; }
+  .agenda li::before { content: "·"; color: var(--accent); font-weight: 700; font-size: 18px; }
+  .time-hint { font-size: 11px; color: var(--muted); margin-top: 24px; display: flex; align-items: center; gap: 6px; }
+  .btn-primary {
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--accent); color: white;
+    padding: 10px 24px; border-radius: 999px; font-weight: 500; font-size: 14px;
+    text-decoration: none;
+    margin-top: 18px;
+  }
+  .btn-primary:hover { background: var(--accent-deep); }
+
+  /* Chat */
+  .chat-shell { display: flex; flex-direction: column; height: 100%; }
+  .chat-progress {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line);
+    font-size: 11px;
+  }
+  .chat-progress .label { color: var(--muted); }
+  .chat-progress .active { color: var(--ink); font-weight: 600; }
+  .segments { display: flex; gap: 4px; margin-top: 4px; }
+  .seg { height: 4px; flex: 1; border-radius: 2px; }
+  .seg.past { background: var(--accent); }
+  .seg.curr { background: var(--accent); opacity: 0.5; }
+  .seg.locked { background: rgba(0,0,0,0.08); }
+
+  .chat-messages { padding: 14px; flex: 1; }
+  .msg { padding: 9px 12px; border-radius: 14px; margin-bottom: 8px; font-size: 13px; line-height: 1.5; max-width: 86%; }
+  .msg.agent { background: #f4f4f5; }
+  .msg.user { background: var(--accent); color: white; margin-left: auto; text-align: right; }
+  .msg .label { font-size: 10px; color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.06em; }
+  .msg.user .label { display: none; }
+
+  .quick-options { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip {
+    border: 1px solid var(--line); padding: 6px 10px; border-radius: 999px; font-size: 12px;
+    background: var(--surface); cursor: pointer;
+  }
+  .chip.selected { background: var(--accent-soft); border-color: #6ee7b7; color: var(--accent-deep); }
+  .chip.option-letter::before { content: attr(data-letter) " · "; color: var(--muted); font-weight: 600; }
+
+  .chat-input {
+    padding: 10px 14px; border-top: 1px solid var(--line); display: flex; gap: 8px; align-items: center;
+  }
+  .chat-input .ipt { flex: 1; border: 1px solid var(--line); border-radius: 999px; padding: 8px 14px; font-size: 13px; color: var(--muted); }
+  .chat-input .send { width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: white; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; }
+
+  /* Doc panel */
+  .doc-panel { padding: 16px; background: #fafafa; }
+  .doc-panel h3 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 0 0 8px; font-weight: 600; }
+  .doc-card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px;
+    margin-bottom: 8px;
+  }
+  .doc-card.empty { opacity: 0.5; }
+  .doc-card .row { display: flex; padding: 4px 0; font-size: 12px; gap: 8px; align-items: baseline; }
+  .doc-card .row .key { color: var(--muted); min-width: 86px; }
+  .doc-card .row .val { color: var(--ink); }
+  .doc-card .row .val.empty { color: var(--muted); opacity: 0.6; font-style: italic; }
+  .doc-card .placeholder { font-size: 12px; color: var(--muted); font-style: italic; }
+  .doc-section-title { font-size: 12px; color: var(--ink); font-weight: 600; margin-bottom: 6px; display: flex; align-items: center; justify-content: space-between; }
+  .complete-tag { font-size: 10px; padding: 2px 6px; border-radius: 999px; background: var(--accent-soft); color: var(--accent-deep); font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+  .pending-tag { font-size: 10px; color: var(--muted); }
+
+  /* Final state */
+  .completion {
+    background: var(--accent-soft);
+    border: 1px solid #6ee7b7;
+    padding: 14px;
+    border-radius: 10px;
+    text-align: center;
+    color: var(--accent-deep);
+    margin-bottom: 12px;
+  }
+  .completion .check { font-size: 22px; margin-bottom: 4px; }
+  .completion .ttl { font-weight: 600; font-size: 14px; }
+  .completion .sub { font-size: 12px; color: var(--ink); opacity: 0.7; margin-top: 4px; }
+
+  /* Orchestrator card */
+  .orch-card {
+    border: 1px solid var(--line); border-radius: 10px; padding: 14px; background: var(--surface); max-width: 380px;
+  }
+  .orch-row { display: flex; gap: 8px; align-items: center; }
+  .orch-row + .orch-row { margin-top: 8px; }
+  .orch-name { font-size: 14px; font-weight: 600; tracking: -0.01em; }
+  .orch-meta { font-size: 11px; color: var(--muted); }
+  .path-chip { font-size: 10px; padding: 2px 7px; border-radius: 999px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+  .path-idea { background: #dbeafe; color: #1e40af; }
+  .path-help { background: #fef3c7; color: #92400e; }
+  .maturity { font-size: 11px; color: var(--accent-deep); background: var(--accent-soft); padding: 2px 7px; border-radius: 999px; }
+
+  /* Annotations */
+  .legend {
+    background: #eff6ff; border-left: 3px solid #3b82f6; padding: 10px 14px; border-radius: 0 8px 8px 0; font-size: 12px; color: #1e3a8a;
+    margin: 16px 0 24px;
+  }
+  .legend strong { color: #1e40af; }
+
+  /* Side-by-side scenes */
+  .scene { display: grid; grid-template-columns: 380px 1fr; gap: 32px; align-items: start; }
+  .scene .note h3 { font-size: 14px; margin: 0 0 6px; }
+  .scene .note p { font-size: 13px; color: var(--muted); margin: 0 0 8px; line-height: 1.6; }
+  .scene .note .kv { font-family: ui-monospace, monospace; font-size: 11px; background: #f4f4f5; padding: 8px 10px; border-radius: 6px; color: var(--ink); margin-top: 12px; white-space: pre; }
+</style>
+</head>
+<body>
+<div class="doc">
+
+  <h1>E1 — Quem somos <span class="small">· mockup walkthrough · 2026-05-15</span></h1>
+  <p class="lede">
+    Five screens that take a CBO from the WhatsApp invite tap to a completed organizational diagnostic.
+    Phone-sized frames on the left, agent + state explanation on the right.
+    No new microapps — chat + doc panel + file drop is enough.
+  </p>
+
+  <div class="legend">
+    <strong>Reading the mockup:</strong> green chips = answers the user picked · grey chips = options still available · the doc panel on the right of each frame shows the CBO profile filling in live. Last screen shows the orchestrator's view of the same CBO.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 1 — Preamble (first entry to E1)</h2>
+  <p class="anno">After tapping the WhatsApp invite, the CBO sees the existing welcome screen, then this E1-specific preamble. Calm, framed. Dismissible.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="header">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="body preamble-bg" style="padding-top: 40px;">
+        <div class="brand-mark">🌿 COUGAR · VILA FLORES</div>
+        <div class="display">
+          <span class="subtle">Encontro 1</span>
+          Quem somos
+        </div>
+        <p class="body-lead">
+          Hoje queremos conhecer sua organização. A gente vai conversar sobre:
+        </p>
+        <ul class="agenda">
+          <li>Quem vocês são e o que vocês fazem</li>
+          <li>Sua equipe e suas experiências</li>
+          <li>Se você já tem uma ideia, ou se quer descobrir uma com a gente</li>
+        </ul>
+        <p class="time-hint">⏱ 20–30 min · Salva sozinho</p>
+        <a href="#" class="btn-primary">Começar →</a>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Why this screen</h3>
+      <p>
+        The chat alone drops the CBO straight into a question — too cold for a stranger they just got a WhatsApp link from.
+        This preamble sets expectations (what we'll cover, how long, that it auto-saves) and gives them one obvious thing to do.
+      </p>
+      <p>Reused pattern across all 6 encontros, content per-workshop.</p>
+      <div class="kv">component: PreambleScreen
+props:
+  encontroNumber: 1
+  title: "Quem somos"
+  agenda: string[3]
+  timeEstimateMin: [20, 30]
+  onStart: () => void</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 2 — Chat early (after “Começar”, first 2-3 turns)</h2>
+  <p class="anno">Agent opens warmly, asks the identity questions, doc panel begins to fill.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="header">📱 Horta Comunitária Cascata · ENCONTRO 1</div>
+      <div class="chat-shell">
+        <div class="chat-progress">
+          <div><span class="label">Seção 1 de 5 · </span><span class="active">Quem somos</span></div>
+          <div class="segments">
+            <div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="chat-messages">
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Olá! Que bom ter você aqui. Antes de qualquer coisa — <strong>como se chama a sua organização</strong> e com quem a gente está falando hoje?
+          </div>
+          <div class="msg user">Horta Comunitária Cascata. Sou a Sandra, coordenadora.</div>
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Prazer, Sandra. Em <strong>uma frase</strong>, o que a Horta Comunitária Cascata faz?
+          </div>
+          <div class="msg user">Cultivamos hortas urbanas com famílias do bairro Cascata, e também damos oficinas de compostagem.</div>
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Adorei. <strong>Há quanto tempo vocês existem e como são organizados?</strong>
+            <div class="quick-options">
+              <span class="chip option-letter" data-letter="A">ONG / Associação</span>
+              <span class="chip option-letter" data-letter="B">Cooperativa</span>
+              <span class="chip option-letter" data-letter="C">Grupo informal</span>
+              <span class="chip option-letter" data-letter="D">Outro</span>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Escreva ou escolha acima…">
+          <div class="send">↑</div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Why this turn order</h3>
+      <p>
+        Identity first → trust-building (one fact she's <em>proud</em> of without asking yet, by responding with "Adorei") → organizational form via chips so we capture the <code>legal_form</code> enum in one tap.
+      </p>
+      <p>
+        Every substantive question has multiple-choice chips <em>plus</em> free-text. This is the existing <code>ask_user</code> pattern. Letter prefixes (A/B/C/D) let keyboard users pick.
+      </p>
+      <p style="color:var(--accent-deep);"><strong>Doc panel state at this moment</strong> →</p>
+      <div class="doc-panel" style="background: white; margin-top: 12px;">
+        <div class="doc-card">
+          <div class="doc-section-title">Quem somos <span class="complete-tag">Em andamento</span></div>
+          <div class="row"><div class="key">Nome</div><div class="val">Horta Comunitária Cascata</div></div>
+          <div class="row"><div class="key">Contato</div><div class="val">Sandra (coordenadora)</div></div>
+          <div class="row"><div class="key">O que faz</div><div class="val">Cultivamos hortas urbanas com famílias do bairro Cascata…</div></div>
+          <div class="row"><div class="key">Forma</div><div class="val empty">— pendente</div></div>
+          <div class="row"><div class="key">Fundação</div><div class="val empty">— pendente</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 3 — Mid-chat (team + prior projects + file drop)</h2>
+  <p class="anno">Now the capacity-scoring questions. Chips do the heavy lifting; uploaded docs auto-fill nuance the agent can read.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="header">📱 Horta Comunitária Cascata · ENCONTRO 1</div>
+      <div class="chat-shell">
+        <div class="chat-progress">
+          <div><span class="label">Seção 1 de 5 · </span><span class="active">Quem somos</span></div>
+          <div class="segments">
+            <div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="chat-messages">
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Que tipo de projetos vocês já realizaram?
+            <div class="quick-options">
+              <span class="chip option-letter" data-letter="A">Nenhum ainda</span>
+              <span class="chip option-letter" data-letter="B">Atividades pontuais</span>
+              <span class="chip option-letter selected" data-letter="C">Projetos com financiamento ✓</span>
+              <span class="chip option-letter" data-letter="D">Parceria pública</span>
+            </div>
+          </div>
+          <div class="msg user">C — Projetos com financiamento</div>
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Ótimo. Se quiser, <strong>arraste algum documento</strong> de um projeto anterior (proposta, relatório, fotos) — me ajuda a entender melhor sua experiência. Senão, segue tudo bem.
+            <div style="margin-top: 8px; padding: 14px; border: 2px dashed var(--line); border-radius: 8px; text-align: center; color: var(--muted); font-size: 12px;">
+              📄 Arraste arquivos aqui<br>
+              <span style="font-size:10px;">PDF, DOCX, fotos · até 10 MB</span>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Escreva ou anexe…">
+          <div class="send">↑</div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Capacity scoring inputs</h3>
+      <p>
+        The "Projetos com financiamento" answer + team_size ≥ 3-5 + at least 2 years existence puts the agent at <strong>Org Delivery Capacity = 2</strong> by default. An uploaded grant-approval document or a partnership letter is what pushes to 3.
+      </p>
+      <p>The file-drop framing is gentle: "se quiser… senão tudo bem." Optional, not required.</p>
+      <p style="color:var(--accent-deep);"><strong>Doc panel state</strong> →</p>
+      <div class="doc-panel" style="background: white; margin-top: 12px;">
+        <div class="doc-card">
+          <div class="doc-section-title">Quem somos <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">Nome</div><div class="val">Horta Comunitária Cascata</div></div>
+          <div class="row"><div class="key">Forma</div><div class="val">Associação</div></div>
+          <div class="row"><div class="key">Fundação</div><div class="val">2018</div></div>
+        </div>
+        <div class="doc-card">
+          <div class="doc-section-title">Equipe <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">Tamanho</div><div class="val">6–15 pessoas</div></div>
+          <div class="row"><div class="key">Composição</div><div class="val">2 pagas · 8 voluntárias</div></div>
+        </div>
+        <div class="doc-card">
+          <div class="doc-section-title">Histórico <span class="complete-tag">Em andamento</span></div>
+          <div class="row"><div class="key">Escala</div><div class="val">Projetos com financiamento</div></div>
+          <div class="row"><div class="key">Experiência NBS</div><div class="val empty">— pendente</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 4 — Path triage</h2>
+  <p class="anno">The branching question. Stored on the cohort_member; E2's skill reads it to decide the opening flow.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="header">📱 Horta Comunitária Cascata · ENCONTRO 1</div>
+      <div class="chat-shell">
+        <div class="chat-progress">
+          <div><span class="label">Seção 1 de 5 · </span><span class="active">Quem somos</span></div>
+          <div class="segments">
+            <div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="chat-messages">
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            Última pergunta importante: <strong>você já tem uma ideia de projeto NBS</strong> (solução baseada na natureza) que quer levar adiante, <strong>ou quer ajuda</strong> da gente para encontrar uma?
+            <div class="quick-options" style="margin-top: 12px;">
+              <span class="chip option-letter" data-letter="A" style="background: #dbeafe; border-color: #93c5fd; color: #1e40af;">💡 Já tenho uma ideia</span>
+              <span class="chip option-letter" data-letter="B" style="background: #fef3c7; border-color: #fcd34d; color: #92400e;">🤝 Quero ajuda</span>
+            </div>
+            <div style="font-size: 11px; color: var(--muted); margin-top: 14px; line-height: 1.5;">
+              Não há resposta certa — só muda como a gente segue no próximo encontro.
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Escolha acima…">
+          <div class="send">↑</div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Why the framing matters</h3>
+      <p>
+        From Julia (Apr 16): communities aren't familiar with the NBS concept formally. Calling out NBS in parens, plus "não há resposta certa," lowers the stakes.
+      </p>
+      <p>The two chips use distinct color codes that carry through to the orchestrator card so JVP and Julia know at a glance which path each org is on.</p>
+      <div class="kv">cohort_members.path = 'has-idea' | 'needs-help'
+
+E2's skill reads this:
+  if path === 'has-idea':
+    "Conta sobre seu projeto atual…"
+  else:
+    "Vamos descobrir juntos…"</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 5 — Encontro complete</h2>
+  <p class="anno">Friendly completion + the full doc panel populated. No score shown to the CBO.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="header">📱 Horta Comunitária Cascata · ENCONTRO 1</div>
+      <div class="chat-shell">
+        <div class="chat-progress">
+          <div><span class="label">Seção 1 de 5 · </span><span class="active">Quem somos · ✓</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr" style="opacity:0.3;"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="chat-messages">
+          <div class="completion">
+            <div class="check">✓</div>
+            <div class="ttl">Diagnóstico concluído</div>
+            <div class="sub">Obrigado pelas respostas, Sandra. Esse perfil já está salvo.</div>
+          </div>
+          <div class="msg agent">
+            <div class="label">Agente</div>
+            <strong>Próximo encontro: 18 de junho — Seu território.</strong>
+            <br><br>
+            Vamos olhar juntos o mapa de Cascata, ver os riscos climáticos do bairro, e — como você já tem uma ideia — começar a conversa pelo seu projeto atual.
+            <br><br>
+            Até lá! 🌱
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Aguardando próximo encontro…" disabled style="opacity:0.6;">
+          <div class="send" style="opacity:0.4;">↑</div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Closing the loop</h3>
+      <p>
+        The CBO sees: ✓ done, your work is saved, here's when we meet again, here's what we'll do.
+        No score, no maturity number — that's a coordinator-side artifact.
+      </p>
+      <p>
+        The next-encontro date is pulled from the workshop cadence config. If the next encontro hasn't been scheduled yet, the message degrades gracefully to "Sua coordenadora vai te avisar quando o próximo encontro abrir."
+      </p>
+      <p style="color:var(--accent-deep);"><strong>Final doc panel</strong> →</p>
+      <div class="doc-panel" style="background: white; margin-top: 12px;">
+        <div class="doc-card">
+          <div class="doc-section-title">Quem somos <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">Nome</div><div class="val">Horta Comunitária Cascata</div></div>
+          <div class="row"><div class="key">Forma</div><div class="val">Associação</div></div>
+          <div class="row"><div class="key">Fundação</div><div class="val">2018</div></div>
+          <div class="row"><div class="key">O que faz</div><div class="val">Hortas urbanas + oficinas de compostagem em Cascata</div></div>
+        </div>
+        <div class="doc-card">
+          <div class="doc-section-title">Equipe <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">Tamanho</div><div class="val">6–15 pessoas</div></div>
+          <div class="row"><div class="key">Composição</div><div class="val">2 pagas · 8 voluntárias</div></div>
+        </div>
+        <div class="doc-card">
+          <div class="doc-section-title">Histórico <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">Escala</div><div class="val">Projetos com financiamento</div></div>
+          <div class="row"><div class="key">Experiência NBS</div><div class="val">Hortas e jardins</div></div>
+          <div class="row"><div class="key">Documentos</div><div class="val">proposta-2023.pdf · relatório-2024.pdf</div></div>
+        </div>
+        <div class="doc-card">
+          <div class="doc-section-title">Caminho <span class="complete-tag">✓</span></div>
+          <div class="row"><div class="key">→</div><div class="val">💡 Já tenho uma ideia</div></div>
+          <div class="row"><div class="key">Atende</div><div class="val">Mulheres · Jovens · Pessoas negras · Comunidade do bairro</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 6 — What Julia (orchestrator) sees</h2>
+  <p class="anno">The coordinator's view of the same CBO after E1 completes. Maturity scores surface here, not on the CBO side.</p>
+
+  <div class="scene" style="grid-template-columns: 1fr 1fr;">
+    <div class="orch-card">
+      <div class="orch-row">
+        <div style="width:36px;height:36px;border-radius:8px;background:var(--accent-soft);color:var(--accent-deep);display:flex;align-items:center;justify-content:center;">🌱</div>
+        <div style="flex:1;">
+          <div class="orch-name">Horta Comunitária Cascata</div>
+          <div class="orch-meta">Cascata · atualizado hoje</div>
+        </div>
+        <span class="path-chip path-idea">💡 Idea</span>
+      </div>
+      <div class="orch-row" style="margin-top: 14px;">
+        <span class="maturity">Capacidade: 2/3</span>
+        <span class="maturity" style="background: #fef9c3; color: #854d0e;">NBS: 2/3</span>
+      </div>
+      <div class="orch-row">
+        <div style="flex:1; font-size: 11px; color: var(--muted);">Seção 1 de 5 completada</div>
+      </div>
+      <div style="margin-top: 12px; height: 1px; background: var(--line);"></div>
+      <div class="orch-row" style="margin-top: 12px;">
+        <div style="flex:1;font-size: 11px; color: var(--ink);">
+          <strong>Atende:</strong> Mulheres · Jovens · Pessoas negras · Comunidade
+        </div>
+      </div>
+      <div class="orch-row">
+        <button class="chip" style="font-size: 11px;">Ver perfil completo</button>
+        <button class="chip" style="font-size: 11px;">Notas internas</button>
+      </div>
+    </div>
+    <div class="note">
+      <h3>What the coordinator gains</h3>
+      <p>
+        Three quick reads: (1) <span class="path-chip path-idea" style="display:inline;padding:1px 6px;">💡 Idea</span> means E2 should open with "tell us about your project", not the educational intro. (2) <span class="maturity" style="display:inline;padding:1px 6px;">Capacidade: 2/3</span> means this org likely needs less hand-holding on operations than a score-1 org. (3) "atende: mulheres · jovens · pessoas negras" pre-fills equity narrative for the project card.
+      </p>
+      <p>
+        New filter on the cohort list: <strong>Show all / Has idea / Needs help</strong>. Lets Julia plan E2 facilitation by group.
+      </p>
+      <p>
+        The "Notas internas" button (deferred to a later block) is where Julia can leave private notes per CBO ("Sandra mentioned conflict with the building owner — check before W3").
+      </p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">What this mockup is <strong>not</strong> showing</h2>
+  <p style="font-size: 13px; color: var(--muted); margin-top: 12px; max-width: 60ch;">
+    The desktop split-screen layout (chat-left / doc-right) on a 1024px+ viewport — we already shipped that.
+    The peer-review surface ("see how others did this") — out of scope for E1.
+    Coordinator's bulk-invite flow — covered in PR #137.
+    The "needs-help" path's variant of screen 5 — same structure, different message ("Vamos descobrir juntos no próximo encontro").
+  </p>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 48px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Companion files: <code>research.md</code> · <code>spec.md</code> · <code>skill.md</code> · all in <code>knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/</code>
+  </p>
+</div>
+</body>
+</html>

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/research.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/research.md
@@ -1,0 +1,125 @@
+# E1 — Quem somos · diagnóstico — Research notes
+
+**Goal of this encontro**: capture enough about each CBO that we can (a) score the two **Phase-1 maturity metrics** required by the COUGAR mapping criteria, (b) set the **two-path triage**, and (c) build trust with the community leader. ~30-40 min of platform time inside a 90-min session.
+
+## What the literature + frameworks say
+
+### COUGAR/Pyxera NBS Mapping Criteria (already in our KB)
+The Phase-1 metrics with concrete 0-3 anchors (`knowledge/_cougar/nbs-mapping-criteria.md`):
+
+| Metric | 0 (Lowest) | 1 | 2 | 3 (Highest) |
+|---|---|---|---|---|
+| **Org Delivery Capacity** | No prior experience | Limited small project experience | Demonstrated project management | Proven multi-stakeholder/funded project track record |
+| **Team Technical Experience** | No relevant experience | General environmental experience | Pilot-scale similar experience | Proven track record in this NBS type |
+
+**Exclusion filters** also matter — disqualifies pure advocacy, research-only, projects <6 months old, projects with unresolved land conflict. We screen for these via free-text "what does your organization do" answers and the path-triage answer.
+
+### Real-world POA benchmarks (`_cougar/ecosystem-assessment-summary.md`)
+The Pyxera ecosystem assessment mapped 50+ POA actors and gives us calibration:
+
+- **Mature (score 3 territory)**: CEA Bom Jesus (~$1M fundraising, innovation hub, city-wide network); Vila Flores (US$900K secured Caixa Federal, 12-yr track record, 40+ initiatives at the hub)
+- **Developing (score 2 territory)**: Translab ($160K Regenera RS, multiple sites)
+- **Emerging (score 1 territory)**: Misturaí — grassroots, Black-woman-led, environmental awareness + community gardens, no formal funding history yet
+- **Early (score 0 territory)**: informal groups, no contracting entity (would fail the "Identifiable Org" eligibility gate)
+
+These benchmarks become the agent's reference points: *"orgs at your level typically have X budget and Y team size."*
+
+### CCAT / OCAT — what NOT to copy
+[CCAT](https://www.tccgrp.com/product/core-capacity-assessment-tool-ccat/) and [McKinsey OCAT](https://www.americorps.gov/sites/default/files/document/09102021_OrganizationalCapacityAssessmentTool-508_ORE.pdf) are the industry standard org-capacity tools. They have **146 questions, 30-45 min** to complete and are designed for board members + senior leaders, not field workshops.
+
+**Don't replicate them.** Those tools serve a different purpose (long-term capacity-building consulting). For E1 we have a single workshop slot to: triage, score 2 metrics, build trust. **5-8 questions max.**
+
+What we borrow from them: the *framing* of capacity as multi-dimensional (governance, programs, finance, evaluation) — we collapse this into a single "delivery capacity" score in COUGAR, which is appropriate at our scale.
+
+### IUCN Global Standard for NbS (Edition 2, Oct 2025)
+[The Global Standard](https://iucn.org/our-work/topic/iucn-global-standard-nature-based-solutions) has 8 criteria + 28 indicators, but they're **project-level not org-level**. Relevant later (E3-E4) but not at E1. The October 2025 second edition put Indigenous peoples and local communities more centrally — reinforces our equity-baseline question.
+
+### UNEP / Adaptation Fund — what funders ask CBOs upfront
+[UNEP AFCIA grants ($50k-$250k for CBOs)](https://www.unep.org/news-and-stories/story/new-fund-leverages-nature-adapt-climate-change) require eligibility as a registered NGO/CSO/CBO in a developing country and ask about scaling potential. The implication: even early-stage CBOs get heard, but they need a **legal contracting entity**. The "Identifiable Org" gate in COUGAR is the same gate.
+
+### BPJP/C40 participatory frameworks (`_inclusive-action/participatory-frameworks.md`)
+For Vila Flores' Brazilian context, BPJP/C40 explicitly score on inclusive action. The 7 vulnerable groups they ask about (mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas) deserve a **single light-touch acknowledgment question at E1**: "Quem você atende?" with optional multi-select chips. NOT the full equity diagnostic (which lives in E2's community_anchoring + the Phase-4 inclusive-action questions in the existing concept-note skill).
+
+## What we therefore ask at E1
+
+Synthesizing the above — a **lean diagnostic that produces a defensible 0-3 score on 2 metrics + path triage + light context + trust-building**:
+
+| # | Question | Captures | Maps to |
+|---|---|---|---|
+| 1 | "Como se chama sua organização e quem fala com a gente hoje?" | org_name, contact_name, contact_role | identity |
+| 2 | "Em uma frase — o que sua organização faz?" | mission_summary | identity + qualitative |
+| 3 | "Há quanto tempo vocês existem e como vocês são organizados?" (chips: ONG/associação/cooperativa/grupo informal + year) | legal_form, year_founded | exclusion filter ("Identifiable Org") |
+| 4 | "Quantas pessoas estão envolvidas e como? (núcleo pago / equipe ampliada / voluntários)" | team_size, paid_vs_volunteer | Org Delivery Capacity input |
+| 5 | "Que tipo de projetos vocês já realizaram?" (chips: nenhum / atividades pontuais / projetos com financiamento / projetos com parceria pública or *"upload a doc"*) | prior_project_scale, evidence | both Phase-1 metrics |
+| 6 | "Qual a sua experiência com soluções baseadas na natureza ou meio ambiente?" (chips: nenhuma / educação ambiental / hortas/jardins / projetos NBS já implementados) | nbs_experience | Team Technical Experience |
+| 7 | **Path triage**: "Você já tem uma ideia de projeto NBS, ou quer ajuda para encontrar uma?" (idea / needs-help) | path | branches E2-E3 |
+| 8 | (Optional trust-build) "Tem algo que sua organização fez que vocês têm orgulho? Pode contar?" | qualitative narrative | trust + qualitative evidence |
+| 9 | "Quem sua organização atende?" (multi-select chips on the 7 BPJP vulnerable groups + "comunidade geral do bairro") | groups_served | E2 equity baseline |
+
+That's **8 substantive + 1 optional**. With multi-choice + free-text mix and the auto-fill from any uploaded docs (the existing file-drop already does this), **20-30 min realistic completion**.
+
+## Maturity scoring — how the agent infers 0-3
+
+The agent reads the answers and the existing rubric to score:
+
+**Org Delivery Capacity (0-3)**:
+- 0: "nenhum" prior projects AND informal organization
+- 1: "atividades pontuais" OR ONG/associação with no funded projects
+- 2: "projetos com financiamento" AND team_size ≥ 3 AND year_founded ≤ today - 2yr
+- 3: "projetos com parceria pública" OR documented multi-stakeholder track record OR uploaded evidence of past funded grant > BRL 100k
+
+**Team Technical Experience (0-3)** (NBS-specific, not generic delivery):
+- 0: nbs_experience = "nenhuma"
+- 1: nbs_experience = "educação ambiental"
+- 2: nbs_experience = "hortas/jardins" OR existing rain garden / urban forest activities (uploads can corroborate)
+- 3: nbs_experience = "projetos NBS já implementados" with evidence
+
+Score is shown to the **coordinator (orchestrator)**, not the CBO — we don't want the CBO to feel graded. The CBO sees a simple "diagnóstico concluído" + their answers visible in the doc panel.
+
+## Path triage — what each path actually looks like at E2
+
+Captured here, branched in E2's skill:
+
+**`has-idea`** path: E2 starts with *"Conta sobre seu projeto atual — onde você quer trabalhar e o que tem em mente?"* Agent guides into the existing-idea framing, asks for any documents/photos, then uses the risk-map to overlay risk on what they describe.
+
+**`needs-help`** path: E2 starts with *"Vamos descobrir juntos."* Agent opens the Site Explorer with the bairro pre-selected (from E1's bairro_of_operation), walks them through the risk overlays, and asks "qual desses riscos te preocupa mais?"
+
+## What we do NOT do at E1 (deliberate exclusions)
+
+These are deferred to keep E1 a **30-min experience that builds confidence**, not a survey:
+
+- Full equity diagnostic (BPJP section 11) → E2's community_anchoring + later phases
+- Site selection (E2)
+- Intervention type (E3)
+- Impact estimates (E4)
+- Operations / financial model (E4)
+- Funding need or permits (E5)
+- Detailed governance / decision-making (could be E4-5)
+
+## Microapps for E1
+
+**None.** Chat + file drop + a doc panel showing the 4 grouped fields filling in:
+
+1. **Quem somos** — org_name, year_founded, legal_form, mission_summary
+2. **Equipe** — team_size, paid_vs_volunteer
+3. **Histórico** — prior_project_scale, uploaded files list, nbs_experience
+4. **Caminho** — path (idea / needs-help) + groups_served
+
+The doc panel is the existing right-rail panel; this is just a content layout change for E1, not a new microapp.
+
+## Open questions
+
+1. **Year founded for informal groups** — what do we accept? Default: ask for "year started doing this work" rather than legal registration. Document the choice in the spec.
+2. **Multiple-contact orgs** — should we capture more than one contact? Probably yes (1 primary + 1 secondary) for funder handoff, but optional at E1.
+3. **Score calibration** — the rubric should be tuned against the 4 POA reference orgs (Vila Flores=3, Translab=2, Misturaí=1, hypothetical informal=0). After the first 2-3 real diagnostics in June, recalibrate.
+
+## Sources
+
+- `knowledge/_cougar/nbs-mapping-criteria.md` — COUGAR 2.0 NBS Mapping Criteria (the rubric)
+- `knowledge/_cougar/ecosystem-assessment-summary.md` — Pyxera POA ecosystem benchmarks
+- `knowledge/_cougar/sample-cbo-vilaflores.md` — calibration example (Vila Flores = score 3)
+- `knowledge/_inclusive-action/participatory-frameworks.md` — BPJP/C40 equity criteria
+- [IUCN Global Standard for NbS](https://iucn.org/our-work/topic/iucn-global-standard-nature-based-solutions) — 8 criteria, project-level (validates we're scoping E1 correctly to org-level)
+- [TCC Core Capacity Assessment Tool (CCAT)](https://www.tccgrp.com/product/core-capacity-assessment-tool-ccat/) — 146 questions, 30-45 min (anti-pattern for us)
+- [McKinsey/AmeriCorps OCA Tool](https://www.americorps.gov/sites/default/files/document/09102021_OrganizationalCapacityAssessmentTool-508_ORE.pdf) — heavier than appropriate
+- [UNEP AFCIA grants](https://www.unep.org/news-and-stories/story/new-fund-leverages-nature-adapt-climate-change) — CBO eligibility validates our "identifiable org" gate

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/skill.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/skill.md
@@ -1,0 +1,175 @@
+# /encontro-1-quem-somos — Agent skill (first draft)
+
+> Loaded by `cboAgent.ts` when `member.unlockedPhases` includes 1 and the user hasn't completed Phase 1 yet. Replaces the Phase-1 section of the current monolithic `cbo-intervention.md` skill. Other phases keep loading the existing skill until they're split too.
+
+## Identity
+
+You're the COUGAR/Vila Flores diagnostic agent. This is **Encontro 1 — Quem somos**. Your job is to capture the CBO's identity, score two maturity metrics, and ask the path-triage question. **~20-30 min of conversation max.** You speak Portuguese with the warmth of a community facilitator, not the precision of a survey enumerator.
+
+You are speaking with a community leader who likely:
+- Knows their work deeply but hasn't formalized it on paper
+- May be hesitant about "filling out forms"
+- Was invited to this platform by Julia/Antônia at Vila Flores
+- Will use the chat on a phone, mid-workshop or at home, possibly with patchy internet
+
+## Voice
+
+- Brazilian Portuguese, warm, second-person singular (tu/você as natural — match what they use)
+- Acknowledge their answers with one or two words before moving on ("Adorei", "Que legal", "Faz sentido")
+- Never use "preencha" or "responda" — use "conta", "me fala"
+- Switch to English **only if the user writes in English first**
+
+## What you capture
+
+Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):
+
+1. `org_name` — the organization's name
+2. `contact_name` — who's talking with us
+3. `contact_role` — their role in the org
+4. `mission_summary` — one-sentence description
+5. `legal_form` — enum: ngo, associação, cooperativa, informal, other
+6. `year_founded` — integer; for informal groups, ask "ano que vocês começaram esse trabalho"
+7. `team_size` — enum: 1-2, 3-5, 6-15, 16+
+8. `paid_vs_volunteer` — rough split, e.g. "2 pagas · 8 voluntárias"
+9. `prior_project_scale` — enum: none, ad-hoc, funded, partnership
+10. `nbs_experience` — enum: none, env-education, gardens-and-greening, implemented-nbs
+11. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
+12. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
+13. `proud_moment` — optional free-text
+14. (cohort-level) `path` — enum on `cohort_members`: has-idea | needs-help
+
+Plus on `state.maturityScores`:
+
+- `org_delivery_capacity` (0-3) — you infer this; see the rubric below
+- `team_technical_experience` (0-3) — you infer this
+
+## Question sequence
+
+You're not strict about order — read the room. But default flow:
+
+1. **Identity** — name, contact, role
+2. **Mission** — one-sentence what they do
+3. **Form + age** — legal_form (chips) + year_founded
+4. **Team** — team_size (chips) + paid/volunteer split
+5. **Prior work** — prior_project_scale (chips); offer file drop after
+6. **NBS experience** — nbs_experience (chips)
+7. **Bairro** — where do you mainly work (suggest from POA list, accept free text)
+8. **Groups served** — multi-select chips
+9. **Path triage** — has-idea / needs-help (chips with distinct colors)
+10. **Optional**: "Tem algo que sua organização fez que vocês têm orgulho? Pode contar?"
+
+Use the `ask_user` tool for every multiple-choice question. Always include a free-text option ("Outra coisa") and a "Não sei / Prefiro pular" option where appropriate.
+
+## Scoring — do this silently, write to state.maturityScores
+
+```
+ORG_DELIVERY_CAPACITY (0-3)
+  Score 0:  prior_project_scale = 'none' AND legal_form = 'informal'
+  Score 1:  prior_project_scale = 'ad-hoc'  OR  (formal org, no funded projects)
+  Score 2:  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND (today − year_founded) ≥ 2y
+  Score 3:  prior_project_scale = 'partnership'  OR  funded project with evidence ≥ BRL 100k
+            OR  uploaded grant approval / partnership letter
+
+TEAM_TECHNICAL_EXPERIENCE (0-3)
+  Score 0:  nbs_experience = 'none'
+  Score 1:  nbs_experience = 'env-education'
+  Score 2:  nbs_experience = 'gardens-and-greening'
+  Score 3:  nbs_experience = 'implemented-nbs' (any evidence corroborates)
+```
+
+Call `score_maturity` immediately after the relevant questions. Justification: 1 sentence each, in Portuguese.
+
+**Do not show scores to the CBO.** Scores are coordinator-side.
+
+## Path triage — the most important question
+
+Ask after the capacity questions, not before — the rest of the diagnostic builds trust that makes either answer feel acceptable.
+
+Frame:
+> "Última pergunta importante: você já tem uma ideia de projeto NBS (solução baseada na natureza) que quer levar adiante, ou quer ajuda da gente para encontrar uma?"
+>
+> Chips: [💡 Já tenho uma ideia] [🤝 Quero ajuda]
+>
+> Note (small, after the chips): "Não há resposta certa — só muda como a gente segue no próximo encontro."
+
+Call `set_path(value)` to write the answer to `cohort_members.path`.
+
+## File drops — encourage gently, never require
+
+After question 5 (prior project scale):
+
+> "Se quiser, **arraste algum documento** de um projeto anterior (proposta, relatório, fotos) — me ajuda a entender melhor sua experiência. Senão, segue tudo bem."
+
+Files auto-parse via the existing fileParser flow. Use the parsed content to:
+- Triangulate `prior_project_scale` (a real grant approval bumps score 2→3)
+- Fill `mission_summary` if the doc is more articulate than the user's free-text answer (ask first: "Posso usar essa frase do documento como descrição da organização?")
+
+## Closing
+
+After all 9 substantive questions are answered:
+
+1. Call `update_section('org_profile', ...)` with the consolidated fields
+2. Call `score_maturity` for both Phase-1 metrics
+3. Call `set_phase(1)` then `set_phase_complete(1)` to mark Encontro 1 done
+4. Render the completion message:
+
+> "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
+>
+> **Próximo encontro: [next_workshop.date] — [next_workshop.name].**
+>
+> [if path = 'has-idea']: Vamos olhar juntos o mapa de [bairro], ver os riscos climáticos, e começar pelo seu projeto atual.
+>
+> [if path = 'needs-help']: Vamos descobrir juntos onde e como atuar — sem pressa, com calma.
+>
+> Até lá! 🌱"
+
+## Things this skill does NOT do
+
+- Ask about the project site (defer to E2)
+- Ask about intervention type (defer to E3)
+- Show maturity scores to the CBO (coordinator-side only)
+- Push the user to upload files if they say no
+- Use the word "fase" or "phase" in conversation — internally we use phases, externally we use "encontros" and "seções"
+- Require year_founded for informal groups — ask for "ano que começaram esse trabalho" instead
+
+## KB grounding the agent has access to
+
+`read_knowledge` is allowed for:
+
+- `knowledge/_cougar/nbs-mapping-criteria.md` — the scoring rubric (use to corroborate your inference)
+- `knowledge/_cougar/ecosystem-assessment-summary.md` — for benchmarking ("orgs like CEA Bom Jesus, Translab, Vila Flores are in your range" — but only mention if the user asks)
+- `knowledge/_cougar/sample-cbo-vilaflores.md` — calibration reference
+
+You should **not** lecture the user with this content. Use it silently to inform your scoring. Surface a benchmark only if it's directly useful and natural ("Pra você ter referência, a Vila Flores começou com ~10 pessoas e cresceu pra 100+").
+
+## When the user gets stuck
+
+Common stuck patterns + responses:
+
+| User says | Why | What you say |
+|---|---|---|
+| "Não sei se a gente conta como organização" | Informal group, hesitant about formality | "Conta sim. Vamos chamar assim por enquanto e refinar depois. Há quanto tempo vocês fazem esse trabalho?" |
+| "Não temos orçamento" | Score-0 fears the platform isn't for them | "Faz parte do diagnóstico saber disso. Muitos projetos importantes começam aí. Vamos seguir." |
+| "Já fiz isso pro Caixa, não quero repetir" | Done a similar form before, frustrated | "Você pode subir esse documento — eu leio e preencho tudo o que conseguir." |
+| Switches to English | First-language English speaker visiting | Switch immediately. |
+
+## Tool calls
+
+- `ask_user(question, options, multiSelect?)` — every substantive question
+- `update_section('org_profile', { field: value })` — after each answer
+- `score_maturity(metric, score, justification)` — after capacity questions
+- `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
+- `set_phase(1)` then `set_phase_complete(1)` — at end
+- `read_knowledge(path)` — silently, to inform scoring
+- `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
+
+## Estimated runtime
+
+- 9 substantive questions × ~1.5 min each (mostly chip taps) = ~14 min
+- Plus 1-2 file upload moments = +3 min
+- Plus closing = +1 min
+- **~20 min average, 30 min worst case.** Inside the 30-40 min platform-time budget for the encontro.
+
+---
+
+**This is a first-draft skill prompt. It needs to be tested live with 2-3 real conversations before going to all 10 CBOs.** Suggested testing approach: dry-run with Antônia (knows the platform), then with one of the CEA Bom Jesus / Misturaí / Translab teams (real CBO, not pre-briefed).

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/spec.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/spec.md
@@ -1,0 +1,135 @@
+# E1 — Quem somos · diagnóstico — Spec
+
+**Status**: draft for review · **Builds on**: `research.md` in this folder · **Date**: 2026-05-15
+
+## In one sentence
+
+In ~30 min of platform time, capture the CBO's identity + a 2-metric capacity diagnostic + the two-path triage, then end with the CBO feeling welcomed (not surveyed).
+
+## Data captured — every field justified
+
+| Field | Type | Why we ask | Skipping cost |
+|---|---|---|---|
+| `org_name` | string | Project card, funder handoff | Can't address the org |
+| `contact_name` | string | Funder/coordinator handoff | Can't reach back out |
+| `contact_role` | string | Calibrate context of answers | Minor |
+| `mission_summary` | string (1 sentence) | Qualitative, project card | Low — but used in pitch |
+| `legal_form` | enum: `ngo`/`associação`/`cooperativa`/`informal`/`other` | Identifiable Org gate; informal flagged for follow-up | High if missing — funder eligibility |
+| `year_founded` | int | Org Delivery Capacity scoring input | Medium |
+| `team_size` | enum: `1-2`/`3-5`/`6-15`/`16+` | Delivery capacity scoring | Medium |
+| `paid_vs_volunteer` | structured: `% paid`, `% volunteer` (ranges OK) | Sustainability signal for E4 | Medium |
+| `prior_project_scale` | enum: `none`/`ad-hoc`/`funded`/`partnership` | **Org Delivery Capacity** primary input | High — main scoring signal |
+| `prior_project_evidence` | files[] | Triangulates the scale claim | Optional but accelerates score 2→3 |
+| `nbs_experience` | enum: `none`/`env-education`/`gardens-and-greening`/`implemented-nbs` | **Team Technical Experience** primary input | High |
+| `path` | enum: `has-idea` / `needs-help` | **Branches E2-E3 experience** | Required |
+| `groups_served` | multi-select chips (8 options) | Equity baseline; consumed by E2's community_anchoring | Medium — can be filled later |
+| `proud_moment` | string (free text, optional) | Trust + qualitative evidence | None — optional |
+| `bairro_of_operation` | string (suggest from a POA bairro list) | Pre-fills E2's site explorer | Medium — saves time in E2 |
+
+**Total: 14 fields** (12 substantive + 1 optional + 1 derived). The chip-heavy design means most are 1-tap answers, not free text.
+
+## What gets scored (0-3) and how
+
+```
+ORG_DELIVERY_CAPACITY (0-3)
+  Inputs: prior_project_scale + team_size + year_founded + evidence files
+
+  Score 0  prior_project_scale = 'none' AND legal_form = 'informal'
+  Score 1  prior_project_scale = 'ad-hoc'  OR  (formal org with no funded projects)
+  Score 2  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND (today − year_founded) ≥ 2y
+  Score 3  prior_project_scale = 'partnership' OR funded project ≥ BRL 100k OR uploaded evidence triangulates
+
+TEAM_TECHNICAL_EXPERIENCE (0-3) — NBS-specific
+  Inputs: nbs_experience + evidence files
+
+  Score 0  nbs_experience = 'none'
+  Score 1  nbs_experience = 'env-education'
+  Score 2  nbs_experience = 'gardens-and-greening'
+  Score 3  nbs_experience = 'implemented-nbs' (corroborated by evidence)
+```
+
+Scores are written into `state.maturityScores[]` and surfaced on the orchestrator card. The CBO does not see numerical scores — they see a friendly "Diagnóstico concluído ✓".
+
+## Doc panel layout — 4 grouped sections
+
+The right-rail document panel (existing surface) renders as 4 cards filling in live:
+
+```
+┌─ Quem somos ──────────────────────────┐
+│ Nome:        Horta Comunitária Cascata│
+│ Fundação:    2018                     │
+│ Forma legal: Associação               │
+│ O que faz:   "Cultivamos hortas       │
+│              urbanas no bairro Cascata"│
+└───────────────────────────────────────┘
+
+┌─ Equipe ──────────────────────────────┐
+│ Tamanho:     6-15 pessoas             │
+│ Composição:  2 pagos · 8 voluntários  │
+└───────────────────────────────────────┘
+
+┌─ Histórico ───────────────────────────┐
+│ Escala anterior: Projetos financiados │
+│ Experiência NBS: Hortas e jardins     │
+│ Documentos:                           │
+│   • proposta-2023.pdf                 │
+│   • relatorio-final.pdf               │
+└───────────────────────────────────────┘
+
+┌─ Caminho ─────────────────────────────┐
+│ ⭢ Já tenho uma ideia                  │
+│ Comunidades servidas:                 │
+│   mulheres · jovens · negras          │
+└───────────────────────────────────────┘
+```
+
+Each card is editable on hover (existing `EditableField` component handles this).
+
+## Out of scope for E1
+
+Explicitly deferred:
+
+- Full equity diagnostic → E2 (community_anchoring) + later phases
+- Site selection → E2
+- Intervention type → E3
+- Detailed financials → E4
+- Permits → E5
+
+## Preamble screen (CBO entry)
+
+1 screen, shown on first entry to E1 only:
+
+```
+ENCONTRO 1 — Quem somos
+━━━━━━━━━━━━━━━━━━━━━━━━
+
+Hoje queremos conhecer sua organização.
+A gente vai conversar sobre:
+
+  · Quem vocês são e o que vocês fazem
+  · Sua equipe e suas experiências
+  · Se você já tem uma ideia de projeto
+    NBS, ou se quer descobrir uma com a
+    gente
+
+Tempo estimado: 20–30 min · Salva sozinho
+
+                    [ Começar  → ]
+```
+
+## Open decisions before building
+
+1. **Bairro suggester** — should we ship a POA bairro autocomplete now (uses the IBGE GeoJSON we already have in `client/public/sample-data/porto-alegre-neighborhood-zones.json`), or accept free text and validate later? Suggestion: **autocomplete** — small lift, big UX win, prepares E2.
+2. **File upload framing** — currently we have "drop anything." Should E1's evidence question say "Want to share past project documents? It helps us understand your work."? Suggestion: **yes**, and make it the only place files are surfaced visibly until E3.
+3. **The chip set for `groups_served`** — should it match the 7 BPJP groups exactly? Suggestion: **yes, plus "comunidade do bairro" as a catch-all** so orgs aren't forced into demographic framing if they don't want to.
+
+## What ships when we build this
+
+- New cohort_member field: `path: 'has-idea' | 'needs-help' | null`
+- New CBO profile fields (added to `cbo-schema.ts`): `paid_vs_volunteer`, `groups_served`, `proud_moment`, `bairro_of_operation`
+- Per-encontro skill loading in `cboAgent.ts` (E1 loads `encontro-1-quem-somos.md`)
+- Preamble screen component (reusable across all encontros)
+- Doc panel: E1-specific 4-card layout
+- Orchestrator card: path chip + filter
+
+No new microapps. The work is mostly schema + skill + UI surface.

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/mockup.html
@@ -1,0 +1,897 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>E2 — Seu território · mockup walkthrough</title>
+<style>
+  :root {
+    --bg: #fafaf9;
+    --surface: #ffffff;
+    --ink: #18181b;
+    --muted: #71717a;
+    --line: rgba(0,0,0,0.08);
+    --accent: #059669;
+    --accent-soft: #ecfdf5;
+    --accent-deep: #047857;
+    --warm: #f59e0b;
+    --warm-soft: #fef3c7;
+    --info: #0284c7;
+    --info-soft: #e0f2fe;
+    --danger: #ef4444;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1280px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  h3.section-heading { font-size: 16px; letter-spacing: -0.01em; margin: 64px 0 16px; padding: 8px 0; border-bottom: 1px solid var(--line); }
+  .lede { color: var(--muted); margin: 8px 0 24px; max-width: 64ch; line-height: 1.6; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 18px; padding-left: 14px; border-left: 2px solid var(--accent); max-width: 64ch; }
+
+  /* Path banner */
+  .path-banner { display: inline-block; padding: 4px 12px; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 8px; }
+  .path-banner.idea { background: #dbeafe; color: #1e40af; }
+  .path-banner.help { background: var(--warm-soft); color: #92400e; }
+
+  /* Two-up grid: phone + note */
+  .scene { display: grid; grid-template-columns: 380px 1fr; gap: 36px; align-items: start; }
+  .scene .note h4 { font-size: 14px; margin: 0 0 6px; }
+  .scene .note p { font-size: 13px; color: var(--muted); margin: 0 0 10px; line-height: 1.6; }
+  .scene .note .kv { font-family: ui-monospace, "JetBrains Mono", monospace; font-size: 11px; background: #f4f4f5; padding: 10px 12px; border-radius: 8px; color: var(--ink); margin-top: 12px; white-space: pre-wrap; line-height: 1.5; }
+
+  /* Phone frame */
+  .phone {
+    width: 380px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 12px 36px -16px rgba(0,0,0,0.18);
+  }
+  .phone .top-chrome {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+    font-size: 10px;
+    color: var(--muted);
+    font-family: ui-monospace, monospace;
+  }
+  .phone .frame-body { min-height: 640px; display: flex; flex-direction: column; }
+
+  .app-header {
+    padding: 12px 16px; border-bottom: 1px solid var(--line);
+    display: flex; align-items: center; gap: 10px;
+  }
+  .app-header .leaf { width: 28px; height: 28px; border-radius: 6px; background: var(--accent-soft); color: var(--accent-deep); display:flex; align-items:center; justify-content:center; font-size: 13px; }
+  .app-header .id { flex: 1; min-width: 0; }
+  .app-header .org-name { font-size: 13px; font-weight: 600; line-height: 1.2; }
+  .app-header .meta { font-size: 10px; color: var(--muted); line-height: 1.2; }
+
+  .progress-strip { padding: 8px 16px; border-bottom: 1px solid var(--line); }
+  .progress-strip .label { font-size: 10px; color: var(--muted); margin-bottom: 4px; }
+  .progress-strip .label .active { color: var(--ink); font-weight: 600; }
+  .segments { display: flex; gap: 3px; }
+  .seg { height: 3px; flex: 1; border-radius: 2px; }
+  .seg.past { background: var(--accent); }
+  .seg.curr { background: var(--accent); opacity: 0.5; }
+  .seg.locked { background: rgba(0,0,0,0.08); }
+
+  .tab-content { flex: 1; padding: 12px 16px; overflow-y: auto; }
+  .tab-content.with-banner { padding-top: 0; }
+
+  /* Chat */
+  .chat-msgs { display: flex; flex-direction: column; gap: 6px; }
+  .msg { padding: 8px 12px; border-radius: 14px; font-size: 13px; line-height: 1.45; max-width: 92%; }
+  .msg.agent { background: #f4f4f5; align-self: flex-start; }
+  .msg.user { background: var(--accent); color: white; align-self: flex-end; }
+  .msg .lbl { font-size: 9px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 3px; }
+  .msg.user .lbl { display: none; }
+
+  /* NEW · Showcase cards inline in chat */
+  .showcase-strip { display: flex; gap: 8px; overflow-x: auto; padding: 4px 0 12px; margin: 6px 0; }
+  .showcase-card {
+    flex: 0 0 200px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--surface);
+    cursor: pointer;
+  }
+  .showcase-photo {
+    height: 90px;
+    background: linear-gradient(135deg, var(--from, #a7f3d0), var(--to, #6ee7b7));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 28px;
+  }
+  .showcase-card.expanded .showcase-photo { height: 110px; }
+  .showcase-body { padding: 8px 10px; }
+  .showcase-place { font-size: 9px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; margin-bottom: 2px; }
+  .showcase-title { font-size: 11px; font-weight: 600; line-height: 1.3; margin-bottom: 3px; }
+  .showcase-tagline { font-size: 10px; color: var(--muted); line-height: 1.4; }
+  .showcase-detail { font-size: 11px; color: var(--ink); line-height: 1.5; margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--line); }
+
+  /* NEW · Risk priority chips */
+  .priority-chips { margin-top: 8px; }
+  .priority-chip {
+    display: flex; align-items: center; gap: 8px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    padding: 8px 12px; border-radius: 10px;
+    margin-bottom: 6px; cursor: pointer;
+  }
+  .priority-chip.ranked { background: var(--accent-soft); border-color: #6ee7b7; }
+  .priority-chip .rank-num {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: var(--accent); color: white; font-size: 11px; font-weight: 600;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .priority-chip:not(.ranked) .rank-num { background: rgba(0,0,0,0.06); color: var(--muted); border: 1px dashed var(--muted); }
+  .priority-chip .hazard-icon { font-size: 18px; }
+  .priority-chip .hazard-name { flex: 1; font-size: 12px; }
+  .priority-chip .drag-handle { color: var(--muted); font-size: 14px; }
+
+  /* NEW · Community anchoring composer */
+  .ca-composer {
+    border: 1px solid var(--line); border-radius: 10px; padding: 10px;
+    background: var(--surface); margin-top: 8px;
+  }
+  .ca-row { margin-bottom: 8px; }
+  .ca-row .label { font-size: 10px; color: var(--muted); margin-bottom: 3px; }
+  .ca-row input { width: 100%; border: 1px solid var(--line); border-radius: 6px; padding: 5px 8px; font-size: 12px; }
+  .ca-chip-row { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+  .ca-chip {
+    border: 1px solid var(--line); padding: 3px 8px; border-radius: 999px; font-size: 10px;
+    background: var(--surface); cursor: pointer;
+  }
+  .ca-chip.selected { background: var(--accent-soft); border-color: #6ee7b7; color: var(--accent-deep); }
+
+  /* Chat input */
+  .chat-input { padding: 8px 12px; border-top: 1px solid var(--line); display: flex; gap: 6px; }
+  .chat-input .ipt { flex: 1; border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; font-size: 12px; color: var(--muted); background: var(--surface); }
+  .chat-input .send { width: 28px; height: 28px; border-radius: 50%; background: var(--accent); color: white; display: inline-flex; align-items: center; justify-content: center; font-size: 13px; }
+
+  /* Tab bar */
+  .tab-bar { border-top: 1px solid var(--line); background: var(--surface); display: flex; padding: 4px 0 8px; }
+  .tab { flex: 1; text-align: center; padding: 6px 4px; font-size: 10px; color: var(--muted); position: relative; cursor: pointer; }
+  .tab .icon { font-size: 18px; line-height: 1; }
+  .tab .label { display: block; margin-top: 2px; font-weight: 500; }
+  .tab.active { color: var(--accent-deep); }
+  .tab.active::after { content:""; position:absolute; bottom:-4px; left:50%; transform:translateX(-50%); width:24px; height:2px; background:var(--accent); border-radius:2px; }
+  .tab .badge { position: absolute; top: 0; right: 50%; transform: translate(14px, 4px); width: 8px; height: 8px; border-radius: 50%; background: var(--danger); }
+
+  /* Map banner + map */
+  .ma-banner {
+    background: var(--accent-soft); border-bottom: 1px solid #a7f3d0; padding: 10px 16px;
+  }
+  .ma-banner .back-link { display: inline-flex; align-items: center; gap: 4px; color: var(--accent-deep); font-size: 11px; font-weight: 500; margin-bottom: 4px; }
+  .ma-banner .by-agent { font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+  .ma-banner .prompt { font-size: 13px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+  .ma-body { flex: 1; display: flex; flex-direction: column; }
+
+  .pretend-map {
+    flex: 1; position: relative; min-height: 320px;
+    background:
+      radial-gradient(circle at 30% 40%, rgba(245, 158, 11, 0.25) 0%, transparent 30%),
+      radial-gradient(circle at 65% 55%, rgba(239, 68, 68, 0.3) 0%, transparent 25%),
+      radial-gradient(circle at 50% 80%, rgba(245, 158, 11, 0.2) 0%, transparent 25%),
+      linear-gradient(135deg, #e5f3e0 0%, #d4e8d4 100%);
+  }
+  .pretend-map.simple {
+    background:
+      linear-gradient(135deg, #e5f3e0 0%, #d4e8d4 100%);
+  }
+  .pretend-map.flood-only {
+    background:
+      radial-gradient(circle at 65% 55%, rgba(239, 68, 68, 0.45) 0%, rgba(239, 68, 68, 0.1) 35%, transparent 50%),
+      radial-gradient(circle at 30% 70%, rgba(239, 68, 68, 0.25) 0%, transparent 30%),
+      linear-gradient(135deg, #e5f3e0 0%, #d4e8d4 100%);
+  }
+  .map-pin { position: absolute; width: 18px; height: 18px; border-radius: 50%; background: var(--accent); border: 3px solid white; box-shadow: 0 2px 6px rgba(0,0,0,0.15); }
+  .map-pulse { position: absolute; width: 30px; height: 30px; border-radius: 50%; background: rgba(5, 150, 105, 0.3); animation: pulse 2s ease-out infinite; }
+  @keyframes pulse { 0% { transform: scale(0.7); opacity: 1; } 100% { transform: scale(2); opacity: 0; } }
+  .neighborhood-outline { position: absolute; border: 2px solid var(--accent); background: rgba(5, 150, 105, 0.08); border-radius: 8px; }
+  .map-overlay-label { position: absolute; font-size: 10px; background: white; padding: 2px 6px; border-radius: 4px; color: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,0.1); font-weight: 600; }
+  .map-legend {
+    position: absolute; bottom: 12px; left: 12px; right: 12px;
+    background: rgba(255,255,255,0.96); border-radius: 8px; padding: 8px 10px;
+    font-size: 10px; color: var(--ink);
+  }
+  .map-legend .title { font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; font-size: 9px; margin-bottom: 4px; }
+  .map-legend .swatches { display: flex; gap: 12px; }
+  .map-legend .swatch { display: inline-flex; align-items: center; gap: 4px; }
+  .map-legend .swatch::before { content: ""; display: inline-block; width: 10px; height: 10px; border-radius: 2px; background: var(--swatch); }
+
+  .ma-action-bar { padding: 12px 16px; border-top: 1px solid var(--line); background: var(--surface); display: flex; gap: 8px; align-items: center; }
+  .ma-action-bar .clear-link { font-size: 11px; color: var(--muted); text-decoration: underline; }
+  .btn-confirm {
+    background: var(--accent); color: white; padding: 9px 16px; border-radius: 10px;
+    font-weight: 500; font-size: 13px; flex: 1; text-align: center;
+  }
+  .btn-confirm.disabled { background: var(--line); color: var(--muted); }
+  .btn-pivot {
+    border: 1px solid var(--accent);
+    color: var(--accent-deep);
+    background: transparent;
+    padding: 9px 16px; border-radius: 10px; font-size: 12px; flex: 1; text-align: center;
+  }
+
+  /* Doc panel */
+  .doc-card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px;
+    margin-bottom: 8px;
+  }
+  .doc-card.empty { opacity: 0.5; }
+  .doc-card .ttl { font-size: 11px; font-weight: 600; color: var(--ink); margin-bottom: 6px; display: flex; align-items: center; justify-content: space-between; }
+  .doc-card .row { display: flex; padding: 3px 0; font-size: 11px; gap: 6px; }
+  .doc-card .row .key { color: var(--muted); min-width: 80px; }
+  .doc-card .row .val { color: var(--ink); flex: 1; }
+  .doc-card .row .val.empty { color: var(--muted); opacity: 0.6; font-style: italic; }
+  .complete-tag { font-size: 9px; padding: 1px 5px; border-radius: 999px; background: var(--accent-soft); color: var(--accent-deep); font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+  .in-progress-tag { font-size: 9px; padding: 1px 5px; border-radius: 999px; background: var(--warm-soft); color: #92400e; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+
+  .legend {
+    background: #eff6ff; border-left: 3px solid #3b82f6; padding: 10px 14px; border-radius: 0 8px 8px 0; font-size: 12px; color: #1e3a8a;
+    margin: 16px 0 24px; max-width: 64ch;
+  }
+  .flow-arrow {
+    display: flex; align-items: center; gap: 8px; color: var(--accent-deep); font-size: 12px; font-weight: 600;
+    margin: 14px 0 4px; text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .flow-arrow::before, .flow-arrow::after { content: ""; flex: 1; height: 1px; background: var(--accent-soft); }
+
+  /* Premium preamble */
+  .preamble-bg {
+    background: linear-gradient(to bottom, var(--accent-soft) 0%, #ffffff 40%, var(--accent-soft) 100%);
+    padding: 32px 24px; min-height: 600px;
+  }
+  .brand-mark { color: var(--accent-deep); font-weight: 600; font-size: 11px; letter-spacing: 0.16em; margin-bottom: 32px; display: flex; align-items: center; gap: 6px; }
+  .display { font-size: 24px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.2; }
+  .display .subtle { color: var(--muted); display: block; font-size: 12px; font-weight: 500; margin-bottom: 6px; letter-spacing: 0.04em; text-transform: uppercase; }
+  .agenda { margin: 20px 0; padding-left: 0; list-style: none; }
+  .agenda li { padding: 6px 0; font-size: 13px; color: var(--ink); display: flex; align-items: center; gap: 10px; }
+  .agenda li::before { content: "·"; color: var(--accent); font-weight: 700; font-size: 18px; }
+  .time-hint { font-size: 11px; color: var(--muted); margin-top: 24px; display: flex; align-items: center; gap: 6px; }
+  .btn-primary { display: inline-flex; align-items: center; justify-content: center; background: var(--accent); color: white; padding: 10px 24px; border-radius: 999px; font-weight: 500; font-size: 14px; margin-top: 18px; }
+</style>
+</head>
+<body>
+<div class="doc">
+
+  <h1>E2 — Seu território · o que é NBS <span class="small">· mockup walkthrough · 2026-05-15</span></h1>
+  <p class="lede">
+    Two-path walkthrough (👁️ <code>has-idea</code> in blue, 🤝 <code>needs-help</code> in amber).
+    First the shared preamble + NBS showcase, then each path's map experience, then both paths converge on hazard priority + community anchoring.
+    Every new UI element appearing in this encontro is annotated.
+  </p>
+
+  <div class="legend">
+    <strong>What's new in E2 visually:</strong> 3 new inline microapp surfaces (<code>NbsShowcaseCard</code>, <code>RiskPriorityChips</code>, <code>CommunityAnchoringComposer</code>) + 2 improvements to <code>MapMicroapp</code> (simplified legend, single-pin mode, browse-only mode for the <code>needs-help</code> path).
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 1 — Preamble (shared, both paths)</h2>
+  <p class="anno">User taps the locked Workshop-2 phase from Chat tab → preamble appears. Dismissible. Same pattern as E1.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="preamble-bg">
+          <div class="brand-mark">🌿 COUGAR · VILA FLORES</div>
+          <div class="display">
+            <span class="subtle">Encontro 2</span>
+            Seu território
+          </div>
+          <p style="font-size: 14px; margin-top: 18px; line-height: 1.6;">
+            Hoje a gente vai conhecer o seu lugar de atuação e os riscos do bairro.
+          </p>
+          <ul class="agenda">
+            <li>Ver exemplos de SbN no Brasil</li>
+            <li>Olhar o mapa do seu bairro</li>
+            <li>Marcar onde você quer atuar</li>
+            <li>Falar dos riscos que mais importam</li>
+          </ul>
+          <p class="time-hint">⏱ 30–45 min · Salva sozinho</p>
+          <a href="#" class="btn-primary">Começar →</a>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>Why "seu território" not "seu site"</h4>
+      <p>
+        Per the Sustainable Favela Network's ABCD framing, we lead with the territory the community knows — not a technical "site." The educational moment (NBS examples) comes first, the technical moment (map) comes second.
+      </p>
+      <p>The preamble is path-agnostic. The agent's first message after "Começar" differs based on path.</p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h3 class="section-heading">🪴 Beat 1 · NBS examples (shared, both paths)</h3>
+
+  <h2 class="screen">SCREEN 2 — NbsShowcaseCard (NEW · inline in chat)</h2>
+  <p class="anno">First agent turn. Inline showcase strip with 3 Brazilian cases. Tap a card to expand. Optional reference for the whole encontro.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · Início</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Oi Sandra. Antes de a gente abrir o mapa, deixa eu te mostrar <strong>como SbN se parece no Brasil</strong>. Toca em qualquer um pra ver mais.
+              <div class="showcase-strip">
+                <div class="showcase-card">
+                  <div class="showcase-photo" style="--from:#a7d5f5; --to:#67b9ec;">🌊</div>
+                  <div class="showcase-body">
+                    <div class="showcase-place">Curitiba · 1996</div>
+                    <div class="showcase-title">Parques do Barigui</div>
+                    <div class="showcase-tagline">Parques que viram retenção de água</div>
+                  </div>
+                </div>
+                <div class="showcase-card expanded">
+                  <div class="showcase-photo" style="--from:#d1fae5; --to:#6ee7b7;">🌳</div>
+                  <div class="showcase-body">
+                    <div class="showcase-place">São Paulo · 1976</div>
+                    <div class="showcase-title">Parque do Tietê</div>
+                    <div class="showcase-tagline">1.400 ha com função ecológica</div>
+                    <div class="showcase-detail">Após décadas de degradação, o Tietê voltou a ter parque, mata e função de drenagem. Hoje recebe US$3.4 bi em restauração contínua.</div>
+                  </div>
+                </div>
+                <div class="showcase-card">
+                  <div class="showcase-photo" style="--from:#fde68a; --to:#f59e0b;">🪴</div>
+                  <div class="showcase-body">
+                    <div class="showcase-place">Porto Alegre · 2026</div>
+                    <div class="showcase-title">Várzea Lab · Vila Flores</div>
+                    <div class="showcase-tagline">Hortas + jardins de chuva no 4º Distrito</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Esses são só exemplos — pra ter ideia do que cabe no conceito. <strong>Pronta pra olhar o seu lugar?</strong>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Sim, vamos lá…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>NbsShowcaseCard · NEW microapp (inline)</h4>
+      <p>
+        Why this exists: per the WRI Brasil + Ekos Brasil framing, NBS is best understood through concrete examples, not the abstract category. Without this surface the educational moment depends entirely on the facilitator's in-room delivery.
+      </p>
+      <p>
+        Horizontal scroller of 3 cards. Tap to expand inline (one card at a time). Photo placeholder gradient + emoji until we source real photos.
+      </p>
+      <div class="kv">component: NbsShowcaseCard
+agent event: show_examples
+params: { tag: 'nbs-intro' }
+data: knowledge/_success-cases/_cards.yaml
+  - curitiba-barigui
+  - sao-paulo-tiete
+  - vila-flores-varzea
+~80 lines of React + 1 YAML file</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h3 class="section-heading">🗺️ Beat 2A · The <span class="path-banner idea">💡 has-idea</span> path</h3>
+
+  <h2 class="screen">SCREEN 3 — has-idea · Agent asks about the project, then opens map (single-pin mode)</h2>
+  <p class="anno">The user already has a project in mind. Agent invites the description first, then opens map filtered to their bairro with just the relevant hazard layer.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · path: 💡 has-idea</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="ma-banner">
+          <a href="#" class="back-link">← Voltar ao chat</a>
+          <div class="by-agent">Pergunta do agente</div>
+          <div class="prompt">Marca o lugar onde você quer atuar. As cores mostram o risco de enchente em Cascata.</div>
+        </div>
+        <div class="ma-body">
+          <div class="pretend-map flood-only">
+            <div class="neighborhood-outline" style="left:18%; top:25%; width:55%; height:45%;"></div>
+            <div class="map-overlay-label" style="left:23%; top:21%;">Cascata</div>
+            <div class="map-pulse" style="left:38%; top:46%;"></div>
+            <div class="map-pin" style="left:42%; top:48%;"></div>
+            <div class="map-legend">
+              <div class="title">Risco de enchente</div>
+              <div class="swatches">
+                <span class="swatch" style="--swatch:#e9d5ff;">baixo</span>
+                <span class="swatch" style="--swatch:#fb923c;">médio</span>
+                <span class="swatch" style="--swatch:#ef4444;">alto</span>
+              </div>
+            </div>
+          </div>
+          <div class="ma-action-bar">
+            <span class="clear-link">Limpar</span>
+            <a href="#" class="btn-confirm">Confirmar local</a>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab active"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>MapMicroapp · IMPROVEMENT — simplified legend + single hazard filter</h4>
+      <p>
+        Today the map shows all 48 layers with a busy legend. For E2 mobile, the agent passes <code>selectionMode: 'site'</code> + <code>hazardFilter: ['flood']</code> + <code>showLegendSimple: true</code>. Map shows only Cascata polygon + flood gradient + 3-chip legend. Single-pin draw mode.
+      </p>
+      <p>
+        For the <code>has-idea</code> path the agent <em>already knows</em> the bairro's primary hazard from the bairro polygon's <code>primaryHazard</code> property — so we filter to just that hazard. Reduces cognitive load.
+      </p>
+      <div class="kv">open_map params for has-idea:
+{
+  selectionMode: 'site',
+  centerBairro: 'cascata',
+  hazardFilter: ['flood'],
+  showLegendSimple: true,
+}</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h3 class="section-heading">🗺️ Beat 2B · The <span class="path-banner help">🤝 needs-help</span> path</h3>
+
+  <h2 class="screen">SCREEN 4 — needs-help · browse-only map (NEW mode — exploration without commitment)</h2>
+  <p class="anno">Path opens with the map in read-only browse mode. All 3 hazards visible. Agent narrates the colors. User explores without pressure to commit.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · path: 🤝 needs-help</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Coletivo Restinga Nova</div>
+            <div class="meta">Restinga · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="ma-banner">
+          <a href="#" class="back-link">← Voltar ao chat</a>
+          <div class="by-agent">Olhe sem pressa</div>
+          <div class="prompt">As cores mostram o que mais afeta Restinga: vermelho = enchente, laranja = calor extremo, amarelo = deslizamento.</div>
+        </div>
+        <div class="ma-body">
+          <div class="pretend-map">
+            <div class="neighborhood-outline" style="left:15%; top:25%; width:60%; height:50%;"></div>
+            <div class="map-overlay-label" style="left:20%; top:21%;">Restinga</div>
+            <div class="map-legend">
+              <div class="title">Riscos visíveis</div>
+              <div class="swatches">
+                <span class="swatch" style="--swatch:#ef4444;">enchente</span>
+                <span class="swatch" style="--swatch:#fb923c;">calor</span>
+                <span class="swatch" style="--swatch:#fbbf24;">deslizamento</span>
+              </div>
+            </div>
+          </div>
+          <div class="ma-action-bar">
+            <a href="#" class="btn-pivot">Pronto, vamos escolher um local →</a>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span><div class="badge"></div></div>
+          <div class="tab active"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>MapMicroapp · IMPROVEMENT — browse-only mode (NEW)</h4>
+      <p>
+        No "Confirmar local" button — instead, a "Pronto, vamos escolher um local" pivot that switches the map into <code>selectionMode: 'site'</code> when the user is ready. They aren't being asked to commit; they're being invited to explore.
+      </p>
+      <p>
+        Per the LEED-UP + ABCD methodology: community knowledge first, technical decision second. The agent's banner explains what the colors mean instead of asking a question.
+      </p>
+      <p>
+        Note the red dot on 💬 — the agent has already sent a follow-up message ("Olha sem pressa, me conta o que você vê") that the user will read when they return to Chat.
+      </p>
+      <div class="kv">open_map params for needs-help (initial):
+{
+  selectionMode: 'browse-only',
+  centerBairro: 'restinga',
+  hazardFilter: ['flood', 'heat', 'landslide'],
+  showLegendSimple: true,
+  pivotCta: 'Pronto, vamos escolher um local →',
+  pivotTo: { selectionMode: 'site' }
+}</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h3 class="section-heading">🎯 Beat 3 · Convergence (shared by both paths)</h3>
+
+  <h2 class="screen">SCREEN 5 — RiskPriorityChips (NEW · inline in chat)</h2>
+  <p class="anno">After site is plotted, both paths see the same drag-rankable hazard chips. Output: ordered primary / secondary / tertiary hazards.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · Beat 3 (qualquer path)</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg user">📍 Local marcado · Pracinha do bairro (~320 m²)</div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Bom, anotado. Esse ponto está em zona de risco <strong>alto de enchente</strong>. Antes da gente falar de intervenção, deixa eu te perguntar: <strong>desses três riscos, qual mais te preocupa no dia a dia?</strong>
+              <div class="priority-chips">
+                <div class="priority-chip ranked">
+                  <span class="rank-num">1</span>
+                  <span class="hazard-icon">🌊</span>
+                  <span class="hazard-name">Enchente</span>
+                  <span class="drag-handle">⋮⋮</span>
+                </div>
+                <div class="priority-chip ranked">
+                  <span class="rank-num">2</span>
+                  <span class="hazard-icon">🌡️</span>
+                  <span class="hazard-name">Calor extremo</span>
+                  <span class="drag-handle">⋮⋮</span>
+                </div>
+                <div class="priority-chip">
+                  <span class="rank-num">3</span>
+                  <span class="hazard-icon">⛰️</span>
+                  <span class="hazard-name">Deslizamento</span>
+                  <span class="drag-handle">⋮⋮</span>
+                </div>
+              </div>
+              <div style="margin-top: 10px;">
+                <a href="#" style="font-size: 12px; color: var(--accent-deep); font-weight: 500;">Confirmar ordem →</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou escreva sua resposta…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>RiskPriorityChips · NEW microapp (inline)</h4>
+      <p>
+        3 hazards, ordered by user concern. Drag handles for desktop; tap-in-order for mobile (1st tap = 1, 2nd = 2, 3rd = 3). The first 2 are required (primary + secondary); the 3rd is optional.
+      </p>
+      <p>
+        Per the US Climate Resilience Toolkit + UN-Habitat, qualitative ranking is the right rigor at the community level. We're not asking the user to assign quantitative scores — just to order them.
+      </p>
+      <div class="kv">component: RiskPriorityChips
+agent event: ask_priority_rank
+params: {
+  question: "...",
+  items: ['flood', 'heat', 'landslide'],
+  minRanked: 2,
+}
+output:
+  { primary_hazard: 'flood',
+    secondary_hazard: 'heat',
+    tertiary_hazard: 'landslide' }</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 6 — CommunityAnchoringComposer (NEW · inline)</h2>
+  <p class="anno">Light-touch structured form scaffolded by labels. Captures who's anchored in the place + how they engage. Maps to the Community Anchoring maturity score.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · Beat 3 · anchoring</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Última coisa por hoje: <strong>quem da comunidade está envolvida nesse trabalho?</strong> Pode ser bem rápido.
+              <div class="ca-composer">
+                <div class="ca-row">
+                  <div class="label">Lideranças</div>
+                  <input value="Sandra, D. Maria" />
+                </div>
+                <div class="ca-row">
+                  <div class="label">Voluntários (quantos / quem)</div>
+                  <input value="8 pessoas regulares" />
+                </div>
+                <div class="ca-row">
+                  <div class="label">Moradores diretamente envolvidos</div>
+                  <input placeholder="ex: 12 famílias atendidas pela horta" />
+                </div>
+                <div class="ca-row">
+                  <div class="label">Como vocês se reúnem? (escolha 1 ou mais)</div>
+                  <div class="ca-chip-row">
+                    <span class="ca-chip selected">Assembleias</span>
+                    <span class="ca-chip selected">Oficinas</span>
+                    <span class="ca-chip">Mutirões</span>
+                    <span class="ca-chip">Conversas no dia a dia</span>
+                    <span class="ca-chip">Outras</span>
+                  </div>
+                </div>
+                <div style="margin-top: 8px; text-align: right;">
+                  <a href="#" style="font-size: 11px; color: var(--accent-deep); font-weight: 500;">Salvar →</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou escreva livre…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>CommunityAnchoringComposer · NEW microapp (inline)</h4>
+      <p>
+        Three labeled free-text fields + a multi-select chip row. Lighter than a full form, more structured than a single free-text. Captures the texture of community engagement (per BPJP/C40 inclusive-action criteria) without forcing demographic-survey framing.
+      </p>
+      <p>
+        Each field is optional — they can leave any blank. The chip-row engagement methods feed the Community Anchoring maturity score: ≥1 active method (oficinas/mutirões) → score 2; assembleias regulares (governance) → score 3.
+      </p>
+      <div class="kv">component: CommunityAnchoringComposer
+output:
+  community_anchoring_lead: "Sandra, D. Maria"
+  community_volunteers: "8 pessoas regulares"
+  community_beneficiaries: ""
+  community_engagement_methods:
+    ['assembleias', 'oficinas']</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 7 — Perfil tab updated · two new cards filled</h2>
+  <p class="anno">Doc panel state after Beat 3. User taps 📋 Perfil to glance at what got captured.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Tab: 📋 Perfil</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="doc-card">
+            <div class="ttl">Quem somos <span class="complete-tag">✓</span></div>
+            <div class="row"><div class="key">Nome</div><div class="val">Horta Comunitária Cascata</div></div>
+            <div class="row"><div class="key">Forma</div><div class="val">Associação · 2018</div></div>
+          </div>
+          <div class="doc-card">
+            <div class="ttl">Equipe · Histórico · Caminho <span class="complete-tag">✓</span></div>
+            <div class="row"><div class="key">Equipe</div><div class="val">6–15 · 2 pagas · 8 voluntárias</div></div>
+            <div class="row"><div class="key">Escala</div><div class="val">Projetos com financiamento</div></div>
+            <div class="row"><div class="key">Caminho</div><div class="val">💡 Já tem uma ideia</div></div>
+          </div>
+          <div class="doc-card" style="border-color: #6ee7b7;">
+            <div class="ttl">Seu território <span class="complete-tag">✓</span></div>
+            <div class="row"><div class="key">Bairro</div><div class="val">Cascata</div></div>
+            <div class="row"><div class="key">Local</div><div class="val">Pracinha do bairro · ~320 m²</div></div>
+            <div class="row"><div class="key">Uso atual</div><div class="val">Misto (calçada + canteiros)</div></div>
+            <div class="row"><div class="key">Domínio</div><div class="val">Público (informal)</div></div>
+            <div class="row"><div class="key">Riscos</div><div class="val">🌊 Enchente · 🌡️ Calor</div></div>
+          </div>
+          <div class="doc-card" style="border-color: #6ee7b7;">
+            <div class="ttl">Comunidade envolvida <span class="complete-tag">✓</span></div>
+            <div class="row"><div class="key">Lideranças</div><div class="val">Sandra, D. Maria</div></div>
+            <div class="row"><div class="key">Voluntários</div><div class="val">8 pessoas regulares</div></div>
+            <div class="row"><div class="key">Forma</div><div class="val">Assembleias · Oficinas</div></div>
+          </div>
+          <div class="doc-card empty">
+            <div class="ttl">Sua intervenção <span style="font-size:9px;color:var(--muted);">— próximo encontro</span></div>
+            <div style="font-size: 11px; color: var(--muted); font-style: italic;">Vamos preencher juntos no Encontro 3.</div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab active"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>Two new cards land in the Perfil tab</h4>
+      <p>
+        <strong>Seu território</strong> + <strong>Comunidade envolvida</strong> join the E1 cards. Each editable on hover. Mature future encontros stay greyed with the "próximo encontro" hint.
+      </p>
+      <p>
+        Both new cards have a green border treatment to highlight they were just completed. After the user navigates away and back, the green border fades to neutral.
+      </p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 8 — Closing message</h2>
+  <p class="anno">Same closing-message pattern as E1. Path-aware messaging about what E3 will cover.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 2 · fim</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território · ✓</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr" style="opacity:0.3;"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div style="background: var(--accent-soft); border: 1px solid #6ee7b7; padding: 14px; border-radius: 10px; text-align: center; color: var(--accent-deep); margin-bottom: 12px;">
+              <div style="font-size: 22px; margin-bottom: 4px;">✓</div>
+              <div style="font-weight: 600; font-size: 14px;">Encontro 2 concluído</div>
+              <div style="font-size: 12px; color: var(--ink); opacity: 0.7; margin-top: 4px;">Obrigado, Sandra. Seu território está marcado.</div>
+            </div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              <strong>Próximo encontro: 25 de junho — Desenhando sua intervenção.</strong>
+              <br><br>
+              Você marcou <strong>Pracinha do bairro</strong>, e o que mais te preocupa é <strong>enchente</strong>. No próximo encontro vamos escolher juntos o tipo de SbN que faz mais sentido pra isso — provavelmente alguma coisa com infiltração e biorretenção. Mas isso a gente vê na hora.
+              <br><br>
+              Até lá! 🌱
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Aguardando próximo encontro…" disabled style="opacity:0.6;">
+          <div class="send" style="opacity:0.4;">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>Closing reuses E1's pattern</h4>
+      <p>
+        Friendly completion banner + next-encontro setup. The agent uses what was just captured — bairro + primary hazard — to set expectations for E3 ("vamos escolher SbN que faz sentido pra enchente"). Doesn't commit to a specific intervention type yet.
+      </p>
+      <p>The Mapa tab stays in the tab bar — Sandra can revisit her site anytime between encontros.</p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">Summary · new microapps & improvements proposed in this encontro</h2>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px;">
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · inline</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">NbsShowcaseCard</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        3-card horizontal showcase of photographed Brazilian NBS cases. Reusable in E3 + E6.
+        <br><br>
+        <strong>Effort:</strong> ~80 lines React + YAML data.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · inline</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">RiskPriorityChips</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        Drag/tap-rankable hazard chips. Output: primary, secondary, tertiary.
+        <br><br>
+        <strong>Effort:</strong> ~50 lines React + new agent event.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · inline</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">CommunityAnchoringComposer</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        Lightweight structured form for who's anchored + how they engage.
+        <br><br>
+        <strong>Effort:</strong> ~60 lines React.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px; background: var(--accent-soft);">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">IMPROVEMENT · MapMicroapp</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">Simpler modes for E2</div>
+      <div style="font-size: 12px; color: var(--ink); line-height: 1.5;">
+        New params: <code>selectionMode: 'site' | 'browse-only'</code>, <code>hazardFilter</code>, <code>showLegendSimple</code>, <code>centerBairro</code>.
+        <br><br>
+        <strong>Effort:</strong> ~120 lines added to existing component.
+      </div>
+    </div>
+  </div>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 48px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Companion files: <code>research.md</code> · <code>spec.md</code> · <code>skill.md</code> · all in <code>knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/</code>
+  </p>
+</div>
+</body>
+</html>

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/research.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/research.md
@@ -1,0 +1,180 @@
+# E2 — Seu território · o que é NBS — Research notes
+
+**Goal of this encontro**: Build a shared understanding of *what NBS is*, ground it in the bairro's actual risks, and let the CBO mark **where** they want to act. Two paths converge here: `has-idea` validates an existing site; `needs-help` discovers one. ~45 min of platform time inside a 90-min session.
+
+## What the research says
+
+### Brazilian framing of NBS for community audiences
+
+CBOs are not the funder audience for whom NBS is a technical category. The Brazilian Portuguese ecosystem already has community-friendly framings worth borrowing.
+
+[**Ekos Brasil — "Soluções Baseadas na Natureza"**](https://www.ekosbrasil.org/solucoes-baseadas-na-natureza/) frames NBS as *"intervenções inspiradas em ecossistemas saudáveis para enfrentar desafios urgentes da sociedade, especialmente nas grandes metrópoles"*. They lead with **concrete examples**, not the abstract category:
+
+- corredor verde na cidade
+- rooftop que vira jardim
+- terreno baldio que vira horta
+- encosta de um viaduto que se transforma em mini floresta vertical
+
+[**WRI Brasil**](https://www.wribrasil.org.br/noticias/solucoes-baseadas-na-natureza-exemplos-implementados-por-cidades-brasileiras) goes further and shows the **three scales** (urban, neighborhood, landscape) with photographed Brazilian examples — Curitiba's Barigui parks, São Paulo's Tietê river restoration, Recife's hortas urbanas. These are the reference cases that *make NBS feel achievable* — they're not Singapore or Copenhagen.
+
+[**USP GIPSBN**](https://sites.usp.br/gipsbn/en/solucoes-baseadas-na-natureza/) (Grupo de Interação à Pesquisa em SbN) emphasizes *"o envolvimento das comunidades locais e o respeito aos conhecimentos tradicionais"* — community knowledge is part of the NBS definition itself, not a participatory add-on.
+
+**Implication for E2**: don't explain NBS as a category. Show **3-4 concrete Brazilian examples** as the educational moment. The category falls out of the examples, not vice versa.
+
+### Participatory methodology — community-led site selection in informal settlements
+
+The literature on participatory NBS in the Global South converges on a few patterns we should adopt.
+
+[**Catalytic Communities — LEED-UP for favelas**](https://rioonwatch.org/?p=17816): A 4-step community-led process where (1) community identifies its own priorities, (2) technical partners help select strategies, (3) catalytic actions are designed, (4) supporting partners are mapped. Critical insight: **community goes first, technical comes second.** This maps directly to our path triage — `needs-help` runs the community-priorities-first arc; `has-idea` has already done its own priorities work.
+
+[**Sustainable Favela Network — Asset-Based Community Development (ABCD)**](https://catcomm.org/sustainable-favela-network/): start from community **talents and assets**, not deficits. *"Focusing development strategies on talents available in each community."* Concrete shift: don't begin E2 with "your bairro has high flood risk"; begin with "tell us about this place that you know best."
+
+[**Frontiers — Participatory NBS in the Global South**](https://www.frontiersin.org/journals/sustainable-cities/articles/10.3389/frsc.2022.956534/full): documents how **citizen science and serious games** shift outcomes for NBS — projects become "more integrated and site-specific" when communities co-produce.
+
+[**ScienceDirect — Participatory approaches for NBS in flood-vulnerable landscapes**](https://www.sciencedirect.com/science/article/abs/pii/S1462901122003525): stakeholder mapping + iterative co-design is the empirical pattern that yields locally-grounded NBS designs.
+
+**Implication for E2**: the map is a **canvas for community knowledge**, not a quiz. The agent's job is to ask *"what does this place mean to you?"* and overlay risk data *underneath* their narrative, not lead with it.
+
+### Hazard prioritization — qualitative is enough at this stage
+
+[**US Climate Resilience Toolkit — Step 2: Assess Vulnerability and Risks**](https://toolkit.climate.gov/content/step-2-assess-vulnerability-and-risks): for community-level assessment, *"qualitative methods… categorizing vulnerability and risk as low, medium, or high… is fairly quick and effective for identifying which assets represent the highest risk."* Quantitative scoring is reserved for design-stage feasibility, not workshop-stage prioritization.
+
+[**UN-Habitat — Community Climate Risk Guide**](https://unhabitat.org/climate-change-vulnerability-and-risk-a-guide-for-community-assessments-action-planning-and): the participatory Community Risk Assessment is *"a participatory process where community members directly assess hazards, vulnerabilities, risks, and their coping capacities."* The output is a **ranked list of hazards**, not a CVI score.
+
+[**NHESS 2025 — Community-driven natural hazard assessment in disaster-prone urban neighborhoods**](https://nhess.copernicus.org/articles/25/4451/2025/): peer-reviewed evidence that community-derived hazard rankings align well with technical assessments — communities are *correct* about their primary hazards. Don't second-guess their priority.
+
+**Implication for E2**: a **3-chip rank (Enchente / Calor / Deslizamento)** drag-or-tap-ordered by what concerns them is the entire hazard-priority output. Overlay technical risk data to **inform** their ranking, not replace it.
+
+### What our existing intervention docs lack for E2 use
+
+Our `_interventions/*.md` files (6 of them) are funder-grade — USD/m² costs, engineering specs, climate-impact ranges with confidence intervals. Excellent for E3 (where the CBO picks an intervention) and E4 (where they design it), but **not appropriate for E2's educational moment**. We need lighter, photo-led "what it is and what it does" cards.
+
+[**Curitiba Barigui parks**](https://www.wribrasil.org.br/noticias/solucoes-baseadas-na-natureza-exemplos-implementados-por-cidades-brasileiras) and [**São Paulo Tietê restoration**](knowledge/_success-cases/brazilian-municipal.md) are already in our KB but in pure-text form — they'd shine as 3-photo cards with 1-line each.
+
+## What we therefore ask + show in E2
+
+Synthesizing — the encontro flows in **3 beats**, with the order swapped between the two paths:
+
+### Beat 1: Educational anchor (~10 min, Antônia/Julia-led offline + platform showcase)
+
+In-room: facilitator introduces NBS using 3-4 photographed Brazilian examples. Coordinator-led, not platform-driven.
+
+Platform: when the CBO opens E2, the chat surfaces a **"Exemplos no Brasil"** card with 3 cases visible inline (Curitiba parks · Tietê · Várzea Lab Vila Flores). Tappable, dismissible, optional reference during the encontro.
+
+### Beat 2: Map + bairro context (~20 min on platform)
+
+Path-aware framing:
+
+**`has-idea` path** opens with: *"Conta sobre seu projeto atual — depois a gente abre o mapa pra você marcar onde fica."*
+1. Free-text + file upload: what's the project, in your words?
+2. Open map → site selection mode → CBO drops a pin / draws a small area
+3. Site name (auto-suggest from OSM if available, accept user override)
+4. Agent overlays the bairro's risk data: *"Esse ponto está em Cascata, numa zona de risco alto de enchente. Faz sentido com o que você vive ali?"*
+
+**`needs-help` path** opens with: *"Vamos olhar o mapa do seu bairro juntos. As cores mostram o que mais afeta essa região."*
+1. Map opens centered on CBO's `bairro_of_operation` from E1
+2. Risk layers visible — agent narrates what the user sees (*"o vermelho é enchente, o laranja é calor extremo"*)
+3. Dialogue: *"O que você vê aí parece com o que vocês vivem no dia a dia?"*
+4. After the conversation grounds: *"Onde, no seu bairro, você acha que faz mais sentido a gente atuar?"* → site selection
+
+### Beat 3: Hazard priority + site detail (~10 min, both paths)
+
+After site is plotted, both paths converge:
+
+1. **Risk Priority chips**: *"Vamos focar — desses três riscos, qual mais te preocupa?"* with 3 drag-rankable chips
+2. **Land tenure**: *"Vocês têm acesso a esse espaço hoje?"* — chips: público / privado / misto / informal
+3. **Community anchoring**: *"Como vocês se conectam com esse lugar? Quem da comunidade está envolvido?"* — free text + optional engagement-type chips
+
+## Maturity scoring (silent, coordinator-side)
+
+```
+SITE_CONTROL (0-3)
+  0  No site identified
+  1  Site identified but no access (e.g. público sem permissão)
+  2  Informal permission OR municipal alignment (e.g. SMAMUS knows)
+  3  Formal agreement OR secure tenure (e.g. owned by org)
+
+COMMUNITY_ANCHORING (0-3)
+  0  No community involvement
+  1  Beneficiaries identified but not engaged
+  2  Community involved in design or implementation
+  3  Community governance or cooperative ownership
+```
+
+Both inferred from the answers to the land-tenure + community-anchoring questions.
+
+## Microapps & improvements proposed by this research
+
+This is where the research drives concrete product decisions. Three are new, two are improvements.
+
+### NEW · `NbsShowcaseCard` (inline in chat)
+A 3-card horizontal scroller surfaced at the **start of E2** showing photographed Brazilian NBS cases. Tap a card → expands inline with a 4-line story. Reusable in E3 + E6 (pitch examples) too.
+
+**Justification**: ABCD + WRI-Brasil framing says lead with examples, not concept. Without a way to show examples on the platform, the educational moment depends entirely on the facilitator's in-room delivery.
+
+**Data**: a small JSON in `knowledge/_success-cases/_cards.yaml` with `{slug, title, place, year, hazard, photo, one_liner}` — pulled from existing case-study docs.
+
+### NEW · `RiskPriorityChips` (inline in chat or as a small step in Site Explorer)
+After the site is plotted, the agent renders 3 chips (Enchente · Calor · Deslizamento) the user **drag-orders** or taps in sequence. Output: `primary_hazard`, `secondary_hazard`, optional `tertiary_hazard`.
+
+**Justification**: US Toolkit + NHESS 2025 say qualitative ranking is the right rigor for this stage. Inline chips beat a sub-microapp because the user is mid-thought after marking the site. We don't make them switch tabs.
+
+**Implementation**: ~50 lines of React inside the chat-message rendering pipeline. New event type `ask_priority_rank` with `{question, items, defaultOrder?}`.
+
+### NEW · Small "Community anchoring" structured composer (inline)
+After the land tenure chip, agent invites a short structured response: *"Quem da comunidade está envolvido?"* with three free-text inputs scaffolded by labels: *"Líderes / Voluntários / Moradores diretamente"*. Optional engagement-type chips below: *"Assembleias · Oficinas · Mutirões · Conversas no dia a dia"*.
+
+**Justification**: Per BPJP/C40 inclusive-action criteria + ABCD methodology, capturing *who* is anchored in the place matters as much as *where*. Free-text alone is too unstructured; chips alone miss nuance. Hybrid form is the sweet spot.
+
+### IMPROVEMENT · `MapMicroapp` — simplification modes for community context
+The existing `MapMicroapp` has composite (zone→assets) mode, draw tools, OSM layers, value tooltips — built for the BPJP municipal-grade use case. For E2's CBO context on mobile, **simpler interface needed**.
+
+Proposed new params:
+- `selectionMode: 'site'` — single-pin or small-polygon draw, no zone stepper. Default for E2.
+- `selectionMode: 'browse-only'` — read-only mode for the `needs-help` path's opening map (no selection, just exploration). New mode.
+- `hazardFilter: ['flood' | 'heat' | 'landslide']` — agent passes which hazard layers to show. Default: all three for `needs-help` start; just the bairro's top hazard for `has-idea`.
+- `showLegendSimple: boolean` — collapses the 48-layer legend to 3 hazard swatches + 1 site-pin swatch.
+
+**Justification**: Current map is "too much" for first-time community users. We don't remove power — we let the agent dial complexity down.
+
+### IMPROVEMENT · Bairro autocomplete (carryover from E1)
+The bairro autocomplete proposed in E1's spec gets used heavily here: the map opens centered on the CBO's `bairro_of_operation` from E1. If unset (E1 was skipped or `bairro_of_operation` was free-text), the agent asks at the start of E2.
+
+## What we do NOT do at E2 (deliberate exclusions)
+
+- Pick a specific intervention type → E3
+- Size the intervention → E3
+- Estimate impact → E4
+- Discuss operations → E4
+- Full equity diagnostic → already light-touched at E1, deepens later in E5 (regulatory awareness) + E6 (pitch)
+
+## Open questions
+
+1. **Map opens in chat? Or tabs immediately to map?** — On mobile, the existing mobile-tabs pattern auto-switches to the Mapa tab when `open_map` fires. On desktop, the right rail shows the map. Either way: when the user opens E2, the *first* agent message stays in chat; the map only opens on a subsequent agent turn after they've responded to the framing question. Pacing matters.
+2. **The `needs-help` opening — map first or chat first?** — Research suggests starting with community knowledge ("what do you see in your day-to-day"), not with the data overlay. So: **chat first, map second.** Tested by JVP + Julia in a dry run before going live.
+3. **Showcase cards: 3 or 6?** — 3 is the design default. If the user wants more after seeing 3 (rare in a 30-min slot), the agent can read additional examples from KB on request.
+
+## Sources
+
+### Internal KB
+- `knowledge/_interventions/*.md` — 6 funder-grade intervention docs (good for E3, lighter version needed for E2)
+- `knowledge/_success-cases/brazilian-municipal.md` — Curitiba + São Paulo + others
+- `knowledge/_cougar/sample-cbo-vilaflores.md` — Várzea Lab as a POA reference
+- `knowledge/_cougar/nbs-mapping-criteria.md` — Site Control + Community Anchoring rubrics
+- `knowledge/_inclusive-action/participatory-frameworks.md` — BPJP/C40 community engagement criteria
+
+### External (Brazilian framing)
+- [Ekos Brasil · Soluções Baseadas na Natureza](https://www.ekosbrasil.org/solucoes-baseadas-na-natureza/) — accessible PT framing + concrete examples
+- [WRI Brasil · Exemplos Brasileiros](https://www.wribrasil.org.br/noticias/solucoes-baseadas-na-natureza-exemplos-implementados-por-cidades-brasileiras) — photographed cases from Brazilian cities
+- [USP GIPSBN](https://sites.usp.br/gipsbn/en/solucoes-baseadas-na-natureza/) — Brazilian academic grounding
+
+### External (community methodology)
+- [Catalytic Communities · LEED-UP](https://rioonwatch.org/?p=17816) — 4-step community-led upgrading
+- [Sustainable Favela Network · ABCD](https://catcomm.org/sustainable-favela-network/) — asset-based development
+- [Frontiers · Participatory NBS in Global South](https://www.frontiersin.org/journals/sustainable-cities/articles/10.3389/frsc.2022.956534/full) — citizen science + serious games
+- [ScienceDirect · Participatory NBS in flood landscapes](https://www.sciencedirect.com/science/article/abs/pii/S1462901122003525) — empirical patterns
+
+### External (hazard prioritization)
+- [US Climate Resilience Toolkit · Step 2](https://toolkit.climate.gov/content/step-2-assess-vulnerability-and-risks) — qualitative is enough
+- [UN-Habitat · Community Climate Risk Guide](https://unhabitat.org/climate-change-vulnerability-and-risk-a-guide-for-community-assessments-action-planning-and) — gold-standard CRA
+- [NHESS 2025 · Community-driven hazard assessment](https://nhess.copernicus.org/articles/25/4451/2025/) — peer-reviewed evidence

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/skill.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/skill.md
@@ -1,0 +1,213 @@
+# /encontro-2-seu-territorio — Agent skill (first draft)
+
+> Loaded by `cboAgent.ts` when the member's current phase is 2 (Encontro 2 unlocked, Encontro 1 complete). Replaces the Phase-2 section of the monolithic `cbo-intervention.md` skill.
+
+## Identity
+
+You're the COUGAR/Vila Flores agent in **Encontro 2 — Seu território**. The CBO already completed Encontro 1, so you know their name, neighborhood, mission, capacity, and most importantly their **path**: `has-idea` or `needs-help`.
+
+Your job in this encontro is to:
+1. Anchor NBS in concrete examples (via the `NbsShowcaseCard`)
+2. Have them pick a **site** they want to act on
+3. Surface the bairro's risk data in dialogue with their experience
+4. Capture the priority hazard ranking + community anchoring
+5. Score Site Control + Community Anchoring (silently, coordinator-side)
+
+~45 min of conversation. You speak Portuguese with the warmth of a community facilitator.
+
+## Read the member's E1 context first
+
+Before saying anything, call `read_cbo_state` to load:
+- `member.orgName`, `member.bairroOfOperation`, `member.path`, `member.groupsServed`
+- All Phase 1 sections to reference earlier answers naturally ("você mencionou que trabalham com hortas em Cascata…")
+
+## Branch on `path` for the opening
+
+### `has-idea` opening
+
+```
+Oi {nome}. Antes de a gente abrir o mapa, deixa eu te mostrar como SbN se parece no Brasil. Toca em qualquer um pra ver mais.
+
+[show_examples tag='nbs-intro']
+
+Esses são só exemplos — pra ter ideia do que cabe no conceito. Pronta pra falar do seu projeto?
+```
+
+After they respond:
+```
+Conta sobre seu projeto atual — o que tem em mente, onde fica, em que ponto está. Se tiver algum documento (proposta, foto, planta), pode arrastar aqui.
+```
+
+Wait for response. Parse any uploaded files. Then:
+```
+Beleza. Vamos abrir o mapa pra você marcar onde fica.
+
+[open_map selectionMode='site' centerBairro={member.bairroOfOperation} hazardFilter=[primary_hazard_of_bairro] showLegendSimple=true]
+```
+
+After site is confirmed (you receive a user message of type `map_selection`):
+```
+Bom, anotado. Esse ponto está em {bairro}, numa zona de risco **{primary_hazard_label}**. Faz sentido com o que você vive ali?
+```
+
+Then proceed to Beat 3 (priority chips + community anchoring).
+
+### `needs-help` opening
+
+```
+Oi {nome}. Vamos descobrir juntos o que faz sentido pra Restinga.
+
+Antes do mapa, deixa eu te mostrar exemplos de SbN no Brasil — pra você ver o tipo de coisa que cabe nessa conversa.
+
+[show_examples tag='nbs-intro']
+
+Tá. Agora vamos olhar o mapa do seu bairro. As cores mostram o que mais afeta essa região.
+```
+
+Then open the map in browse-only mode:
+```
+[open_map selectionMode='browse-only' centerBairro={member.bairroOfOperation} hazardFilter=['flood','heat','landslide'] showLegendSimple=true pivotCta='Pronto, vamos escolher um local →']
+```
+
+While they explore, send a follow-up content message:
+```
+Olha sem pressa. O vermelho é enchente, laranja é calor extremo, amarelo é deslizamento. **O que você vê aí parece com o que vocês vivem no dia a dia?**
+```
+
+After they respond, transition to site selection:
+```
+[open_map selectionMode='site' centerBairro={member.bairroOfOperation} hazardFilter=[primary_hazard_they_mentioned] showLegendSimple=true]
+```
+
+After site confirmed, proceed to Beat 3 — same as has-idea.
+
+## Beat 3 — converge (both paths)
+
+### 3a · Risk priority chips
+
+```
+Antes da gente falar de intervenção, deixa eu te perguntar: **desses três riscos, qual mais te preocupa no dia a dia?**
+
+[ask_priority_rank items=['flood','heat','landslide'] minRanked=2]
+```
+
+After ranking received: write to `state.sections.intervention_site.fields`:
+- `primary_hazard` = ranks[0]
+- `secondary_hazard` = ranks[1]
+- `tertiary_hazard` = ranks[2] || null
+
+### 3b · Land tenure
+
+```
+E vocês têm acesso a esse espaço hoje?
+
+[ask_user options=[
+  'Sim, somos donas (privada)',
+  'Sim, é da prefeitura mas a gente usa (público, informal)',
+  'Sim, com acordo formal',
+  'É público mas a gente não tem acesso garantido',
+  'Misto / Não sei certinho'
+]]
+```
+
+Map answer → `land_tenure` enum.
+
+### 3c · Community anchoring composer
+
+```
+Última coisa por hoje: quem da comunidade está envolvida nesse trabalho? Pode ser bem rápido.
+
+[ask_community_anchoring]
+```
+
+This invokes the `CommunityAnchoringComposer` microapp inline. Output fields:
+- `community_anchoring_lead`
+- `community_volunteers`
+- `community_beneficiaries`
+- `community_engagement_methods[]`
+
+## Scoring (silent, coordinator-side)
+
+```
+SITE_CONTROL (0-3)
+  0  land_tenure unanswered OR no site
+  1  land_tenure = 'informal' AND no permissions mentioned
+  2  land_tenure = 'mixed' OR 'public with informal permission' OR municipal awareness implied
+  3  land_tenure = 'private with org ownership' OR formal agreement evidence
+
+COMMUNITY_ANCHORING (0-3)
+  0  no community_anchoring_lead provided
+  1  beneficiaries named, no engagement methods
+  2  ≥1 active method (oficinas / mutirões)
+  3  governance methods (assembleias regulares) OR cooperative ownership
+```
+
+Call `score_maturity` after 3c.
+
+## Closing
+
+After all three Beat-3 questions answered:
+
+1. `update_section('intervention_site', { ... })` with the consolidated fields
+2. `score_maturity` for Site Control + Community Anchoring
+3. `set_phase_complete(2)`
+4. Render:
+
+```
+✓ **Encontro 2 concluído** — obrigada, {nome}. Seu território está marcado.
+
+**Próximo encontro: {next_workshop.date} — Desenhando sua intervenção.**
+
+Você marcou **{site_name}**, e o que mais te preocupa é **{primary_hazard_label}**. No próximo encontro vamos escolher juntos o tipo de SbN que faz mais sentido pra isso — provavelmente alguma coisa com {hint_for_primary_hazard}. Mas isso a gente vê na hora.
+
+Até lá! 🌱
+```
+
+`hint_for_primary_hazard` mapping:
+- `flood` → "infiltração e biorretenção"
+- `heat` → "área verde e sombreamento"
+- `landslide` → "estabilização de encostas e cobertura vegetal"
+
+## Tool calls (new + existing)
+
+**New events the agent emits** (client-side, will need wiring in cbo-profile.tsx):
+- `show_examples({ tag })` → renders `NbsShowcaseCard` inline
+- `ask_priority_rank({ question, items, minRanked })` → renders `RiskPriorityChips`
+- `ask_community_anchoring({ }) ` → renders `CommunityAnchoringComposer`
+
+**Existing events with new params**:
+- `open_map` with new params: `selectionMode`, `hazardFilter`, `showLegendSimple`, `centerBairro`, `pivotCta`, `pivotTo`
+
+**Unchanged**:
+- `update_section`, `score_maturity`, `set_phase_complete`, `read_knowledge`, `read_cbo_state`, `ask_user`, `flag_gap`
+
+## KB grounding
+
+`read_knowledge` permitted for:
+- `knowledge/_success-cases/_cards.yaml` (the showcase data)
+- `knowledge/_glossary/o-que-e-nbs-comunidade.md` (community NBS explainer)
+- `knowledge/_interventions/*.md` (existing intervention docs — sometimes useful for "what hint to give for primary hazard")
+- `knowledge/_inclusive-action/participatory-frameworks.md` (when the user asks about community engagement)
+- `knowledge/_cougar/nbs-mapping-criteria.md` (Site Control + Community Anchoring rubrics)
+
+## Common stuck patterns
+
+| User says | Why | What you say |
+|---|---|---|
+| "Não sei dizer onde" (needs-help) | Decision paralysis | "Tá tudo bem. Toca em qualquer pedaço e a gente vai vendo. Pode mudar depois." |
+| "Não temos acesso ao terreno" | Site Control = 0/1 | "Faz parte — pelo menos sabemos o que falta. Vamos seguir; isso aparece no plano." |
+| "Não tem 'comunidade envolvida', sou só eu" | Score 0 territory | "Conta sim. A maioria começa de uma pessoa. Vamos por aí." |
+| "É no meu terreno" | Score 3 territory | "Ótimo — isso facilita bastante. Anotado." |
+| Switches to English | First-language English speaker | Switch immediately. |
+
+## Estimated runtime
+
+- Beat 1 (showcase + framing) — 5 min
+- Beat 2 (map + site, path-aware) — 25 min
+- Beat 3 (priority + tenure + anchoring) — 10 min
+- Closing — 2 min
+- **~42 min average**, inside the 45-min platform-time budget.
+
+---
+
+**This is a first-draft skill. Like E1, test live with 2-3 real conversations before rolling out to all 10 CBOs.** Suggest dry-running both paths separately — `has-idea` with someone like Antônia (Vila Flores team), `needs-help` with a representative of an org that's still finding their NBS angle.

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/spec.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/spec.md
@@ -1,0 +1,175 @@
+# E2 — Seu território · o que é NBS — Spec
+
+**Status**: draft for review · **Builds on**: `research.md` in this folder · **Date**: 2026-05-15
+
+## In one sentence
+
+In ~45 min of platform time, the CBO learns what NBS *is* through Brazilian examples, marks **where** they want to act on their bairro map, and ranks the hazards they care about — generating two coordinator-side maturity scores along the way.
+
+## Path-aware flow
+
+E2 is the first encontro where the two paths diverge meaningfully (re-converge at beat 3).
+
+| Beat | `has-idea` path | `needs-help` path | Time |
+|---|---|---|---|
+| 1. Educational anchor | NbsShowcaseCard rendered inline at start; CBO can skim while reading agent's opening message | Same showcase, but agent explicitly says *"Vamos olhar exemplos antes de abrir o mapa"* and pauses for the user to tap through | ~5 min |
+| 2. Map + site | Agent: *"Conta sobre seu projeto atual"* → upload offer → opens Map (`selectionMode: 'site'`) → CBO drops pin → agent overlays risk for that site | Agent: *"Conta o que você vive nesse bairro"* → opens Map (`selectionMode: 'browse-only'`) with 3 hazard layers → agent narrates the colors → then reopens Map (`selectionMode: 'site'`) → CBO picks site | ~25 min |
+| 3. Priority + tenure + anchoring | RiskPriorityChips → land tenure chip → community anchoring composer | Identical | ~10 min |
+
+Both paths end with the same "Próximo encontro" closing pattern from E1.
+
+## Data captured — every field justified
+
+| Field | Type | Why | Skipping cost |
+|---|---|---|---|
+| `bairro` | string (POA bairro slug) | Geocoding context; agent uses for risk lookup | High — required for risk overlay |
+| `site_lat`, `site_lng` | float, float | Specific intervention site | Required |
+| `site_geometry` | GeoJSON (point or polygon) | If user drew an area, persist it | Optional — falls back to point |
+| `site_area_m2` | int (rough estimate) | Feeds E3 sizing + E4 impact | Medium — auto-computed if polygon drawn |
+| `site_name` | string | What they call this place (Pracinha do Bairro, Lote do Lourival, etc.) | Optional but humanizes |
+| `current_use` | enum: `paved`/`vegetated`/`mixed`/`abandoned`/`under-construction` | E3 sizing context; E4 baseline | Medium |
+| `land_tenure` | enum: `public`/`private`/`mixed`/`informal` | **Site Control** maturity primary input | High |
+| `community_anchoring_lead` | string (free text) | Who's anchored | Medium |
+| `community_engagement_methods` | multi-chip: `assembleias`/`oficinas`/`mutirões`/`conversas`/`outras` | **Community Anchoring** maturity input | Medium |
+| `primary_hazard` | enum: `flood`/`heat`/`landslide` | Drives E3 intervention recommendations | High |
+| `secondary_hazard` | enum (same), optional | E3 secondary recommendations | Medium |
+| `hazard_priority_rationale` | string (1 sentence, optional) | Qualitative why-it-matters | Optional |
+| `nbs_familiarity` | enum: `none`/`some`/`a lot`, inferred | Calibrates agent's depth of explanation in E3 | Optional |
+
+**Total: 13 fields** (12 substantive + 1 inferred). Most are chip-driven or auto-derived from map clicks. Site name + community anchoring lead are the only required free-text fields.
+
+## Maturity scoring (silent, written to `state.maturityScores`)
+
+```
+SITE_CONTROL (0-3)
+  0  land_tenure unanswered OR no site identified
+  1  land_tenure = 'informal' AND no permissions mentioned
+  2  land_tenure = 'mixed' OR 'public with informal permission' OR municipal awareness implied
+  3  land_tenure = 'private with org ownership' OR formal agreement uploaded as evidence
+
+COMMUNITY_ANCHORING (0-3)
+  0  no community_anchoring_lead provided
+  1  beneficiaries named but no engagement methods
+  2  community_engagement_methods includes ≥1 active method (oficinas / mutirões)
+  3  evidence of community governance (assembleias regulares) OR cooperative ownership
+```
+
+## Microapps & improvements proposed by this research
+
+### NEW · `NbsShowcaseCard` (inline in chat)
+Horizontal scroll of 3 photographed Brazilian NBS cases. Card shape: 220px wide, photo on top, 1-line story below, tap-to-expand for a 4-line detail. Data from `knowledge/_success-cases/_cards.yaml` (new — to be authored).
+
+Default seed (3 cards):
+- **Curitiba · Parques do Barigui** · 1996 · enchente · "Parques que viram retenção de água quando chove forte"
+- **São Paulo · Parque do Tietê** · 1976 · enchente + biodiversidade · "1.400 hectares de área verde com função ecológica"
+- **Porto Alegre · Várzea Lab · Vila Flores** · 2026 · adaptação · "Hortas + jardins de chuva no 4º Distrito pós-enchente"
+
+Agent invokes via new event `show_examples` with `{tag: 'nbs-intro'}`.
+
+**Photo curation** — every showcase photo must be sourced from Wikimedia Commons, a Brazilian prefeitura/government gallery, Agência Brasil, a vetted NGO publication, or directly from a partner org. **No stock photography, no AI-generated images, no unattributed sources.** Sourced URLs + licenses for the 3 seed cards live in [`docs/photo-curation.md`](../../../../docs/photo-curation.md). Cards render as gradient + emoji placeholders until verified-source photos are downloaded and registered in the manifest.
+
+### NEW · `RiskPriorityChips` (inline)
+3 drag-rankable chips appearing as a single agent turn. Output: ordered array of `{hazard, rank}`. Drag for desktop; tap-in-order for mobile. The first-ranked chip becomes `primary_hazard`, second is `secondary_hazard`.
+
+Agent invokes via new event `ask_priority_rank` with `{question, items: ['flood','heat','landslide']}`.
+
+### NEW · Inline `CommunityAnchoringComposer` (lightweight structured form)
+Three labeled free-text fields (Líderes / Voluntários / Moradores diretamente) + a chip multi-select for engagement methods. ~60 lines of React, rendered as one chat message.
+
+### IMPROVEMENT · `MapMicroapp` simplification modes
+Existing component, new params:
+- `selectionMode: 'site'` — single-pin or small-polygon draw, no zone stepper
+- `selectionMode: 'browse-only'` — read-only, exploration mode
+- `hazardFilter: ('flood' | 'heat' | 'landslide')[]` — visible hazard layers
+- `showLegendSimple: boolean` — collapsed 3-chip legend instead of 48-layer toolkit
+- `centerBairro: string` — opens centered on a named POA bairro polygon
+
+These all default to backwards-compatible behavior. The cboAgent passes them when invoking `open_map` for E2.
+
+### IMPROVEMENT · Persist drafts on map exit
+Currently if a CBO opens the map, drops a pin, and switches tabs without confirming, the pin is lost. Persist `openMapParams.draftSelection` to localStorage so resuming the encontro keeps their pin.
+
+## Doc panel layout for E2
+
+Adds two cards to the existing E1 layout:
+
+```
+┌─ Quem somos ──────────────────────┐  ← from E1, ✓
+└───────────────────────────────────┘
+┌─ Equipe ──────────────────────────┐  ← from E1, ✓
+└───────────────────────────────────┘
+┌─ Histórico ───────────────────────┐  ← from E1, ✓
+└───────────────────────────────────┘
+┌─ Caminho ─────────────────────────┐  ← from E1, ✓
+└───────────────────────────────────┘
+┌─ Seu território ──────────────────┐  ← NEW
+│ Bairro:       Cascata             │
+│ Local:        Pracinha do bairro  │
+│ Área:         ~320 m²             │
+│ Uso atual:    Misto (pavimentado +│
+│               canteiros)          │
+│ Domínio:      Público (informal)  │
+│ Riscos:       Enchente (1º) ·     │
+│               Calor (2º)          │
+└───────────────────────────────────┘
+┌─ Comunidade envolvida ────────────┐  ← NEW
+│ Lideranças:   Sandra, D. Maria    │
+│ Voluntários:  8 pessoas           │
+│ Forma:        Oficinas · Mutirões │
+└───────────────────────────────────┘
+```
+
+## Preamble screen (CBO entry)
+
+```
+ENCONTRO 2 — Seu território
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Hoje a gente vai:
+
+  · Ver exemplos de SbN no Brasil
+  · Olhar o mapa do seu bairro
+  · Marcar onde você quer atuar
+  · Falar dos riscos que mais importam
+
+Você vai usar:
+  · Exemplos visuais
+  · O mapa do bairro
+
+Tempo estimado: 30–45 min · Salva sozinho
+
+                  [ Começar  → ]
+```
+
+## What ships when we build E2
+
+**New components:**
+- `NbsShowcaseCard.tsx` (inline chat card) + companion `_cards.yaml` data
+- `RiskPriorityChips.tsx` (inline chat composer)
+- `CommunityAnchoringComposer.tsx` (inline chat form)
+- `encontro-2-seu-territorio.md` agent skill (path-aware)
+
+**Modified components:**
+- `MapMicroapp.tsx` — add the new selection modes + simplified legend
+- `cbo-profile.tsx` — register the new agent events (`show_examples`, `ask_priority_rank`)
+- `cbo-schema.ts` — extend `intervention_site` section with the new fields
+- `cboAgent.ts` — load `encontro-2-seu-territorio.md` when phase = 2
+
+**KB content to author:**
+- `knowledge/_success-cases/_cards.yaml` (3 seed cards, structured data)
+- `knowledge/_glossary/o-que-e-nbs-comunidade.md` (community-friendly NBS explainer, ~250 words PT)
+- `knowledge/_interventions/_community/*.md` — community-friendly versions of the 6 intervention docs (deferred to E3)
+
+## Out of scope for E2
+
+- Specific intervention type selection → E3
+- Sizing the intervention → E3
+- Impact computation → E4
+- Operations design → E4
+- Funding need / permits → E5
+
+## Open decisions before building
+
+1. **NbsShowcaseCard photos** — do we have rights-cleared photos of the 3 seed cases? If not, ship with placeholder illustrations (emoji + tinted gradient) for v1; swap to photos when sourced.
+2. **Drag-to-rank on mobile** — touch drag-and-drop is finicky. Fallback: tap chips in priority order (first tap = 1st, second = 2nd, third = 3rd). Probably better default behavior on mobile regardless.
+3. **`browse-only` map mode** — should it have a "I've seen enough, let's pick a spot" CTA at the bottom that transitions to `site` selection mode? Yes — saves the user from waiting for the agent's prompt.

--- a/knowledge/runs/2026-05-15-encontros-curriculum/_mobile/mobile-tabs-mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/_mobile/mobile-tabs-mockup.html
@@ -1,0 +1,668 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mobile tabs · agent-driven focus · mockup</title>
+<style>
+  :root {
+    --bg: #fafaf9;
+    --surface: #ffffff;
+    --ink: #18181b;
+    --muted: #71717a;
+    --line: rgba(0,0,0,0.08);
+    --accent: #059669;
+    --accent-soft: #ecfdf5;
+    --accent-deep: #047857;
+    --warm: #f59e0b;
+    --warm-soft: #fef3c7;
+    --info: #0284c7;
+    --danger: #ef4444;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1280px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); letter-spacing: 0; }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  .lede { color: var(--muted); margin: 8px 0 24px; max-width: 64ch; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 18px; padding-left: 14px; border-left: 2px solid var(--accent); max-width: 64ch; }
+
+  /* Two-up grid: phone + note */
+  .scene { display: grid; grid-template-columns: 380px 1fr; gap: 36px; align-items: start; }
+  .scene .note h3 { font-size: 14px; margin: 0 0 6px; }
+  .scene .note p { font-size: 13px; color: var(--muted); margin: 0 0 10px; line-height: 1.6; }
+  .scene .note .kv { font-family: ui-monospace, "JetBrains Mono", monospace; font-size: 11px; background: #f4f4f5; padding: 10px 12px; border-radius: 8px; color: var(--ink); margin-top: 12px; white-space: pre-wrap; line-height: 1.5; }
+
+  /* Phone frame */
+  .phone {
+    width: 380px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 12px 36px -16px rgba(0,0,0,0.18);
+    position: relative;
+  }
+  .phone .top-chrome {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+    font-size: 10px;
+    color: var(--muted);
+    font-family: ui-monospace, monospace;
+  }
+  .phone .frame-body {
+    min-height: 600px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* App header (org name) */
+  .app-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .app-header .leaf { width: 28px; height: 28px; border-radius: 6px; background: var(--accent-soft); color: var(--accent-deep); display:flex; align-items:center; justify-content:center; font-size: 13px; }
+  .app-header .id { flex: 1; min-width: 0; }
+  .app-header .org-name { font-size: 13px; font-weight: 600; tracking: -0.01em; line-height: 1.2; }
+  .app-header .meta { font-size: 10px; color: var(--muted); line-height: 1.2; }
+
+  /* Progress strip */
+  .progress-strip { padding: 8px 16px; border-bottom: 1px solid var(--line); }
+  .progress-strip .label { font-size: 10px; color: var(--muted); margin-bottom: 4px; }
+  .progress-strip .label .active { color: var(--ink); font-weight: 600; }
+  .segments { display: flex; gap: 3px; }
+  .seg { height: 3px; flex: 1; border-radius: 2px; }
+  .seg.past { background: var(--accent); }
+  .seg.curr { background: var(--accent); opacity: 0.5; }
+  .seg.locked { background: rgba(0,0,0,0.08); }
+
+  /* Tab content area */
+  .tab-content { flex: 1; padding: 12px 16px; overflow-y: auto; }
+
+  /* Chat tab */
+  .chat-msgs { display: flex; flex-direction: column; gap: 6px; }
+  .msg { padding: 8px 12px; border-radius: 14px; font-size: 13px; line-height: 1.45; max-width: 86%; }
+  .msg.agent { background: #f4f4f5; align-self: flex-start; }
+  .msg.user { background: var(--accent); color: white; align-self: flex-end; }
+  .msg .lbl { font-size: 9px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 3px; }
+  .msg.user .lbl { display: none; }
+  .msg-new-pill { display: inline-block; font-size: 9px; background: var(--accent-soft); color: var(--accent-deep); padding: 1px 6px; border-radius: 999px; margin-left: 6px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+  .qopts { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 5px; }
+  .chip { border: 1px solid var(--line); padding: 5px 9px; border-radius: 999px; font-size: 11px; background: var(--surface); }
+  .chip.selected { background: var(--accent-soft); border-color: #6ee7b7; color: var(--accent-deep); }
+  .chip.option-letter::before { content: attr(data-letter) " · "; color: var(--muted); font-weight: 600; }
+
+  /* Chat input */
+  .chat-input { padding: 8px 12px; border-top: 1px solid var(--line); display: flex; gap: 6px; }
+  .chat-input .ipt { flex: 1; border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; font-size: 12px; color: var(--muted); background: var(--surface); }
+  .chat-input .send { width: 28px; height: 28px; border-radius: 50%; background: var(--accent); color: white; display: inline-flex; align-items: center; justify-content: center; font-size: 13px; flex-shrink: 0; }
+
+  /* Tab bar */
+  .tab-bar {
+    border-top: 1px solid var(--line);
+    background: var(--surface);
+    display: flex;
+    padding: 4px 0 8px;
+  }
+  .tab {
+    flex: 1;
+    text-align: center;
+    padding: 6px 4px;
+    font-size: 10px;
+    color: var(--muted);
+    position: relative;
+    cursor: pointer;
+  }
+  .tab .icon { font-size: 18px; line-height: 1; }
+  .tab .label { display: block; margin-top: 2px; font-weight: 500; }
+  .tab.active { color: var(--accent-deep); }
+  .tab.active::after {
+    content: ""; position: absolute; bottom: -4px; left: 50%; transform: translateX(-50%);
+    width: 24px; height: 2px; background: var(--accent); border-radius: 2px;
+  }
+  .tab .badge {
+    position: absolute; top: 0; right: 50%; transform: translate(14px, 4px);
+    width: 8px; height: 8px; border-radius: 50%; background: var(--danger);
+  }
+
+  /* Microapp banner */
+  .ma-banner {
+    background: var(--accent-soft);
+    border-bottom: 1px solid #a7f3d0;
+    padding: 10px 16px;
+  }
+  .ma-banner .back-link {
+    display: inline-flex; align-items: center; gap: 4px;
+    color: var(--accent-deep); font-size: 11px; font-weight: 500; text-decoration: none;
+    margin-bottom: 4px;
+  }
+  .ma-banner .prompt {
+    font-size: 13px; color: var(--ink); font-weight: 500; line-height: 1.4;
+  }
+  .ma-banner .by-agent {
+    font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600;
+  }
+
+  /* Microapp body — pretend-map / selector */
+  .ma-body { flex: 1; padding: 0; display: flex; flex-direction: column; }
+
+  .pretend-map {
+    flex: 1; position: relative; min-height: 320px;
+    background:
+      radial-gradient(circle at 30% 40%, rgba(245, 158, 11, 0.25) 0%, transparent 30%),
+      radial-gradient(circle at 65% 55%, rgba(239, 68, 68, 0.3) 0%, transparent 25%),
+      radial-gradient(circle at 50% 80%, rgba(245, 158, 11, 0.2) 0%, transparent 25%),
+      linear-gradient(135deg, #e5f3e0 0%, #d4e8d4 100%);
+  }
+  .map-pin {
+    position: absolute;
+    width: 18px; height: 18px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 3px solid white;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  }
+  .neighborhood-outline {
+    position: absolute;
+    border: 2px solid var(--accent);
+    background: rgba(5, 150, 105, 0.1);
+    border-radius: 8px;
+  }
+  .map-overlay-label {
+    position: absolute;
+    font-size: 10px;
+    background: white;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--ink);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    font-weight: 600;
+  }
+  .map-legend {
+    position: absolute;
+    bottom: 12px;
+    left: 12px;
+    background: rgba(255,255,255,0.95);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 10px;
+    color: var(--ink);
+    display: flex;
+    gap: 10px;
+  }
+  .map-legend .swatch { display: inline-flex; align-items: center; gap: 4px; }
+  .map-legend .swatch::before {
+    content: ""; display: inline-block; width: 10px; height: 10px; border-radius: 2px;
+    background: var(--swatch);
+  }
+
+  .ma-action-bar {
+    padding: 12px 16px;
+    border-top: 1px solid var(--line);
+    background: var(--surface);
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .ma-action-bar .clear-link {
+    font-size: 11px; color: var(--muted); text-decoration: underline;
+  }
+  .btn-confirm {
+    background: var(--accent); color: white;
+    padding: 9px 16px; border-radius: 10px; font-weight: 500; font-size: 13px;
+    flex: 1;
+    text-align: center;
+  }
+  .btn-confirm.disabled { background: var(--line); color: var(--muted); }
+
+  /* Intervention selector cards */
+  .int-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 12px 16px; }
+  .int-card {
+    border: 1px solid var(--line); border-radius: 10px; padding: 10px;
+    background: var(--surface); cursor: pointer;
+  }
+  .int-card.selected {
+    border-color: var(--accent); background: var(--accent-soft);
+  }
+  .int-card .thumb {
+    height: 60px; border-radius: 6px; margin-bottom: 6px;
+    background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px;
+  }
+  .int-card .name { font-size: 11px; font-weight: 600; color: var(--ink); line-height: 1.2; }
+  .int-card .sub { font-size: 9px; color: var(--muted); margin-top: 2px; line-height: 1.2; }
+
+  /* Perfil doc panel */
+  .doc-card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px;
+    margin-bottom: 8px;
+  }
+  .doc-card .ttl { font-size: 11px; font-weight: 600; color: var(--ink); margin-bottom: 6px; display: flex; align-items: center; justify-content: space-between; }
+  .doc-card .row { display: flex; padding: 3px 0; font-size: 11px; gap: 6px; }
+  .doc-card .row .key { color: var(--muted); min-width: 80px; }
+  .doc-card .row .val { color: var(--ink); flex: 1; }
+  .edit-link { font-size: 10px; color: var(--accent-deep); text-decoration: underline; }
+  .complete-tag { font-size: 9px; padding: 1px 5px; border-radius: 999px; background: var(--accent-soft); color: var(--accent-deep); font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+
+  /* Annotations */
+  .legend {
+    background: #eff6ff; border-left: 3px solid #3b82f6; padding: 10px 14px; border-radius: 0 8px 8px 0; font-size: 12px; color: #1e3a8a;
+    margin: 16px 0 24px;
+    max-width: 64ch;
+  }
+
+  /* Arrow flow visualization between phones */
+  .flow-arrow {
+    display: flex; align-items: center; gap: 8px; color: var(--accent-deep); font-size: 12px; font-weight: 600;
+    margin: 14px 0 4px;
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .flow-arrow::before, .flow-arrow::after {
+    content: ""; flex: 1; height: 1px; background: var(--accent-soft);
+  }
+
+  .draft-pill {
+    font-size: 9px; padding: 1px 6px; border-radius: 999px; background: #fef3c7; color: #92400e; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-left: 6px;
+  }
+</style>
+</head>
+<body>
+<div class="doc">
+
+  <h1>Mobile tabs · agent-driven focus <span class="small">· 2026-05-15</span></h1>
+  <p class="lede">
+    The mobile CBO surface as a single-pane app with bottom tabs. The agent drives which tab is in focus —
+    when it invokes a microapp, the UI auto-switches. Chat input only lives on the Chat tab. Microapp tabs
+    have a single concern (make a selection); the user taps back to Chat to message the agent.
+  </p>
+
+  <div class="legend">
+    <strong>Reading the mockup</strong> · 5 screens in narrative order, showing the agent–user back-and-forth across tabs.
+    Each screen is one moment in time; each annotation explains what just happened and the relevant state changes.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN A — Chat tab (default) · agent asks a free-text question</h2>
+  <p class="anno">User opened the platform · landed on Chat tab · agent is mid-conversation in Encontro 2 · no microapps active yet.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Olá Sandra. No último encontro você mencionou hortas em Cascata — bairro que está numa região com risco alto de enchente. Antes de a gente entrar no mapa: <strong>qual desses riscos te preocupa mais?</strong>
+              <div class="qopts">
+                <span class="chip option-letter" data-letter="A">Enchente</span>
+                <span class="chip option-letter" data-letter="B">Calor extremo</span>
+                <span class="chip option-letter" data-letter="C">Deslizamento</span>
+                <span class="chip option-letter" data-letter="D">Os três se misturam</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Escreva ou escolha acima…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Initial state</h3>
+      <p>Two tabs visible: <strong>Chat</strong> (active) and <strong>Perfil</strong> (always-on, read-only). No <strong>Mapa</strong> tab yet — the agent hasn't invoked any map tool.</p>
+      <p>Chat input is at the bottom, just above the tab bar. Both visible at all times on this tab.</p>
+      <div class="kv">state.mobileActiveTab = 'chat'
+state.openMapParams = null
+state.interventionSelectorParams = null
+state.mobileChatUnread = false
+
+Visible tabs: ['chat', 'perfil']</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">User taps "A · Enchente" → agent processes → invokes open_map</div>
+
+  <h2 class="screen">SCREEN B — Mapa tab opens (agent-driven auto-switch)</h2>
+  <p class="anno">Agent emits an <code>open_map</code> event with parameters for site selection. UI immediately switches to the Mapa tab. Agent's prompt becomes the banner header. Microapp shows the risk overlay for the bairro.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="ma-banner">
+          <a href="#" class="back-link">← Voltar ao chat</a>
+          <div class="by-agent">Pergunta do agente</div>
+          <div class="prompt">Marque seu local no mapa. As cores mostram o risco de enchente.</div>
+        </div>
+        <div class="ma-body">
+          <div class="pretend-map">
+            <div class="neighborhood-outline" style="left:20%; top:30%; width:50%; height:40%;"></div>
+            <div class="map-overlay-label" style="left:25%; top:25%;">Cascata</div>
+            <div class="map-pin" style="left:42%; top:48%;"></div>
+            <div class="map-legend">
+              <span class="swatch" style="--swatch:#e9d5ff;">baixo</span>
+              <span class="swatch" style="--swatch:#fbbf24;">médio</span>
+              <span class="swatch" style="--swatch:#ef4444;">alto</span>
+            </div>
+          </div>
+          <div class="ma-action-bar">
+            <span class="clear-link">Limpar</span>
+            <a href="#" class="btn-confirm">Confirmar seleção</a>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab active"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Agent drives the UI</h3>
+      <p>The agent's <code>open_map</code> tool call carried site-selection parameters. The UI did three things at once:</p>
+      <ol style="font-size: 13px; color: var(--ink); padding-left: 18px;">
+        <li>Made the <strong>Mapa</strong> tab visible (it wasn't before)</li>
+        <li>Auto-switched to it</li>
+        <li>Rendered the agent's prompt as a banner above the map</li>
+      </ol>
+      <p>The chat input is now <strong>hidden</strong>. This tab has one concern: the map selection. To ask the agent a question, the user taps <strong>💬 Chat</strong>.</p>
+      <p>The "<strong>← Voltar ao chat</strong>" link in the banner is an explicit escape hatch — for users who don't notice the tab bar.</p>
+      <div class="kv">state.mobileActiveTab = 'map'
+state.openMapParams = {
+  selectionMode: 'site',
+  zoneSource: 'neighborhoods',
+  ...
+}
+state.agentPrompt = "Marque seu local no mapa…"
+
+Visible tabs: ['chat', 'map', 'perfil']</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">User drops a pin · taps "Confirmar seleção"</div>
+
+  <h2 class="screen">SCREEN C — Selection confirmed · auto-switch back to Chat</h2>
+  <p class="anno">The microapp's "Confirmar seleção" sends the result to the agent. UI auto-switches back to Chat. The selection appears as a user message; agent responds. <strong>Mapa</strong> tab stays available — the user can return to adjust if they want.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg user">📍 Site marcado em Cascata <br>(Rua das Flores, 142)</div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Bom, anotado. Esse ponto está numa zona de risco <strong>alto de enchente</strong> — exatamente o que você mencionou. <br><br>
+              A área é de uns 320 m². Existe alguma infraestrutura de drenagem ali perto, ou é parte da rua mesmo?
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Escreva…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>The auto-return</h3>
+      <p>When the user taps <strong>Confirmar seleção</strong>:</p>
+      <ol style="font-size: 13px; color: var(--ink); padding-left: 18px;">
+        <li>The map's selection result is posted to the agent (becomes a user chat message)</li>
+        <li>UI switches back to Chat</li>
+        <li>Agent streams its response in the chat panel</li>
+        <li>Mapa tab stays in the tab bar — the user can return to adjust without re-invoking</li>
+      </ol>
+      <p>Note the user message is rendered with a 📍 emoji + a short summary, not the raw geo-JSON the agent receives. Two views of the same data.</p>
+      <div class="kv">state.mobileActiveTab = 'chat'  (auto-set)
+state.openMapParams = STILL SET
+  (tab stays available)
+last user message:
+  type: 'map_selection',
+  display: '📍 Site marcado em Cascata',
+  payload: { lat, lng, area_m2, ... }</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">User taps Perfil tab while agent is still typing the next question</div>
+
+  <h2 class="screen">SCREEN D — Perfil tab (user-driven · agent still working in background)</h2>
+  <p class="anno">User wants to glance at what's saved so far. Taps <strong>📋 Perfil</strong>. Agent's next message lands while they're on this tab — Chat tab gets a 🔴 dot.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 2</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 2 de 5 · Seu território</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="doc-card">
+            <div class="ttl">Quem somos <span class="complete-tag">✓</span></div>
+            <div class="row"><div class="key">Nome</div><div class="val">Horta Comunitária Cascata</div></div>
+            <div class="row"><div class="key">Forma</div><div class="val">Associação</div></div>
+            <div class="row"><div class="key">Equipe</div><div class="val">6–15 (2 pagas · 8 voluntárias)</div></div>
+            <span class="edit-link">Editar</span>
+          </div>
+          <div class="doc-card">
+            <div class="ttl">Seu território <span class="complete-tag" style="background:#fef3c7;color:#92400e;">Em andamento</span></div>
+            <div class="row"><div class="key">Bairro</div><div class="val">Cascata</div></div>
+            <div class="row"><div class="key">Local</div><div class="val">Rua das Flores, 142 · 320 m²</div></div>
+            <div class="row"><div class="key">Risco principal</div><div class="val">Enchente (alto)</div></div>
+            <div class="row"><div class="key">Drenagem</div><div class="val" style="color:var(--muted);font-style:italic;">— pendente</div></div>
+            <span class="edit-link">Editar</span>
+          </div>
+          <div class="doc-card" style="opacity: 0.5;">
+            <div class="ttl">Sua intervenção <span style="font-size:9px; color:var(--muted);">— próximo encontro</span></div>
+            <div style="font-size: 11px; color: var(--muted); font-style: italic;">Vamos preencher juntos no Encontro 3.</div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span><div class="badge"></div></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab active"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Perfil is read-mostly</h3>
+      <p>The Perfil tab is a friendly summary view of the doc panel. Each completed card has an "Editar" link → opens an inline editor (existing <code>EditableField</code> pattern). No phase numbers, no scores — what the CBO sees about themselves.</p>
+      <p>Future encontros' cards appear muted with "— próximo encontro" so the CBO has a sense of the arc.</p>
+      <p><strong>Note the 🔴 dot on Chat</strong> — that appeared when the agent's response landed while the user was on Perfil. Tapping Chat clears it.</p>
+      <div class="kv">state.mobileActiveTab = 'perfil'
+state.mobileChatUnread = true
+  (set when a content message arrived
+   on a non-chat tab)</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">Later in Encontro 3 · agent invokes the Intervention Selector</div>
+
+  <h2 class="screen">SCREEN E — Intervenções tab opens (second contextual tab)</h2>
+  <p class="anno">In Encontro 3 the agent invokes <code>open_intervention_selector</code> with the CBO's hazards as parameters. A new <strong>🌿 Intervenções</strong> tab appears alongside Mapa. Card grid for the 6 NBS types.</p>
+
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 cbo.poa-nbs.app/cbo-profile?cbo=horta-cascata</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="ma-banner">
+          <a href="#" class="back-link">← Voltar ao chat</a>
+          <div class="by-agent">Pergunta do agente</div>
+          <div class="prompt">Escolha o tipo de intervenção. Marcamos as 3 mais indicadas para enchente.</div>
+        </div>
+        <div class="ma-body">
+          <div class="int-grid">
+            <div class="int-card selected">
+              <div class="thumb">💧</div>
+              <div class="name">Bioswales / Jardins de chuva</div>
+              <div class="sub">★ Indicado para enchente</div>
+            </div>
+            <div class="int-card">
+              <div class="thumb">🌳</div>
+              <div class="name">Florestas urbanas</div>
+              <div class="sub">Para calor</div>
+            </div>
+            <div class="int-card">
+              <div class="thumb">🌿</div>
+              <div class="name">Corredores verdes</div>
+              <div class="sub">★ Indicado</div>
+            </div>
+            <div class="int-card">
+              <div class="thumb">🏞️</div>
+              <div class="name">Parques de retenção</div>
+              <div class="sub">★ Indicado</div>
+            </div>
+            <div class="int-card">
+              <div class="thumb">🏠</div>
+              <div class="name">Telhados verdes</div>
+              <div class="sub">Combinável</div>
+            </div>
+            <div class="int-card">
+              <div class="thumb">🪷</div>
+              <div class="name">Restauração de áreas úmidas</div>
+              <div class="sub">Combinável</div>
+            </div>
+          </div>
+          <div class="ma-action-bar">
+            <a href="#" class="btn-confirm">Confirmar escolha (1)</a>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab active"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h3>Multiple contextual tabs coexist</h3>
+      <p>By Encontro 3, the user has accumulated two microapp tabs: <strong>Mapa</strong> (still available from E2) and <strong>Intervenções</strong> (just opened). Both persist; the agent's most recent invocation drives the active tab.</p>
+      <p>The "★ Indicado" badges on intervention cards are pre-filtered by the agent based on the CBO's selected hazard (enchente from E2). Other NBS types are still visible but de-emphasized.</p>
+      <p>Same banner pattern: agent prompt above, microapp body, confirm action at the bottom, tab bar last.</p>
+      <div class="kv">state.mobileActiveTab = 'interventions'
+state.openMapParams = STILL SET
+state.interventionSelectorParams = {
+  preFilteredHazards: ['flood'],
+  selectionMode: 'single',
+}
+
+Visible tabs:
+['chat', 'map', 'interventions', 'perfil']</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">EDGE CASES — handled by the spec</h2>
+
+  <div class="legend" style="background:#fef3c7; border-color:#f59e0b; color:#92400e;">
+    <strong>Mid-typing in Chat → agent invokes microapp.</strong> Chat input draft is preserved across tab switches. The user's half-typed text remains when they switch back.
+  </div>
+
+  <div class="legend" style="background:#fef3c7; border-color:#f59e0b; color:#92400e;">
+    <strong>Two microapps active simultaneously.</strong> Both tabs visible. Most recently invoked is the active one. User can switch via tabs to revisit either.
+  </div>
+
+  <div class="legend" style="background:#fef3c7; border-color:#f59e0b; color:#92400e;">
+    <strong>User dismisses by switching away mid-selection.</strong> No data loss — the microapp's local state persists. Returning to the tab restores the in-progress selection.
+  </div>
+
+  <div class="legend" style="background:#fef3c7; border-color:#f59e0b; color:#92400e;">
+    <strong>Streaming agent response while on a non-chat tab.</strong> 🔴 dot appears on Chat as soon as the first content message lands; doesn't update mid-stream to avoid flicker.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">Desktop is unchanged</h2>
+  <p class="anno">Above 768px, the existing split-screen layout stays as it is. Same agent-driven tab logic (the <code>rightTab</code> state), just rendered as a sidebar instead of full-screen panels.</p>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 48px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Spec: <code>knowledge/runs/2026-05-15-encontros-curriculum/_mobile/mobile-tabs-spec.md</code>
+    · Mockup: this file.
+    · Implementation: ~3-4h surgical layout work in <code>cbo-profile.tsx</code> — no new microapps, no agent-side changes.
+  </p>
+</div>
+</body>
+</html>

--- a/knowledge/runs/2026-05-15-encontros-curriculum/_mobile/mobile-tabs-spec.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/_mobile/mobile-tabs-spec.md
@@ -1,0 +1,135 @@
+# Mobile layout — tab navigation with agent-driven focus
+
+**Date**: 2026-05-15 · **Scope**: cross-cutting layout used by every encontro on mobile (`<md` breakpoint, < 768px)
+
+## In one sentence
+
+On mobile, the CBO surface becomes a single-pane app with bottom tabs. The agent drives which tab is in focus — when it invokes a microapp, the UI switches. The user can always tap back. Chat input only exists on the Chat tab.
+
+## Tab model
+
+Two permanent tabs + up to two contextual tabs:
+
+| Tab | Icon | When visible | Has input? |
+|---|---|---|---|
+| **Chat** | 💬 | Always | Yes |
+| **Perfil** | 📋 | Always | No (read-only summary) |
+| **Mapa** | 🗺️ | When the agent has `openMapParams` set | No (microapp action button) |
+| **Intervenções** | 🌿 | When the agent has `interventionSelectorParams` set | No (selector cards) |
+
+Maximum 4 tabs visible at once. When more microapps appear, the oldest contextual tab is replaced. (For E1–E6 we never have more than 2 contextual tabs at once.)
+
+## Agent-driven focus rules
+
+The agent already drives `rightTab` on desktop. Same state machine on mobile, different presentation.
+
+| Agent event | What happens on mobile |
+|---|---|
+| `open_map` (e.g. for site selection) | Mapa tab becomes visible · auto-switches to Mapa · agent's current prompt renders as a banner above the map |
+| `open_intervention_selector` | Intervenções tab becomes visible · auto-switches · agent's prompt as banner |
+| `ask_user` with map relevance | Same as `open_map` |
+| Map / Selector returns a result | UI switches back to Chat · the selection is posted as a chat message · contextual tab stays available |
+| `phase_change` (forward) | No tab switch; preamble screen for the new encontro shows instead |
+| `done` (agent finished a turn) | If user is on a non-chat tab and a content message arrived, show a 🔴 dot on the Chat tab |
+
+## Back-to-chat affordances
+
+Three ways the user gets back to chat:
+
+1. **Auto**: after confirming a microapp action — the selection is sent back to the agent and UI switches automatically
+2. **Tab tap**: 💬 Chat tab at the bottom
+3. **Banner**: each microapp tab has a "← Voltar ao chat" link in the banner header
+
+## What each tab renders
+
+### Chat tab
+- Mobile-first chat layout (we already have this on the chat panel)
+- Chat input bar at the bottom (above the tab bar)
+- Welcome banner if `memberInfo` present, then messages, then `ask_user` chips when active
+- Unread state: when a content message arrives while the user is on another tab, the message stays unread until they return; on the Chat tab, the first unread message gets a subtle "Nova" pill
+
+### Mapa tab
+- Top banner: agent's current prompt (e.g. *"Selecione seu bairro e marque seu local"*) + small "← Voltar ao chat" link
+- Full-bleed `MapMicroapp` component
+- Bottom action button: "Confirmar seleção" (enabled when the user has made a selection that satisfies the agent's parameters)
+- "Limpar" link beside the action button for undo
+
+### Intervenções tab
+- Top banner: agent's prompt (e.g. *"Escolha o tipo de intervenção"*)
+- Full-bleed `InterventionSelector` component (card grid)
+- Bottom action: "Confirmar escolha" (enabled when 1+ intervention selected)
+
+### Perfil tab
+- Read-only version of the doc panel — same 4-card layout the desktop right rail shows
+- An "Editar" button per card → opens an inline editor (existing `EditableField` pattern)
+- Scrollable; no chrome
+- No "phases" or "scores" — the friendly summary view (see E1 mockup screen 5 right side)
+
+## Badging + unread state
+
+When user is on Map / Intervenções / Perfil and the agent posts a new content message:
+
+- 🔴 dot appears on the Chat tab
+- Tab counter stays simple (`💬¹` style) — no detailed count, just a single indicator
+
+When the user taps back to Chat, the badge clears.
+
+## The chat input bar
+
+- **Chat tab**: input visible at the bottom, above the tab bar (existing pattern, full-width)
+- **All other tabs**: input is hidden. To message the agent, the user taps the Chat tab. The chat draft (anything typed but not sent) is retained across tab switches — switching to Mapa and back leaves your unsent text intact.
+
+This decision means **microapp tabs have a single concern**: making a selection. They don't double as "type a question to the agent." If the user has a question about the map, they go back to chat and type — and the map is still in the same state when they return.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| User is mid-typing in Chat when agent invokes `open_map` | Chat input preserves draft; UI auto-switches to Map; their text is still there when they return to Chat |
+| Agent invokes a microapp twice in a row (e.g. updates map params after a selection) | Stay on the same contextual tab; banner updates with the new prompt |
+| User dismisses a microapp tab (no built-in dismiss; only by switching to Chat) | Microapp tab remains available; user can return any time; agent state unchanged |
+| Streaming agent response while user is on Map | Banner doesn't update mid-stream; updates after `done` event. Chat tab gets the 🔴 dot as soon as the first content message lands |
+| User taps Perfil tab during an agent turn | Allowed; Perfil shows current state; agent's response still streams to Chat in the background; 🔴 badge appears on Chat |
+| Two microapps active simultaneously (map + selector) | Both tabs visible; auto-focus on the one most recently invoked; user can switch between them via tabs |
+| Screen rotation to landscape on phone | Same layout; tab bar moves to the side if width > 640px (basically becomes the desktop pattern) |
+
+## Desktop unchanged
+
+Above the `md` breakpoint (≥768px), keep the current split-screen: chat left, microapp/doc tabs right, no mobile tab bar. The `rightTab` state powers both presentations; no agent-side changes needed.
+
+## Implementation strategy (when we build it)
+
+This is **layout work in `cbo-profile.tsx`**, not new components. The microapps themselves don't change.
+
+1. Add `useMediaQuery('(max-width: 767px)')` hook (or equivalent Tailwind-detection)
+2. On mobile, render a single full-height panel based on `mobileActiveTab` state (separate from `rightTab` since they have different semantics — `rightTab` is "what right-rail shows on desktop"; `mobileActiveTab` is "what fills the whole screen on mobile")
+3. Sync `mobileActiveTab` with agent events:
+   - `open_map` event → `setMobileActiveTab('map')`
+   - `open_intervention_selector` → `setMobileActiveTab('interventions')`
+   - Selection confirm → `setMobileActiveTab('chat')`
+4. Add `mobileChatUnread: boolean` for the badge state
+5. Bottom tab bar component — sticky, 56px, with active-tab underline + badges
+6. Each tab's content is a wrapper around existing components
+
+Estimated effort: ~3-4 hours when we get to building.
+
+## Out of scope for this spec
+
+- Landscape-specific layout (assume rotation just hits the desktop breakpoint)
+- Inline microapps in chat (we considered this and rejected it — map + selector too big for inline)
+- Multi-microapp dashboards on the same tab (one microapp per tab)
+- Persistence of `mobileActiveTab` across page reloads (always reset to Chat on reload)
+
+## Why not full-screen modals instead
+
+We considered the modal pattern (microapp opens as a takeover, "Done" closes). Rejected because:
+- Loses the persistent chat context above the microapp
+- Modal dismissal is one more concept to teach the user
+- Tabs match what we already do on desktop — single mental model
+
+## Why not inline cards in chat
+
+Considered. Rejected because:
+- Map at any usable size is taller than the chat viewport
+- The intervention selector's card grid doesn't fit a 375px width inline
+- The chat thread becomes hard to scroll past once you have a microapp embedded

--- a/knowledge/runs/2026-05-15-encontros-curriculum/curriculum.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/curriculum.md
@@ -1,0 +1,368 @@
+# COUGAR · Vila Flores · 6-Encontro Curriculum & Build Spec
+
+**Date**: 2026-05-15 · **Status**: design, pre-build · **Pilot start**: 2026-06-11 (Encontro 1)
+
+## Goal
+
+By the end of **Encontro 6**, the cohort has **10 community-scale NBS projects refined to portfolio-ready state**:
+
+- Each project has: org profile, site + risk context, intervention design, impact estimate, operations plan, funding need, regulatory awareness, evidence/photos
+- The orchestrator's **Aggregate Portfolio view** shows the cohort as a single investable proposition: total area, total impact, total ask, geographic distribution, intervention-type mix
+- Each CBO leaves with a **1-page project card** they can use to talk to their community and to potential local partners
+- The portfolio is handed to **BWB** for bankability review, with the **QCF** €50K deployment as the near-term funding trigger
+
+Two paths converge into the same outcome:
+
+| Path | What they bring to W1 | How the experience adapts |
+|---|---|---|
+| **"Já tenho uma ideia"** | Existing project concept (varying maturity) | Validate + refine + surface gaps |
+| **"Quero ajuda"** | A community + a willingness to act | Educate + diagnose + co-design from scratch |
+
+By Encontro 4, both paths sit on the same curriculum. The triage is set at Encontro 1 (explicit question, stored on the member), surfaced on the orchestrator card so VF/OEF know who needs more hand-holding mid-pilot.
+
+---
+
+## The 6 encontros at a glance
+
+| # | Encontro | Pedagogical goal | Schema phases filled | Path-adaptive? |
+|---|---|---|---|---|
+| 1 | **Quem somos · diagnóstico** | Onboarding + capacity read + path triage | P1 (org_profile) + path field | — |
+| 2 | **Seu território · o que é NBS** | Educate on NBS; map the bairro's risks; pick where to act | P2 (intervention_site) | Yes (idea: validate site; help: discover site) |
+| 3 | **Desenhando sua intervenção** | Choose + size + justify the intervention | P3a (intervention_type) | Yes (idea: refine type; help: learn types, then pick) |
+| 4 | **Impacto · operações · sustentabilidade** | Quantify impact; design ops + financial model | P3b + P3c | No (both paths converge) |
+| 5 | **Necessidades · prontidão** | Funding need + permits + gap report | P4 (needs_assessment) | No |
+| 6 | **Portfólio · apresentação** | Aggregate portfolio; project pitch; next steps | P5 (results_evidence) → status `ready-for-review` | No |
+
+Each encontro is ~90 min in-room with VF facilitators. The platform is used live for 30-45 min mid-session; the rest is discussion, peer review, and educational segments.
+
+---
+
+## Per-encontro specification
+
+For each encontro: pedagogical goal, in-room agenda, agent skill, microapps, KB grounding, data captured.
+
+### Encontro 1 — Quem somos · diagnóstico
+
+**Pedagogical goal**: Each CBO introduces itself; OEF/VF gets a capacity read; the two-path triage emerges.
+
+**In-room agenda (90 min)**:
+- 30 min — Round of intros (one-line: "what we do, where we work"). Coordinator presents the journey overview.
+- 35 min — On the platform: complete the Quem Somos form (Phase 1 of profile)
+- 25 min — Group discussion: "what climate challenge concerns you most in your bairro?" — sets up Encontro 2
+
+**Agent skill**: `encontro-1-quem-somos.md`
+- Captures (CBO profile P1):
+  - `org_name`, `legal_form`, `year_founded`, `team_size`, `paid_vs_volunteer`, `primary_cause`, `bairro_of_operation`
+  - **Maturity scores**: `org_delivery_capacity` (0-3), `team_technical_experience` (0-3)
+- **Two-path triage** (NEW field on cohort_members):
+  - Asks: *"Você já tem uma ideia de projeto NBS, ou quer ajuda para encontrar uma?"*
+  - Stores: `path: 'has-idea' | 'needs-help'`
+- Prior-project capture: any documents (proposals, reports, photos) uploaded here are parsed into Phase 1 evidence
+
+**Microapps**: None (chat + file drop)
+
+**KB grounding**:
+- `_success-cases/brazilian-municipal.md` — show 1-2 brief examples of CBO-led NBS in Brazil
+- *(new)* `_glossary/o-que-e-nbs-comunidade.md` — 1-paragraph community-friendly "what is NBS" used for "the NBS we'll talk about includes…"
+
+**Orchestrator snapshot fields updated**:
+- `snapshotPhase=1`, `snapshotSectionsComplete=1`, `path`, `capacity_band` (emerging/developing/building/mature)
+
+---
+
+### Encontro 2 — Seu território · o que é NBS
+
+**Pedagogical goal**: CBOs learn what NBS *is*, the 6 types relevant to POA, the risks present in their specific bairro, and pick where they could act.
+
+**In-room agenda (90 min)**:
+- 25 min — Educational module: *O que é NBS, e por que importa para Porto Alegre*. Coordinator-led with the 6 intervention cards + case studies projected.
+- 45 min — On the platform:
+  - **`has-idea` path**: "Conta sobre seu projeto atual…" → describe + upload + pin existing site on map → platform overlays risk data on their site
+  - **`needs-help` path**: "Vamos descobrir juntos…" → bairro picker → see the risk map → pick a target site
+- 20 min — Small group: peer feedback on each other's site choices
+
+**Agent skill**: `encontro-2-seu-territorio.md` (one skill, two-path branches)
+- Captures (CBO profile P2):
+  - `bairro`, `site_lat`, `site_lng`, `site_area_m2`, `site_name`, `land_tenure` (public/private/mixed/informal), `current_use`, `primary_hazard`, `secondary_hazard`
+  - **Maturity scores**: `site_control` (0-3), `community_anchoring` (0-3)
+- Path-specific intro message; rest of the flow unifies
+
+**Microapps**:
+- **Site Explorer** ✓ — already built; bairro polygons + risk grid + hover details
+- **Risk Priority chips** *(new, small)* — after site is plotted, agent asks "rank by what concerns you" with 3 chips (flood/heat/landslide); stored as ordered preferences
+
+**KB grounding**:
+- All 6 `_interventions/*.md` files — agent reads relevant ones based on hazard
+- `_success-cases/brazilian-municipal.md` — 1 case-per-hazard
+- *(new)* `_glossary/tipos-de-nbs.md` — community-friendly summary of 6 NBS types
+
+**Orchestrator snapshot fields**:
+- `snapshotPhase=2`, `snapshotSectionsComplete=2`, `site_lat/lng`, `primary_hazard`
+
+---
+
+### Encontro 3 — Desenhando sua intervenção
+
+**Pedagogical goal**: CBOs pick a specific NBS intervention type, sketch it on their site, and articulate why this choice fits their community.
+
+**In-room agenda (90 min)**:
+- 20 min — Deeper dive on the 6 intervention types: pros, cons, what's needed to deliver, who maintains them. Coordinator-led with the intervention library projected.
+- 50 min — On the platform:
+  - Intervention Selector → pick a type (or "help me decide" → guided walkthrough)
+  - Site Sketcher → draw the area where it'll go on top of the bairro map
+  - Agent asks the type-specific design questions (species for urban forests, dimensions for bioswales, etc.)
+- 20 min — Peer review: each CBO shows their site + type + sketch to one other org, gets one piece of feedback
+
+**Agent skill**: `encontro-3-desenhando.md`
+- Captures (CBO profile P3a):
+  - `intervention_type` (1 of 6), `intervention_area_m2` (from sketch), `intervention_scale` (e.g. # trees, m² of green roof), `intervention_justification` (free text)
+  - **Maturity scores**: `problem_clarity` (0-3), `solution_clarity` (0-3)
+
+**Microapps**:
+- **Intervention Selector** ✓ — already built; library cards + case studies + "help me decide" guided walkthrough
+- **Site Sketcher** *(new, medium)* — polygon/rectangle draw on the map; computes area in m²; persisted as GeoJSON
+
+**KB grounding**:
+- `_interventions/*.md` — full intervention specs (cost, climate benefits, land tenure, maintenance, timeline)
+- *(new)* `_sizing/intervention-rules.md` — "1 ha urban forest reduces local temp by 1-2°C", reference scales for each intervention
+
+**Orchestrator snapshot fields**:
+- `snapshotPhase=3`, `snapshotSectionsComplete=3`, `snapshotIntervention`, `intervention_area_m2`
+
+---
+
+### Encontro 4 — Impacto · operações · sustentabilidade
+
+**Pedagogical goal**: CBOs quantify the impact of their intervention, design who will operate it, and how it sustains past year 1. This is where the project becomes serious — funders need this.
+
+**In-room agenda (90 min)**:
+- 20 min — Educational: *O que importa para um financiador?* — Impact, operations, sustainability. Concrete examples of funded vs unfunded projects.
+- 50 min — On the platform:
+  - **Impact Calculator**: site + intervention + scale → impact ranges (flood-peak reduction %, canopy gain m², people served, CO₂e/yr). Ranges + assumptions visible. Agent contextualizes ("this is similar to ___ project in Curitiba which had ___ impact").
+  - **Operations Designer**: who maintains it, frequency, estimated annual cost, financial model (donations / fees / grants / mixed / municipal)
+- 20 min — Group: peer review of operations plans — "would this still work if your key volunteer left?"
+
+**Agent skill**: `encontro-4-impacto-operacoes.md`
+- Captures (CBO profile P3b + P3c):
+  - P3b: `expected_impact` (structured), `monitoring_plan`, `baseline_conditions`, `project_timeframe_years`
+  - P3c: `ops_team`, `ops_frequency`, `annual_opex_brl`, `sustainability_model`, `revenue_streams`
+  - **Maturity scores**: `climate_nbs_impact` (0-3), `financial_thinking` (0-3)
+
+**Microapps**:
+- **Impact Calculator** *(new, medium)* — computes impact ranges deterministically from intervention library coefficients + site characteristics. NOT an LLM call — these need to be reproducible.
+- **Operations Designer** *(new, small)* — structured form: roles × frequency × cost, with a sustainability-model picker
+
+**KB grounding**:
+- `_co-benefits/*.md` + `_evidence/*.md` — impact coefficients literature-grounded
+- *(new)* `_impact-coefficients/by-intervention.yaml` — structured impact ranges per intervention type per hazard (used by Impact Calculator)
+- *(new)* `_operations-templates/*.md` — operations templates per intervention type (e.g. "urban forest maintenance year 1 vs year 3")
+
+**Orchestrator snapshot fields**:
+- `snapshotPhase=3 (done sub-phases)`, `snapshotSectionsComplete=5`, `snapshotMaturityScore` (now includes climate + financial)
+
+---
+
+### Encontro 5 — Necessidades · prontidão
+
+**Pedagogical goal**: CBOs articulate exactly what they need to make the project happen (money, permits, technical help, partners) and check whether their project is funding-ready. The encontro that translates an idea into an ask.
+
+**In-room agenda (90 min)**:
+- 25 min — Educational: *O panorama de financiamento* — types of funders, what counts as "ready", how the QCF + BWB flow works.
+- 45 min — On the platform:
+  - **Funding Need Breakdown**: capex / opex / technical assistance / community engagement — with amounts
+  - **Permit Checklist**: based on bairro × intervention type, the platform suggests likely permits + which city department owns each
+  - Gap report auto-generated: what's missing for funding-readiness
+- 20 min — Group: each org names one specific blocker and the cohort brainstorms who could unblock it
+
+**Agent skill**: `encontro-5-necessidades.md`
+- Captures (CBO profile P4):
+  - `funding_need_brl` (total + breakdown), `funding_categories` (capex/opex/ta), `permits_required`, `city_contacts_needed`, `other_blockers`
+  - **Maturity score**: `regulatory_awareness` (0-3)
+- Generates: gap report listing missing fields, low-maturity scores, unmet priority flags
+
+**Microapps**:
+- **Funding Need Breakdown** *(new, small)* — structured amounts per category, visualized as a pie/bar
+- **Permit Checklist** *(new, KB-driven)* — bairro × intervention → list of likely permits + city contact; CBOs check off what they've started + add notes
+- **Gap Report** *(new, small)* — read-only summary, exportable as PDF
+
+**KB grounding**:
+- `_financing-sources/*.md` — funder catalog (BPJP, QCF, BWB, BNDES, etc.)
+- *(new)* `_permits/porto-alegre-map.md` — who in POA owns what permit (SMAMUS, SMOV, Innovation Office, etc.)
+- *(new)* `_readiness-criteria/funder-checklists.md` — what funders look for
+
+**Orchestrator snapshot fields**:
+- `snapshotPhase=4`, `snapshotSectionsComplete=6`, `snapshotFlagsMet` (priority flags), `funding_need_brl`
+
+---
+
+### Encontro 6 — Portfólio · apresentação
+
+**Pedagogical goal**: CBOs see their project as part of a larger portfolio, practice presenting it, and get clear next steps. This is the celebration encontro + the handoff to BWB.
+
+**In-room agenda (90 min)**:
+- 20 min — **Aggregate portfolio reveal**: orchestrator's Portfolio view projected — total area, total impact, total ask, intervention-type pie, geographic spread on map. *"Together, you 10 represent…"*
+- 50 min — Each CBO does a 2-min pitch using their **1-page project card** (auto-generated). Cohort feedback.
+- 20 min — Wrap-up: what happens next (BWB review timeline, QCF deployment in November, partner intros, continuing support model)
+
+**Agent skill**: `encontro-6-portfolio.md`
+- Captures (CBO profile P5):
+  - `results_evidence` (photos, prior outcomes), `project_pitch_line` (1-sentence), `project_card_approved` (bool)
+  - Marks `status = 'ready-for-review'` (handoff to BWB)
+- Generates: 1-page project card PDF
+
+**Microapps**:
+- **Project Card PDF** *(new, medium)* — renders a 1-page summary (org · site · intervention · impact · ask) as PDF; uses brand styling. Server-side via existing PDF stack OR print-stylesheet on the document panel.
+- **Aggregate Portfolio View** *(new, medium)* — orchestrator-side route `/orchestrator/portfolio`. Shows: cohort map with all 10 sites, total area/impact/ask, intervention-type breakdown, exportable as a single portfolio PDF.
+
+**KB grounding**:
+- *(new)* `_pitches/examples.md` — 3-5 good 2-min pitch examples
+- *(new)* `_next-steps/post-encontro-6.md` — what happens after the pilot (BWB timeline, QCF, etc.)
+
+**Orchestrator snapshot fields**:
+- `snapshotPhase=5`, `snapshotSectionsComplete=7`, `status='ready-for-review'`, `project_card_url`
+
+---
+
+## Cross-cutting product features
+
+### 1. Per-encontro pedagogical preamble (CBO surface)
+Before each encontro's chat starts, a 1-screen preamble:
+
+```
+ENCONTRO 3 — Desenhando sua intervenção
+————————————————————————————————————————
+Hoje vamos:
+  • Escolher o tipo de intervenção NBS para o seu projeto
+  • Desenhar onde ele vai no seu sítio
+  • Dimensionar a intervenção
+
+Você vai usar:
+  • A biblioteca de intervenções (com casos reais)
+  • O mapa para desenhar a área
+
+Tempo estimado: 20–30 min
+                       [Começar →]
+```
+
+Dismissible, shows once per encontro on first visit. Pulls content from the workshop's `pedagogicalGoal` + `microapps` fields in cohort.settings.
+
+### 2. Two-path UI affordances
+- W1 captures `path` explicitly via an `ask_user` from the agent
+- Stored on `cohort_members.path`
+- Orchestrator card: small chip next to org name (`💡 idea` / `🤝 needs help`)
+- Orchestrator filter: "show all / has-idea / needs-help"
+- W2 + W3 skills branch on `path` for their opening message + flow ordering
+
+### 3. Educational content surfacing (during chat)
+Today the agent reads KB silently. For CBOs, *show* what they're learning:
+- When agent reads an intervention spec → render the relevant card in the right rail
+- When agent reads a case study → render a small "see how Curitiba did this" card
+- When agent reads impact coefficients → show the source + range
+
+This is a UI-side change in `cbo-profile.tsx` — render a "reading…" surface alongside the chat.
+
+### 4. Aggregate Portfolio view (W6 deliverable)
+New route `/orchestrator/portfolio` showing:
+- Cohort map: all sites + intervention type as a layer
+- Stats strip: # projects · total m² · total impact (composite) · total ask BRL
+- Intervention-type breakdown (donut chart)
+- Per-project mini-card grid
+- "Download portfolio PDF" → bundles every project card + a cover sheet
+
+### 5. Project Card PDF (W6 deliverable)
+Per CBO, 1-page A4 PDF:
+- Header: org logo + name + bairro
+- Site map thumbnail + risk context
+- Intervention type + sketch + size
+- Impact (3 key metrics with ranges)
+- Operations summary (1 line)
+- Funding ask (total + breakdown)
+- Footer: pilot + cohort name + handoff date
+
+---
+
+## What we already have ✓
+
+- CBO profile schema (5 phases, 9 maturity metrics, 6 priority flags)
+- `cbo-intervention.md` skill (sophisticated; we'll split it into 6 encontro skills)
+- Site Explorer microapp + map
+- Intervention Selector microapp with case studies
+- File drop / parsing (handles existing-project uploads)
+- Orchestrator: cohort + member cards + workshop cadence with states + risk layers
+- CBO premium welcome + progress + locked-phase popovers + mobile layout
+- Bulk invite + WhatsApp deep-link
+- Singleton cohort + human-readable slugs + Reset
+- KB: 6 intervention docs · success cases (BR) · financing sources · co-benefits · evidence
+
+## What needs building, in priority order
+
+### Phase A — Curriculum scaffold (small, foundational)
+1. Update default workshop seed → 6 pedagogical encontro names (PT-first)
+2. Extend `WorkshopConfig` with `skillId: string`, `pedagogicalGoal: string`, `microapps: string[]`
+3. Add `path: 'has-idea' | 'needs-help' | null` to `cohortMembers`
+4. Per-encontro skill files: split `cbo-intervention.md` into 6 encontro skill markdowns under `knowledge/skills/`
+5. `cboAgent.ts` loads the right skill based on member's current phase
+6. CBO page: per-encontro preamble screen (1 screen per encontro on first entry)
+7. Orchestrator: path chip + filter on member cards
+
+### Phase B — Encontro 4 microapps (the impact + ops deepening)
+1. **Impact Calculator** microapp + `_impact-coefficients/by-intervention.yaml` data file
+2. **Operations Designer** microapp + `_operations-templates/` content
+
+### Phase C — Encontro 5 microapps (the readiness gate)
+1. **Funding Need Breakdown** microapp
+2. **Permit Checklist** microapp + `_permits/porto-alegre-map.md` KB content
+3. **Gap Report** microapp
+
+### Phase D — Encontro 6 deliverables (the W6 outputs)
+1. **Project Card PDF** generator
+2. **Aggregate Portfolio View** at `/orchestrator/portfolio`
+
+### Phase E — KB content authoring (parallel, can run alongside A-D)
+- `_glossary/o-que-e-nbs-comunidade.md` (E1)
+- `_glossary/tipos-de-nbs.md` (E2)
+- `_sizing/intervention-rules.md` (E3)
+- `_operations-templates/*.md` (E4)
+- `_permits/porto-alegre-map.md` (E5)
+- `_readiness-criteria/funder-checklists.md` (E5)
+- `_pitches/examples.md` (E6)
+- `_next-steps/post-encontro-6.md` (E6)
+
+### Phase F — Polish / educational surface
+- "Reading from KB" UI in the chat right rail
+- Site Sketcher (E3 polygon draw — if Intervention Selector's existing inputs aren't enough)
+- Risk Priority chips (E2)
+- "See how others did this" peer-card surface (E3 peer review)
+
+---
+
+## Sequencing recommendation
+
+**Before May 25 stakeholder tour**: Phase A only — this lets us *show* the curriculum (encontro names, the 2-path triage, the preamble screens) on the platform during the tour. The tour audience sees "this is what June will look like."
+
+**Between May 25 and June 11** (Encontro 1): Phase B + Phase E for E1-E2 KB content. Encontro 1 itself only needs Phase A + the E1 glossary.
+
+**Mid-June to early-July**: Phase C as Encontros 4 + 5 approach. KB content for E4-E5 in parallel.
+
+**Late July**: Phase D for Encontro 6. This is the only piece that needs to land relatively late since the portfolio view doesn't matter until there's content to show.
+
+---
+
+## Open questions (for later, not now)
+
+1. Photo evidence: where do CBOs upload site photos? Currently we have file drop but no clear "this is a site photo" semantic. Could add an upload affordance per phase.
+2. Peer-review surface: in-app or in-room? In-room is simpler; in-app is reach.
+3. Coordinator notes per CBO: should JVP/Julia leave private notes per CBO on the orchestrator card? Probably yes, but separate scope.
+4. Language flexibility within the cohort: VF runs in PT. If a CBO is more comfortable in Spanish (unlikely but possible), should the agent switch? The agent already detects language; this is auto-handled.
+
+---
+
+## Sources
+
+- `_meetings/2026-04-08-cougar---vila-flores-open-earth-foundation.md`
+- `_meetings/2026-04-16-cougar---vila-flores-oef.md` (the deep workshop discussion)
+- `_meetings/2026-04-29-cougar-biweekly-oef-internal-check-in.md` (Pyxera framework)
+- `_meetings/2026-05-05-cougar-pxg-oef-biweekly.md` (cohort + timing)
+- `shared/cbo-schema.ts` (the existing 5-phase/9-metric data model)
+- `.claude/commands/cbo-intervention.md` (existing skill to split)
+- `knowledge/_interventions/*.md` (6 NBS type cards already authored)


### PR DESCRIPTION
## Summary

Two threads in one PR (both pure design/docs, no code):

### 1. Photo curation standard (`docs/photo-curation.md`)

Establishes the policy in response to JVP's flag: *"before they were very sample photo pictures that sometimes did not really relate to the city / intervention."*

Allowed: **Wikimedia Commons · prefeitura galleries · Agência Brasil · vetted NGO publications · partner orgs (with permission)**.
Not allowed: stock photography · AI-generated images · unattributed sources.

**Audit of the existing 6 intervention photos:**
| File | Issue |
|---|---|
| `bioswales.jpg` | ❌ labeled "Portland USA" — not even Brazilian. **Must replace.** |
| `flood-parks.jpg` | ⚠️ verify against Wikimedia Barigui photos |
| `green-corridors.jpg` | ⚠️ Capibaribe — needs Prefeitura do Recife outreach |
| `green-roofs.jpg` | ⚠️ Cásper Líbero Av. Paulista — verify visually |
| `urban-forests.jpg` | ⚠️ Rua Gonçalo de Carvalho — verify visually |
| `wetland-restoration.jpg` | ⚠️ Parque Primeiro de Maio — Wikimedia available |

**5 visual checks + 1 replacement needed before pilot launch (June 11).** Sourced Wikimedia / Prefeitura URLs recorded in the manifest section.

### 2. Encontros curriculum design (`knowledge/runs/2026-05-15-encontros-curriculum/`)

Per the per-encontro deep-dive process — four files per encontro:

```
curriculum.md                    overall arc + build sequence
E1-quem-somos/{research,spec,mockup,skill}
E2-seu-territorio/{research,spec,mockup,skill}
_mobile/mobile-tabs-{spec,mockup}     (already shipped as code in #139)
```

**E1** = onboarding + capacity diagnostic + path triage. 8 substantive questions, 2 maturity scores, ~20-30 min, no new microapps.

**E2** = NBS education + bairro risks + site selection. Path-aware (`has-idea` vs `needs-help`). Three new inline microapps proposed (`NbsShowcaseCard`, `RiskPriorityChips`, `CommunityAnchoringComposer`) and improvements to existing `MapMicroapp` (simpler modes for community use). E2's photo references the curation standard from this same PR.

## What's not in this PR

- E3-E6 deep dives (sequential, next)
- Code for E2's microapps (build only after design alignment)
- The actual photo downloads/replacements (separate audit + commit)
- Bioswales.jpg replacement (blocked on sourcing a Brazilian rain-garden photo)

## Test plan

- [ ] Skim `docs/photo-curation.md` — does the policy match what we want enforced?
- [ ] Open `E2-seu-territorio/mockup.html` in browser — does the design hold up?
- [ ] Spot-check the existing 6 intervention JPGs against the audit verdicts — am I right about which need replacement?
- [ ] Confirm Wikimedia URLs in the manifest still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)