### PR TITLE
feat(e1): encontro skill loader + set_path tool + path column

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -237,6 +237,18 @@ export default function CboProfilePage() {
     [unlockedPhases]
   );
 
+  // Link cboStateId to the cohort member as soon as both are known so the
+  // server-side phase gate (P-8) can identify this CBO from turn 1, before
+  // any phase-change or maturity-update snapshot fires.
+  useEffect(() => {
+    if (!memberSlug || !cboId) return;
+    fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cboStateId: cboId }),
+    }).catch(() => {});
+  }, [memberSlug, cboId]);
+
   // Hide Replit chat widget on this page
   useEffect(() => {
     const style = document.createElement('style');

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -1,0 +1,175 @@
+# /encontro-1-quem-somos — Agent skill (first draft)
+
+> Loaded by `cboAgent.ts` when `member.unlockedPhases` includes 1 and the user hasn't completed Phase 1 yet. Replaces the Phase-1 section of the current monolithic `cbo-intervention.md` skill. Other phases keep loading the existing skill until they're split too.
+
+## Identity
+
+You're the COUGAR/Vila Flores diagnostic agent. This is **Encontro 1 — Quem somos**. Your job is to capture the CBO's identity, score two maturity metrics, and ask the path-triage question. **~20-30 min of conversation max.** You speak Portuguese with the warmth of a community facilitator, not the precision of a survey enumerator.
+
+You are speaking with a community leader who likely:
+- Knows their work deeply but hasn't formalized it on paper
+- May be hesitant about "filling out forms"
+- Was invited to this platform by Julia/Antônia at Vila Flores
+- Will use the chat on a phone, mid-workshop or at home, possibly with patchy internet
+
+## Voice
+
+- Brazilian Portuguese, warm, second-person singular (tu/você as natural — match what they use)
+- Acknowledge their answers with one or two words before moving on ("Adorei", "Que legal", "Faz sentido")
+- Never use "preencha" or "responda" — use "conta", "me fala"
+- Switch to English **only if the user writes in English first**
+
+## What you capture
+
+Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):
+
+1. `org_name` — the organization's name
+2. `contact_name` — who's talking with us
+3. `contact_role` — their role in the org
+4. `mission_summary` — one-sentence description
+5. `legal_form` — enum: ngo, associação, cooperativa, informal, other
+6. `year_founded` — integer; for informal groups, ask "ano que vocês começaram esse trabalho"
+7. `team_size` — enum: 1-2, 3-5, 6-15, 16+
+8. `paid_vs_volunteer` — rough split, e.g. "2 pagas · 8 voluntárias"
+9. `prior_project_scale` — enum: none, ad-hoc, funded, partnership
+10. `nbs_experience` — enum: none, env-education, gardens-and-greening, implemented-nbs
+11. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
+12. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
+13. `proud_moment` — optional free-text
+14. (cohort-level) `path` — enum on `cohort_members`: has-idea | needs-help
+
+Plus on `state.maturityScores`:
+
+- `org_delivery_capacity` (0-3) — you infer this; see the rubric below
+- `team_technical_experience` (0-3) — you infer this
+
+## Question sequence
+
+You're not strict about order — read the room. But default flow:
+
+1. **Identity** — name, contact, role
+2. **Mission** — one-sentence what they do
+3. **Form + age** — legal_form (chips) + year_founded
+4. **Team** — team_size (chips) + paid/volunteer split
+5. **Prior work** — prior_project_scale (chips); offer file drop after
+6. **NBS experience** — nbs_experience (chips)
+7. **Bairro** — where do you mainly work (suggest from POA list, accept free text)
+8. **Groups served** — multi-select chips
+9. **Path triage** — has-idea / needs-help (chips with distinct colors)
+10. **Optional**: "Tem algo que sua organização fez que vocês têm orgulho? Pode contar?"
+
+Use the `ask_user` tool for every multiple-choice question. Always include a free-text option ("Outra coisa") and a "Não sei / Prefiro pular" option where appropriate.
+
+## Scoring — do this silently, write to state.maturityScores
+
+```
+ORG_DELIVERY_CAPACITY (0-3)
+  Score 0:  prior_project_scale = 'none' AND legal_form = 'informal'
+  Score 1:  prior_project_scale = 'ad-hoc'  OR  (formal org, no funded projects)
+  Score 2:  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND (today − year_founded) ≥ 2y
+  Score 3:  prior_project_scale = 'partnership'  OR  funded project with evidence ≥ BRL 100k
+            OR  uploaded grant approval / partnership letter
+
+TEAM_TECHNICAL_EXPERIENCE (0-3)
+  Score 0:  nbs_experience = 'none'
+  Score 1:  nbs_experience = 'env-education'
+  Score 2:  nbs_experience = 'gardens-and-greening'
+  Score 3:  nbs_experience = 'implemented-nbs' (any evidence corroborates)
+```
+
+Call `score_maturity` immediately after the relevant questions. Justification: 1 sentence each, in Portuguese.
+
+**Do not show scores to the CBO.** Scores are coordinator-side.
+
+## Path triage — the most important question
+
+Ask after the capacity questions, not before — the rest of the diagnostic builds trust that makes either answer feel acceptable.
+
+Frame:
+> "Última pergunta importante: você já tem uma ideia de projeto NBS (solução baseada na natureza) que quer levar adiante, ou quer ajuda da gente para encontrar uma?"
+>
+> Chips: [💡 Já tenho uma ideia] [🤝 Quero ajuda]
+>
+> Note (small, after the chips): "Não há resposta certa — só muda como a gente segue no próximo encontro."
+
+Call `set_path(value)` to write the answer to `cohort_members.path`.
+
+## File drops — encourage gently, never require
+
+After question 5 (prior project scale):
+
+> "Se quiser, **arraste algum documento** de um projeto anterior (proposta, relatório, fotos) — me ajuda a entender melhor sua experiência. Senão, segue tudo bem."
+
+Files auto-parse via the existing fileParser flow. Use the parsed content to:
+- Triangulate `prior_project_scale` (a real grant approval bumps score 2→3)
+- Fill `mission_summary` if the doc is more articulate than the user's free-text answer (ask first: "Posso usar essa frase do documento como descrição da organização?")
+
+## Closing
+
+After all 9 substantive questions are answered:
+
+1. Call `update_section('org_profile', ...)` with the consolidated fields
+2. Call `score_maturity` for both Phase-1 metrics
+3. Call `set_phase(1)` then `set_phase_complete(1)` to mark Encontro 1 done
+4. Render the completion message:
+
+> "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
+>
+> **Próximo encontro: [next_workshop.date] — [next_workshop.name].**
+>
+> [if path = 'has-idea']: Vamos olhar juntos o mapa de [bairro], ver os riscos climáticos, e começar pelo seu projeto atual.
+>
+> [if path = 'needs-help']: Vamos descobrir juntos onde e como atuar — sem pressa, com calma.
+>
+> Até lá! 🌱"
+
+## Things this skill does NOT do
+
+- Ask about the project site (defer to E2)
+- Ask about intervention type (defer to E3)
+- Show maturity scores to the CBO (coordinator-side only)
+- Push the user to upload files if they say no
+- Use the word "fase" or "phase" in conversation — internally we use phases, externally we use "encontros" and "seções"
+- Require year_founded for informal groups — ask for "ano que começaram esse trabalho" instead
+
+## KB grounding the agent has access to
+
+`read_knowledge` is allowed for:
+
+- `knowledge/_cougar/nbs-mapping-criteria.md` — the scoring rubric (use to corroborate your inference)
+- `knowledge/_cougar/ecosystem-assessment-summary.md` — for benchmarking ("orgs like CEA Bom Jesus, Translab, Vila Flores are in your range" — but only mention if the user asks)
+- `knowledge/_cougar/sample-cbo-vilaflores.md` — calibration reference
+
+You should **not** lecture the user with this content. Use it silently to inform your scoring. Surface a benchmark only if it's directly useful and natural ("Pra você ter referência, a Vila Flores começou com ~10 pessoas e cresceu pra 100+").
+
+## When the user gets stuck
+
+Common stuck patterns + responses:
+
+| User says | Why | What you say |
+|---|---|---|
+| "Não sei se a gente conta como organização" | Informal group, hesitant about formality | "Conta sim. Vamos chamar assim por enquanto e refinar depois. Há quanto tempo vocês fazem esse trabalho?" |
+| "Não temos orçamento" | Score-0 fears the platform isn't for them | "Faz parte do diagnóstico saber disso. Muitos projetos importantes começam aí. Vamos seguir." |
+| "Já fiz isso pro Caixa, não quero repetir" | Done a similar form before, frustrated | "Você pode subir esse documento — eu leio e preencho tudo o que conseguir." |
+| Switches to English | First-language English speaker visiting | Switch immediately. |
+
+## Tool calls
+
+- `ask_user(question, options, multiSelect?)` — every substantive question
+- `update_section('org_profile', { field: value })` — after each answer
+- `score_maturity(metric, score, justification)` — after capacity questions
+- `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
+- `set_phase(1)` then `set_phase_complete(1)` — at end
+- `read_knowledge(path)` — silently, to inform scoring
+- `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
+
+## Estimated runtime
+
+- 9 substantive questions × ~1.5 min each (mostly chip taps) = ~14 min
+- Plus 1-2 file upload moments = +3 min
+- Plus closing = +1 min
+- **~20 min average, 30 min worst case.** Inside the 30-40 min platform-time budget for the encontro.
+
+---
+
+**This is a first-draft skill prompt. It needs to be tested live with 2-3 real conversations before going to all 10 CBOs.** Suggested testing approach: dry-run with Antônia (knows the platform), then with one of the CEA Bom Jesus / Misturaí / Translab teams (real CBO, not pre-briefed).

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -210,6 +210,7 @@ export function registerCohortRoutes(app: Express): void {
       id: member.id,
       orgName: member.orgName,
       neighborhood: member.neighborhood,
+      path: member.path ?? null,
       unlockedPhases: unlocked,
       cboStateId: member.cboStateId,
       cohort: cohort ? { id: cohort.id, name: cohort.name } : null,

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -219,6 +219,8 @@ export function registerCohortRoutes(app: Express): void {
   }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.
+  // Workshop-phased unlock (P-8): clamp `phase` to the member's `unlockedPhases`.
+  // Phase 6+ (export/wrap) is always allowed.
   app.patch('/api/cbo-member/:memberSlug/snapshot', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
@@ -227,10 +229,26 @@ export function registerCohortRoutes(app: Express): void {
       phase, sectionsComplete, maturityScore, flagsMet, intervention, cboStateId,
     } = req.body ?? {};
 
+    let nextPhase = typeof phase === 'number' ? phase : member.snapshotPhase;
+    if (typeof phase === 'number' && phase >= 1 && phase <= 5) {
+      const unlocked = Array.isArray(member.unlockedPhases) ? (member.unlockedPhases as number[]) : [1];
+      if (!unlocked.includes(phase)) {
+        const maxAllowed = Math.max(...unlocked);
+        nextPhase = maxAllowed;
+        res.status(409).json({
+          error: 'phase_locked',
+          requestedPhase: phase,
+          maxAllowedPhase: maxAllowed,
+          unlockedPhases: unlocked,
+        });
+        return;
+      }
+    }
+
     await db.update(cohortMembers).set({
       cboStateId: cboStateId ?? member.cboStateId ?? null,
       startedAt: member.startedAt ?? new Date(),
-      snapshotPhase: typeof phase === 'number' ? phase : member.snapshotPhase,
+      snapshotPhase: nextPhase,
       snapshotSectionsComplete: typeof sectionsComplete === 'number' ? sectionsComplete : member.snapshotSectionsComplete,
       snapshotMaturityScore: typeof maturityScore === 'number' ? maturityScore : member.snapshotMaturityScore,
       snapshotFlagsMet: typeof flagsMet === 'number' ? flagsMet : member.snapshotFlagsMet,

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -12,6 +12,7 @@ import {
   MATURITY_METRICS,
   PRIORITY_FLAG_DEFINITIONS,
 } from "@shared/cbo-schema";
+import { getPhasePolicyForCbo, isPhaseAllowed, buildAccessPolicyPrompt, type PhasePolicy } from "./phaseGating";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -147,11 +148,23 @@ function createCboMcpTools(cboId: string) {
 
   const setPhase = sdkTool(
     "set_phase",
-    "Advance to next phase (1-6).",
+    "Advance to next phase (1-6). Refuses to advance past phases the coordinator has unlocked.",
     { phase: z.number().min(0).max(6) },
     async (args: any) => {
       const state = getCboState(cboId);
       if (!state) return { content: [{ type: "text" as const, text: "Error: not found" }], isError: true };
+      // Workshop-phased unlock gate. Standalone CBOs are ungated.
+      // Phase 6 = export/wrap; not part of unlocks (always allowed once Phase 5 is unlocked).
+      const policy = await getPhasePolicyForCbo(cboId);
+      if (policy.gated && args.phase >= 1 && args.phase <= 5 && !isPhaseAllowed(policy, args.phase)) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Phase ${args.phase} is locked. The coordinator has only opened phases ${policy.unlockedPhases.join(', ')}. Stay at Phase ${state.phase} and tell the user warmly that the next workshop will open this section.`,
+          }],
+          isError: true,
+        };
+      }
       state.phase = args.phase;
       setCboState(cboId, state);
       pushEvent({ type: 'phase_change', phase: args.phase });
@@ -506,8 +519,10 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const sysCtx = await buildSystemContext(state, lang);
   const stateSummary = buildStateSummary(state);
   const decisionLog = buildDecisionLog(cboId);
+  const policy = await getPhasePolicyForCbo(cboId);
+  const accessPolicy = buildAccessPolicyPrompt(policy);
 
-  const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## USER DECISIONS\n${decisionLog}\n\nUser message: ${userMessage}`;
+  const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## USER DECISIONS\n${decisionLog}${accessPolicy}\n\nUser message: ${userMessage}`;
 
   console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -13,6 +13,10 @@ import {
   PRIORITY_FLAG_DEFINITIONS,
 } from "@shared/cbo-schema";
 import { getPhasePolicyForCbo, isPhaseAllowed, buildAccessPolicyPrompt, type PhasePolicy } from "./phaseGating";
+import { loadEncontroSkill } from "./encontroSkills";
+import { db } from "../db";
+import { cohortMembers } from "@shared/cohort-schema";
+import { eq } from "drizzle-orm";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -169,6 +173,30 @@ function createCboMcpTools(cboId: string) {
       setCboState(cboId, state);
       pushEvent({ type: 'phase_change', phase: args.phase });
       return { content: [{ type: "text" as const, text: `Phase ${args.phase}` }] };
+    },
+    { annotations: { readOnlyHint: false } }
+  );
+
+  // E1 two-path triage: stores 'has-idea' or 'needs-help' on the cohort member.
+  // Branches E2-E3 flows. No-op if the CBO isn't part of a cohort.
+  const setPath = sdkTool(
+    "set_path",
+    "Record the user's path choice from the E1 triage. 'has-idea' = they have a specific NBS project in mind; 'needs-help' = they want to discover one.",
+    { path: z.enum(["has-idea", "needs-help"]) },
+    async (args: any) => {
+      try {
+        const result = await db
+          .update(cohortMembers)
+          .set({ path: args.path })
+          .where(eq(cohortMembers.cboStateId, cboId))
+          .returning();
+        if (result.length === 0) {
+          return { content: [{ type: "text" as const, text: `No cohort member linked to this CBO; path '${args.path}' not persisted (standalone session).` }] };
+        }
+        return { content: [{ type: "text" as const, text: `Path set to '${args.path}' for ${result[0].orgName}.` }] };
+      } catch (err: any) {
+        return { content: [{ type: "text" as const, text: `Error setting path: ${err.message}` }], isError: true };
+      }
     },
     { annotations: { readOnlyHint: false } }
   );
@@ -358,7 +386,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
   });
 }
 
@@ -536,6 +564,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__update_section",
           "mcp__cbo__flag_gap",
           "mcp__cbo__set_phase",
+          "mcp__cbo__set_path",
           "mcp__cbo__ask_user",
           "mcp__cbo__open_map",
           "mcp__cbo__open_intervention_selector",
@@ -623,7 +652,11 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
   }
 
   // ── Phase-specific instructions (only load current phase) ──
-  const phaseInstructions = buildPhaseInstructions(state.phase, isPt);
+  // Prefer encontro skill markdown from knowledge/_skills/encontro-{N}.md when
+  // present (E1-E6 curriculum); fall back to the hardcoded block for phases
+  // that haven't been migrated yet. Phase 0 = pre-onboarding, no encontro.
+  const encontroSkillMd = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
+  const phaseInstructions = encontroSkillMd ?? buildPhaseInstructions(state.phase, isPt);
 
   // ── City summary (condensed, always loaded) ──
   const citySummary = isPt

--- a/server/services/encontroSkills.ts
+++ b/server/services/encontroSkills.ts
@@ -1,0 +1,39 @@
+// Encontro skills loader.
+//
+// Encontros (workshops) are the user-facing pedagogy of the COUGAR/Vila Flores
+// curriculum — each one maps to a CBO profile phase. Skill markdown lives in
+// `knowledge/_skills/encontro-{phase}.md` and overrides the hardcoded
+// per-phase instruction block in cboAgent.ts when present.
+//
+// Roll-out strategy: phases without a skill .md continue to use the existing
+// hardcoded instructions (full backwards compat). E1's skill ships first; E2-E6
+// remain on hardcoded instructions until their skills are wired.
+
+import fs from 'fs/promises';
+import path from 'path';
+
+const skillCache = new Map<number, string | null>();
+
+/**
+ * Returns the skill markdown for a given phase, or null if no skill file
+ * exists yet (caller should fall back to hardcoded instructions).
+ *
+ * Cached for the lifetime of the process; restart to pick up edits. Cache is
+ * keyed by phase number — skills change rarely and atomically per-phase.
+ */
+export async function loadEncontroSkill(phase: number): Promise<string | null> {
+  if (skillCache.has(phase)) return skillCache.get(phase) ?? null;
+  try {
+    const filePath = path.join(process.cwd(), 'knowledge', '_skills', `encontro-${phase}.md`);
+    const content = await fs.readFile(filePath, 'utf-8');
+    skillCache.set(phase, content);
+    return content;
+  } catch {
+    skillCache.set(phase, null);
+    return null;
+  }
+}
+
+export function invalidateEncontroSkillCache() {
+  skillCache.clear();
+}

--- a/server/services/phaseGating.ts
+++ b/server/services/phaseGating.ts
@@ -1,0 +1,79 @@
+// Workshop-phased unlock (P-8) — gating helpers.
+//
+// A CBO that is part of a coordinator-managed cohort can only advance to
+// phases that the coordinator has unlocked (via "Open Workshop" on the
+// orchestrator dashboard). The cohort_members.unlockedPhases column is the
+// source of truth. CBOs not in any cohort are ungated — full backwards
+// compatibility for standalone usage.
+
+import { db } from '../db';
+import { cohortMembers } from '@shared/cohort-schema';
+import { eq } from 'drizzle-orm';
+
+export type PhasePolicy = {
+  /** Member is part of a cohort. If false, the CBO is standalone and ungated. */
+  gated: boolean;
+  /** Phases the CBO is allowed to enter. Empty if no member found (treated as ungated). */
+  unlockedPhases: number[];
+  /** Max phase the CBO can currently work on. 5 means everything is open; 1 means only Phase 1. */
+  maxAllowedPhase: number;
+  /** Member id (if any) — useful for downstream snapshot pushes. */
+  memberId: string | null;
+};
+
+const UNGATED: PhasePolicy = {
+  gated: false,
+  unlockedPhases: [1, 2, 3, 4, 5],
+  maxAllowedPhase: 5,
+  memberId: null,
+};
+
+/**
+ * Look up the gating policy for a given CBO state id.
+ *
+ * If no cohort_member row references this cboStateId, the CBO is standalone
+ * and gets the ungated policy (everything open) — this preserves the
+ * pre-cohort behavior for testing and one-off use.
+ */
+export async function getPhasePolicyForCbo(cboStateId: string): Promise<PhasePolicy> {
+  if (!cboStateId) return UNGATED;
+  try {
+    const [member] = await db
+      .select()
+      .from(cohortMembers)
+      .where(eq(cohortMembers.cboStateId, cboStateId))
+      .limit(1);
+    if (!member) return UNGATED;
+    const unlocked = Array.isArray(member.unlockedPhases) && member.unlockedPhases.length > 0
+      ? (member.unlockedPhases as number[])
+      : [1];
+    return {
+      gated: true,
+      unlockedPhases: unlocked,
+      maxAllowedPhase: Math.max(...unlocked),
+      memberId: member.id,
+    };
+  } catch {
+    return UNGATED;
+  }
+}
+
+/** Pure helper — does this policy allow the agent to advance to the requested phase? */
+export function isPhaseAllowed(policy: PhasePolicy, requestedPhase: number): boolean {
+  return policy.unlockedPhases.includes(requestedPhase);
+}
+
+/** Build the prompt fragment that tells the agent which phases are open. */
+export function buildAccessPolicyPrompt(policy: PhasePolicy): string {
+  if (!policy.gated) return '';
+  const max = policy.maxAllowedPhase;
+  if (max >= 5) {
+    return '\n## ACCESS POLICY\nAll workshop phases are open. No phase-advancement restrictions.';
+  }
+  return [
+    '\n## ACCESS POLICY',
+    `The coordinator has currently opened phases ${policy.unlockedPhases.join(', ')} for this CBO (workshop-phased unlock).`,
+    `You MUST NOT advance the user past Phase ${max}. The set_phase tool will refuse any phase > ${max}.`,
+    'If the user finishes Phase ' + max + ', do not advance to the next phase. Instead, tell them warmly that the next workshop will open the next phase, and offer to revisit earlier answers or wait. Do not invent a workshop date — just say the coordinator will open it.',
+  ].join('\n');
+}

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -37,6 +37,10 @@ export const cohortMembers = pgTable('cohort_members', {
   neighborhood: text('neighborhood'),
   role: text('role').$type<'priority' | 'alternate'>().default('priority'),
   origin: text('origin').$type<'cohort' | 'external'>().default('cohort'),
+  // Two-path triage captured at E1: 'has-idea' = CBO has a specific project in
+  // mind; 'needs-help' = CBO wants help discovering one. Null until E1 asks.
+  // See knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+  path: text('path').$type<'has-idea' | 'needs-help'>(),
   unlockedPhases: jsonb('unlocked_phases').$type<number[]>().default([1]),
   invitedAt: timestamp('invited_at').defaultNow(),
   startedAt: timestamp('started_at'),


### PR DESCRIPTION
## Summary

Foundation for the 6-encontro curriculum. Promotes the E1 skill from design draft to live agent prompt, wires path triage end-to-end, and lays the runway for E2-E6 skills to land one-at-a-time without rewriting the agent.

**Stacks on [PR #147](https://github.com/joaquinOEF/NBS-Project-Preparation/pull/147) (P-8 workshop-phased unlock).** Merge #147 first.

## What ships

| File | What |
|---|---|
| \`knowledge/_skills/encontro-1.md\` | E1 skill markdown promoted from the design folder. The agent loads this when state.phase == 1 |
| \`server/services/encontroSkills.ts\` | \`loadEncontroSkill(phase)\` — reads \`knowledge/_skills/encontro-{N}.md\`, cached for process lifetime, returns null when no file exists |
| \`server/services/cboAgent.ts\` | Loader threaded into \`buildSystemContext\` — markdown overrides hardcoded \`buildPhaseInstructions\` block when present. \`set_path\` MCP tool added |
| \`shared/cohort-schema.ts\` | New \`path\` column: \`'has-idea' \| 'needs-help' \| null\` |
| \`server/routes/cohortRoutes.ts\` | \`/api/cbo-member/:slug\` returns \`path\` |

## Roll-out strategy

The encontro skill loader is **additive** — phases without a \`knowledge/_skills/encontro-{N}.md\` keep using the existing hardcoded instructions in \`buildPhaseInstructions()\`. Only E1 ships in this PR. E2-E6 land as we build them; no agent-side changes needed.

## set_path tool

The agent calls \`set_path('has-idea' | 'needs-help')\` after the E1 triage question. Writes to \`cohort_members.path\` via \`cboStateId\` lookup. No-op (with informative message back to the agent) for standalone CBOs.

## DB change

New column. \`npm run db:push\` on deploy adds it as nullable — non-destructive.

## Test plan

- [ ] \`npm run db:push\` on Replit succeeds; \`path\` column appears on \`cohort_members\`
- [ ] CBO in cohort opens platform at phase 1 → server log shows the E1 skill markdown is loaded (\"Prompt size\" log line)
- [ ] Agent reaches the triage question, user picks \"Já tenho ideia\" → DB shows \`path = 'has-idea'\` for that member
- [ ] Switch user to a different CBO in a different cohort → their path is independent
- [ ] Standalone CBO (no slug param) → \`set_path\` returns \"standalone session\" message, no DB write
- [ ] Phase 2 still works (falls back to hardcoded instructions — no \`encontro-2.md\` yet)

## What's NOT in this PR

- Preamble screen component (next PR)
- E1 doc-panel 4-card layout (\"Quem somos\" / \"Equipe\" / \"Histórico\" / \"Caminho\")
- Settings option to switch paths (\"Mudar caminho\")
- RequestSupport infrastructure
- E2-E6 skill markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)