### PR TITLE
docs(e3): deep-dive design for Encontro 3 — Desenhando sua intervenção

### DIFF
--- a/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/mockup.html
@@ -1,0 +1,600 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>E3 — Desenhando sua intervenção · mockup walkthrough</title>
+<style>
+  :root {
+    --bg: #fafaf9; --surface: #ffffff; --ink: #18181b; --muted: #71717a;
+    --line: rgba(0,0,0,0.08); --accent: #059669; --accent-soft: #ecfdf5;
+    --accent-deep: #047857; --warm: #f59e0b; --warm-soft: #fef3c7;
+    --info: #0284c7; --danger: #ef4444;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1280px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  .lede { color: var(--muted); margin: 8px 0 24px; max-width: 64ch; line-height: 1.6; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 18px; padding-left: 14px; border-left: 2px solid var(--accent); max-width: 64ch; }
+  .scene { display: grid; grid-template-columns: 380px 1fr; gap: 36px; align-items: start; }
+  .scene .note h4 { font-size: 14px; margin: 0 0 6px; }
+  .scene .note p { font-size: 13px; color: var(--muted); margin: 0 0 10px; line-height: 1.6; }
+  .scene .note .kv { font-family: ui-monospace, monospace; font-size: 11px; background: #f4f4f5; padding: 10px 12px; border-radius: 8px; color: var(--ink); margin-top: 12px; white-space: pre-wrap; line-height: 1.5; }
+  .phone {
+    width: 380px; background: var(--surface); border: 1px solid var(--line);
+    border-radius: 28px; overflow: hidden; box-shadow: 0 12px 36px -16px rgba(0,0,0,0.18);
+  }
+  .phone .top-chrome { padding: 10px 16px; border-bottom: 1px solid var(--line); font-size: 10px; color: var(--muted); font-family: ui-monospace, monospace; }
+  .phone .frame-body { min-height: 640px; display: flex; flex-direction: column; }
+  .app-header { padding: 12px 16px; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: 10px; }
+  .app-header .leaf { width: 28px; height: 28px; border-radius: 6px; background: var(--accent-soft); color: var(--accent-deep); display:flex; align-items:center; justify-content:center; font-size: 13px; }
+  .app-header .id { flex: 1; min-width: 0; }
+  .app-header .org-name { font-size: 13px; font-weight: 600; line-height: 1.2; }
+  .app-header .meta { font-size: 10px; color: var(--muted); line-height: 1.2; }
+  .progress-strip { padding: 8px 16px; border-bottom: 1px solid var(--line); }
+  .progress-strip .label { font-size: 10px; color: var(--muted); margin-bottom: 4px; }
+  .progress-strip .label .active { color: var(--ink); font-weight: 600; }
+  .segments { display: flex; gap: 3px; }
+  .seg { height: 3px; flex: 1; border-radius: 2px; }
+  .seg.past { background: var(--accent); }
+  .seg.curr { background: var(--accent); opacity: 0.5; }
+  .seg.locked { background: rgba(0,0,0,0.08); }
+  .tab-content { flex: 1; padding: 12px 16px; overflow-y: auto; }
+  .chat-msgs { display: flex; flex-direction: column; gap: 6px; }
+  .msg { padding: 8px 12px; border-radius: 14px; font-size: 13px; line-height: 1.45; max-width: 92%; }
+  .msg.agent { background: #f4f4f5; align-self: flex-start; }
+  .msg.user { background: var(--accent); color: white; align-self: flex-end; }
+  .msg .lbl { font-size: 9px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 3px; }
+  .msg.user .lbl { display: none; }
+  /* InterventionSelector cards (already exist, just mocked here) */
+  .int-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 10px; }
+  .int-card { border: 1px solid var(--line); border-radius: 10px; padding: 8px; background: var(--surface); cursor: pointer; }
+  .int-card.recommended { border-color: var(--accent); background: var(--accent-soft); }
+  .int-card.selected { border-color: var(--accent); background: var(--accent-soft); box-shadow: 0 0 0 2px var(--accent-soft); }
+  .int-thumb { height: 56px; border-radius: 6px; margin-bottom: 6px; display: flex; align-items: center; justify-content: center; font-size: 22px; }
+  .int-thumb.placeholder { background: linear-gradient(135deg, #d1fae5, #6ee7b7); }
+  .int-name { font-size: 10px; font-weight: 600; line-height: 1.2; }
+  .int-tag { font-size: 9px; padding: 1px 5px; border-radius: 999px; background: var(--accent-deep); color: white; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; display: inline-block; margin-top: 4px; }
+  .int-tag.secondary { background: var(--warm); }
+  /* Sizing helper bands */
+  .sizing-bands { margin-top: 8px; }
+  .band { border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; margin-bottom: 4px; background: var(--surface); display: flex; align-items: center; gap: 8px; }
+  .band.current { border-color: var(--accent); background: var(--accent-soft); }
+  .band .name { font-size: 11px; font-weight: 600; min-width: 60px; }
+  .band .range { font-size: 10px; color: var(--muted); flex: 1; }
+  .band .cost { font-size: 10px; color: var(--ink); font-weight: 500; }
+  .band-detail { background: var(--surface); border: 1px solid var(--accent); border-radius: 8px; padding: 8px 10px; margin-top: 6px; font-size: 11px; color: var(--ink); }
+  .band-detail strong { color: var(--accent-deep); }
+  /* Justification composer */
+  .ca-composer { border: 1px solid var(--line); border-radius: 10px; padding: 10px; background: var(--surface); margin-top: 8px; }
+  .ca-row { margin-bottom: 8px; }
+  .ca-row .label { font-size: 10px; color: var(--muted); margin-bottom: 3px; }
+  .ca-row input, .ca-row textarea { width: 100%; border: 1px solid var(--line); border-radius: 6px; padding: 5px 8px; font-size: 12px; }
+  .ca-row textarea { resize: vertical; min-height: 38px; }
+  .ca-chip-row { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+  .ca-chip { border: 1px solid var(--line); padding: 3px 8px; border-radius: 999px; font-size: 10px; background: var(--surface); cursor: pointer; }
+  .ca-chip.selected { background: var(--accent-soft); border-color: #6ee7b7; color: var(--accent-deep); }
+  /* Chat input */
+  .chat-input { padding: 8px 12px; border-top: 1px solid var(--line); display: flex; gap: 6px; }
+  .chat-input .ipt { flex: 1; border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; font-size: 12px; color: var(--muted); background: var(--surface); }
+  .chat-input .send { width: 28px; height: 28px; border-radius: 50%; background: var(--accent); color: white; display: inline-flex; align-items: center; justify-content: center; font-size: 13px; }
+  /* Tab bar */
+  .tab-bar { border-top: 1px solid var(--line); background: var(--surface); display: flex; padding: 4px 0 8px; }
+  .tab { flex: 1; text-align: center; padding: 6px 4px; font-size: 10px; color: var(--muted); position: relative; cursor: pointer; }
+  .tab .icon { font-size: 18px; line-height: 1; }
+  .tab .label { display: block; margin-top: 2px; font-weight: 500; }
+  .tab.active { color: var(--accent-deep); }
+  .tab.active::after { content:""; position:absolute; bottom:-4px; left:50%; transform:translateX(-50%); width:24px; height:2px; background:var(--accent); border-radius:2px; }
+  /* Sketch map */
+  .ma-banner { background: var(--accent-soft); border-bottom: 1px solid #a7f3d0; padding: 10px 16px; }
+  .ma-banner .by-agent { font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+  .ma-banner .prompt { font-size: 13px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+  .ma-banner .area-display { display: inline-block; font-size: 12px; font-weight: 600; color: var(--accent-deep); margin-top: 6px; padding: 3px 9px; border-radius: 999px; background: white; border: 1px solid var(--accent); }
+  .pretend-map {
+    flex: 1; position: relative; min-height: 320px;
+    background: radial-gradient(circle at 65% 55%, rgba(239, 68, 68, 0.25) 0%, transparent 30%), linear-gradient(135deg, #e5f3e0 0%, #d4e8d4 100%);
+  }
+  .map-pin { position: absolute; width: 14px; height: 14px; border-radius: 50%; background: var(--accent); border: 3px solid white; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
+  .sketch-polygon { position: absolute; background: rgba(5, 150, 105, 0.25); border: 2px solid var(--accent); border-radius: 4px; }
+  .sketch-corner { position: absolute; width: 14px; height: 14px; background: var(--accent); border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.2); cursor: move; }
+  .ma-action-bar { padding: 12px 16px; border-top: 1px solid var(--line); background: var(--surface); display: flex; gap: 8px; align-items: center; }
+  .btn-confirm { background: var(--accent); color: white; padding: 9px 16px; border-radius: 10px; font-weight: 500; font-size: 13px; flex: 1; text-align: center; }
+  .legend { background: #eff6ff; border-left: 3px solid #3b82f6; padding: 10px 14px; border-radius: 0 8px 8px 0; font-size: 12px; color: #1e3a8a; margin: 16px 0 24px; max-width: 64ch; }
+  .flow-arrow { display: flex; align-items: center; gap: 8px; color: var(--accent-deep); font-size: 12px; font-weight: 600; margin: 14px 0 4px; text-transform: uppercase; letter-spacing: 0.08em; }
+  .flow-arrow::before, .flow-arrow::after { content: ""; flex: 1; height: 1px; background: var(--accent-soft); }
+</style>
+</head>
+<body>
+<div class="doc">
+  <h1>E3 — Desenhando sua intervenção <span class="small">· mockup walkthrough · 2026-05-15</span></h1>
+  <p class="lede">
+    Three beats over ~50 min: pick the intervention type (selector pre-filtered by E2's hazard) → sketch the area on the map → articulate why. Both paths converge here. New microapps shown: <strong>SiteSketcher</strong>, <strong>InterventionSizingHelper</strong>, <strong>JustificationComposer</strong>. The existing <code>InterventionSelector</code> gets community-tone content + pre-filtered recommendations.
+  </p>
+  <div class="legend">
+    <strong>Photo placeholders:</strong> intervention cards render gradient + emoji until the photo curation work in PRs #140/#141 lands verified images.
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 1 — Selector opens with pre-filtered recommendations</h2>
+  <p class="anno">Agent invokes InterventionSelector with <code>recommendedTypes</code> derived from E2's primary_hazard. ★ badges on the 3 most relevant types.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 3 · escolha</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              No último encontro você marcou <strong>Pracinha do bairro · Cascata · risco alto de enchente</strong>. Vou abrir a biblioteca de intervenções — as recomendadas pra enchente estão marcadas com ★. Toca em qualquer uma pra ler mais.
+              <div class="int-grid">
+                <div class="int-card recommended selected">
+                  <div class="int-thumb placeholder">💧</div>
+                  <div class="int-name">Jardim de chuva / Bioswale</div>
+                  <div class="int-tag">★ recomendado</div>
+                </div>
+                <div class="int-card recommended">
+                  <div class="int-thumb placeholder" style="background: linear-gradient(135deg, #bae6fd, #67b9ec);">🌊</div>
+                  <div class="int-name">Parque inundável</div>
+                  <div class="int-tag">★ recomendado</div>
+                </div>
+                <div class="int-card recommended">
+                  <div class="int-thumb placeholder" style="background: linear-gradient(135deg, #fbcfe8, #e9d5ff);">🪷</div>
+                  <div class="int-name">Restauração de áreas úmidas</div>
+                  <div class="int-tag">★ recomendado</div>
+                </div>
+                <div class="int-card">
+                  <div class="int-thumb placeholder" style="background: linear-gradient(135deg, #d9f99d, #84cc16);">🌳</div>
+                  <div class="int-name">Florestas urbanas</div>
+                  <div class="int-tag secondary">útil pra calor</div>
+                </div>
+                <div class="int-card">
+                  <div class="int-thumb placeholder" style="background: linear-gradient(135deg, #fde68a, #f59e0b);">🌿</div>
+                  <div class="int-name">Corredores verdes</div>
+                </div>
+                <div class="int-card">
+                  <div class="int-thumb placeholder" style="background: linear-gradient(135deg, #c7d2fe, #818cf8);">🏠</div>
+                  <div class="int-name">Telhados / paredes verdes</div>
+                </div>
+              </div>
+              <div style="margin-top: 10px; font-size: 11px; color: var(--muted);">
+                Selecionou: <strong>Jardim de chuva</strong>. Pode escolher mais uma se quiser combinar.
+              </div>
+              <div style="margin-top: 8px;">
+                <a href="#" style="font-size: 12px; color: var(--accent-deep); font-weight: 500;">Confirmar escolha →</a>
+                · <a href="#" style="font-size: 11px; color: var(--muted);">Me ajude a decidir</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou pergunte algo…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab active"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>InterventionSelector · IMPROVEMENT — recommended pre-filter + community tone</h4>
+      <p>The component already exists. Two improvements:</p>
+      <ol style="font-size: 13px; color: var(--ink); padding-left: 18px;">
+        <li><strong>★ recomendado</strong> badges come from the existing <code>HAZARD_WEIGHTS</code> + the user's primary_hazard from E2. The agent passes <code>recommendedTypes</code> when invoking.</li>
+        <li>Card content reads from <strong>community-tone</strong> docs (<code>_interventions/_community/*.md</code>) instead of the funder-grade originals. New <code>tone</code> param defaults to <code>community</code>.</li>
+      </ol>
+      <p>Photos are gradient + emoji placeholders until the verified-photo work lands.</p>
+      <div class="kv">params: {
+  recommendedTypes: ['bioswales-rain-gardens', 'flood-parks', 'wetland-restoration'],
+  tone: 'community',
+  multiSelect: true,
+  maxRecommendations: 3,
+}</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">User confirms · agent suggests a combo</div>
+
+  <h2 class="screen">SCREEN 2 — Agent suggests a complementary intervention</h2>
+  <p class="anno">After single-type confirm, agent surfaces a combinable recommendation based on E2's secondary hazard (calor). Not pushy — a teaching moment.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 3 · combinação?</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg user">Escolho jardim de chuva.</div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Boa escolha — combina muito com o seu site.
+              <br><br>
+              No último encontro você também mencionou <strong>calor</strong> como segundo risco. Jardim de chuva ajuda mais com enchente; pra calor, <strong>florestas urbanas</strong> (sombra + evapotranspiração) seriam um complemento natural.
+              <br><br>
+              Quer pensar em <strong>combinar as duas</strong>? Não precisa decidir agora — pode também seguir só com o jardim de chuva.
+              <div style="margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px;">
+                <span style="border: 1px solid var(--accent); padding: 5px 11px; border-radius: 999px; font-size: 11px; background: var(--accent-soft); color: var(--accent-deep); font-weight: 500;">Sim, combinar com florestas urbanas</span>
+                <span style="border: 1px solid var(--line); padding: 5px 11px; border-radius: 999px; font-size: 11px;">Só o jardim de chuva por enquanto</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou escreva sua resposta…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>Combinable interventions surfaced as a teaching moment</h4>
+      <p>
+        Per Springer 2025 + Nature npj review, most community NBS projects are 2-3 combined types, not single. But the user shouldn't feel pushed. The agent frames it as <em>"want to think about combining"</em> — not <em>"you should add this."</em>
+      </p>
+      <p>If user picks "Sim, combinar," the selector reopens with the second hazard's recommendations pre-filtered. If "Só o jardim de chuva," we capture <code>secondary_intervention_consideration</code> as "declined" and move on.</p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <div class="flow-arrow">User declines combo · agent moves to sketch</div>
+
+  <h2 class="screen">SCREEN 3 — SiteSketcher (NEW · extends MapMicroapp)</h2>
+  <p class="anno">Map opens centered on E2's site pin. A small editable rectangle is pre-seeded. User drags corners to fit their actual area. Live m² readout.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 3 · desenho</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="ma-banner">
+          <div class="by-agent">Pergunta do agente</div>
+          <div class="prompt">Arraste os cantos pra desenhar a área da intervenção. Use o pin como referência do local que você marcou antes.</div>
+          <span class="area-display">Sua área: <strong>320 m²</strong></span>
+        </div>
+        <div class="pretend-map">
+          <div class="map-pin" style="left:43%; top:52%;"></div>
+          <div class="sketch-polygon" style="left:34%; top:42%; width:30%; height:30%;"></div>
+          <div class="sketch-corner" style="left:31%; top:39%;"></div>
+          <div class="sketch-corner" style="left:62%; top:39%;"></div>
+          <div class="sketch-corner" style="left:31%; top:69%;"></div>
+          <div class="sketch-corner" style="left:62%; top:69%;"></div>
+        </div>
+        <div class="ma-action-bar">
+          <span style="font-size: 11px; color: var(--muted); text-decoration: underline;">Resetar</span>
+          <a href="#" class="btn-confirm">Confirmar área</a>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab active"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>SiteSketcher · NEW (extends MapMicroapp)</h4>
+      <p>
+        Reuses existing custom-draw infrastructure. New <code>selectionMode: 'sketch-intervention-area'</code>. Pre-seeds a 50×30m rectangle centered on the E2 site pin. 4 draggable corners. Live area readout at the top.
+      </p>
+      <p>
+        On mobile, drag-corner is fiddly on a small touchscreen — per the spec's open decision #2, may switch to a simpler "drag the circle's radius" model after Antônia tests.
+      </p>
+      <div class="kv">open_map params for sketch:
+{
+  selectionMode: 'sketch-intervention-area',
+  centerOn: { lat: site_lat, lng: site_lng },
+  centerBairro: 'cascata',
+  initialShape: { type: 'rectangle', w_m: 50, h_m: 30 },
+  showSitePin: true,    // reference, not editable
+  lockBairroBounds: true,
+}
+→ result: { polygon_geojson, area_m2 }</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 4 — InterventionSizingHelper (NEW · inline)</h2>
+  <p class="anno">After polygon confirm, inline card shows the 3 sizing bands with user's polygon highlighted in whichever band it falls.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 3 · sizing</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg user">📐 Área desenhada · 320 m²</div>
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Você desenhou <strong>320 m²</strong>. Pra um jardim de chuva, isso é escala <strong>média</strong>.
+              <div class="sizing-bands">
+                <div class="band">
+                  <span class="name">Pequeno</span>
+                  <span class="range">50–200 m²</span>
+                  <span class="cost">R$ 10–40k</span>
+                </div>
+                <div class="band current">
+                  <span class="name">✦ Médio</span>
+                  <span class="range">200–1.000 m²</span>
+                  <span class="cost">R$ 40–300k</span>
+                </div>
+                <div class="band">
+                  <span class="name">Grande</span>
+                  <span class="range">1.000+ m²</span>
+                  <span class="cost">R$ 300k+</span>
+                </div>
+                <div class="band-detail">
+                  Pra sua área: típico <strong>R$ 50–110k</strong> de implementação, capta cerca de <strong>2.500 m² de chuva</strong> (rua + telhados próximos).
+                </div>
+              </div>
+              <p style="font-size: 12px; margin-top: 10px;">Faz sentido essa escala, ou quer ajustar?</p>
+              <div style="display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px;">
+                <span style="border: 1px solid var(--accent); padding: 5px 11px; border-radius: 999px; font-size: 11px; background: var(--accent-soft); color: var(--accent-deep);">Faz sentido</span>
+                <span style="border: 1px solid var(--line); padding: 5px 11px; border-radius: 999px; font-size: 11px;">Quero ajustar →</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou escreva…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>InterventionSizingHelper · NEW (inline)</h4>
+      <p>
+        Three bands with the user's polygon highlighted in whichever band it lands. Cost ranges + impact estimates come from <code>_sizing/intervention-rules.yaml</code> (new — to be authored).
+      </p>
+      <p>
+        Per US/CNT benchmarks: a rain garden should be ~5-10% of contributing impervious area. The "captures ~2,500 m² of rain" calculation reverse-engineers from 320 m² × 8 (typical capture ratio for medium-scale).
+      </p>
+      <p>If user clicks "Quero ajustar," they go back to the SiteSketcher with their polygon preserved.</p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 5 — JustificationComposer (NEW · inline)</h2>
+  <p class="anno">3 short labeled fields + chip multi-select for construction model. Same pattern as E2's CommunityAnchoringComposer.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Encontro 3 · justificativa</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · Desenhando sua intervenção</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg curr"></div><div class="seg locked"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div class="chat-msgs">
+            <div class="msg agent">
+              <div class="lbl">Agente</div>
+              Última coisa por hoje: <strong>conta o "por quê"</strong>. Isso vai ajudar a defender o projeto pra parceiros e financiadores. Pode ser curto.
+              <div class="ca-composer">
+                <div class="ca-row">
+                  <div class="label">Por que jardim de chuva, aqui em Cascata?</div>
+                  <textarea>Porque a rua alaga todo verão. Esse pedaço da praça já tem solo permeável — dá pra ampliar e fazer captar mais água antes de descer pra parte baixa.</textarea>
+                </div>
+                <div class="ca-row">
+                  <div class="label">O que muda pra comunidade?</div>
+                  <textarea>Menos enchente nas casas da Rua das Flores, espaço bonito que dá vontade de cuidar. Pode ter uma horta de ervas junto.</textarea>
+                </div>
+                <div class="ca-row">
+                  <div class="label">Como vocês imaginam construir?</div>
+                  <div class="ca-chip-row">
+                    <span class="ca-chip selected">Mutirão comunitário</span>
+                    <span class="ca-chip selected">Parceria universidade</span>
+                    <span class="ca-chip">Contratar empreiteira</span>
+                    <span class="ca-chip">Assistência da prefeitura</span>
+                    <span class="ca-chip">Outro</span>
+                  </div>
+                </div>
+                <div style="margin-top: 8px; text-align: right;">
+                  <a href="#" style="font-size: 11px; color: var(--accent-deep); font-weight: 500;">Salvar →</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat-input">
+          <input class="ipt" placeholder="Ou escreva livre…">
+          <div class="send">↑</div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab active"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab"><div class="icon">🗺️</div><span class="label">Mapa</span></div>
+          <div class="tab"><div class="icon">🌿</div><span class="label">Intervenções</span></div>
+          <div class="tab" style="opacity:0.4;"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>JustificationComposer · NEW (inline)</h4>
+      <p>3 short text fields + 1 chip-row. Same pattern as E2's CommunityAnchoringComposer. The answers feed Solution Clarity scoring + the E6 pitch.</p>
+      <p><strong>Why these specific questions:</strong> "por que aqui" → Solution Clarity. "o que muda" → Problem Clarity. "como construir" → E4 ops planning.</p>
+      <div class="kv">component: JustificationComposer
+output:
+  justification_why_here: "..."
+  justification_what_changes: "..."
+  construction_model: ['mutirao',
+                       'parceria-universidade']</div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">SCREEN 6 — Perfil tab · "Sua intervenção" card filled</h2>
+  <p class="anno">Doc panel state at the end of E3. The new card joins the existing 4.</p>
+  <div class="scene">
+    <div class="phone">
+      <div class="top-chrome">📱 Tab: 📋 Perfil · após E3</div>
+      <div class="frame-body">
+        <div class="app-header">
+          <div class="leaf">🌱</div>
+          <div class="id">
+            <div class="org-name">Horta Comunitária Cascata</div>
+            <div class="meta">Cascata · Encontro 3 ✓</div>
+          </div>
+        </div>
+        <div class="progress-strip">
+          <div class="label"><span class="active">Seção 3 de 5 · ✓</span></div>
+          <div class="segments">
+            <div class="seg past"></div><div class="seg past"></div><div class="seg past"></div><div class="seg curr" style="opacity:0.3;"></div><div class="seg locked"></div>
+          </div>
+        </div>
+        <div class="tab-content">
+          <div style="background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin-bottom: 8px;">
+            <div style="font-size: 11px; font-weight: 600; margin-bottom: 6px;">Quem somos · Equipe · Caminho ✓</div>
+            <div style="font-size: 11px; color: var(--muted);">… (de E1)</div>
+          </div>
+          <div style="background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin-bottom: 8px;">
+            <div style="font-size: 11px; font-weight: 600; margin-bottom: 6px;">Seu território · Comunidade ✓</div>
+            <div style="font-size: 11px; color: var(--muted);">Pracinha do bairro · 320 m² · Enchente + Calor (de E2)</div>
+          </div>
+          <div style="background: var(--surface); border: 1px solid var(--accent); border-radius: 8px; padding: 10px 12px; margin-bottom: 8px;">
+            <div style="font-size: 11px; font-weight: 600; margin-bottom: 6px; display: flex; justify-content: space-between;">
+              <span>Sua intervenção</span>
+              <span style="font-size: 9px; padding: 1px 5px; border-radius: 999px; background: var(--accent-soft); color: var(--accent-deep); font-weight: 600; text-transform: uppercase;">✓ novo</span>
+            </div>
+            <div style="font-size: 11px; padding: 2px 0;"><span style="color: var(--muted); min-width: 70px; display: inline-block;">Tipo</span> Jardim de chuva</div>
+            <div style="font-size: 11px; padding: 2px 0;"><span style="color: var(--muted); min-width: 70px; display: inline-block;">Combina?</span> Considerou florestas urbanas, segue só com jardim</div>
+            <div style="font-size: 11px; padding: 2px 0;"><span style="color: var(--muted); min-width: 70px; display: inline-block;">Área</span> 320 m² (escala média)</div>
+            <div style="font-size: 11px; padding: 2px 0;"><span style="color: var(--muted); min-width: 70px; display: inline-block;">Por quê</span> "Rua alaga todo verão; solo permeável já existe"</div>
+            <div style="font-size: 11px; padding: 2px 0;"><span style="color: var(--muted); min-width: 70px; display: inline-block;">Como</span> Mutirão + parceria UFRGS</div>
+          </div>
+          <div style="background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin-bottom: 8px; opacity: 0.5;">
+            <div style="font-size: 11px; font-weight: 600;">Impacto · operações <span style="font-size: 9px; color: var(--muted);">— próximo encontro</span></div>
+            <div style="font-size: 11px; color: var(--muted); font-style: italic; margin-top: 4px;">Vamos preencher juntos no Encontro 4.</div>
+          </div>
+        </div>
+        <div class="tab-bar">
+          <div class="tab"><div class="icon">💬</div><span class="label">Chat</span></div>
+          <div class="tab active"><div class="icon">📋</div><span class="label">Perfil</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="note">
+      <h4>One new card lands</h4>
+      <p>
+        <strong>Sua intervenção</strong> joins the existing 4 cards. Editable on hover. Green border highlights it as just-completed; fades after navigation.
+      </p>
+      <p>The closing chat message follows the same pattern as E1/E2 — "✓ Encontro 3 concluído · próximo encontro: 2 de julho — Impacto, operações, sustentabilidade."</p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2 class="screen">Summary · what's new in E3</h2>
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px;">
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · extends MapMicroapp</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">SiteSketcher</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        Drag-corner polygon over the E2 site pin. Auto-computes m². Reuses existing custom-draw infrastructure.
+        <br><br>
+        <strong>Effort:</strong> ~80 lines added.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · inline</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">InterventionSizingHelper</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        3-band sizing card showing where the user's polygon lands + typical cost + impact.
+        <br><br>
+        <strong>Effort:</strong> ~60 lines + sizing rules YAML.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px;">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">NEW · inline</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">JustificationComposer</div>
+      <div style="font-size: 12px; color: var(--muted); line-height: 1.5;">
+        3 short fields + chip multi-select for construction model. Feeds Solution Clarity scoring.
+        <br><br>
+        <strong>Effort:</strong> ~50 lines.
+      </div>
+    </div>
+    <div style="border: 1px solid var(--line); border-radius: 10px; padding: 16px; background: var(--accent-soft);">
+      <div style="font-size: 10px; color: var(--accent-deep); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;">IMPROVEMENT · InterventionSelector</div>
+      <div style="font-size: 15px; font-weight: 600; margin: 4px 0 8px;">Recommended pre-filter + community tone</div>
+      <div style="font-size: 12px; color: var(--ink); line-height: 1.5;">
+        Pre-filter by E2's primary_hazard, render community-tone card content. Photos blocked on curation work.
+        <br><br>
+        <strong>Effort:</strong> ~30 lines + 6 community-version KB docs.
+      </div>
+    </div>
+  </div>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 48px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Companion files: <code>research.md</code> · <code>spec.md</code> · <code>skill.md</code> · all in <code>knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/</code>
+  </p>
+</div>
+</body>
+</html>

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/research.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/research.md
@@ -1,0 +1,179 @@
+# E3 — Desenhando sua intervenção — Research notes
+
+**Goal of this encontro**: The CBO picks a specific NBS intervention type (or 2 combined), sketches it on their site, sizes it, and articulates why this choice fits their context. ~50 min of platform time inside 90-min session.
+
+By E3 the two paths from E1 have **converged**. `has-idea` orgs validate / refine the intervention they brought; `needs-help` orgs make their first design choice. Same flow.
+
+## What the research says
+
+### Intervention selection methodology
+
+The literature converges on **multi-criteria decision frameworks** for NBS site / type selection — but they're built for technical practitioners, not community workshops.
+
+[**ScienceDirect — Multi-criteria assessment of NbS for flood management**](https://www.sciencedirect.com/science/article/pii/S0048969725025884) systematic review: AHP + GIS-coupled MCDA is the academic gold standard. **Anti-pattern for us** — too heavy.
+
+[**Nature Sustainability — NbS suitability for flood risk reduction**](https://www.naturebasedsolutionsinitiative.org/publications/planning-and-suitability-assessment-of-large-scale-nature-based-solutions-for-flood-risk-reduction/) proposes a 3-stage hierarchy: land suitability → socio-environmental risk → NBS benefits. Useful framing; the *order* matters — start with what the land can hold, then what risks matter, then which interventions deliver value.
+
+[**World Bank — Nature-based Solutions for Disaster Risk Management**](https://documents1.worldbank.org/curated/en/253401551126252092/pdf/Booklet.pdf) gives a hazard → intervention mapping that's already encoded in our existing `InterventionSelector` component as `HAZARD_WEIGHTS`. Confirms our current 6-type taxonomy is reasonable.
+
+[**C40 Knowledge Hub — NbS for cities**](https://www.c40knowledgehub.org/s/article/Nature-based-solutions-How-cities-can-use-nature-to-manage-climate-risks) maps interventions to multiple hazards. Validates our multi-select default — most community projects address ≥2 hazards (e.g. flood + heat).
+
+**Implication for E3**: don't reinvent MCDA at community-workshop scale. Use **hazard-weighted recommendation** (which we already do) + **CBO's qualitative judgement on top**. The agent's job is to make the trade-offs legible, not optimize them.
+
+### Sizing benchmarks for community-scale interventions
+
+Sizing rules are the gap our existing intervention docs don't address well — they have cost ranges per m² but not "what size should this be for your site?"
+
+[**Terra Brasil / Cronoshare**](https://terrabrasilnoticias.com/2025/08/como-jardins-podem-segurar-agua-da-chuva-e-prevenir-alagamentos/) on Brazilian rain gardens: **R$ 150–400/m²** for residential. Scales linearly to ~R$ 100–280/m² at community scale (200–500 m² projects). Sizing rule: each downspout ~50 m² catchment area.
+
+[**Fresh Coast Guardians sizing tool**](https://www.freshcoastguardians.com/resources/services/green-infrastructure-sizing) — US municipal but transferable: a rain garden should be **5–10% of the contributing impervious area** (rooftops, paved areas). Bioretention cells: similar ratio.
+
+[**CNT Green Values Calculator**](https://cnt.org/tools/green-values-calculator) gives community-scale benchmarks: 1 ha (10,000 m²) urban forest reduces local temperature by 1–2°C; 100 m² of bioretention captures ~80% of stormwater from a 1,000 m² contributing area.
+
+[**Our existing `_interventions/bioswales-rain-gardens.md`**](knowledge/_interventions/bioswales-rain-gardens.md) has detailed cost matrices (USD/m²). Need a complementary "community sizing rules" doc with rough heuristics.
+
+**Implication for E3**: a small **InterventionSizingHelper** microapp showing 3 ranges per intervention type — small (50–200 m²) / medium (200–1,000 m²) / large (1,000+ m²) — with typical cost + impact band. Lets the user pick a scale that matches what they drew on the map.
+
+### Combinable interventions — the rule, not the exception
+
+[**Springer City and Built Environment — Urban resilience review 2025**](https://link.springer.com/article/10.1007/s44213-025-00063-6): single-hazard NBS measures dominate literature, but **multi-hazard combinations** are what community projects actually need. Most Brazilian peripheral neighborhoods face flood + heat together; a rain garden alone doesn't solve heat.
+
+[**Nature npj Urban Sustainability**](https://www.nature.com/articles/s42949-024-00162-z) on coupled social-ecological systems confirms: community-led NBS are typically **2–3 combinable interventions** (e.g. rain garden + green corridor + community garden), not a single type.
+
+**Implication for E3**: multi-select is the right default (we already have it). The selector should make combinations visible — e.g. when the user picks "Urban Forest" for heat, surface "Want to add a Bioswale for flooding?" as a recommendation. Not a hard sell — a teaching moment.
+
+### Sketching at community scale — UX research
+
+There's not a deep UX literature for community-scale site sketching, but a few practical patterns from related domains:
+
+- [**OpenStreetMap iD editor**](https://wiki.openstreetmap.org/wiki/ID): drag-corner polygon editing is the most natural primitive for "this is where it goes"
+- **Google Maps area selection**: rectangle + freeform shapes both work; rectangle is faster, freeform is more accurate
+- **Catalytic Communities / SFN community mapping**: peer-reviewed pattern is **single primitive at a time** (pin OR polygon, not both) — don't make the user choose tools
+
+**Implication**: ship one mode — polygon draw with **drag-corner editing**. Pre-seed the polygon as a small rectangle centered on the E2 site pin; user adjusts corners to match. Auto-computes m².
+
+## What we already have ✓
+
+- `InterventionSelector.tsx` — sophisticated component already. 6 NBS types, hazard-weighted recommendations, multi-select, "I don't know" help mode, detail panel with 9 sections per type, PT/EN bilingual, case-study photos (3 wrong per the audit)
+- 6 `_interventions/*.md` files with technical specs (cost, impact, site conditions, risks, Brazilian examples) — funder-grade content
+- `MapMicroapp.tsx` with composite mode + custom draw tools — has the polygon-drawing capability but it's currently for site picking, not intervention area sketching
+- `HAZARD_WEIGHTS` mapping in `InterventionSelector` — gives us the recommendation engine
+- COUGAR/Pyxera maturity rubric for E3: **Problem Clarity (0-3)**, **Solution Clarity (0-3)** with concrete anchors
+
+## What's missing for E3
+
+1. **Sizing-rule benchmarks** — community-scale heuristics (small / medium / large bands per intervention type)
+2. **Community-friendly intervention cards** — current docs are funder-grade
+3. **Site Sketcher** — polygon-draw mode focused on intervention area (vs site selection)
+4. **Justification capture** — structured "why this fits" answers feeding Solution Clarity score
+5. **Combinable recommendations** — agent surfaces complementary intervention suggestions naturally
+6. **Verified photos** — depends on the photo curation audit (PR #140 + #141)
+
+## What we therefore do in E3
+
+3 beats, ~50 min platform time:
+
+### Beat 1: Choose the type (~20 min)
+
+For `has-idea`: agent opens with *"No último encontro você marcou Cascata, com risco de enchente. Vou abrir a biblioteca de intervenções pra você confirmar (ou trocar) o tipo que tinha em mente."* Opens InterventionSelector with pre-filtered recommendations for `flood` hazard.
+
+For `needs-help`: agent opens with *"Hora de escolher. Vou abrir a biblioteca — toca em qualquer card pra ver mais. Se tiver dúvida, escolhe 'Me ajude a decidir'."* Same selector, same hazard pre-filter.
+
+After type selected: **if the user picked one type but a second is highly relevant (per HAZARD_WEIGHTS for their site's secondary hazard)**, agent surfaces: *"Boa escolha. Cascata também tem risco de calor. Quer combinar com uma intervenção pra isso? Florestas urbanas funcionam bem juntas com jardins de chuva."* → user can add a second type or move on.
+
+### Beat 2: Size the intervention (~20 min)
+
+Agent opens the **Site Sketcher** (new microapp, or extends MapMicroapp). Pre-seeded polygon = small rectangle centered on the E2 site pin. User drags corners to match the actual area. Auto-computes m².
+
+After polygon confirmed, agent surfaces the **InterventionSizingHelper** inline: "Você desenhou 320 m². Para um jardim de chuva, isso é uma escala média — tipicamente R$ 50–110k pra implementar, atende uma área de captação de ~2.500 m². Faz sentido pra você?"
+
+### Beat 3: Articulate why (~10 min)
+
+The justification capture — 3 short structured fields:
+
+1. *Por que esse tipo, pra esse local?* (free text, 1-2 sentences)
+2. *O que essa intervenção vai mudar pra sua comunidade?* (free text)
+3. *Como vocês imaginam construir essa intervenção?* (chips: mutirão comunitário / contratar empreiteira / parceria com universidade / outro)
+
+These feed **Solution Clarity** scoring + the eventual project pitch (E6).
+
+## Maturity scoring (silent, coordinator-side)
+
+```
+PROBLEM_CLARITY (0-3)
+  0  No problem articulated
+  1  Generic problem (e.g. "enchente é ruim")
+  2  Local problem with specifics (which streets, frequency, who's affected)
+  3  Local problem + data/photos + quantification
+
+SOLUTION_CLARITY (0-3)
+  0  No intervention chosen
+  1  Type chosen but no implementation logic
+  2  Type chosen with clear connection to problem + implementation idea
+  3  Type chosen + sized + plan with steps + community involvement model
+```
+
+Problem Clarity uses E2's `hazard_priority_rationale` + the justification field 1. Solution Clarity uses the intervention choice + sketched area + justification fields 2-3.
+
+## Microapps & improvements proposed by this research
+
+### IMPROVEMENT · `InterventionSelector` — community-friendly content + pre-filter
+The component exists and is sophisticated. Three concrete improvements:
+
+- **Pre-filter by E2's primary_hazard** — when invoked, the agent passes `recommendedTypes` based on the site's hazard. Already supported by params; just need the cboAgent skill to pass them.
+- **Use community-friendly card content** — current cards read from `_interventions/*.md` (funder-grade). Add a community-version section to each doc, or a separate `_interventions/_community/*.md` set, and have the selector fetch the right one based on a `tone: 'community' | 'funder'` param. Default to community.
+- **Verified photos** — depends on PR #140 + #141. Until photos are sourced, render gradient + emoji placeholders.
+
+### NEW · `SiteSketcher` (extends `MapMicroapp` polygon mode)
+Reuse `MapMicroapp` with a new param `selectionMode: 'sketch-intervention-area'`. Pre-seeds a small editable polygon centered on the E2 site pin. Drag-corner editing. Confirms with computed m².
+
+Implementation: ~80 lines added to `MapMicroapp.tsx` (most of the polygon draw infrastructure already exists for the custom-draw mode).
+
+### NEW · `InterventionSizingHelper` (inline composer)
+After polygon confirm, agent renders an inline card showing 3 sizing bands for the chosen intervention type:
+- **Pequeno (50-200 m²)** — escala residencial / cantinho
+- **Médio (200-1,000 m²)** — escala de quarteirão
+- **Grande (1,000+ m²)** — escala de bairro / parque
+
+Each band shows typical cost range (R$) and impact band ("captura ~X m³ de água"). User's polygon is highlighted in whichever band it lands. Agent confirms or invites adjustment.
+
+Implementation: ~60 lines React + a new `_sizing/intervention-rules.yaml` data file.
+
+### NEW · `JustificationComposer` (inline form)
+Three labeled free-text fields + a chip multi-select for construction model. Same pattern as E2's `CommunityAnchoringComposer`. Lightweight.
+
+Implementation: ~50 lines React.
+
+## KB content to author
+
+1. `knowledge/_interventions/_community/*.md` (6 files) — community-friendly companion to each intervention doc. Tone: less numbers, more "what it looks like + how it changes daily life." 1 page each.
+2. `knowledge/_sizing/intervention-rules.yaml` — structured sizing bands per intervention type with cost ranges + impact estimates. Used by `InterventionSizingHelper`.
+3. **Photo work** (already tracked in `docs/photo-curation.md`) — verified photos for each intervention type, replacing the 3 wrong ones.
+
+## What we do NOT do at E3
+
+- Compute impact in detail → E4
+- Operations / sustainability plan → E4
+- Funding amount → E5
+- Permits → E5
+- Project pitch → E6
+
+## Sources
+
+### Internal
+- `client/src/core/components/concept-note/InterventionSelector.tsx` — existing 6-type selector
+- `knowledge/_interventions/*.md` — 6 funder-grade intervention docs
+- `knowledge/_cougar/nbs-mapping-criteria.md` — Problem Clarity + Solution Clarity rubrics
+- `docs/photo-curation.md` — audit of intervention photos (3 wrong, must replace)
+
+### External (intervention selection methodology)
+- [ScienceDirect · Multi-criteria assessment of NbS for flood management](https://www.sciencedirect.com/science/article/pii/S0048969725025884) — academic MCDA gold standard (anti-pattern for us)
+- [Nature Sustainability · NbS suitability framework](https://www.naturebasedsolutionsinitiative.org/publications/planning-and-suitability-assessment-of-large-scale-nature-based-solutions-for-flood-risk-reduction/) — 3-stage hierarchy
+- [World Bank · NbS for Disaster Risk Management](https://documents1.worldbank.org/curated/en/253401551126252092/pdf/Booklet.pdf) — hazard→intervention mapping
+- [C40 · NbS for cities](https://www.c40knowledgehub.org/s/article/Nature-based-solutions-How-cities-can-use-nature-to-manage-climate-risks) — multi-hazard validation
+- [Springer · Urban resilience review 2025](https://link.springer.com/article/10.1007/s44213-025-00063-6) — combinable interventions
+
+### External (sizing benchmarks)
+- [Terra Brasil · Jardins de chuva no Brasil](https://terrabrasilnoticias.com/2025/08/como-jardins-podem-segurar-agua-da-chuva-e-prevenir-alagamentos/) — R$/m² ranges
+- [Fresh Coast Guardians · GI sizing](https://www.freshcoastguardians.com/resources/services/green-infrastructure-sizing) — 5-10% of impervious area rule
+- [CNT Green Values Calculator](https://cnt.org/tools/green-values-calculator) — community-scale benchmarks

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/skill.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/skill.md
@@ -1,0 +1,193 @@
+# /encontro-3-desenhando — Agent skill (first draft)
+
+> Loaded by `cboAgent.ts` when phase = 3 (E3 unlocked, E2 complete). Replaces the Phase-3a section of the monolithic `cbo-intervention.md` skill.
+
+## Identity
+
+You're the COUGAR/Vila Flores agent in **Encontro 3 — Desenhando sua intervenção**. The CBO has E1's identity + E2's site + primary hazard. Both paths converged at the end of E2 — same flow here regardless of `path` value.
+
+Your job in this encontro:
+1. Help them pick 1-2 intervention types (the selector does the heavy lifting)
+2. Suggest a complementary intervention if there's a clear secondary hazard
+3. Get them to sketch the area on the map
+4. Surface the sizing band + cost/impact context
+5. Capture the *why* (justification + construction model)
+6. Score Problem Clarity + Solution Clarity (silent, coordinator-side)
+
+~50 min of conversation. Portuguese, warm, community-facilitator voice.
+
+## Read context first
+
+Call `read_cbo_state` for:
+- `member.orgName`, `member.path`, `member.bairroOfOperation`
+- All Phase 1-2 sections: especially `intervention_site.primary_hazard`, `intervention_site.secondary_hazard`, `intervention_site.site_lat/lng`, `intervention_site.site_area_m2`
+
+Use these to personalize the opening — *"No último encontro você marcou {site_name}, com risco de {primary_hazard_label}..."*
+
+## Beat 1 — Choose the type (~20 min)
+
+Opening message:
+```
+No último encontro você marcou {site_name} · {bairro} · risco de {primary_hazard_label}. Vou abrir a biblioteca de intervenções — as recomendadas pra {primary_hazard_label} estão marcadas com ★.
+```
+
+Invoke selector:
+```
+[open_intervention_selector
+  recommendedTypes={hazard_weighted_top_3_for_primary_hazard}
+  tone='community'
+  multiSelect=true
+  maxRecommendations=3]
+```
+
+Wait for selection. Expect 1-2 types.
+
+### Combinable suggestion
+
+If the user selected 1 type AND there's a clear `secondary_hazard` AND that hazard has different top-recommended types:
+
+```
+Boa escolha. No último encontro você também mencionou {secondary_hazard_label} como segundo risco — {primary_intervention_label} ajuda mais com {primary_hazard_label}; pra {secondary_hazard_label}, {best_secondary_intervention_label} seria um complemento natural.
+
+Quer pensar em combinar as duas? Não precisa decidir agora.
+```
+
+Provide 2 chips: *"Sim, combinar"* (reopens selector for secondary hazard) and *"Só {first_type} por enquanto"*.
+
+If user declines: capture `secondary_intervention_consideration: "declined: {first_type} only"` and proceed. If user accepts: relaunch selector with `recommendedTypes` for secondary_hazard.
+
+## Beat 2 — Sketch + size (~20 min)
+
+After type(s) confirmed, transition:
+```
+Bom. Agora vamos desenhar onde vai e quanto vai ocupar. Vou abrir o mapa.
+```
+
+Invoke sketch:
+```
+[open_map
+  selectionMode='sketch-intervention-area'
+  centerOn={ lat: site_lat, lng: site_lng }
+  centerBairro={ bairro }
+  initialShape={ type: 'rectangle', w_m: 50, h_m: 30 }
+  showSitePin=true
+  lockBairroBounds=true]
+```
+
+Wait for polygon confirmation. You receive `{ area_m2, polygon_geojson }`.
+
+After confirm, surface sizing:
+```
+[ask_sizing
+  intervention_type={primary_type}
+  area_m2={area_m2}]
+```
+
+This invokes `InterventionSizingHelper` which reads from `_sizing/intervention-rules.yaml` and renders the 3-band card with the user's polygon highlighted.
+
+Agent narrates the result inline:
+```
+Você desenhou **{area_m2} m²**. Pra {primary_intervention_label}, isso é escala **{scale_band}** — tipicamente {cost_range}, capta cerca de {impact_estimate}. Faz sentido essa escala?
+```
+
+If user says "ajustar": loop back to the sketch with their polygon preserved.
+
+## Beat 3 — Justification (~10 min)
+
+After sizing confirmed:
+```
+Última coisa por hoje: conta o "por quê". Isso vai ajudar a defender o projeto pra parceiros e financiadores. Pode ser curto.
+
+[ask_justification
+  intervention_label={primary_intervention_label}
+  bairro={bairro}]
+```
+
+This invokes `JustificationComposer` with 3 fields + chip multi-select. Output captured into `state.sections.intervention_type.fields`:
+
+- `justification_why_here`
+- `justification_what_changes`
+- `construction_model[]`
+
+## Scoring (silent, coordinator-side)
+
+```
+PROBLEM_CLARITY (0-3)
+  Inputs: intervention_site.hazard_priority_rationale (E2) +
+          intervention_type.justification_what_changes (E3)
+
+  0  No problem articulated (both fields blank or generic)
+  1  Generic problem ("enchente é ruim")
+  2  Local + specific ("alaga a Rua X toda chuva forte, atinge ~12 famílias")
+  3  Local + specific + quantification or evidence (photos uploaded, frequency
+     data, specific damage stories)
+
+SOLUTION_CLARITY (0-3)
+  Inputs: intervention_type.intervention_types[] + intervention_area_m2 +
+          justification_why_here + construction_model[]
+
+  0  No intervention chosen (shouldn't reach this state — required field)
+  1  Type chosen, area drawn, but justification weak
+  2  Type + area + clear "why" + at least one construction model selected
+  3  Type + area + "why" + ≥2 construction models OR named partners in
+     free-text justification
+```
+
+Call `score_maturity` after Beat 3.
+
+## Closing
+
+After all of Beat 3:
+
+1. `update_section('intervention_type', { ... })` with consolidated fields
+2. `score_maturity` for Problem Clarity + Solution Clarity
+3. `set_phase_complete(3)`
+4. Render:
+
+```
+✓ **Encontro 3 concluído** — obrigada, {nome}. Sua intervenção está desenhada.
+
+**Próximo encontro: {next_workshop.date} — Impacto · Operações · Sustentabilidade.**
+
+Você escolheu **{primary_intervention_label}** em {area_m2} m², no {site_name}. No próximo encontro vamos calcular o impacto desse projeto e pensar em quem vai cuidar dele depois de pronto.
+
+Até lá! 🌱
+```
+
+## New events to wire in `cbo-profile.tsx`
+
+- `open_intervention_selector` already exists — just need new params `tone` + `recommendedTypes` usage in selector
+- `open_map` with `selectionMode='sketch-intervention-area'` — new mode, extends existing handling
+- `ask_sizing({ intervention_type, area_m2 })` — NEW event renders `InterventionSizingHelper`
+- `ask_justification({ intervention_label, bairro })` — NEW event renders `JustificationComposer`
+
+## KB grounding
+
+`read_knowledge` permitted for:
+- `knowledge/_interventions/_community/*.md` (new — community-friendly versions) — agent uses for the selector's card content and any "tell me more" follow-ups
+- `knowledge/_interventions/*.md` (existing) — agent uses for funder-grade details if user asks technical questions
+- `knowledge/_sizing/intervention-rules.yaml` (new) — sizing bands data
+- `knowledge/_cougar/nbs-mapping-criteria.md` — Problem Clarity + Solution Clarity rubrics
+- `knowledge/_success-cases/brazilian-municipal.md` — for "show me an example" requests
+
+## Common stuck patterns
+
+| User says | Why | What you say |
+|---|---|---|
+| "Não sei qual escolher" | Doesn't recognize the types | "Toca em 'Me ajude a decidir' — eu te faço 2-3 perguntas e a gente chega lá." |
+| "Quero todos os 6" | Hazard everywhere | "Faz sentido — sua área tem problema múltiplo. Mas a gente sugere começar com 1-2 pra esse projeto. Quais 2 te chamam mais atenção?" |
+| "A área desenhada é muito pequena" | Sized below typical range | "Tudo bem começar pequeno. Pra escala assim, o orçamento fica em torno de R$ X. Quer ajustar pra maior, ou seguir?" |
+| "Não sei o porquê — só sei que precisa" | Score 0-1 territory on justification | "Conta o que você vê acontecer no bairro. Aquilo que te incomoda virar o por quê." |
+| Switches to English | Bilingual user | Switch immediately. |
+
+## Estimated runtime
+
+- Beat 1 (selector + optional combo) — 20 min
+- Beat 2 (sketch + sizing) — 20 min  
+- Beat 3 (justification) — 10 min
+- Closing — 2 min
+- **~52 min**, fits the 45-60 min platform-time budget for the encontro.
+
+---
+
+**First-draft skill. Test with at least one `has-idea` org and one `needs-help` org before pilot launch.** The combinable-intervention prompt (Beat 1) is the most novel piece — needs to feel like a teaching moment, not a sales pitch.

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/spec.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/spec.md
@@ -1,0 +1,199 @@
+# E3 — Desenhando sua intervenção — Spec
+
+**Status**: draft for review · **Builds on**: `research.md` in this folder · **Date**: 2026-05-15
+
+## In one sentence
+
+In ~50 min, the CBO picks 1-2 NBS interventions, sketches the area on their site, and articulates *why* — generating two more maturity scores (Problem Clarity, Solution Clarity) along the way.
+
+## Flow — 3 beats, paths unified
+
+By E3 both paths converge. Same flow for `has-idea` (validating their plan) and `needs-help` (making first choice).
+
+| Beat | What happens | Time | Microapp |
+|---|---|---|---|
+| 1. **Escolha** — type selection | Agent invokes `InterventionSelector` pre-filtered by E2's primary_hazard. Multi-select default (1-2 types typical). "I don't know" guides via help mode. | ~20 min | `InterventionSelector` (existing, improved) |
+| 2. **Desenho + tamanho** — sketch + size | Agent invokes `SiteSketcher` (extends `MapMicroapp`). Pre-seeded polygon over E2 site pin. User drags corners. After confirm, `InterventionSizingHelper` shows where their size lands on small/medium/large bands. | ~20 min | `SiteSketcher` (new) + `InterventionSizingHelper` (new inline) |
+| 3. **Por quê** — justification | `JustificationComposer` inline: 3 short fields capturing "why this fits, what it changes, how you'd build it." | ~10 min | `JustificationComposer` (new inline) |
+
+## Data captured — every field justified
+
+| Field | Type | Why | Skipping cost |
+|---|---|---|---|
+| `intervention_types[]` | `NbsInterventionTypeId[]` (1-3, multi-select) | The core choice; feeds E4 impact + E5 funding need | Required |
+| `intervention_combination_rationale` | string (optional) | If multi-select, why these together | Optional but anchors Solution Clarity scoring |
+| `intervention_area_geojson` | GeoJSON Polygon | The drawn area on the site | Required (auto-computed from sketch) |
+| `intervention_area_m2` | int | Derived from geojson | Required (auto) |
+| `intervention_scale_band` | enum: `small`/`medium`/`large` | Bucket for sizing comms | Auto-derived from area_m2 |
+| `justification_why_here` | string (free text, 1-2 sentences) | **Solution Clarity** input — why this type, this site | High |
+| `justification_what_changes` | string (free text) | **Problem Clarity** input — what shifts for the community | Medium |
+| `construction_model` | multi-chip: `mutirão` / `empreiteira` / `parceria universidade` / `outro` | Implementation logic — feeds E4 ops planning | Medium |
+| `secondary_intervention_consideration` | string (optional) | If agent suggested combo and user declined, capture why | Optional |
+
+**Total: 9 fields** (5 substantive + 2 free-text + 1 multi-chip + 1 optional). Mostly auto-computed from sketch + selector; user types 2-3 short paragraphs total.
+
+## Maturity scoring (silent, coordinator-side)
+
+```
+PROBLEM_CLARITY (0-3)
+  Inputs: E2's hazard_priority_rationale + this encontro's justification_what_changes
+
+  0  No problem articulated
+  1  Generic ("enchente é ruim", "tá quente demais")
+  2  Local + specific ("alaga na Rua X toda chuva forte, atinge ~12 famílias")
+  3  Local + specific + quantification or evidence (photos, frequency data)
+
+SOLUTION_CLARITY (0-3)
+  Inputs: intervention_types + intervention_area_m2 + justification_why_here + construction_model
+
+  0  No intervention chosen
+  1  Type chosen but no clear logic
+  2  Type + clear connection to the problem + a vague plan ("vamos fazer mutirão")
+  3  Type + sized + plan with steps + named partners or roles
+```
+
+## Microapps & improvements proposed by this research
+
+### IMPROVEMENT · `InterventionSelector` — three changes
+
+1. **Pre-filter by E2's primary_hazard.** The agent invokes the selector with `recommendedTypes` already filtered. Currently the param exists but isn't used in flow; the E3 skill must pass it.
+2. **Community tone for card content.** Today the selector reads from `_interventions/*.md` which is funder-grade. New `tone` param: `'community' | 'funder'`. When `community`, fetch from `_interventions/_community/*.md` (new content to author). Default: community.
+3. **Verified photos** (blocked on `docs/photo-curation.md` action items). Until photos land, gradient + emoji placeholders.
+
+Effort: ~30 lines of params changes + KB content authoring.
+
+### NEW · `SiteSketcher` (extends `MapMicroapp`)
+A new `selectionMode: 'sketch-intervention-area'` on `MapMicroapp`. Reuses the existing custom-draw polygon infrastructure. Differences:
+
+- Pre-seeds a small editable rectangle (50 m × 30 m default) centered on the E2 site pin
+- Drag-corner editing (existing draw tools support this)
+- Locks the map to the bairro of operation (no panning out)
+- Shows the existing E2 site pin as a reference layer (can't move it)
+- Auto-computes area in m² and displays at the top of the map ("Sua área: 320 m²")
+- "Confirmar" sends the GeoJSON polygon + area to the agent
+
+Effort: ~80 lines added to `MapMicroapp.tsx`.
+
+### NEW · `InterventionSizingHelper` (inline composer)
+Renders inline in chat after polygon confirm. Three horizontal bands with the user's polygon area highlighted:
+
+```
+PEQUENO          MÉDIO              GRANDE
+50-200 m²        200-1,000 m²       1,000+ m²
+R$ 10-40k        R$ 40-300k         R$ 300k+
+                 ✦ Você está aqui
+                  (320 m²)
+                  ~R$ 50-110k
+                  capta ~2.500 m²
+```
+
+The bands + cost ranges + impact estimates come from a new `_sizing/intervention-rules.yaml`. Different bands per intervention type.
+
+Effort: ~60 lines React + the YAML data file.
+
+### NEW · `JustificationComposer` (inline form)
+Three labeled free-text fields (1-2 sentences each) + a chip multi-select for construction model. Pattern identical to E2's `CommunityAnchoringComposer`.
+
+Effort: ~50 lines React.
+
+## KB content to author
+
+1. **`knowledge/_interventions/_community/*.md`** — 6 community-friendly companion docs. Tone: less USD/m² tables, more "this is what it looks like + how it changes daily life." Each ~300-500 words. Photos referenced from the verified manifest.
+
+2. **`knowledge/_sizing/intervention-rules.yaml`** — structured sizing bands. Example:
+
+```yaml
+bioswales-rain-gardens:
+  small:    { min_m2: 50,    max_m2: 200,    cost_brl_per_m2: [120, 280],  impact: "captures ~500 m² of stormwater runoff" }
+  medium:   { min_m2: 200,   max_m2: 1000,   cost_brl_per_m2: [100, 220],  impact: "captures ~2,500 m² runoff" }
+  large:    { min_m2: 1000,  max_m2: null,   cost_brl_per_m2: [80, 180],   impact: "captures 5,000+ m² runoff" }
+
+urban-forests:
+  small:    { min_m2: 50,    max_m2: 500,    cost_brl_per_m2: [80, 200],   impact: "shade for ~20-50 m² ground surface" }
+  medium:   { min_m2: 500,   max_m2: 5000,   cost_brl_per_m2: [60, 150],   impact: "1-1.5°C cooling within 50m radius" }
+  large:    { min_m2: 5000,  max_m2: null,   cost_brl_per_m2: [50, 120],   impact: "2°C cooling at neighborhood scale" }
+# ... 4 more types
+```
+
+3. **Verified photos for the 6 intervention types** (blocked on photo curation work).
+
+## Doc panel layout for E3
+
+Adds two cards after E2's layout:
+
+```
+┌─ Quem somos ──────────────────────┐  ← E1, ✓
+└───────────────────────────────────┘
+┌─ Equipe · Histórico · Caminho ────┐  ← E1, ✓
+└───────────────────────────────────┘
+┌─ Seu território ──────────────────┐  ← E2, ✓
+└───────────────────────────────────┘
+┌─ Comunidade envolvida ────────────┐  ← E2, ✓
+└───────────────────────────────────┘
+┌─ Sua intervenção ─────────────────┐  ← NEW (E3)
+│ Tipo:         Jardim de chuva     │
+│ + opcional:   Floresta urbana     │
+│ Área:         ~320 m² (médio)     │
+│ Por quê:      "Pra capturar a     │
+│               água que alaga      │
+│               a rua todo verão"   │
+│ Como fazer:   Mutirão comunitário │
+│               + parceria UFRGS    │
+└───────────────────────────────────┘
+```
+
+## Preamble screen
+
+```
+ENCONTRO 3 — Desenhando sua intervenção
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Hoje a gente vai:
+
+  · Escolher o tipo de SbN para sua área
+  · Desenhar onde vai e quanto vai ocupar
+  · Falar do "por quê" — que muda na
+    comunidade
+
+Você vai usar:
+  · A biblioteca de intervenções
+  · O mapa pra desenhar a área
+
+Tempo estimado: 45–60 min · Salva sozinho
+
+                    [ Começar  → ]
+```
+
+## What ships when we build E3
+
+**New components**
+- `SiteSketcher` (extends `MapMicroapp`)
+- `InterventionSizingHelper` (inline)
+- `JustificationComposer` (inline)
+- `encontro-3-desenhando.md` agent skill
+
+**Modified components**
+- `InterventionSelector` — `tone` param + recommended-types passthrough
+- `MapMicroapp` — new `'sketch-intervention-area'` selection mode
+- `cbo-profile.tsx` — register new agent events (`open_sketch`, `ask_sizing`, `ask_justification`)
+- `cbo-schema.ts` — extend `intervention_type` section with the new fields
+
+**KB content**
+- `_interventions/_community/*.md` (6 files)
+- `_sizing/intervention-rules.yaml`
+- Verified photos (blocked on curation)
+
+## Out of scope for E3
+
+- Impact computation in detail → E4
+- Operations / financial model → E4
+- Funding amount + breakdown → E5
+- Permits / regulatory → E5
+- Project pitch → E6
+
+## Open decisions before building
+
+1. **Combinable interventions limit** — cap at 2 types or allow 3? Recommended: cap at 2 for the pilot. Easier to scope, easier for CBOs to talk about.
+2. **Sketch UX on mobile** — drag-corner editing on a 375px touchscreen is fiddly. Alternative: pre-seed a circle, let the user drag the radius. Simpler but less expressive. Test with Antônia first.
+3. **"Help me decide" workflow** — when invoked, should the agent ask 3 short questions (problem / site type / budget hint) then recommend, or just show all 6 with hazard-weighted ordering? Lit suggests guided question is better; existing selector has both.
+4. **Construction model chips list** — `mutirão` / `empreiteira` / `parceria universidade` / `outro` covers most cases. Should we add `assistência técnica do estado` or `mão de obra da prefeitura`? Probably yes — flag for review with Vila Flores.


### PR DESCRIPTION
## Summary

Per the per-encontro design process. Same 4-file deliverable as E1 + E2:

- `research.md` — selection methodology + sizing benchmarks lit review
- `spec.md` — refined fields with justifications + microapp list
- `mockup.html` — 6-screen mobile walkthrough
- `skill.md` — first-draft agent prompt with all 3 beats

## Flow (~50 min, 3 beats)

Both paths from E1 converge here.

1. **Escolha** (20 min) — pick 1-2 NBS types. Selector pre-filtered by E2's primary_hazard. Agent suggests a combo if there's a clear secondary hazard.
2. **Desenho + tamanho** (20 min) — sketch the area on the site, see where it lands on the small/medium/large sizing bands.
3. **Por quê** (10 min) — 3 short justification fields + construction model chips.

Two new maturity scores: **Problem Clarity** + **Solution Clarity**.

## Microapps & improvements proposed by this research

| Type | Name | Effort |
|---|---|---|
| **NEW** · extends MapMicroapp | `SiteSketcher` — drag-corner polygon over the E2 site pin, auto-computes m² | ~80 lines added |
| **NEW** · inline | `InterventionSizingHelper` — 3-band sizing card with user's polygon highlighted | ~60 lines + YAML data file |
| **NEW** · inline | `JustificationComposer` — 3 labeled fields + chip multi-select for construction model | ~50 lines |
| **IMPROVEMENT** · existing | `InterventionSelector` — pre-filter by hazard + community-tone content | ~30 lines + 6 KB docs |

## Key calls grounded in the research

- **Multi-criteria MCDA is too heavy** for a workshop. Use hazard-weighted recommendation (we already have it) + CBO's judgement on top.
- **Multi-select is the right default**: most community NBS projects are 2-3 combined types (Springer 2025 + Nature npj review). Agent suggests combos as a teaching moment.
- **Sizing benchmarks from Brazilian sources** ([Terra Brasil](https://terrabrasilnoticias.com/2025/08/como-jardins-podem-segurar-agua-da-chuva-e-prevenir-alagamentos/), CNT calculator): rain gardens R\$150-400/m² residential, scales linearly at community scale. Each downspout ≈ 50 m² catchment.
- **Sketching pattern**: pre-seed a small rectangle on the E2 site pin, drag-corner edit. Single primitive at a time per [Catalytic Communities mapping pattern](https://catcomm.org/sustainable-favela-network/).

## KB content to author (referenced, not yet built)

- `_interventions/_community/*.md` — 6 community-friendly companion docs
- `_sizing/intervention-rules.yaml` — sizing bands data
- Verified photos — **blocked on PR #140 + #141** (photo curation)

## Open decisions before building

1. Cap combinable interventions at 2 types or allow 3? (rec: 2 for pilot)
2. Sketch UX on 375px mobile is fiddly. Drag-corner or drag-circle-radius? Test with Antônia.
3. "Help me decide" flow — guided question or just hazard-weighted ordering? (existing selector has both)
4. Construction model chip list — add "assistência da prefeitura"? Flag for Vila Flores review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)