### PR TITLE
feat(p8): workshop-phased unlock — agent + server-side phase gating

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -237,6 +237,18 @@ export default function CboProfilePage() {
     [unlockedPhases]
   );
 
+  // Link cboStateId to the cohort member as soon as both are known so the
+  // server-side phase gate (P-8) can identify this CBO from turn 1, before
+  // any phase-change or maturity-update snapshot fires.
+  useEffect(() => {
+    if (!memberSlug || !cboId) return;
+    fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cboStateId: cboId }),
+    }).catch(() => {});
+  }, [memberSlug, cboId]);
+
   // Hide Replit chat widget on this page
   useEffect(() => {
     const style = document.createElement('style');

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -219,6 +219,8 @@ export function registerCohortRoutes(app: Express): void {
   }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.
+  // Workshop-phased unlock (P-8): clamp `phase` to the member's `unlockedPhases`.
+  // Phase 6+ (export/wrap) is always allowed.
   app.patch('/api/cbo-member/:memberSlug/snapshot', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
@@ -227,10 +229,26 @@ export function registerCohortRoutes(app: Express): void {
       phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
     } = req.body ?? {};
 
+    let nextPhase = typeof phase === 'number' ? phase : member.snapshotPhase;
+    if (typeof phase === 'number' && phase >= 1 && phase <= 5) {
+      const unlocked = Array.isArray(member.unlockedPhases) ? (member.unlockedPhases as number[]) : [1];
+      if (!unlocked.includes(phase)) {
+        const maxAllowed = Math.max(...unlocked);
+        nextPhase = maxAllowed;
+        res.status(409).json({
+          error: 'phase_locked',
+          requestedPhase: phase,
+          maxAllowedPhase: maxAllowed,
+          unlockedPhases: unlocked,
+        });
+        return;
+      }
+    }
+
     await db.update(cohortMembers).set({
       cboStateId: cboStateId ?? member.cboStateId ?? null,
       startedAt: member.startedAt ?? new Date(),
-      snapshotPhase: typeof phase === 'number' ? phase : member.snapshotPhase,
+      snapshotPhase: nextPhase,
       snapshotSectionsComplete: typeof sectionsComplete === 'number' ? sectionsComplete : member.snapshotSectionsComplete,
       snapshotMaturityScore: typeof maturityScore === 'number' ? maturityScore : member.snapshotMaturityScore,
       snapshotFlagsMet: typeof flagsMet === 'number' ? flagsMet : member.snapshotFlagsMet,

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -12,6 +12,7 @@ import {
   MATURITY_METRICS,
   PRIORITY_FLAG_DEFINITIONS,
 } from "@shared/cbo-schema";
+import { getPhasePolicyForCbo, isPhaseAllowed, buildAccessPolicyPrompt, type PhasePolicy } from "./phaseGating";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -147,11 +148,23 @@ function createCboMcpTools(cboId: string) {
 
   const setPhase = sdkTool(
     "set_phase",
-    "Advance to next phase (1-6).",
+    "Advance to next phase (1-6). Refuses to advance past phases the coordinator has unlocked.",
     { phase: z.number().min(0).max(6) },
     async (args: any) => {
       const state = getCboState(cboId);
       if (!state) return { content: [{ type: "text" as const, text: "Error: not found" }], isError: true };
+      // Workshop-phased unlock gate. Standalone CBOs are ungated.
+      // Phase 6 = export/wrap; not part of unlocks (always allowed once Phase 5 is unlocked).
+      const policy = await getPhasePolicyForCbo(cboId);
+      if (policy.gated && args.phase >= 1 && args.phase <= 5 && !isPhaseAllowed(policy, args.phase)) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Phase ${args.phase} is locked. The coordinator has only opened phases ${policy.unlockedPhases.join(', ')}. Stay at Phase ${state.phase} and tell the user warmly that the next workshop will open this section.`,
+          }],
+          isError: true,
+        };
+      }
       state.phase = args.phase;
       setCboState(cboId, state);
       pushEvent({ type: 'phase_change', phase: args.phase });
@@ -506,8 +519,10 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const sysCtx = await buildSystemContext(state, lang);
   const stateSummary = buildStateSummary(state);
   const decisionLog = buildDecisionLog(cboId);
+  const policy = await getPhasePolicyForCbo(cboId);
+  const accessPolicy = buildAccessPolicyPrompt(policy);
 
-  const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## USER DECISIONS\n${decisionLog}\n\nUser message: ${userMessage}`;
+  const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## USER DECISIONS\n${decisionLog}${accessPolicy}\n\nUser message: ${userMessage}`;
 
   console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 

--- a/server/services/phaseGating.ts
+++ b/server/services/phaseGating.ts
@@ -1,0 +1,79 @@
+// Workshop-phased unlock (P-8) — gating helpers.
+//
+// A CBO that is part of a coordinator-managed cohort can only advance to
+// phases that the coordinator has unlocked (via "Open Workshop" on the
+// orchestrator dashboard). The cohort_members.unlockedPhases column is the
+// source of truth. CBOs not in any cohort are ungated — full backwards
+// compatibility for standalone usage.
+
+import { db } from '../db';
+import { cohortMembers } from '@shared/cohort-schema';
+import { eq } from 'drizzle-orm';
+
+export type PhasePolicy = {
+  /** Member is part of a cohort. If false, the CBO is standalone and ungated. */
+  gated: boolean;
+  /** Phases the CBO is allowed to enter. Empty if no member found (treated as ungated). */
+  unlockedPhases: number[];
+  /** Max phase the CBO can currently work on. 5 means everything is open; 1 means only Phase 1. */
+  maxAllowedPhase: number;
+  /** Member id (if any) — useful for downstream snapshot pushes. */
+  memberId: string | null;
+};
+
+const UNGATED: PhasePolicy = {
+  gated: false,
+  unlockedPhases: [1, 2, 3, 4, 5],
+  maxAllowedPhase: 5,
+  memberId: null,
+};
+
+/**
+ * Look up the gating policy for a given CBO state id.
+ *
+ * If no cohort_member row references this cboStateId, the CBO is standalone
+ * and gets the ungated policy (everything open) — this preserves the
+ * pre-cohort behavior for testing and one-off use.
+ */
+export async function getPhasePolicyForCbo(cboStateId: string): Promise<PhasePolicy> {
+  if (!cboStateId) return UNGATED;
+  try {
+    const [member] = await db
+      .select()
+      .from(cohortMembers)
+      .where(eq(cohortMembers.cboStateId, cboStateId))
+      .limit(1);
+    if (!member) return UNGATED;
+    const unlocked = Array.isArray(member.unlockedPhases) && member.unlockedPhases.length > 0
+      ? (member.unlockedPhases as number[])
+      : [1];
+    return {
+      gated: true,
+      unlockedPhases: unlocked,
+      maxAllowedPhase: Math.max(...unlocked),
+      memberId: member.id,
+    };
+  } catch {
+    return UNGATED;
+  }
+}
+
+/** Pure helper — does this policy allow the agent to advance to the requested phase? */
+export function isPhaseAllowed(policy: PhasePolicy, requestedPhase: number): boolean {
+  return policy.unlockedPhases.includes(requestedPhase);
+}
+
+/** Build the prompt fragment that tells the agent which phases are open. */
+export function buildAccessPolicyPrompt(policy: PhasePolicy): string {
+  if (!policy.gated) return '';
+  const max = policy.maxAllowedPhase;
+  if (max >= 5) {
+    return '\n## ACCESS POLICY\nAll workshop phases are open. No phase-advancement restrictions.';
+  }
+  return [
+    '\n## ACCESS POLICY',
+    `The coordinator has currently opened phases ${policy.unlockedPhases.join(', ')} for this CBO (workshop-phased unlock).`,
+    `You MUST NOT advance the user past Phase ${max}. The set_phase tool will refuse any phase > ${max}.`,
+    'If the user finishes Phase ' + max + ', do not advance to the next phase. Instead, tell them warmly that the next workshop will open the next phase, and offer to revisit earlier answers or wait. Do not invent a workshop date — just say the coordinator will open it.',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Closes **P-8 Workshop-phased unlock** — the first item in the May 14 → 28 build order. Coordinators gate the 6-encontro Vila Flores cadence so communities can't run ahead of the workshops.

The CBO-side UI already disabled locked chips (\`CboProgress\`) and the orchestrator-side \"Open Workshop\" button already bulk-unlocked phases for everyone. The gap was **enforcement** — the agent could happily advance a CBO past the coordinator's gate. This PR adds the missing teeth.

## What ships

| File | What |
|---|---|
| \`server/services/phaseGating.ts\` (new) | \`getPhasePolicyForCbo(cboStateId)\` reads \`cohort_members.unlockedPhases\`. Standalone CBOs (no member row) → ungated policy → pre-cohort behavior preserved |
| \`server/services/cboAgent.ts\` | \`set_phase\` MCP tool refuses to advance past \`max(unlockedPhases)\` when gated. Error instructs the agent to stay put + tell the user warmly. System prompt gains an \`ACCESS POLICY\` block |
| \`server/routes/cohortRoutes.ts\` | \`/api/cbo-member/:slug/snapshot\` returns 409 \`phase_locked\` on out-of-bounds phase push (defense-in-depth) |
| \`client/src/core/pages/cbo-profile.tsx\` | Links \`cboStateId\` to the member row on mount so the gate is enforceable from turn 1 (not just after the first phase-change event) |

## Flow

1. Coordinator opens dashboard, clicks **\"Open Workshop\"** on Workshop 2 → \`handleOpenWorkshop\` calls \`unlockPhase('all', 2)\` + stamps \`openedAt = today\` ✓ (already existed)
2. Members now have \`unlockedPhases = [1, 2]\`
3. CBO opens their slug URL → \`cboStateId\` linked to member row immediately
4. CBO chats → agent's system prompt includes *\"phases 1, 2 are open. MUST NOT advance past Phase 2.\"*
5. Agent tries \`set_phase(3)\` → tool returns error → agent stays at Phase 2 and tells user *\"vamos esperar a coordenadora abrir o próximo encontro\"*
6. Coordinator opens Workshop 3 next week → unlockedPhases = [1, 2, 3] → agent can now advance

## Standalone CBO behavior

CBOs not in any cohort (no \`cohort_members\` row referencing their \`cboStateId\`) get the **ungated policy** — every phase open. Standalone use unchanged.

## Test plan

- [ ] Open a fresh cohort, invite a CBO, leave Workshop 1 unopened → CBO's agent can't advance from Phase 0
- [ ] Open Workshop 1 only → agent can do Phase 1 but can't \`set_phase(2)\`
- [ ] Open Workshop 2 → re-fetch member; \`unlockedPhases\` now \`[1, 2]\` → agent can advance
- [ ] Try to PATCH \`/api/cbo-member/:slug/snapshot\` with \`phase: 3\` when only \`[1, 2]\` unlocked → 409
- [ ] Standalone CBO (no slug URL param) → no gating
- [ ] Manual: confirm the \`ACCESS POLICY\` line lands in the system prompt (server log shows it)

## Source

Ana Radzevicius @ 42:04 of the April 16 Vila Flores meeting — *\"as comunidades não podem correr na frente dos encontros, isso quebra a dinâmica em sala.\"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)