### PR TITLE
docs: photo curation — visual audit (3 wrong / 3 correct)

### DIFF
--- a/docs/photo-curation.md
+++ b/docs/photo-curation.md
@@ -41,18 +41,24 @@ The `photoCredit` field on `caseStudies[]` in `shared/cbo-schema.ts` should be a
 
 ## Audit of existing intervention case-study photos
 
-Six photos already shipping in `client/public/assets/interventions/`. Verdicts based on the schema labels in `shared/cbo-schema.ts:87-142` (full visual audit requires opening each JPG; this doc flags what's verified by label-vs-source-search).
+Visual audit completed 2026-05-15 by reading each JPG directly. **Three are wrong, three plausibly correct.**
 
-| File | Labeled as | Verdict | Action |
-|---|---|---|---|
-| `bioswales.jpg` | "Bioretention Rain Garden, Portland USA" | ❌ **Not Brazilian.** Schema says Portland — this is the single clearest miss. The whole intervention library is supposed to read as Brazilian. | **Replace** with a Brazilian case. Recife UFPE pilot project documented at [scielo.br](http://www.scielo.br/j/ac/a/3mKRyFjSkPdBkhdvyVGZZLL/?lang=pt); São Paulo has multiple municipal projects. Need a verified-source photo. |
-| `flood-parks.jpg` | "Parque Barigui, Curitiba" | ⚠️ **Verify against Wikimedia.** Multiple high-quality Wikimedia photos exist for this park. | **Verify or replace** with `Parque_Barigui_-_Curitiba_DSC04494.JPG` (CC-BY-SA, photographer Agrinaldo Caires Fonseca). |
-| `green-corridors.jpg` | "Parque Capibaribe, Recife" | ⚠️ **Wikimedia category exists but no canonical photo found for Capibaribe specifically.** | **Verify** — if the existing JPG looks like the Recife Capibaribe project (linear riverside park, palms, walking paths), keep + attribute. Otherwise pull from [Prefeitura do Recife photo gallery](http://meioambiente.recife.pe.gov.br/parque-capibaribe) with permission. |
-| `green-roofs.jpg` | "Fundação Cásper Líbero, São Paulo" | ⚠️ **Specific project — Av. Paulista 900, Edifício Gazeta, 700 m² Mata Atlântica green roof by botanist Ricardo Cardim.** | **Verify** — the photo should show the rooftop forest with 130 native plant species, urban Av. Paulista context. If it's a generic green roof, replace. |
-| `urban-forests.jpg` | "Rua Gonçalo de Carvalho, Porto Alegre" | ⚠️ **Very recognizable place — 500m tipuana tree tunnel.** Easy to verify visually. | **Verify** — if the JPG isn't unmistakably the green-tunnel street with cobblestones + 19th-century buildings, replace. [Wikipedia article](https://pt.wikipedia.org/wiki/Rua_Gon%C3%A7alo_de_Carvalho) has source photos. |
-| `wetland-restoration.jpg` | "DRENURBS Parque Primeiro de Maio, Belo Horizonte" | ⚠️ **Verify against Wikimedia.** | **Verify or replace** with [`Parque_Primeiro_de_Maio_01.JPG`](https://commons.wikimedia.org/wiki/File:Parque_Primeiro_de_Maio_01.JPG) (Wikimedia Commons). |
+| File | What the photo actually shows | Verdict |
+|---|---|---|
+| `bioswales.jpg` | Single-story brick building with white-trimmed windows, sidewalk, lawn, mixed grasses + shrubs, metal drainage grate. **North American suburban institutional landscaping** (school or community-center grounds). Matches the schema's "Portland USA" label. | ❌ **Replace** — not Brazilian. Breaks the premise that our library shows Brazilian community-scale NBS. |
+| `flood-parks.jpg` | Park with palms, small pond, and a prominent **industrial brick chimney** in the background. The chimney is the giveaway — Parque Barigui is dominated by the Barigui river/lake and has no chimney landmark. The photo looks like **Parque Tanguá** or **Parque das Pedreiras** (former quarry/industrial sites Curitiba reclaimed). | ❌ **Replace** — wrong project. Photo is genuinely Brazilian, just mislabeled. |
+| `green-corridors.jpg` | Recife skyline across the Capibaribe river, with dense mangrove forest along the riverbank. Distinctively Recife — the mangrove + the specific high-rise cluster + the river width all match the Parque Capibaribe corridor. | ✅ **Looks correct.** Verify Wikimedia source for proper attribution. |
+| `green-roofs.jpg` | Rooftop garden viewed from above: pergola, lawn patches, benches, manicured paths. Surrounded by São Paulo residential buildings. **Not** the Fundação Cásper Líbero green roof — that's a famously dense 700m² Mata Atlântica forest with 130 native trees (designed by botanist Ricardo Cardim). This is a generic ornamental rooftop garden. | ❌ **Replace** — wrong project. Generic São Paulo rooftop, not the iconic Cásper Líbero forest. |
+| `urban-forests.jpg` | Tree-canopied cobblestone street with dense tipuana canopy forming a tunnel overhead, hanging epiphytes/bromeliads on the trunks, parked cars in the characteristic angled arrangement. Recognizably the famous "túnel verde." | ✅ **Correct.** Verify Wikimedia source for attribution. |
+| `wetland-restoration.jpg` | Modern engineered park with concrete retaining walls, an oval retention pond, paved walkways. Background shows peripheral urban housing. Matches the DRENURBS engineered-urban-park pattern in peripheral neighborhoods. | ✅ **Plausibly correct.** Compare with [`Parque_Primeiro_de_Maio_01.JPG`](https://commons.wikimedia.org/wiki/File:Parque_Primeiro_de_Maio_01.JPG) on Wikimedia for confirmation. |
 
-**One definite replacement (`bioswales.jpg`) + five visual verifications needed before pilot launch.**
+**Summary**: 3 must replace (`bioswales`, `flood-parks`, `green-roofs`), 3 keep + attribute (`green-corridors`, `urban-forests`, `wetland-restoration`).
+
+### Replacement sourcing notes
+
+- **`bioswales.jpg`** → Brazilian rain-garden case. Candidates: Recife UFPE pilot ([scielo.br](http://www.scielo.br/j/ac/a/3mKRyFjSkPdBkhdvyVGZZLL/?lang=pt)) · São Paulo municipal jardins de chuva program · Fortaleza tropical rain garden pilot. All academic-published — outreach needed for usable photo with permission.
+- **`flood-parks.jpg`** → Two options: (a) keep the photo but rename the case to match what it actually shows (Parque Tanguá / Pedreiras — both are valid Curitiba NBS examples), or (b) replace with verified Parque Barigui photo from [Wikimedia Commons DSC04494](https://commons.wikimedia.org/wiki/File:Parque_Barigui_-_Curitiba_DSC04494.JPG) (CC-BY-SA, Agrinaldo Caires Fonseca). Option (a) is faster + truthful.
+- **`green-roofs.jpg`** → Need a verified photo of the Av. Paulista 900 / Cásper Líbero Mata Atlântica forest. Direct outreach to [Eccaplan](https://eccaplan.com.br/conheca-o-primeiro-telhado-verde-da-avenida-paulista-em-sao-paulo/) (the source article) or to Ricardo Cardim's Sky Garden company.
 
 ## New photos to source for E2 NbsShowcaseCard
 
@@ -203,11 +209,13 @@ nbs_showcase_e2:
 
 Before pilot launch (June 11):
 
-1. **Visually audit** the 5 "needs_visual_check" interventions JPGs. Anything that doesn't clearly represent the named project gets replaced.
-2. **Replace** `bioswales.jpg` with a Brazilian rain-garden case.
-3. **Source the 3 E2 showcase cards** — Wikimedia for #1-2 is straightforward; reach out to Vila Flores for #3.
-4. **Outreach** for Prefeitura do Recife (Parque Capibaribe) + Eccaplan/Cásper Líbero (telhado verde) reuse permissions.
-5. **Add `photoSource`, `photoLicense`, `photoVerifiedAt` fields** to the case-study schema for machine-readable provenance, if not already present.
+1. ~~**Visually audit** the 6 existing JPGs~~ → ✅ done 2026-05-15 (see audit table above)
+2. **Replace `bioswales.jpg`** with a Brazilian rain-garden case (outreach to UFPE / São Paulo prefeitura)
+3. **Decide on `flood-parks.jpg`**: rename the case to match what's shown (Parque Tanguá), or replace with a verified Parque Barigui photo from Wikimedia
+4. **Replace `green-roofs.jpg`** with a verified Cásper Líbero Mata Atlântica forest photo (outreach to Eccaplan / Sky Garden)
+5. **Attribute the 3 keepers** (`green-corridors`, `urban-forests`, `wetland-restoration`) — find their actual source URLs, fill `photoCredit` properly
+6. **Source the 3 E2 showcase cards** — Wikimedia for #1-2 is straightforward; reach out to Vila Flores for #3
+7. **Add `photoSource`, `photoLicense`, `photoVerifiedAt` fields** to the case-study schema for machine-readable provenance, if not already present
 
 ## A word on tooling
 


### PR DESCRIPTION
## Summary

Completes the visual audit started in #140. **3 of 6 intervention JPGs are wrong; 3 are correct.**

Should have done this in #140 — the Read tool supports images, I just didn't try it.

## Findings

| File | Actually shows | Verdict |
|---|---|---|
| `bioswales.jpg` | North American suburban institutional landscape | ❌ Replace |
| `flood-parks.jpg` | Brazilian park with industrial chimney — Parque Tanguá / Pedreiras, **not Barigui** | ❌ Replace OR rename |
| `green-corridors.jpg` | Recife skyline + Capibaribe mangroves | ✅ Keep + attribute |
| `green-roofs.jpg` | Generic SP ornamental rooftop garden — **not the iconic Cásper Líbero Mata Atlântica forest** | ❌ Replace |
| `urban-forests.jpg` | Rua Gonçalo de Carvalho túnel verde — recognizable cobblestones + tipuana canopy | ✅ Keep + attribute |
| `wetland-restoration.jpg` | Plausibly Parque Primeiro de Maio DRENURBS | ✅ Keep + attribute |

## What changes in this PR

Just one file: `docs/photo-curation.md`. The audit table is rewritten with the real visual findings. Open action items list updated to reflect what actually needs doing.

## What's NOT in this PR

- Actual photo downloads / replacements (separate work — needs outreach for Cásper Líbero specifically)
- The `flood-parks.jpg` decision (rename vs replace) — flagged for JVP to call
- Schema changes (`photoSource` / `photoLicense` / `photoVerifiedAt` fields) — deferred

## Notable insight

The single most credibility-damaging miss is `green-roofs.jpg`. The Cásper Líbero rooftop at Av. Paulista 900 is **the** iconic Brazilian NBS rooftop — 700m² of Mata Atlântica with 130 native trees up to 4m tall, designed by botanist Ricardo Cardim. Replacing it with a generic ornamental rooftop garden makes the whole intervention library feel like it wasn't curated by someone who knows the Brazilian NBS scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)