### PR TITLE
docs(paths): two-path triage — cross-cutting design + E2/E3 refinement

### DIFF
--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/spec.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/spec.md
@@ -8,15 +8,32 @@ In ~45 min of platform time, the CBO learns what NBS *is* through Brazilian exam
 
 ## Path-aware flow
 
-E2 is the first encontro where the two paths diverge meaningfully (re-converge at beat 3).
+E2 is where the two paths diverge most. See [`_paths/two-path-triage.md`](../_paths/two-path-triage.md) for the cross-cutting design — this section spells out the E2-specific implementation.
 
-| Beat | `has-idea` path | `needs-help` path | Time |
+### `has-idea` flow (~25 min, linear)
+
+| Beat | What happens | Time | Microapp |
 |---|---|---|---|
-| 1. Educational anchor | NbsShowcaseCard rendered inline at start; CBO can skim while reading agent's opening message | Same showcase, but agent explicitly says *"Vamos olhar exemplos antes de abrir o mapa"* and pauses for the user to tap through | ~5 min |
-| 2. Map + site | Agent: *"Conta sobre seu projeto atual"* → upload offer → opens Map (`selectionMode: 'site'`) → CBO drops pin → agent overlays risk for that site | Agent: *"Conta o que você vive nesse bairro"* → opens Map (`selectionMode: 'browse-only'`) with 3 hazard layers → agent narrates the colors → then reopens Map (`selectionMode: 'site'`) → CBO picks site | ~25 min |
-| 3. Priority + tenure + anchoring | RiskPriorityChips → land tenure chip → community anchoring composer | Identical | ~10 min |
+| 1. Educational anchor | NbsShowcaseCard inline, horizontal scroll. CBO can skim or skip. Agent: *"Antes do mapa, dois exemplos rápidos."* | ~3 min | `NbsShowcaseCard` |
+| 2. Site selection | Agent: *"Conta sobre seu projeto — onde fica?"* → upload offer → opens Map (`selectionMode: 'site'`) centered on E1 bairro → CBO drops pin or draws polygon → agent overlays risk for that site | ~12 min | `MapMicroapp` |
+| 3. Priority + tenure + anchoring | RiskPriorityChips → land tenure chip → `CommunityAnchoringComposer` | ~10 min | inline composers |
 
-Both paths end with the same "Próximo encontro" closing pattern from E1.
+### `needs-help` flow (~30-45 min, discovery — may pause and resume)
+
+| Beat | What happens | Time | Microapp |
+|---|---|---|---|
+| 1. Extended educational anchor | NbsShowcaseCards as the *first action*, not skimmable. Agent: *"Vamos criar repertório antes do mapa."* User taps through 3-5 cards, picks 1-2 that resonate → saved as `inspiration_picks[]` (used by E3 to pre-filter) | ~10 min | `NbsShowcaseCard` (favoriting added) |
+| 2a. Hazard browse | Agent: *"Vamos ver onde os perigos estão no seu bairro."* Opens Map (`selectionMode: 'browse-only'`) with 3 hazard layers visible. **No site commitment.** Agent narrates colors. User asks questions. | ~10 min | `MapMicroapp` browse-only |
+| 2b. Save-the-spot prompt | Agent: *"Algum lugar te chama atenção?"* → 3 options:<br>· **Já sei onde** → transitions to `selectionMode: 'site'` (joins has-idea Beat 2)<br>· **Quero ver mais** → continues browse (loop back to 2a)<br>· **Quero conversar com a coordenadora** → triggers `RequestSupport` and pauses E2 in state `awaiting-support` | ~5 min | `MapMicroapp` site mode OR `RequestSupport` |
+| 3. Priority + tenure + anchoring | Identical to has-idea Beat 3 — runs once a site is selected. If user paused at 2b without site, Beat 3 doesn't run this session. | ~10 min | inline composers |
+
+**Key design choice (needs-help)**: E2 **must allow exit without a site selection**. A `needs-help` CBO can leave the encontro in state `path: 'needs-help' · awaiting-support` after Beat 2b and resume next session with the same accumulated context (inspiration picks, hazard awareness, pending support request).
+
+Both paths end with the same "Próximo encontro" closing pattern from E1, modulo the paused-state branch above.
+
+### Cross-cutting: `RequestSupport` button
+
+Visible in chat header on both paths. More prominent for `needs-help` (header sticky, has a subtle pulse). On tap, opens the form defined in [`_paths/two-path-triage.md`](../_paths/two-path-triage.md). Submission writes `support_requests[]` to `member_state` and notifies the orchestrator dashboard.
 
 ## Data captured — every field justified
 
@@ -35,8 +52,10 @@ Both paths end with the same "Próximo encontro" closing pattern from E1.
 | `secondary_hazard` | enum (same), optional | E3 secondary recommendations | Medium |
 | `hazard_priority_rationale` | string (1 sentence, optional) | Qualitative why-it-matters | Optional |
 | `nbs_familiarity` | enum: `none`/`some`/`a lot`, inferred | Calibrates agent's depth of explanation in E3 | Optional |
+| `inspiration_picks` | `NbsShowcaseCardId[]` (0-3, needs-help path only) | E3 pre-filters InterventionSelector with these | Optional but accelerates E3 |
+| `support_requests` | `SupportRequest[]` | Async coordinator escalation across both paths | Optional |
 
-**Total: 13 fields** (12 substantive + 1 inferred). Most are chip-driven or auto-derived from map clicks. Site name + community anchoring lead are the only required free-text fields.
+**Total: 13 fields** (12 substantive + 1 inferred) plus 2 path/support fields. Most are chip-driven or auto-derived from map clicks. Site name + community anchoring lead are the only required free-text fields.
 
 ## Maturity scoring (silent, written to `state.maturityScores`)
 
@@ -57,7 +76,9 @@ COMMUNITY_ANCHORING (0-3)
 ## Microapps & improvements proposed by this research
 
 ### NEW · `NbsShowcaseCard` (inline in chat)
-Horizontal scroll of 3 photographed Brazilian NBS cases. Card shape: 220px wide, photo on top, 1-line story below, tap-to-expand for a 4-line detail. Data from `knowledge/_success-cases/_cards.yaml` (new — to be authored).
+Horizontal scroll of 3-5 photographed Brazilian NBS cases. Card shape: 220px wide, photo on top, 1-line story below, tap-to-expand for a 4-line detail. Data from `knowledge/_success-cases/_cards.yaml` (new — to be authored).
+
+**Favorites mode (needs-help path)**: each card has a "Salvar" toggle. The agent's chat message above the cards changes from *"Olha esses exemplos"* (has-idea) to *"Salve os que te chamam atenção — 1 ou 2 que parecem que poderiam funcionar no seu bairro"* (needs-help). Saved cards persist as `inspiration_picks[]` and E3's InterventionSelector pre-filters by them.
 
 Default seed (3 cards):
 - **Curitiba · Parques do Barigui** · 1996 · enchente · "Parques que viram retenção de água quando chove forte"
@@ -79,12 +100,16 @@ Three labeled free-text fields (Líderes / Voluntários / Moradores diretamente)
 ### IMPROVEMENT · `MapMicroapp` simplification modes
 Existing component, new params:
 - `selectionMode: 'site'` — single-pin or small-polygon draw, no zone stepper
-- `selectionMode: 'browse-only'` — read-only, exploration mode
+- `selectionMode: 'browse-only'` — read-only, exploration mode (needs-help Beat 2a). No bottom CTA forcing a selection — only a "voltar ao chat" link.
 - `hazardFilter: ('flood' | 'heat' | 'landslide')[]` — visible hazard layers
 - `showLegendSimple: boolean` — collapsed 3-chip legend instead of 48-layer toolkit
 - `centerBairro: string` — opens centered on a named POA bairro polygon
+- `narrationOverlay: string` — agent-supplied caption rendered as a translucent banner over the map ("Os tons mais escuros são onde a água acumula mais"). Needs-help path only.
 
 These all default to backwards-compatible behavior. The cboAgent passes them when invoking `open_map` for E2.
+
+### NEW · `RequestSupport` (cross-cutting, but lives in E2's surface for the first time)
+Form + dialog defined in [`_paths/two-path-triage.md`](../_paths/two-path-triage.md). Surfaces as a button in the chat header. On the needs-help path, the agent can also offer it inline at Beat 2b. Both paths can invoke at any time.
 
 ### IMPROVEMENT · Persist drafts on map exit
 Currently if a CBO opens the map, drops a pin, and switches tabs without confirming, the pin is lost. Persist `openMapParams.draftSelection` to localStorage so resuming the encontro keeps their pin.
@@ -144,10 +169,11 @@ Tempo estimado: 30–45 min · Salva sozinho
 ## What ships when we build E2
 
 **New components:**
-- `NbsShowcaseCard.tsx` (inline chat card) + companion `_cards.yaml` data
+- `NbsShowcaseCard.tsx` (inline chat card with optional favoriting) + companion `_cards.yaml` data
 - `RiskPriorityChips.tsx` (inline chat composer)
 - `CommunityAnchoringComposer.tsx` (inline chat form)
-- `encontro-2-seu-territorio.md` agent skill (path-aware)
+- `RequestSupport.tsx` (cross-cutting; header button + dialog form)
+- `encontro-2-seu-territorio.md` agent skill (explicit two-path branching)
 
 **Modified components:**
 - `MapMicroapp.tsx` — add the new selection modes + simplified legend

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/spec-addendum-paths.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E3-desenhando/spec-addendum-paths.md
@@ -1,0 +1,170 @@
+# E3 — Spec addendum · two-path divergence
+
+**Date**: 2026-05-15 · **Status**: addendum to be merged into `E3-desenhando/spec.md` (PR #142) once that PR lands
+**Supersedes**: the line in the current E3 spec that says *"By E3 both paths converge. Same flow for has-idea (validating their plan) and needs-help (making first choice)"* — this is the corrected design.
+
+## What this addendum changes
+
+The current E3 spec is mostly correct for the `has-idea` path. It under-specifies the `needs-help` path. They converge **at the output** (chosen intervention + sketch + justification), but the path **through Beat 1** differs.
+
+## Replace Beat 1 (Escolha) with this two-path version
+
+### `has-idea` Beat 1 — *Confirm + refine* (~5-10 min)
+
+1. **Selector opens pre-filtered.** Agent invokes `InterventionSelector` with:
+   ```
+   mode: 'confirm'
+   recommendedTypes: ['<filtered by E2 primary_hazard>']
+   preSelected: '<best guess from E1+E2 narrative>'
+   ```
+2. **Confirm or swap.** Agent: *"Pelo que conversamos, parece que **{type}** faz sentido pro seu projeto. É isso mesmo? Posso mostrar alternativas se quiser."*
+   - [ É isso ] → joins Beat 2 (sketch)
+   - [ Quero ver alternativas ] → switches selector to `mode: 'browse'` (joins needs-help flow at step 2 below)
+
+### `needs-help` Beat 1 — *Discover + decide* (~10-20 min)
+
+1. **Selector opens in browse mode.** Agent invokes `InterventionSelector` with:
+   ```
+   mode: 'browse'
+   recommendedTypes: ['<filtered by E2 primary_hazard>']
+   highlightFromInspiration: state.inspiration_picks
+   preSelected: null
+   ```
+2. **Browse through cards.** All 6 types visible. Cards from E2's `inspiration_picks[]` highlighted with a *"você marcou em E2"* badge. Each card shows:
+   - Photo (verified) + 1-line description
+   - "Bom para": hazard chips (matches E2's primary_hazard get a 🎯 marker)
+   - "Tamanho típico": small/medium/large ranges
+   - "Já feito em": real Brazilian city/org example with link to the case
+   - **"Salvar pra comparar"** toggle (per-card)
+3. **Compare drawer.** Once 2+ saved, a sticky "Comparar X intervenções" button appears at bottom of selector. Opens a side-by-side mini-table:
+   ```
+   ┌────────────────┬───────────────┬───────────────┐
+   │                │ Jardim de     │ Floresta      │
+   │                │ chuva         │ urbana        │
+   ├────────────────┼───────────────┼───────────────┤
+   │ Bom para       │ 🎯 Enchente   │ Calor         │
+   │ Tamanho típico │ 50-1000 m²    │ 500-5000 m²   │
+   │ Esforço Y1     │ Médio         │ Alto          │
+   │ Manutenção     │ Baixa         │ Média         │
+   └────────────────┴───────────────┴───────────────┘
+   ```
+4. **Decide or escalate.** Agent: *"Qual ou quais te chamam atenção? Você pode escolher 1 ou 2, ou conversar com a coordenadora se ficar travada."*
+   - [ Escolho essa(s) ] → joins Beat 2 (sketch)
+   - [ Quero conversar ] → triggers `RequestSupport` and pauses E3 in `awaiting-support` state
+
+**Key design choice**: the `needs-help` E3 flow uses **save + compare** as the bridge between "I'm encountering this for the first time" and "I'm committing to a choice." Mimics how people actually shop for unfamiliar things.
+
+## Beats 2 + 3 unchanged
+
+Beat 2 (sketch + size) and Beat 3 (justification) are identical regardless of path. Both paths produce the same output:
+- `intervention_types[]`
+- `intervention_area_geojson` + `intervention_area_m2`
+- `justification_why_here` + `justification_what_changes`
+- `construction_model[]`
+
+E4 onwards: fully converged. No more path branching.
+
+## `InterventionSelector` — required new params
+
+| Param | Type | Default | What it does |
+|---|---|---|---|
+| `mode` | `'browse' \| 'confirm'` | `'browse'` | `confirm` shows preSelected with confirm/swap CTAs. `browse` shows all cards with multi-favorite. |
+| `preSelected` | `NbsInterventionTypeId \| null` | `null` | Pre-check this card on open (confirm mode) |
+| `highlightFromInspiration` | `NbsShowcaseCardId[]` | `[]` | Cards matching these E2 inspiration picks get a *"você marcou em E2"* badge |
+| `recommendedTypes` | `NbsInterventionTypeId[]` | `[]` | Show these cards first, others below a divider |
+| `allowFavorites` | `boolean` | `true` | Render the per-card save toggle (false for confirm-only flows) |
+| `maxFavorites` | `number` | `3` | Soft cap; over this, oldest favorite drops |
+
+When `mode: 'confirm'` and `preSelected` is set, the card grid is **collapsed by default** with only `preSelected` visible plus a "ver alternativas" link that expands to browse mode.
+
+## New data fields for E3
+
+| Field | Type | Why |
+|---|---|---|
+| `intervention_browse_favorites` | `NbsInterventionTypeId[]` | Persists user's favorites across page reloads + back-button navigation |
+| `intervention_compare_viewed` | `boolean` | Telemetry — did needs-help users actually use the compare drawer? |
+
+## Skill prompt — branching pseudocode
+
+```
+// At E3 start:
+if (state.path === 'has-idea') {
+  agent.say("Pelo que conversamos, parece que {pred} faz sentido. É isso?")
+  agent.invoke('open_intervention_selector', {
+    mode: 'confirm',
+    preSelected: predict(state),
+    recommendedTypes: filterByHazard(state.primary_hazard)
+  })
+} else {  // 'needs-help'
+  agent.say("Vamos olhar as opções. Salva 1 ou 2 que te chamam atenção.")
+  agent.invoke('open_intervention_selector', {
+    mode: 'browse',
+    recommendedTypes: filterByHazard(state.primary_hazard),
+    highlightFromInspiration: state.inspiration_picks,
+    allowFavorites: true
+  })
+}
+
+// On user confirm:
+state.intervention_types = chosen
+proceed to Beat 2 (sketch)
+
+// On user request support:
+trigger RequestSupport()
+pause E3
+```
+
+## Preamble screen — path-aware wording
+
+```
+// has-idea
+ENCONTRO 3 — Desenhando sua intervenção
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Hoje vamos formalizar sua ideia:
+  · Confirmar o tipo de intervenção
+  · Desenhar onde vai e quanto vai ocupar
+  · Falar do por quê
+
+Tempo estimado: 40 min · Salva sozinho
+                    [ Começar  → ]
+
+// needs-help
+ENCONTRO 3 — Desenhando sua intervenção
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Hoje vamos descobrir o que cabe no seu bairro:
+  · Conhecer as 6 opções de SbN
+  · Salvar 1-2 que te chamam atenção
+  · Comparar e escolher
+  · Desenhar e falar do por quê
+
+Tempo estimado: 50-60 min · Salva sozinho
+                    [ Começar  → ]
+```
+
+## What ships when we build E3 (updated)
+
+Adds to the existing E3 spec's "What ships":
+
+**Modified components**
+- `InterventionSelector` — `mode`, `preSelected`, `highlightFromInspiration`, `allowFavorites`, `maxFavorites` params + compare drawer UI
+- `cboAgent.ts` — branches skill behavior on `state.path` at E3 start
+
+**New components**
+- `InterventionCompareDrawer.tsx` — side-by-side mini-table, ~80 lines
+
+**KB content**
+- Already-planned community-tone intervention cards (no new content needed for paths)
+
+## Open decisions
+
+1. **Confirm-mode swap into browse**: when has-idea user clicks "quero alternativas", do we keep the original `preSelected` checked or clear it? Recommendation: keep it checked, surface as one of the cards with "sua escolha original" badge.
+2. **Compare drawer max items**: 3 or 4? Recommendation: **3** — forces prioritization, fits comfortably on mobile.
+3. **What happens if needs-help user saves 0 favorites and tries to advance?** Recommendation: agent gently nudges *"Salve pelo menos 1 antes de avançar — ou conversa com a coordenadora se nenhum encaixa."*
+
+## See also
+
+- [`../_paths/two-path-triage.md`](../_paths/two-path-triage.md) — cross-cutting design (this addendum implements its E3 section)
+- [`../E2-seu-territorio/spec.md`](../E2-seu-territorio/spec.md) — `inspiration_picks` source
+- E3 main spec — still in PR #142; merge this addendum into it after #142 lands

--- a/knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
@@ -1,0 +1,218 @@
+# Two-path triage — cross-cutting design
+
+**Date**: 2026-05-15 · **Scope**: cross-cutting design across E1-E6. Source of truth for how `has-idea` vs `needs-help` paths diverge and re-converge.
+**Status**: draft for review
+
+## In one sentence
+
+We onboard two kinds of CBOs — those who already have a project idea, and those who don't — through one curriculum. The paths diverge at E2-E3 (where "I have a site + idea to refine" looks very different from "I need to discover what's possible"), then converge at E4 where both have a site + intervention + justification and the rest of the journey is identical.
+
+## Why this matters
+
+The COUGAR ecosystem assessment found roughly half the CBOs in our Vila Flores cohort fall into each bucket. A single linear flow that assumes everyone has an idea fails the `needs-help` group (they bail at E2 when asked *"where do you want to put it?"*). A flow that assumes nobody has an idea fails the `has-idea` group (they get bored sitting through inspirational examples they don't need). The triage at E1 lets us serve both.
+
+## Audit of where each spec stands today
+
+| Encontro | Path-aware status today | Gap |
+|---|---|---|
+| **E1** | ✓ Captures `path` field as last question | None — already split-aware |
+| **E2** | ⚠ Has a 3-row "Path-aware flow" table in spec, but only Beat 2 differs (map mode); examples + chips don't adapt | needs-help path under-specified; no "I want to explore more before committing" affordance |
+| **E3** | ⚠ Spec says *"By E3 both paths converge"* — handwaved. `InterventionSelector` has a vague "help mode" but no actual divergence designed | Biggest gap. needs-help folks see 6 cards for the first time at E3 — they need browse + favorite + compare, not "pick now" |
+| **E4** | ✓ Genuinely converges — by here both have site + intervention | None |
+| **E5** | ✓ Converges | None |
+| **E6** | ✓ Converges | None |
+
+**Cross-cutting gap**: no "pedir apoio" / "talk to the coordinator" affordance. Both paths benefit but `needs-help` folks especially need this — they may want to escalate to a real human at any point.
+
+## The two paths — operational definitions
+
+### `path = 'has-idea'`
+The CBO arrives with a specific intervention idea (or close enough — *"we want a community garden in the empty lot on Rua X"*). The platform's job: validate, refine, formalize, get it BWB-ready.
+
+Characteristics:
+- Has a specific site in mind, often with land tenure clarity
+- Has a rough sense of the intervention (even if not the formal NBS name)
+- Wants forward motion, not inspiration
+
+### `path = 'needs-help'`
+The CBO arrives wanting to act on something (climate, neighborhood, equity) but doesn't have a specific project in mind. The platform's job: help them discover a fit between their bairro, their capacity, and what NBS can do.
+
+Characteristics:
+- May know the bairro but no specific site yet, or vice versa
+- Has hazard awareness but no intervention vocabulary
+- Wants to see options before committing
+
+**Crucially**: `needs-help` is *not* "less serious" or "less capable." Many strong CBOs arrive without a fixed idea because they're trying to do this right.
+
+## Per-encontro divergence
+
+### E1 — Quem somos · diagnóstico
+
+**No divergence here.** Identical flow. Triage happens at the **last question**:
+
+> "Você já tem uma ideia de projeto NBS em mente, ou quer descobrir uma com a gente?"
+> 
+> [ Já tenho ideia ] [ Quero descobrir ]
+
+Stored as `state.path`. Path is changeable at any time later via settings (see "Path change" below).
+
+The card on the doc panel updates to show `⭢ Já tenho uma ideia` or `⭢ Quero descobrir`.
+
+### E2 — Seu território · o que é NBS
+
+**Biggest divergence after triage.** Beat 1 (educational anchor) + Beat 2 (map + site) diverge meaningfully. Beat 3 (priorities + tenure + anchoring) re-converges.
+
+#### `has-idea` flow at E2
+
+Linear, forward-leaning:
+
+1. **Opening** (~2 min) — Agent: *"Vamos olhar 2 exemplos rápidos antes do mapa."* NbsShowcaseCards rendered inline as a horizontal scroll. CBO can skim or skip.
+2. **Site** (~15 min) — Agent: *"Conta sobre seu projeto atual — onde fica?"* → opens Map (`selectionMode: 'site'`) centered on their E1 bairro → CBO drops pin / draws polygon → agent overlays risk for that site.
+3. **Priorities + anchoring** (~10 min) — RiskPriorityChips + land tenure + CommunityAnchoringComposer. (Identical to needs-help path.)
+
+Total: ~25 min platform time.
+
+#### `needs-help` flow at E2
+
+Discovery-mode, with permission to wander:
+
+1. **Opening + extended examples** (~10 min) — Agent: *"Antes de abrir o mapa, vamos ver alguns exemplos pra criar repertório."* NbsShowcaseCards rendered inline. Agent asks the user to tap through and pick the 1-2 that resonate. Persists as `inspiration_picks[]` — used by E3 to pre-filter.
+2. **Hazard browse** (~10 min) — Agent: *"Vamos ver onde os perigos estão no seu bairro."* Opens Map (`selectionMode: 'browse-only'`) with the 3 hazard layers (flood / heat / landslide) visible. Agent narrates colors. **No site commitment yet.** User can ask questions about what they see.
+3. **Save-the-spot prompt** (~5 min) — Agent: *"Algum lugar onde sua organização atua ou tem laços te chama atenção?"* Two options:
+   - [ Já sei onde ] → transitions to `selectionMode: 'site'` (same as has-idea step 2)
+   - [ Quero conversar com a coordenadora ] → triggers `RequestSupport` (see cross-cutting affordance below) and saves state as `path: 'needs-help' · awaiting-support`. **They can pause E2 here and resume later.** The orchestrator card flags this CBO for follow-up.
+4. **Priorities + anchoring** — Same Beat 3 as has-idea, once a site is selected.
+
+Total: ~30-45 min platform time (highly variable — they may pause and resume).
+
+**Key design choice**: the `needs-help` path **must allow exit-without-site**. We don't force a pin drop. The encontro can end in an in-between state — "explored, talked to coordinator, still deciding" — and they re-enter the same flow next week with fresh context.
+
+### E3 — Desenhando sua intervenção
+
+**Medium divergence.** The current E3 spec says "by E3 both paths converge" — that's wrong. They converge at the *output* of E3 (chosen intervention + sketch + justification), but the *path through* E3 differs because needs-help folks are encountering the intervention vocabulary for the first time.
+
+#### `has-idea` flow at E3 — *Confirm + refine*
+
+1. **Selector opens pre-filtered** — Agent invokes `InterventionSelector` with:
+   - `mode: 'confirm'`
+   - `recommendedTypes` filtered by E2's `primary_hazard`
+   - **Best-guess pre-selection** from E2 narrative (if user mentioned "jardim de chuva" or "horta", that card is pre-checked)
+2. **Confirm or swap** (~5 min) — *"É isso mesmo? Posso mostrar alternativas se quiser."* If they confirm, skip to sketch. If they want alternatives, switch to browse mode (next path).
+3. **Sketch + size + justify** — As currently specified in E3 spec.
+
+#### `needs-help` flow at E3 — *Discover + decide*
+
+1. **Selector opens in browse mode** — `mode: 'browse'`. All 6 intervention types visible, but `inspiration_picks[]` from E2 are highlighted first. No pre-selection.
+2. **Browse + compare** (~10-15 min) — User taps through cards. Each card has:
+   - Photo (verified) + 1-line description
+   - "Bom para": which hazards
+   - "Tamanho típico": ranges
+   - "Já feito em": which Brazilian city / org example
+   - "Salvar pra comparar" button (toggle)
+3. **Compare drawer** — Once 2+ saved, a "Comparar" sticky button appears. Opens a side-by-side mini-table (hazard fit · size band · effort).
+4. **Decide or escalate** — Agent: *"Qual ou quais te chamam atenção? Você pode escolher 1 ou 2, ou conversar com a coordenadora se ficar travada."*
+   - [ Escolho essa(s) ] → joins has-idea flow from "Confirm or swap" onwards
+   - [ Quero conversar ] → `RequestSupport` (see below)
+5. **Sketch + size + justify** — As specified.
+
+**Key design choice**: the `needs-help` E3 flow uses **save + compare** as the bridge between "I'm encountering this for the first time" and "I'm committing to a choice." It mimics the way humans actually shop for unfamiliar things: browse → save a few → compare → decide.
+
+### E4-E6 — Convergence
+
+Once a CBO has site + intervention + justification, the rest is identical. Both paths use the same ImpactCalculator, OperationsDesigner, FundingNeedBreakdown, ProjectCardPDF, etc.
+
+The only difference: in coordinator-side scoring, the orchestrator card surfaces *which path the CBO took* — useful context for the coordinator when reviewing maturity scorecards (a `needs-help` CBO scoring 16/27 at E5 traveled a much further distance than a `has-idea` CBO who already had a partnership).
+
+## Cross-cutting affordance — `RequestSupport`
+
+Available on every encontro's chat header for both paths. More prominent for `needs-help` folks. The minimum viable form:
+
+```
+┌─ Pedir apoio ─────────────────────────────────────┐
+│ Selecione o tipo de apoio:                        │
+│  ◯ Conversa com a coordenadora                    │
+│  ◯ Pergunta técnica pra equipe OEF                │
+│  ◯ Conexão com outro CBO que já fez algo parecido │
+│  ◯ Algo sobre finanças / parceiros               │
+│                                                   │
+│ Mensagem (opcional):                              │
+│ [____________________________________]            │
+│                                                   │
+│              [ Cancelar ]    [ Enviar pedido ]   │
+└───────────────────────────────────────────────────┘
+```
+
+On submit: writes a `support_requests[]` entry to `member_state`, raises a notification on the orchestrator dashboard, and (optionally) posts to a Slack channel for the OEF/Vila Flores team.
+
+The CBO sees an inline confirmation:
+> Pedido enviado. {coordinator_name} vai entrar em contato em até 2 dias úteis. Você pode continuar trabalhando aqui no platform — quando ela responder, você vai ver aqui no chat.
+
+The orchestrator-side `CohortMembersTable` (P-8 work item) gains a column "🟡 1 pendência" / "✅ atendido" for support requests.
+
+Effort: ~120 lines (form + dialog + server route + orchestrator-side surface).
+
+## Path change — letting people switch
+
+A `needs-help` CBO who discovers a clear idea mid-stream (e.g., at E2 after the hazard browse) might want to switch to `has-idea`. And vice versa: a `has-idea` CBO who realizes their initial plan doesn't fit the bairro's actual hazards might want to switch to `needs-help` for a re-do.
+
+**Mechanism**: settings option *"Mudar caminho"*. Switching:
+- Updates `state.path`
+- The current encontro re-renders with the new path's flow
+- Already-collected data is preserved (e.g. site pin from has-idea path is kept when switching to needs-help — it just stops being treated as a commitment)
+
+**No path-locking.** This is a self-service decision.
+
+## Scoring impact
+
+Path does NOT affect maturity scoring directly. The 9 COUGAR criteria are identical regardless of path — what changes is *how the data is collected*, not *what counts as evidence*.
+
+However, the **`band` interpretation** in E5's GapReport can mention path context:
+
+> *"Sua jornada começou com 'quero descobrir' — você chegou de 7 → 18 em 5 encontros. Isso é distância significativa pra construir."*
+
+This humanizes the score without distorting the underlying metric.
+
+## What ships when we build this
+
+**New components**
+- `RequestSupport.tsx` (dialog + form + chat header button)
+- `InterventionSelector` — new `mode: 'browse' | 'confirm'` param + save-favorites state + compare drawer
+- `MapMicroapp` — already has `'browse-only'` mode planned in E2 spec; expand its narration UX
+
+**Modified components**
+- `cbo-profile.tsx` — render path-aware skill loading; surface "Pedir apoio" button
+- `cbo-schema.ts` — add `inspiration_picks[]` (E2), `intervention_browse_favorites[]` (E3), `support_requests[]`
+- `cboAgent.ts` — load encontro skills with `path` context; pass to skill markdown for branching
+- Settings screen — "Mudar caminho" toggle
+
+**Modified skill prompts (E1-E3)**
+- E1 skill — already has triage; no change
+- E2 skill — explicit two-flow branching; add `RequestSupport` trigger
+- E3 skill — replace handwaved "converged" intro with the confirm-vs-browse split spelled out here
+
+**Orchestrator-side**
+- `CohortMembersTable` — path chip + support-request indicator
+- `RequestSupport` admin view — see incoming requests, mark as resolved
+
+**KB content**
+- Already-planned (NbsShowcaseCards, intervention cards, etc.) — no new KB needed for path support itself
+
+## Open decisions
+
+1. **Path switching mid-encontro vs at session boundaries** — recommendation: anytime via settings, but the agent doesn't proactively offer the switch (avoids decision fatigue).
+2. **`RequestSupport` notification channel** — Slack for v1 (fits team's existing comms), email later. Coordinator-side dashboard surface is non-negotiable.
+3. **Should the agent ever auto-suggest `RequestSupport`?** Recommendation: yes, on signal detection — repeated "não sei", visible struggle (e.g. 3+ tries on a single question), explicit *"não tenho certeza"*. Soft suggestion, not modal interruption.
+4. **`inspiration_picks[]` cardinality** — limit to 3 to force prioritization, or unlimited? Recommendation: limit to 3 with override.
+
+## Out of scope here
+
+- Cohort-level reflection sessions (cross-CBO discussion) — coordinator runs these in-room, no platform surface
+- Synchronous chat with coordinator (just async `RequestSupport`)
+- Translation between paths' data shapes (they share schema — just collected differently)
+
+## See also
+
+- [`E1-quem-somos/spec.md`](../E1-quem-somos/spec.md) — where triage is captured
+- [`E2-seu-territorio/spec.md`](../E2-seu-territorio/spec.md) — has-idea Beat 2 flow
+- [`E3-desenhando/spec.md`](../E3-desenhando/spec.md) — to be updated per this doc (still in PR #142)
+- [`_mobile/mobile-tabs-spec.md`](../_mobile/mobile-tabs-spec.md) — how `RequestSupport` button surfaces on mobile (lives in chat header; tap to open dialog)

--- a/knowledge/runs/2026-05-15-encontros-curriculum/curriculum.md
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/curriculum.md
@@ -20,6 +20,8 @@ Two paths converge into the same outcome:
 
 By Encontro 4, both paths sit on the same curriculum. The triage is set at Encontro 1 (explicit question, stored on the member), surfaced on the orchestrator card so VF/OEF know who needs more hand-holding mid-pilot.
 
+> **Path divergence in detail**: see [`_paths/two-path-triage.md`](_paths/two-path-triage.md) for the cross-cutting authority — flow per encontro, the `RequestSupport` affordance, and path-switching mechanics.
+
 ---
 
 ## The 6 encontros at a glance


### PR DESCRIPTION
## Summary

Audits and refines the **has-idea vs needs-help** two-path triage that E1 captures. The triage existed in name only — E2's spec gave it 3 rows where only Beat 2 differed, and E3's spec hand-waved that *"both paths converge at E3."* In practice the `needs-help` path was failing silently at exactly the points it's needed most.

Both paths now have a fully designed flow that **ends in the same spot at E4**, with explicit **\"pedir apoio\"** affordances so CBOs who get stuck can escalate to a real human without abandoning the platform.

## What's in this PR

| File | What |
|---|---|
| `_paths/two-path-triage.md` (new) | Cross-cutting authority. Per-encontro divergence, RequestSupport, path-switching |
| `E2-seu-territorio/spec.md` (refined) | Replaces 3-row table with full has-idea (~25 min linear) and needs-help (~30-45 min discovery with pause-and-resume) flows |
| `E3-desenhando/spec-addendum-paths.md` (new) | Addendum to be merged into the E3 spec (PR #142) once it lands. Replaces \"converged\" hand-wave with confirm-vs-browse split + save-favorites + compare drawer |
| `curriculum.md` (refined) | Pointer to the cross-cutting doc |

## Convergence

| Encontro | Path-aware? |
|---|---|
| E1 | Triage point — no divergence in flow |
| E2 | **Big divergence** — different opening, different map mode, different commitment moment |
| E3 | **Medium divergence** — confirm-mode (has-idea) vs browse-mode-with-favorites (needs-help) |
| E4-E6 | Fully converged — same flow regardless of path |

## Cross-cutting: \`RequestSupport\`

Visible in chat header on every encontro. Form: pick support type (conversa com coordenadora / pergunta técnica / conexão com outro CBO / finanças+parceiros) + optional message → notifies orchestrator. The orchestrator-side CohortMembersTable gains a pendency indicator.

\`needs-help\` agent surfaces it more proactively (e.g., when user is stuck on a question for 3+ tries, or says *\"não tenho certeza\"*). Both paths can invoke anytime.

## Path switching

Self-service via settings. \`needs-help\` CBOs who discover a clear idea mid-E2 can promote to \`has-idea\`; data is preserved. No path-locking.

## Test plan

- [ ] Review against the COUGAR ecosystem assessment for how often each path is expected
- [ ] Decide RequestSupport notification channel (recommend Slack for v1)
- [ ] Confirm \`inspiration_picks[]\` cardinality (recommend max 3 with override)
- [ ] After PR #142 lands, merge \`spec-addendum-paths.md\` into the E3 spec
- [ ] Wire E2 + E3 path branches into \`encontro-2-seu-territorio.md\` and \`encontro-3-desenhando.md\` skills when we build

## Related

- E1 captures \`path\` (already on main)
- E2 spec refinement (this PR)
- E3 spec addendum (this PR) — to merge with E3 spec from PR #142
- E4-E6 specs (PRs #143, #144, #145) — no changes needed; they're path-agnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)