### PR TITLE
feat(orchestrator): show path chip on cohort member cards

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -1,0 +1,173 @@
+// E1 — "Quem somos" 4-card layout for the right-rail doc panel.
+//
+// Per knowledge/runs/2026-05-15-encontros-curriculum/E1-quem-somos/spec.md, the
+// flat field table is replaced by 4 grouped cards so the CBO sees their
+// profile take shape thematically rather than as a flat survey.
+//
+// Pulls named fields from state.sections.org_profile + path from the cohort
+// member. Any field the agent writes that isn't in our 4 groups falls into
+// the "Outros" card so nothing is hidden.
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
+import { AlertTriangle, Lightbulb, Compass } from 'lucide-react';
+import type { CboSectionState, CboGapEntry } from '@shared/cbo-schema';
+
+type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
+
+const FIELD_GROUPS: Record<Exclude<GroupKey, 'outros'>, string[]> = {
+  // Identity — what + who
+  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'legal_form', 'year_founded'],
+  // Team — size + composition
+  equipe: ['team_size', 'paid_vs_volunteer'],
+  // History — prior work + NBS experience
+  historico: ['prior_project_scale', 'nbs_experience', 'proud_moment'],
+  // Path — the triage answer + community served + bairro
+  caminho: ['bairro_of_operation', 'groups_served'],
+};
+
+const ALL_KNOWN_FIELDS = new Set<string>([
+  ...FIELD_GROUPS['quem-somos'],
+  ...FIELD_GROUPS.equipe,
+  ...FIELD_GROUPS.historico,
+  ...FIELD_GROUPS.caminho,
+]);
+
+export function E1Cards({
+  section,
+  gaps,
+  path,
+  onFieldEdit,
+  EditableField,
+}: {
+  section: CboSectionState;
+  gaps: CboGapEntry[];
+  /** Two-path triage answer captured at E1 — drives the Caminho card chip. */
+  path: 'has-idea' | 'needs-help' | null;
+  onFieldEdit: (sectionId: string, field: string, value: string) => void;
+  /** Injected from the parent — same EditableField used elsewhere on this page,
+   *  so we don't duplicate the markdown + textarea behavior. */
+  EditableField: React.ComponentType<{ value: string; userEdited?: boolean; onSave: (v: string) => void }>;
+}) {
+  const { t, i18n } = useTranslation();
+  const isPt = i18n.language?.startsWith('pt');
+  const fields = section.fields;
+
+  // Anything the agent wrote that isn't in our 4 groups → Outros so it's
+  // visible. (Defensive: future agent versions may add fields we don't yet
+  // know how to bucket.)
+  const otrosKeys = Object.keys(fields).filter(k => !ALL_KNOWN_FIELDS.has(k));
+
+  const renderGroup = (key: Exclude<GroupKey, 'outros'>, title: string, icon?: React.ReactNode, footer?: React.ReactNode) => {
+    const keys = FIELD_GROUPS[key].filter(k => fields[k]);
+    if (keys.length === 0 && !footer) return null;
+    const hasGroupGap = gaps.some(g => g.sectionId === section.id && FIELD_GROUPS[key].includes(g.field));
+    return (
+      <Card className={`${hasGroupGap ? 'border-orange-300' : ''} transition-all`}>
+        <CardHeader className="py-2.5 px-4">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-medium flex items-center gap-1.5">
+              {icon}
+              <span>{title}</span>
+            </CardTitle>
+            {hasGroupGap && <AlertTriangle className="w-3.5 h-3.5 text-orange-500" />}
+          </div>
+        </CardHeader>
+        {(keys.length > 0 || footer) && (
+          <CardContent className="pt-0 px-4 pb-4 space-y-2">
+            {keys.length > 0 && (
+              <div className="rounded-md border overflow-hidden">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {keys.map(k => {
+                      const v = fields[k];
+                      return (
+                        <tr key={k} className="border-b last:border-b-0">
+                          <td className="px-3 py-1.5 text-xs text-muted-foreground w-[120px] font-medium">
+                            {t(`cbo.fields.${k}`, k.replace(/_/g, ' '))}
+                          </td>
+                          <td className="px-3 py-1.5 text-sm">
+                            <EditableField
+                              value={String(v.value || '')}
+                              userEdited={v.userEdited}
+                              onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {footer}
+          </CardContent>
+        )}
+      </Card>
+    );
+  };
+
+  // Caminho card has a special pre-table chip showing the triage answer
+  const pathChip = path ? (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40">
+      {path === 'has-idea' ? <Lightbulb className="w-4 h-4 text-emerald-700 dark:text-emerald-400" /> : <Compass className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />}
+      <span className="text-sm text-emerald-900 dark:text-emerald-200 font-medium">
+        {path === 'has-idea'
+          ? (isPt ? 'Já tem uma ideia de projeto NBS' : 'Has an NBS project idea')
+          : (isPt ? 'Quer descobrir uma ideia de projeto' : 'Wants to discover a project idea')}
+      </span>
+    </div>
+  ) : (
+    <div className="text-xs text-muted-foreground italic px-3 py-2">
+      {isPt ? 'Caminho ainda não escolhido' : 'Path not yet chosen'}
+    </div>
+  );
+
+  const renderOutros = () => {
+    if (otrosKeys.length === 0) return null;
+    return (
+      <Card>
+        <CardHeader className="py-2.5 px-4">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {isPt ? 'Outros' : 'Other'}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 px-4 pb-4">
+          <div className="rounded-md border overflow-hidden">
+            <table className="w-full text-sm">
+              <tbody>
+                {otrosKeys.map(k => {
+                  const v = fields[k];
+                  return (
+                    <tr key={k} className="border-b last:border-b-0">
+                      <td className="px-3 py-1.5 text-xs text-muted-foreground w-[120px] font-medium">
+                        {t(`cbo.fields.${k}`, k.replace(/_/g, ' '))}
+                      </td>
+                      <td className="px-3 py-1.5 text-sm">
+                        <EditableField
+                          value={String(v.value || '')}
+                          userEdited={v.userEdited}
+                          onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {renderGroup('quem-somos', isPt ? 'Quem somos' : 'Who we are')}
+      {renderGroup('equipe', isPt ? 'Equipe' : 'Team')}
+      {renderGroup('historico', isPt ? 'Histórico' : 'History')}
+      {renderGroup('caminho', isPt ? 'Caminho' : 'Path', undefined, pathChip)}
+      {renderOutros()}
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -33,6 +33,7 @@ import { CboWelcome } from '@/core/components/cbo/CboWelcome';
 import { CboProgress } from '@/core/components/cbo/CboProgress';
 import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
 import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
+import { E1Cards } from '@/core/components/cbo/E1Cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -198,6 +199,10 @@ export default function CboProfilePage() {
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
+  // Two-path triage from E1: 'has-idea' | 'needs-help' | null (until triaged).
+  // Sourced from cohort_members.path via /api/cbo-member/:slug. Drives the
+  // Caminho card chip in E1Cards.
+  const [memberPath, setMemberPath] = useState<'has-idea' | 'needs-help' | null>(null);
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
@@ -218,6 +223,8 @@ export default function CboProfilePage() {
       if (!data) return;
       if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
+      if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
+      else if (data.path === null) setMemberPath(null);
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
@@ -855,6 +862,23 @@ export default function CboProfilePage() {
               {CBO_SECTIONS.map(sec => {
                 const section = state.sections[sec.id];
                 if (!section) return null;
+                // E1 "Quem somos" 4-card layout — replaces the flat field table
+                // for org_profile when the user is still in the early encontros
+                // (phase 1 or 2). After phase 2, we revert to the flat table so
+                // the user can see all fields together when reviewing later.
+                if (sec.id === 'org_profile' && (state.phase <= 2 || state.phase === 0)) {
+                  return (
+                    <div key={sec.id} ref={(el) => { sectionRefs.current[sec.id] = el; }}>
+                      <E1Cards
+                        section={section}
+                        gaps={state.gaps}
+                        path={memberPath}
+                        onFieldEdit={handleFieldEdit}
+                        EditableField={EditableField}
+                      />
+                    </div>
+                  );
+                }
                 const fields = Object.entries(section.fields);
                 const hasGaps = state.gaps.some(g => g.sectionId === sec.id);
                 const isHL = highlightedSections.includes(sec.id);

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,7 +19,7 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, MapPin,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, Lightbulb, MapPin,
   Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
@@ -75,6 +75,10 @@ type CboDemoProject = {
   updatedDaysAgo: number;
   /** i18n key for the 'next action' line on the card. */
   nextActionKey: string;
+  /** Two-path triage answer from E1 — drives a chip on the card so the
+   *  coordinator sees who needs more hand-holding (needs-help) vs who has
+   *  a concrete idea (has-idea). Null until E1's set_path tool fires. */
+  path: 'has-idea' | 'needs-help' | null;
 };
 
 const TOTAL_SECTIONS = 7;
@@ -115,6 +119,7 @@ function memberToView(m: CohortMember): CboDemoProject {
     priorityFlagsMet: m.snapshotFlagsMet ?? 0,
     updatedDaysAgo: daysAgo,
     nextActionKey: NEXT_ACTION_KEY[phaseNum] ?? NEXT_ACTION_KEY[1],
+    path: (m.path as 'has-idea' | 'needs-help' | null | undefined) ?? null,
   };
 }
 
@@ -480,11 +485,26 @@ function ProjectCard({
             </div>
           </div>
 
-          {/* Phase + Intervention row */}
+          {/* Phase + Path + Intervention row */}
           <div className="flex flex-wrap items-center gap-2">
             <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border border-foreground/10 bg-foreground/5 text-foreground/75">
               {t(`orchestrator.demo.phase.${project.currentPhase}`)}
             </span>
+            {project.path && (
+              <span
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200/60 dark:border-emerald-900/40"
+                title={project.path === 'has-idea'
+                  ? t('orchestrator.demo.path.hasIdeaFull', { defaultValue: 'CBO arrived with a specific NBS project in mind' })
+                  : t('orchestrator.demo.path.needsHelpFull', { defaultValue: 'CBO wants help discovering a project — needs more hand-holding' })}
+              >
+                {project.path === 'has-idea'
+                  ? <Lightbulb className="w-3 h-3" strokeWidth={2} />
+                  : <Compass className="w-3 h-3" strokeWidth={2} />}
+                {project.path === 'has-idea'
+                  ? t('orchestrator.demo.path.hasIdea', { defaultValue: 'Tem ideia' })
+                  : t('orchestrator.demo.path.needsHelp', { defaultValue: 'Quer descobrir' })}
+              </span>
+            )}
             {hasIntervention ? (
               <span
                 className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1804,7 +1804,16 @@
       "team_technical_experience": "Technical Experience",
       "financial_thinking": "Financial Thinking",
       "community_anchoring": "Community Anchoring",
-      "regulatory_awareness": "Regulatory Awareness"
+      "regulatory_awareness": "Regulatory Awareness",
+      "mission_summary": "Mission",
+      "legal_form": "Legal form",
+      "year_founded": "Founded",
+      "paid_vs_volunteer": "Composition",
+      "prior_project_scale": "Prior project scale",
+      "nbs_experience": "NBS experience",
+      "bairro_of_operation": "Neighborhood",
+      "groups_served": "Groups served",
+      "proud_moment": "Proud moment"
     },
     "sections": {
       "org_profile": "1. Who We Are",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1783,7 +1783,16 @@
       "team_technical_experience": "Experiência Técnica",
       "financial_thinking": "Planejamento Financeiro",
       "community_anchoring": "Ancoragem Comunitária",
-      "regulatory_awareness": "Consciência Regulatória"
+      "regulatory_awareness": "Consciência Regulatória",
+      "mission_summary": "Missão",
+      "legal_form": "Forma legal",
+      "year_founded": "Fundação",
+      "paid_vs_volunteer": "Composição",
+      "prior_project_scale": "Escala anterior",
+      "nbs_experience": "Experiência SbN",
+      "bairro_of_operation": "Bairro de atuação",
+      "groups_served": "Comunidades servidas",
+      "proud_moment": "Momento de orgulho"
     },
     "sections": {
       "org_profile": "1. Quem Somos",


### PR DESCRIPTION
## Summary

After a CBO completes E1's two-path triage, the orchestrator card surfaces which path they took. Coordinator sees at a glance who has a concrete idea (💡 \"Tem ideia\") vs who needs more hand-holding (🧭 \"Quer descobrir\") — and can plan check-ins, support, and in-room time allocation accordingly.

**Stacks on PRs #147, #148, #149, #150.**

## What ships

Just a presentation change:

- \`memberToView()\` adapter reads \`m.path\` (already flowing through after PR #148's schema change)
- \`ProjectCard\` renders a small chip between Phase and Intervention badges
- Tooltip explains what each chip means for first-time coordinators

No new endpoints, no new schema, no new hooks. ~22 lines.

## Visual

\`\`\`
┌─────────────────────────────────────┐
│ 🌱  Horta Comunitária Cascata       │
│    📍 Cascata                       │
│                                      │
│ [WHO] [💡 Tem ideia]  [🌿 Bioswales]│
│                                      │
│ ── Sections ─────────────  3/7  ──  │
│ ── Maturity ────────────  17/27 ──  │
└─────────────────────────────────────┘
\`\`\`

## Test plan

- [ ] CBO completes E1 triage with \"Já tenho ideia\" → orchestrator card shows 💡 chip
- [ ] Different CBO picks \"Quero descobrir\" → 🧭 chip on that card
- [ ] CBO who hasn't done triage yet → no chip (chip is null-safe)
- [ ] Hover the chip → tooltip explains the path

## What's NOT in this PR

- Per-metric maturity scores on the card (org_delivery_capacity, etc.) — defer; would need a schema change to denormalize per-metric scores into the snapshot
- Filter/sort by path — easy follow-up
- RequestSupport pendency indicator on the card (next: task #2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)