### PR TITLE
feat(preamble): per-encontro framing screen (E1 + E2 wired)

### DIFF
--- a/client/src/core/components/cbo/EncontroPreamble.tsx
+++ b/client/src/core/components/cbo/EncontroPreamble.tsx
@@ -1,0 +1,131 @@
+// Per-encontro preamble — shown once at the start of each workshop session.
+// Frames what this encontro covers, what tools the user will encounter, and
+// the time budget. Dismissable; the dismissal is persisted per-encontro per-CBO
+// in localStorage so the same preamble doesn't fire twice.
+//
+// Spec: knowledge/runs/2026-05-15-encontros-curriculum/E{N}-*/spec.md (Preamble section)
+
+import { useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
+import { Clock, ArrowRight } from 'lucide-react';
+import { Button } from '@/core/components/ui/button';
+
+export type EncontroPreambleConfig = {
+  /** 1-6 — used for the storage key and the eyebrow ("ENCONTRO 1") */
+  encontroNumber: number;
+  /** Title under the eyebrow */
+  title: string;
+  /** Lead sentence — "Hoje queremos…" */
+  lead: string;
+  /** Bullet list of what they'll do */
+  bullets: string[];
+  /** Optional second list — "you'll use" — for encontros with microapps */
+  toolsTheyWillUse?: string[];
+  /** Display string like "20–30 min · Salva sozinho" */
+  timeEstimate: string;
+  /** CTA label */
+  cta: string;
+};
+
+export function EncontroPreamble({
+  config,
+  onContinue,
+}: {
+  config: EncontroPreambleConfig;
+  onContinue: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
+      <main className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full px-5 sm:px-8 py-8">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+          className="space-y-7"
+        >
+          <div className="space-y-1.5">
+            <p className="text-[10px] uppercase tracking-[0.2em] text-emerald-700/80 dark:text-emerald-300/80 font-semibold">
+              {t('cbo.encontroPreamble.eyebrow', {
+                defaultValue: 'Encontro {{n}}',
+                n: config.encontroNumber,
+              })}
+            </p>
+            <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight text-foreground">
+              {config.title}
+            </h1>
+          </div>
+
+          <p className="text-base text-foreground/85 leading-relaxed">{config.lead}</p>
+
+          <div className="space-y-1.5">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+              {t('cbo.encontroPreamble.whatWeWillDo', { defaultValue: "What we'll do together" })}
+            </p>
+            <ul className="space-y-1.5">
+              {config.bullets.map((b, i) => (
+                <li key={i} className="flex items-start gap-2.5 text-sm text-foreground/85 leading-relaxed">
+                  <span className="shrink-0 mt-2 w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {config.toolsTheyWillUse && config.toolsTheyWillUse.length > 0 && (
+            <div className="space-y-1.5">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                {t('cbo.encontroPreamble.youWillUse', { defaultValue: "You'll use" })}
+              </p>
+              <ul className="space-y-1.5">
+                {config.toolsTheyWillUse.map((b, i) => (
+                  <li key={i} className="flex items-start gap-2.5 text-sm text-foreground/70 leading-relaxed">
+                    <span className="shrink-0 mt-2 w-1.5 h-1.5 rounded-full bg-foreground/20" />
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="pt-2 space-y-2">
+            <Button
+              size="lg"
+              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white rounded-full h-12 text-base font-medium shadow-sm"
+              onClick={onContinue}
+              data-testid={`button-encontro-${config.encontroNumber}-start`}
+            >
+              {config.cta}
+              <ArrowRight className="w-4 h-4 ml-1.5" />
+            </Button>
+            <p className="flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground/70 pt-1">
+              <Clock className="w-3 h-3" />
+              {config.timeEstimate}
+            </p>
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+/** Storage helpers — per (memberSlug, encontroNumber) pair so a fresh-invite
+ *  CBO always sees their preambles, but the same CBO doesn't see them twice. */
+export function preambleSeenKey(memberSlugOrCboId: string, encontroNumber: number) {
+  return `cbo-encontro-${encontroNumber}-preamble-seen-${memberSlugOrCboId}`;
+}
+
+export function markPreambleSeen(memberSlugOrCboId: string, encontroNumber: number) {
+  try {
+    localStorage.setItem(preambleSeenKey(memberSlugOrCboId, encontroNumber), '1');
+  } catch {}
+}
+
+export function hasPreambleBeenSeen(memberSlugOrCboId: string, encontroNumber: number): boolean {
+  try {
+    return localStorage.getItem(preambleSeenKey(memberSlugOrCboId, encontroNumber)) === '1';
+  } catch {
+    return false;
+  }
+}

--- a/client/src/core/components/cbo/encontroConfig.ts
+++ b/client/src/core/components/cbo/encontroConfig.ts
@@ -1,0 +1,89 @@
+// Per-encontro preamble content. Configs are language-aware (PT default, EN fallback).
+// Each encontro's spec lives at knowledge/runs/2026-05-15-encontros-curriculum/E{N}-*/spec.md.
+// Only E1 is wired in v1 — E2-E6 land alongside their respective skill markdown.
+
+import type { EncontroPreambleConfig } from './EncontroPreamble';
+
+type Lang = 'pt' | 'en';
+type EncontroBase = Omit<EncontroPreambleConfig, 'encontroNumber'>;
+
+const E1: Record<Lang, EncontroBase> = {
+  pt: {
+    title: 'Quem somos',
+    lead: 'Hoje queremos conhecer sua organização — sem pressa, sem formulário longo.',
+    bullets: [
+      'Quem vocês são e o que vocês fazem',
+      'Sua equipe e suas experiências',
+      'Se você já tem uma ideia de projeto NBS, ou se quer descobrir uma com a gente',
+    ],
+    timeEstimate: '20–30 min · Salva sozinho',
+    cta: 'Começar',
+  },
+  en: {
+    title: 'Who we are',
+    lead: "Today we'd like to meet your organization — no rush, no long form.",
+    bullets: [
+      'Who you are and what you do',
+      'Your team and experiences',
+      'Whether you already have an NBS project idea, or want to discover one with us',
+    ],
+    timeEstimate: '20–30 min · Saves automatically',
+    cta: 'Start',
+  },
+};
+
+const E2: Record<Lang, EncontroBase> = {
+  pt: {
+    title: 'Seu território',
+    lead: 'Hoje a gente vai olhar o mapa do seu bairro e os riscos que mais importam.',
+    bullets: [
+      'Ver exemplos de SbN no Brasil',
+      'Olhar o mapa do seu bairro',
+      'Marcar onde você quer atuar',
+      'Falar dos riscos que mais importam',
+    ],
+    toolsTheyWillUse: ['Exemplos visuais', 'O mapa do bairro'],
+    timeEstimate: '30–45 min · Salva sozinho',
+    cta: 'Começar',
+  },
+  en: {
+    title: 'Your territory',
+    lead: "Today we'll look at your neighborhood map and the risks that matter most.",
+    bullets: [
+      'See NBS examples from Brazil',
+      'Look at your neighborhood map',
+      'Mark where you want to work',
+      'Talk about the risks that matter most',
+    ],
+    toolsTheyWillUse: ['Visual examples', 'Neighborhood map'],
+    timeEstimate: '30–45 min · Saves automatically',
+    cta: 'Start',
+  },
+};
+
+const ENCONTRO_CONFIGS: Partial<Record<number, Record<Lang, EncontroBase>>> = {
+  1: E1,
+  2: E2,
+  // 3, 4, 5, 6 — to be added with their respective skill PRs
+};
+
+export function getEncontroPreambleConfig(
+  encontroNumber: number,
+  lang: 'pt' | 'en',
+): EncontroPreambleConfig | null {
+  const base = ENCONTRO_CONFIGS[encontroNumber];
+  if (!base) return null;
+  const langBase = base[lang] ?? base.pt;
+  return { encontroNumber, ...langBase };
+}
+
+/**
+ * Map a CBO phase number (1-5) to the encontro that introduces it. Most are
+ * 1:1, but Phase 3 spans 3 encontros (E3=3a, E4=3b/3c). For now we treat
+ * entry-into-phase-N as "encontro N's first session" — Phase 3 sub-phases
+ * collapse to E3 only. Refine when E4 ships explicit sub-phase preambles.
+ */
+export function encontroForPhase(phase: number): number | null {
+  if (phase < 1 || phase > 5) return null;
+  return phase; // 1:1 for now; revisit when E4 needs a separate preamble
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -31,6 +31,8 @@ import {
 } from 'lucide-react';
 import { CboWelcome } from '@/core/components/cbo/CboWelcome';
 import { CboProgress } from '@/core/components/cbo/CboProgress';
+import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
+import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -203,6 +205,9 @@ export default function CboProfilePage() {
   // When arriving via ?cbo=<slug>, render the premium welcome screen until
   // the user taps Start / Continue. Flipped to true once member-fetch lands.
   const [welcomeMode, setWelcomeMode] = useState(false);
+  // Per-encontro preamble — once dismissed, the encontro's first session reveals
+  // the chat. State is encontro number 1-6 OR null (no preamble showing).
+  const [preambleEncontro, setPreambleEncontro] = useState<number | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -557,9 +562,23 @@ export default function CboProfilePage() {
   // Cohort welcome screen — only when the user arrived via an invite and
   // hasn't dismissed the welcome. Replaces the entire chrome with a calm,
   // single-CTA first-impression. Tapping Start (or Continue) flips
-  // welcomeMode off and reveals the chat.
+  // welcomeMode off and reveals either the encontro preamble or the chat.
   if (welcomeMode && memberInfo) {
     const hasExistingProgress = messages.length > 0 || (state?.phase ?? 0) > 0;
+    // Show preamble for current phase if not yet seen. Fires for both
+    // first-time Start and Resume — the seen flag handles dedup so the same
+    // CBO doesn't see E1's preamble twice, but they DO see E2's the first
+    // time they come back after the coordinator unlocked Workshop 2.
+    const tryShowPreamble = () => {
+      const encontro = encontroForPhase(Math.max(1, state?.phase ?? 1));
+      if (encontro == null) return false;
+      const cfg = getEncontroPreambleConfig(encontro, lang as 'pt' | 'en');
+      if (!cfg) return false;
+      const seenKey = memberSlug ?? cboId ?? '';
+      if (!seenKey || hasPreambleBeenSeen(seenKey, encontro)) return false;
+      setPreambleEncontro(encontro);
+      return true;
+    };
     return (
       <CboWelcome
         orgName={memberInfo.orgName}
@@ -568,10 +587,37 @@ export default function CboProfilePage() {
         nextWorkshop={nextWorkshop}
         unlockedPhases={unlockedPhases}
         hasExistingProgress={hasExistingProgress}
-        onStart={() => { setWelcomeMode(false); if (!hasExistingProgress) kickoffChat(); }}
-        onResume={() => setWelcomeMode(false)}
+        onStart={() => {
+          setWelcomeMode(false);
+          if (!tryShowPreamble() && !hasExistingProgress) kickoffChat();
+        }}
+        onResume={() => {
+          setWelcomeMode(false);
+          tryShowPreamble();
+        }}
       />
     );
+  }
+
+  // Encontro preamble — covers the chat surface until dismissed. One-shot per
+  // encontro per CBO (localStorage). Tapping the CTA marks it seen and either
+  // kicks off the chat (first session) or just reveals it (later sessions).
+  if (preambleEncontro != null) {
+    const cfg = getEncontroPreambleConfig(preambleEncontro, lang as 'pt' | 'en');
+    if (cfg) {
+      const seenKey = memberSlug ?? cboId ?? '';
+      return (
+        <EncontroPreamble
+          config={cfg}
+          onContinue={() => {
+            if (seenKey) markPreambleSeen(seenKey, preambleEncontro);
+            const wasFirstSession = messages.length === 0;
+            setPreambleEncontro(null);
+            if (wasFirstSession) kickoffChat();
+          }}
+        />
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

Per-encontro framing screen between \`CboWelcome\` and the chat. Each encontro deserves a moment of *\"here's what we'll do today, here's how long, here's what tools you'll use.\"* The reusable \`EncontroPreamble\` makes this trivial to add for each encontro as we build them.

**Stacks on [PR #147](https://github.com/joaquinOEF/joaquinOEF/NBS-Project-Preparation/pull/147) (P-8) and [PR #148](https://github.com/joaquinOEF/NBS-Project-Preparation/pull/148) (E1 skill loader).**

## What ships

| File | What |
|---|---|
| \`client/src/core/components/cbo/EncontroPreamble.tsx\` | Reusable component (~120 lines). Title, lead, bullets, optional \"you'll use\" list, time estimate, CTA. Animated reveal. Dismissal helpers (localStorage-backed) exported |
| \`client/src/core/components/cbo/encontroConfig.ts\` | Per-encontro content map. E1 \"Quem somos\" + E2 \"Seu território\" wired with PT+EN. \`encontroForPhase()\` maps state.phase → encontro number (1:1 for now; revisit when E4 needs a separate preamble) |
| \`client/src/core/pages/cbo-profile.tsx\` | \`preambleEncontro\` state + \`tryShowPreamble()\` helper. Fires on Welcome → Start AND Welcome → Resume |

## Show rules

- **On Welcome → Start**: try preamble first; fall back to kickoff if seen
- **On Welcome → Resume**: show preamble for current phase if unseen, else go straight to chat
- **After preamble dismiss**: marks seen + kicks off chat if first session

Per (memberSlug | cboId, encontroNumber) localStorage key — same CBO doesn't see E1's preamble twice, but **does** see E2's the first time they come back after the coordinator opens Workshop 2.

## Visual

The preamble is calm and considered, matching CboWelcome's design language:

\`\`\`
      ENCONTRO 1
      Quem somos

      Hoje queremos conhecer sua organização —
      sem pressa, sem formulário longo.

      O QUE VAMOS FAZER JUNTOS
        · Quem vocês são e o que vocês fazem
        · Sua equipe e suas experiências
        · Se você já tem uma ideia de projeto…

      ⏱️ 20–30 min · Salva sozinho

              [ Começar  → ]
\`\`\`

## Test plan

- [ ] Cohort CBO opens fresh slug URL → Welcome → Start → **E1 preamble** → Começar → chat kicks off
- [ ] Same CBO closes and re-opens → Welcome → Resume → straight to chat (preamble dismissed)
- [ ] Coordinator opens W2 (P-8); CBO advances to phase 2; CBO closes and re-opens → Welcome → Resume → **E2 preamble** appears → Começar → chat continues
- [ ] Standalone CBO (no slug param) → no Welcome, no preamble — chat surface unchanged
- [ ] PT and EN both render correctly via \`i18n.language\`

## What's NOT in this PR

- E1 doc-panel 4-card layout (\"Quem somos\" / \"Equipe\" / \"Histórico\" / \"Caminho\") — next PR
- E3-E6 preamble content — lands with their respective skill PRs
- Path-aware preamble copy (e.g. needs-help variant for E2) — can layer on later

🤖 Generated with [Claude Code](https://claude.com/claude-code)