### PR TITLE
feat(e1): doc-panel 4-card layout — Quem somos / Equipe / Histórico / Caminho

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -1,0 +1,173 @@
+// E1 — "Quem somos" 4-card layout for the right-rail doc panel.
+//
+// Per knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/spec.md, the
+// flat field table is replaced by 4 grouped cards so the CBO sees their
+// profile take shape thematically rather than as a flat survey.
+//
+// Pulls named fields from state.sections.org_profile + path from the cohort
+// member. Any field the agent writes that isn't in our 4 groups falls into
+// the "Outros" card so nothing is hidden.
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
+import { AlertTriangle, Lightbulb, Compass } from 'lucide-react';
+import type { CboSectionState, CboGapEntry } from '@shared/cbo-schema';
+
+type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
+
+const FIELD_GROUPS: Record<Exclude<GroupKey, 'outros'>, string[]> = {
+  // Identity — what + who
+  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'legal_form', 'year_founded'],
+  // Team — size + composition
+  equipe: ['team_size', 'paid_vs_volunteer'],
+  // History — prior work + NBS experience
+  historico: ['prior_project_scale', 'nbs_experience', 'proud_moment'],
+  // Path — the triage answer + community served + bairro
+  caminho: ['bairro_of_operation', 'groups_served'],
+};
+
+const ALL_KNOWN_FIELDS = new Set<string>([
+  ...FIELD_GROUPS['quem-somos'],
+  ...FIELD_GROUPS.equipe,
+  ...FIELD_GROUPS.historico,
+  ...FIELD_GROUPS.caminho,
+]);
+
+export function E1Cards({
+  section,
+  gaps,
+  path,
+  onFieldEdit,
+  EditableField,
+}: {
+  section: CboSectionState;
+  gaps: CboGapEntry[];
+  /** Two-path triage answer captured at E1 — drives the Caminho card chip. */
+  path: 'has-idea' | 'needs-help' | null;
+  onFieldEdit: (sectionId: string, field: string, value: string) => void;
+  /** Injected from the parent — same EditableField used elsewhere on this page,
+   *  so we don't duplicate the markdown + textarea behavior. */
+  EditableField: React.ComponentType<{ value: string; userEdited?: boolean; onSave: (v: string) => void }>;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const fields = section.fields;
+
+  // Anything the agent wrote that isn't in our 4 groups → Outros so it's
+  // visible. (Defensive: future agent versions may add fields we don't yet
+  // know how to bucket.)
+  const otrosKeys = Object.keys(fields).filter(k => !ALL_KNOWN_FIELDS.has(k));
+
+  const renderGroup = (key: Exclude<GroupKey, 'outros'>, title: string, icon?: React.ReactNode, footer?: React.ReactNode) => {
+    const keys = FIELD_GROUPS[key].filter(k => fields[k]);
+    if (keys.length === 0 && !footer) return null;
+    const hasGroupGap = gaps.some(g => g.sectionId === section.id && FIELD_GROUPS[key].includes(g.field));
+    return (
+      <Card className={`${hasGroupGap ? 'border-orange-300' : ''} transition-all`}>
+        <CardHeader className="py-2.5 px-4">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-medium flex items-center gap-1.5">
+              {icon}
+              <span>{title}</span>
+            </CardTitle>
+            {hasGroupGap && <AlertTriangle className="w-3.5 h-3.5 text-orange-500" />}
+          </div>
+        </CardHeader>
+        {(keys.length > 0 || footer) && (
+          <CardContent className="pt-0 px-4 pb-4 space-y-2">
+            {keys.length > 0 && (
+              <div className="rounded-md border overflow-hidden">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {keys.map(k => {
+                      const v = fields[k];
+                      return (
+                        <tr key={k} className="border-b last:border-b-0">
+                          <td className="px-3 py-1.5 text-xs text-muted-foreground w-[120px] font-medium">
+                            {t(`cbo.fields.${k}`, k.replace(/_/g, ' '))}
+                          </td>
+                          <td className="px-3 py-1.5 text-sm">
+                            <EditableField
+                              value={String(v.value || '')}
+                              userEdited={v.userEdited}
+                              onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {footer}
+          </CardContent>
+        )}
+      </Card>
+    );
+  };
+
+  // Caminho card has a special pre-table chip showing the triage answer
+  const pathChip = path ? (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40">
+      {path === 'has-idea' ? <Lightbulb className="w-4 h-4 text-emerald-700 dark:text-emerald-400" /> : <Compass className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />}
+      <span className="text-sm text-emerald-900 dark:text-emerald-200 font-medium">
+        {path === 'has-idea'
+          ? (isPt ? 'Já tem uma ideia de projeto NBS' : 'Has an NBS project idea')
+          : (isPt ? 'Quer descobrir uma ideia de projeto' : 'Wants to discover a project idea')}
+      </span>
+    </div>
+  ) : (
+    <div className="text-xs text-muted-foreground italic px-3 py-2">
+      {isPt ? 'Caminho ainda não escolhido' : 'Path not yet chosen'}
+    </div>
+  );
+
+  const renderOutros = () => {
+    if (otrosKeys.length === 0) return null;
+    return (
+      <Card>
+        <CardHeader className="py-2.5 px-4">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {isPt ? 'Outros' : 'Other'}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 px-4 pb-4">
+          <div className="rounded-md border overflow-hidden">
+            <table className="w-full text-sm">
+              <tbody>
+                {otrosKeys.map(k => {
+                  const v = fields[k];
+                  return (
+                    <tr key={k} className="border-b last:border-b-0">
+                      <td className="px-3 py-1.5 text-xs text-muted-foreground w-[120px] font-medium">
+                        {t(`cbo.fields.${k}`, k.replace(/_/g, ' '))}
+                      </td>
+                      <td className="px-3 py-1.5 text-sm">
+                        <EditableField
+                          value={String(v.value || '')}
+                          userEdited={v.userEdited}
+                          onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {renderGroup('quem-somos', isPt ? 'Quem somos' : 'Who we are')}
+      {renderGroup('equipe', isPt ? 'Equipe' : 'Team')}
+      {renderGroup('historico', isPt ? 'Histórico' : 'History')}
+      {renderGroup('caminho', isPt ? 'Caminho' : 'Path', undefined, pathChip)}
+      {renderOutros()}
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -33,6 +33,7 @@ import { CboWelcome } from '@/core/components/cbo/CboWelcome';
 import { CboProgress } from '@/core/components/cbo/CboProgress';
 import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
 import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
+import { E1Cards } from '@/core/components/cbo/E1Cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -198,6 +199,10 @@ export default function CboProfilePage() {
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
+  // Two-path triage from E1: 'has-idea' | 'needs-help' | null (until triaged).
+  // Sourced from cohort_members.path via /api/cbo-member/:slug. Drives the
+  // Caminho card chip in E1Cards.
+  const [memberPath, setMemberPath] = useState<'has-idea' | 'needs-help' | null>(null);
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
@@ -218,6 +223,8 @@ export default function CboProfilePage() {
       if (!data) return;
       if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
+      if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
+      else if (data.path === null) setMemberPath(null);
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
@@ -855,6 +862,23 @@ export default function CboProfilePage() {
               {CBO_SECTIONS.map(sec => {
                 const section = state.sections[sec.id];
                 if (!section) return null;
+                // E1 "Quem somos" 4-card layout — replaces the flat field table
+                // for org_profile when the user is still in the early encontros
+                // (phase 1 or 2). After phase 2, we revert to the flat table so
+                // the user can see all fields together when reviewing later.
+                if (sec.id === 'org_profile' && (state.phase <= 2 || state.phase === 0)) {
+                  return (
+                    <div key={sec.id} ref={(el) => { sectionRefs.current[sec.id] = el; }}>
+                      <E1Cards
+                        section={section}
+                        gaps={state.gaps}
+                        path={memberPath}
+                        onFieldEdit={handleFieldEdit}
+                        EditableField={EditableField}
+                      />
+                    </div>
+                  );
+                }
                 const fields = Object.entries(section.fields);
                 const hasGaps = state.gaps.some(g => g.sectionId === sec.id);
                 const isHL = highlightedSections.includes(sec.id);

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1804,7 +1804,16 @@
       "team_technical_experience": "Technical Experience",
       "financial_thinking": "Financial Thinking",
       "community_anchoring": "Community Anchoring",
-      "regulatory_awareness": "Regulatory Awareness"
+      "regulatory_awareness": "Regulatory Awareness",
+      "mission_summary": "Mission",
+      "legal_form": "Legal form",
+      "year_founded": "Founded",
+      "paid_vs_volunteer": "Composition",
+      "prior_project_scale": "Prior project scale",
+      "nbs_experience": "NBS experience",
+      "bairro_of_operation": "Neighborhood",
+      "groups_served": "Groups served",
+      "proud_moment": "Proud moment"
     },
     "sections": {
       "org_profile": "1. Who We Are",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1783,7 +1783,16 @@
       "team_technical_experience": "Experiência Técnica",
       "financial_thinking": "Planejamento Financeiro",
       "community_anchoring": "Ancoragem Comunitária",
-      "regulatory_awareness": "Consciência Regulatória"
+      "regulatory_awareness": "Consciência Regulatória",
+      "mission_summary": "Missão",
+      "legal_form": "Forma legal",
+      "year_founded": "Fundação",
+      "paid_vs_volunteer": "Composição",
+      "prior_project_scale": "Escala anterior",
+      "nbs_experience": "Experiência SbN",
+      "bairro_of_operation": "Bairro de atuação",
+      "groups_served": "Comunidades servidas",
+      "proud_moment": "Momento de orgulho"
     },
     "sections": {
       "org_profile": "1. Quem Somos",


### PR DESCRIPTION
## Summary

Per the [E1 spec](knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/spec.md), the flat field table for \`org_profile\` is replaced with **4 thematic cards** so the CBO sees their profile take shape by topic, not as a 14-field survey.

**Stacks on [PR #147](https://github.com/joaquinOEF/NBS-Project-Preparation/pull/147), [#148](https://github.com/joaquinOEF/NBS-Project-Preparation/pull/148), [#149](https://github.com/joaquinOEF/NBS-Project-Preparation/pull/149).**

## The 4 cards

| Card | Fields |
|---|---|
| **Quem somos** | org_name, contact_name, contact_role, mission_summary, legal_form, year_founded |
| **Equipe** | team_size, paid_vs_volunteer |
| **Histórico** | prior_project_scale, nbs_experience, proud_moment |
| **Caminho** | bairro_of_operation, groups_served + **path chip** (has-idea / needs-help) |
| Outros (defensive) | Anything else the agent writes that isn't in the 4 groups |

The path chip in **Caminho** reads from \`cohort_members.path\` (column from PR #148). Renders as either:
- 💡 \"Já tem uma ideia de projeto NBS\"
- 🧭 \"Quer descobrir uma ideia de projeto\"
- italic \"Caminho ainda não escolhido\" before the triage

## What ships

| File | What |
|---|---|
| \`client/src/core/components/cbo/E1Cards.tsx\` | New component (~165 lines). Takes section + gaps + path + EditableField as props |
| \`client/src/core/pages/cbo-profile.tsx\` | \`memberPath\` state synced from \`/api/cbo-member/:slug\`. \`org_profile\` section render special-cased to \`E1Cards\` when \`state.phase ≤ 2\` |
| \`client/src/locales/{pt,en}.json\` | 9 new field labels each |

## Phase 1 ↔ Phase 3+ behavior

- **Phase 0–2** (E1 + E2 surfaces): 4-card layout
- **Phase 3+** (E3 onwards): falls back to the flat field table

This way the CBO sees the curated thematic view while they're still building their profile, but can scan all fields flat once they're mid-curriculum.

## Test plan

- [ ] Open a fresh CBO profile → 4 cards render in document tab (org_profile section)
- [ ] Agent writes \`org_name\` → appears in \"Quem somos\" card
- [ ] Agent writes \`mission_summary\` → also in \"Quem somos\"
- [ ] Agent calls \`set_path('has-idea')\` → chip appears in \"Caminho\" within ~1 focus event
- [ ] Edit any field inline → persists via \`update_section\` (EditableField is the same component used elsewhere)
- [ ] Advance to phase 3 → 4 cards collapse to flat table
- [ ] Agent writes an unexpected field (e.g. \`favorite_color\`) → shows up in \"Outros\" card

## What's NOT in this PR

- Orchestrator-side path display (next: task #3)
- RequestSupport button in chat header (task #2)
- E2-E6 doc-panel layouts (stay on the flat table for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)