### PR TITLE
feat(e2): NbsShowcaseCard component + 4 Brazilian seed cases

### DIFF
--- a/client/src/core/components/cbo/NbsShowcaseCard.tsx
+++ b/client/src/core/components/cbo/NbsShowcaseCard.tsx
@@ -1,0 +1,176 @@
+// NbsShowcaseCard — inline chat card showing Brazilian NBS examples.
+// Used at the start of E2 to build vocabulary before the user touches the
+// bairro map. Two render modes:
+//   - browse: read-only horizontal scroll (has-idea path)
+//   - favorites: per-card "Salvar" toggle; saves to inspiration_picks[]
+//     which E3's InterventionSelector pre-filters by (needs-help path)
+//
+// Photo manifest: docs/photo-curation.md. Verified photos render normally;
+// unverified entries render a gradient + emoji placeholder.
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bookmark, BookmarkCheck, MapPin, Calendar, ChevronDown, ChevronUp } from 'lucide-react';
+import type { NbsShowcaseCard as Card, ShowcasePlaceholder } from '@shared/nbs-showcase-cards';
+
+const GRADIENTS: Record<ShowcasePlaceholder['gradient'], string> = {
+  flood: 'linear-gradient(135deg, #cffafe 0%, #67e8f9 100%)',
+  heat: 'linear-gradient(135deg, #fef3c7 0%, #fcd34d 100%)',
+  biodiversity: 'linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%)',
+};
+
+const HAZARD_LABELS = {
+  pt: { flood: 'enchente', heat: 'calor', biodiversity: 'biodiv', mixed: 'misto' },
+  en: { flood: 'flood', heat: 'heat', biodiversity: 'biodiv', mixed: 'mixed' },
+};
+
+function CardThumbnail({ card }: { card: Card }) {
+  if (card.photo) {
+    return (
+      <div className="relative h-32 w-full overflow-hidden bg-muted">
+        <img
+          src={card.photo.path}
+          alt={card.org}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+        <div className="absolute bottom-0 right-0 px-1.5 py-0.5 bg-black/50 text-[8px] text-white font-medium tracking-tight">
+          {card.photo.photographer} · {card.photo.license}
+        </div>
+      </div>
+    );
+  }
+  if (card.placeholder) {
+    return (
+      <div
+        className="relative h-32 w-full overflow-hidden flex items-center justify-center"
+        style={{ background: GRADIENTS[card.placeholder.gradient] }}
+      >
+        <span className="text-5xl" role="img" aria-hidden="true">{card.placeholder.emoji}</span>
+      </div>
+    );
+  }
+  return <div className="h-32 w-full bg-muted" />;
+}
+
+export function NbsShowcaseCardItem({
+  card,
+  lang,
+  isSaved,
+  onToggleSave,
+  mode,
+}: {
+  card: Card;
+  lang: 'pt' | 'en';
+  isSaved: boolean;
+  onToggleSave: (id: string, next: boolean) => void;
+  mode: 'browse' | 'favorites';
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const summary = lang === 'pt' ? card.summaryPt : card.summaryEn;
+  const detail = lang === 'pt' ? card.detailPt : card.detailEn;
+  const hazardLabel = HAZARD_LABELS[lang][card.hazard];
+
+  return (
+    <div
+      className={`shrink-0 w-[240px] rounded-xl border bg-card overflow-hidden transition-all ${
+        isSaved ? 'border-emerald-500 ring-2 ring-emerald-500/20' : 'border-foreground/10 hover:border-foreground/25'
+      }`}
+      data-testid={`showcase-card-${card.id}`}
+    >
+      <CardThumbnail card={card} />
+
+      <div className="p-3 space-y-1.5">
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="text-sm font-semibold leading-tight">{card.org}</h4>
+          {mode === 'favorites' && (
+            <button
+              type="button"
+              onClick={() => onToggleSave(card.id, !isSaved)}
+              className={`shrink-0 -mr-1 -mt-1 p-1 rounded-md transition-colors ${
+                isSaved ? 'text-emerald-600 hover:bg-emerald-50' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+              }`}
+              aria-label={isSaved ? t('cbo.showcase.unsave', { defaultValue: 'Remover dos favoritos' }) : t('cbo.showcase.save', { defaultValue: 'Salvar' })}
+              data-testid={`showcase-toggle-${card.id}`}
+            >
+              {isSaved ? <BookmarkCheck className="w-4 h-4" /> : <Bookmark className="w-4 h-4" />}
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+          <span className="inline-flex items-center gap-0.5">
+            <MapPin className="w-2.5 h-2.5" />
+            {card.city}
+          </span>
+          <span>·</span>
+          <span className="inline-flex items-center gap-0.5">
+            <Calendar className="w-2.5 h-2.5" />
+            {card.year}
+          </span>
+          <span>·</span>
+          <span>{hazardLabel}</span>
+        </div>
+
+        <p className="text-xs text-foreground/85 leading-snug">{summary}</p>
+
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="flex items-center gap-1 text-[10px] font-medium text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 -ml-0.5 pt-0.5"
+          data-testid={`showcase-expand-${card.id}`}
+        >
+          {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {expanded
+            ? t('cbo.showcase.less', { defaultValue: 'Menos' })
+            : t('cbo.showcase.more', { defaultValue: 'Saber mais' })}
+        </button>
+
+        {expanded && (
+          <p className="text-[11px] text-muted-foreground leading-relaxed pt-1">{detail}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function NbsShowcaseCardStrip({
+  cards,
+  mode,
+  savedIds,
+  onToggleSave,
+  intro,
+}: {
+  cards: Card[];
+  mode: 'browse' | 'favorites';
+  savedIds: string[];
+  onToggleSave: (id: string, next: boolean) => void;
+  /** Optional lead text rendered above the strip — e.g. "Salve 1-2 que parecem que poderiam funcionar no seu bairro" */
+  intro?: string;
+}) {
+  const { i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const savedSet = new Set(savedIds);
+
+  return (
+    <div className="space-y-2">
+      {intro && (
+        <p className="text-xs text-muted-foreground px-1 leading-relaxed">{intro}</p>
+      )}
+      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+        {cards.map(card => (
+          <div key={card.id} className="snap-start">
+            <NbsShowcaseCardItem
+              card={card}
+              lang={lang}
+              isSaved={savedSet.has(card.id)}
+              onToggleSave={onToggleSave}
+              mode={mode}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/RequestSupportDialog.tsx
+++ b/client/src/core/components/cbo/RequestSupportDialog.tsx
@@ -1,0 +1,195 @@
+// RequestSupport — async escalation form available to every CBO across all
+// encontros. Surfaces as a button in the chat header (more prominent for the
+// needs-help path). On submit, writes a SupportRequest to cohort_members and
+// notifies the orchestrator (visible as a pending-count chip on their card).
+//
+// Spec: knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/core/components/ui/dialog';
+import { Button } from '@/core/components/ui/button';
+import { Textarea } from '@/core/components/ui/textarea';
+import { Users, HelpCircle, Network, Wallet, Loader2 } from 'lucide-react';
+import type { SupportRequestType } from '@shared/cohort-schema';
+
+type OptionDef = {
+  value: SupportRequestType;
+  icon: React.ComponentType<{ className?: string }>;
+  pt: { label: string; hint: string };
+  en: { label: string; hint: string };
+};
+
+const OPTIONS: OptionDef[] = [
+  {
+    value: 'coordinator-chat',
+    icon: Users,
+    pt: { label: 'Conversa com a coordenadora', hint: 'Falar com Julia/Antônia sobre dúvidas, decisões ou bloqueios.' },
+    en: { label: 'Chat with the coordinator', hint: 'Talk to Julia/Antônia about questions, decisions, or blockers.' },
+  },
+  {
+    value: 'oef-technical',
+    icon: HelpCircle,
+    pt: { label: 'Pergunta técnica pra equipe OEF', hint: 'Algo técnico sobre SbN, impacto, dimensionamento.' },
+    en: { label: 'Technical question for OEF', hint: 'Something technical about NBS, impact, sizing.' },
+  },
+  {
+    value: 'cbo-connection',
+    icon: Network,
+    pt: { label: 'Conexão com outro CBO', hint: 'Conhecer alguém que já fez algo parecido no Brasil.' },
+    en: { label: 'Connect with another CBO', hint: 'Meet someone who has done something similar in Brazil.' },
+  },
+  {
+    value: 'finance-partners',
+    icon: Wallet,
+    pt: { label: 'Finanças / parceiros', hint: 'Dúvidas sobre financiamento, editais, parceiros locais.' },
+    en: { label: 'Finance / partners', hint: 'Funding, grants, local partners.' },
+  },
+];
+
+export function RequestSupportDialog({
+  open,
+  onOpenChange,
+  memberSlug,
+  onSubmitted,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The CBO's slug — submit endpoint is /api/cbo-member/:slug/support-request */
+  memberSlug: string;
+  /** Called after a successful POST so the parent can refresh state / toast. */
+  onSubmitted?: (req: { id: string; type: SupportRequestType }) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const [selectedType, setSelectedType] = useState<SupportRequestType | null>(null);
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState<{ id: string; type: SupportRequestType } | null>(null);
+
+  const reset = () => {
+    setSelectedType(null);
+    setMessage('');
+    setSubmitting(false);
+    setSubmitted(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const submit = async () => {
+    if (!selectedType) return;
+    setSubmitting(true);
+    try {
+      const r = await fetch(`/api/cbo-member/${memberSlug}/support-request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: selectedType, message: message.trim() || undefined }),
+      });
+      if (!r.ok) throw new Error('submit failed');
+      const data = await r.json();
+      setSubmitted({ id: data.entry.id, type: data.entry.type });
+      onSubmitted?.({ id: data.entry.id, type: data.entry.type });
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {submitted ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('cbo.support.submittedTitle', { defaultValue: 'Pedido enviado' })}</DialogTitle>
+              <DialogDescription className="pt-1.5">
+                {t('cbo.support.submittedBody', {
+                  defaultValue: 'A coordenadora vai entrar em contato em até 2 dias úteis. Você pode continuar trabalhando aqui — quando ela responder, você vai ver no chat.',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="mt-4">
+              <Button onClick={() => handleOpenChange(false)} className="bg-emerald-600 hover:bg-emerald-700">
+                {t('cbo.support.close', { defaultValue: 'Fechar' })}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('cbo.support.title', { defaultValue: 'Pedir apoio' })}</DialogTitle>
+              <DialogDescription className="pt-1.5">
+                {t('cbo.support.lead', {
+                  defaultValue: 'Sem pressa. Conta o que você precisa — a coordenadora responde em até 2 dias úteis.',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2 mt-3">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                {t('cbo.support.typeLabel', { defaultValue: 'Tipo de apoio' })}
+              </p>
+              <div className="space-y-1.5">
+                {OPTIONS.map(opt => {
+                  const isActive = selectedType === opt.value;
+                  const Icon = opt.icon;
+                  const copy = opt[lang];
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setSelectedType(opt.value)}
+                      className={`w-full text-left p-3 rounded-lg border transition-colors flex items-start gap-3 ${
+                        isActive
+                          ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/30 ring-1 ring-emerald-500'
+                          : 'border-foreground/10 hover:border-foreground/20 hover:bg-muted/50'
+                      }`}
+                      data-testid={`support-option-${opt.value}`}
+                    >
+                      <Icon className={`w-4 h-4 mt-0.5 shrink-0 ${isActive ? 'text-emerald-700 dark:text-emerald-400' : 'text-muted-foreground'}`} />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium leading-tight">{copy.label}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">{copy.hint}</p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-1.5 mt-4">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                {t('cbo.support.messageLabel', { defaultValue: 'Mensagem (opcional)' })}
+              </p>
+              <Textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={t('cbo.support.messagePlaceholder', { defaultValue: 'Conta um pouco mais se quiser…' }) as string}
+                rows={3}
+                maxLength={2000}
+                className="resize-none text-sm"
+              />
+            </div>
+
+            <DialogFooter className="mt-4">
+              <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={submitting}>
+                {t('cbo.support.cancel', { defaultValue: 'Cancelar' })}
+              </Button>
+              <Button
+                onClick={submit}
+                disabled={!selectedType || submitting}
+                className="bg-emerald-600 hover:bg-emerald-700"
+                data-testid="support-submit"
+              >
+                {submitting && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}
+                {t('cbo.support.submit', { defaultValue: 'Enviar pedido' })}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -34,6 +34,8 @@ import { CboProgress } from '@/core/components/cbo/CboProgress';
 import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
 import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
 import { E1Cards } from '@/core/components/cbo/E1Cards';
+import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
+import { LifeBuoy } from 'lucide-react';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -203,6 +205,11 @@ export default function CboProfilePage() {
   // Sourced from cohort_members.path via /api/cbo-member/:slug. Drives the
   // Caminho card chip in E1Cards.
   const [memberPath, setMemberPath] = useState<'has-idea' | 'needs-help' | null>(null);
+  // RequestSupport — async escalation. Available across all encontros via the
+  // chat header. Pending count comes from /api/cbo-member/:slug; agent or
+  // coordinator-side flows can also nudge the user to open this.
+  const [supportDialogOpen, setSupportDialogOpen] = useState(false);
+  const [supportPendingCount, setSupportPendingCount] = useState(0);
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
@@ -225,6 +232,7 @@ export default function CboProfilePage() {
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
       if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
       else if (data.path === null) setMemberPath(null);
+      if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
@@ -630,6 +638,14 @@ export default function CboProfilePage() {
   return (
     <div className="h-screen flex flex-col bg-background">
       <Header />
+      {memberSlug && (
+        <RequestSupportDialog
+          open={supportDialogOpen}
+          onOpenChange={setSupportDialogOpen}
+          memberSlug={memberSlug}
+          onSubmitted={() => setSupportPendingCount(c => c + 1)}
+        />
+      )}
       <div className="flex flex-1 min-h-0">
         {/* LEFT: Chat — full width on mobile (when Chat tab active), half on md+ */}
         <div
@@ -678,6 +694,31 @@ export default function CboProfilePage() {
               </div>
             </div>
             <div className="flex gap-1">
+              {memberSlug && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={memberPath === 'needs-help' && supportPendingCount === 0 ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setSupportDialogOpen(true)}
+                      className={memberPath === 'needs-help' && supportPendingCount === 0 ? 'bg-emerald-600 hover:bg-emerald-700 text-white' : ''}
+                      data-testid="button-request-support"
+                    >
+                      <LifeBuoy className="w-4 h-4" />
+                      {supportPendingCount > 0 && (
+                        <span className="ml-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                          {supportPendingCount}
+                        </span>
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {supportPendingCount > 0
+                      ? t('cbo.support.tooltipPending', { defaultValue: '{{n}} pedido(s) aguardando resposta', n: supportPendingCount })
+                      : t('cbo.support.tooltip', { defaultValue: 'Pedir apoio à coordenadora' })}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <Tooltip><TooltipTrigger asChild><Button variant={state.phase >= 6 ? 'default' : 'outline'} size="sm" className={state.phase >= 6 ? 'bg-green-600 hover:bg-green-700 animate-pulse' : ''} onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" />{state.phase >= 6 && <span className="ml-1 text-xs">{t('cbo.export')}</span>}</Button></TooltipTrigger><TooltipContent>{t('cbo.export')}</TooltipContent></Tooltip>
               <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.startOver')}</TooltipContent></Tooltip>
             </div>

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,7 +19,7 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, Lightbulb, MapPin,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin,
   Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
@@ -79,6 +79,9 @@ type CboDemoProject = {
    *  coordinator sees who needs more hand-holding (needs-help) vs who has
    *  a concrete idea (has-idea). Null until E1's set_path tool fires. */
   path: 'has-idea' | 'needs-help' | null;
+  /** Count of unresolved RequestSupport entries — surfaces an amber chip
+   *  on the card so the coordinator can sweep pendencies daily. */
+  supportPendingCount: number;
 };
 
 const TOTAL_SECTIONS = 7;
@@ -120,6 +123,9 @@ function memberToView(m: CohortMember): CboDemoProject {
     updatedDaysAgo: daysAgo,
     nextActionKey: NEXT_ACTION_KEY[phaseNum] ?? NEXT_ACTION_KEY[1],
     path: (m.path as 'has-idea' | 'needs-help' | null | undefined) ?? null,
+    supportPendingCount: Array.isArray((m as any).supportRequests)
+      ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
+      : 0,
   };
 }
 
@@ -503,6 +509,21 @@ function ProjectCard({
                 {project.path === 'has-idea'
                   ? t('orchestrator.demo.path.hasIdea', { defaultValue: 'Tem ideia' })
                   : t('orchestrator.demo.path.needsHelp', { defaultValue: 'Quer descobrir' })}
+              </span>
+            )}
+            {project.supportPendingCount > 0 && (
+              <span
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border border-amber-200/60 dark:border-amber-900/40"
+                title={t('orchestrator.demo.support.pendingTooltip', {
+                  defaultValue: '{{n}} pedido(s) de apoio aguardando',
+                  n: project.supportPendingCount,
+                })}
+              >
+                <LifeBuoy className="w-3 h-3" strokeWidth={2} />
+                {t('orchestrator.demo.support.pendingChip', {
+                  defaultValue: '{{n}} pedência(s)',
+                  n: project.supportPendingCount,
+                })}
               </span>
             )}
             {hasIntervention ? (

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/showcase-mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/showcase-mockup.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NbsShowcaseCard · mockup</title>
+<style>
+  :root {
+    --bg: #fafaf9; --surface: #ffffff; --ink: #18181b; --muted: #71717a;
+    --line: rgba(0,0,0,0.08); --accent: #059669; --accent-soft: #ecfdf5;
+    --accent-deep: #047857;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1280px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  .lede { color: var(--muted); margin: 8px 0 24px; max-width: 64ch; line-height: 1.6; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 18px; padding-left: 14px; border-left: 2px solid var(--accent); max-width: 64ch; }
+  .scene { background: var(--surface); border: 1px solid var(--line); border-radius: 14px; padding: 20px; margin-bottom: 8px; }
+  .agent-msg {
+    background: #f4f4f5; border-radius: 14px; padding: 10px 14px;
+    font-size: 13px; line-height: 1.5; max-width: 600px; margin-bottom: 12px;
+  }
+  .strip-intro { font-size: 12px; color: var(--muted); padding-left: 4px; margin-bottom: 8px; }
+  .strip { display: flex; gap: 10px; overflow-x: auto; padding-bottom: 8px; }
+  .card {
+    flex-shrink: 0; width: 240px;
+    border: 1px solid var(--line); border-radius: 12px; background: var(--surface);
+    overflow: hidden; transition: all 0.15s;
+  }
+  .card.saved {
+    border-color: var(--accent); box-shadow: 0 0 0 2px rgba(5,150,105,0.2);
+  }
+  .thumb {
+    height: 128px; position: relative;
+    background-size: cover; background-position: center;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .thumb.placeholder { font-size: 48px; }
+  .thumb.barigui { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0" stop-color="%23bfdbfe"/><stop offset="1" stop-color="%2334d399"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><ellipse cx="120" cy="100" rx="80" ry="22" fill="%2306b6d4" opacity="0.4"/><circle cx="60" cy="60" r="18" fill="%2316a34a" opacity="0.7"/><circle cx="180" cy="55" r="22" fill="%2316a34a" opacity="0.8"/><circle cx="120" cy="50" r="20" fill="%2316a34a" opacity="0.75"/></svg>') center/cover;
+  }
+  .thumb.goncalo { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="0" y1="0" y2="1"><stop offset="0" stop-color="%23166534"/><stop offset="0.5" stop-color="%2316a34a"/><stop offset="1" stop-color="%2386efac"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><rect x="60" y="80" width="120" height="48" fill="%2354382d" opacity="0.5"/><ellipse cx="40" cy="30" rx="32" ry="40" fill="%23166534"/><ellipse cx="120" cy="20" rx="40" ry="45" fill="%2315803d"/><ellipse cx="200" cy="35" rx="34" ry="42" fill="%23166534"/></svg>') center/cover; }
+  .thumb.drenurbs { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0" stop-color="%23dcfce7"/><stop offset="1" stop-color="%2306b6d4"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><path d="M0 100 Q60 80 120 95 T240 90 L240 128 L0 128 Z" fill="%2306b6d4" opacity="0.6"/><circle cx="40" cy="70" r="12" fill="%2316a34a"/><circle cx="170" cy="65" r="14" fill="%2316a34a"/><circle cx="210" cy="78" r="10" fill="%2316a34a"/></svg>') center/cover; }
+  .thumb.placeholder.biodiversity { background: linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%); }
+  .credit {
+    position: absolute; bottom: 0; right: 0;
+    padding: 2px 6px; background: rgba(0,0,0,0.5); color: white;
+    font-size: 8px; font-weight: 500;
+  }
+  .card-body { padding: 12px; }
+  .card-title { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+  .card-title h4 { margin: 0; font-size: 13px; font-weight: 600; line-height: 1.25; }
+  .save-btn {
+    flex-shrink: 0; width: 24px; height: 24px; border-radius: 6px;
+    background: transparent; border: 0; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--muted); transition: all 0.15s;
+  }
+  .save-btn:hover { background: #f4f4f5; color: var(--ink); }
+  .save-btn.active { color: var(--accent); }
+  .meta {
+    font-size: 10px; color: var(--muted); margin-top: 5px;
+    display: flex; gap: 6px;
+  }
+  .summary { font-size: 11px; color: var(--ink); opacity: 0.85; line-height: 1.4; margin-top: 6px; }
+  .more {
+    font-size: 10px; font-weight: 500; color: var(--accent-deep);
+    margin-top: 6px; cursor: pointer; display: inline-flex; align-items: center; gap: 2px;
+  }
+
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 20px; }
+  .compare-cell { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 16px; }
+  .compare-cell .lbl { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; margin-bottom: 8px; }
+  .compare-cell p { font-size: 12px; color: var(--muted); line-height: 1.5; margin: 8px 0 0; }
+</style>
+</head>
+<body>
+<div class="doc">
+  <h1>NbsShowcaseCard <span class="small">· inline chat card · 4 verified examples</span></h1>
+  <p class="lede">
+    Shown at the start of E2 to build NBS vocabulary before the CBO touches the map. Renders horizontal-scroll inside the chat thread. Two modes: <strong>browse</strong> (has-idea path) and <strong>favorites</strong> (needs-help path, with per-card save toggle).
+  </p>
+
+  <h2 class="screen">browse mode · has-idea path</h2>
+  <p class="anno">Agent introduces the cards briefly, then the strip renders inline. No save buttons; user can scroll and tap "Saber mais" to expand any card.</p>
+
+  <div class="scene">
+    <div class="agent-msg">
+      Antes de abrir o mapa, dois exemplos rápidos pra você ter referência:
+    </div>
+
+    <div class="strip">
+      <div class="card">
+        <div class="thumb barigui">
+          <div class="credit">A. C. Fonseca · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>Parques do Barigui</h4></div>
+          <div class="meta">📍 Curitiba, PR · 📅 1996 · enchente</div>
+          <p class="summary">Parques que viram retenção de água quando chove forte</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb goncalo">
+          <div class="credit">Amigos da Rua · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>Rua Gonçalo de Carvalho</h4></div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 1930 · calor</div>
+          <p class="summary">Túnel de copa formado por 100+ Tipuanas em 3 quarteirões</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb drenurbs">
+          <div class="credit">M. A. Dutra · CC-BY</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>DRENURBS — Primeiro de Maio</h4></div>
+          <div class="meta">📍 Belo Horizonte, MG · 📅 2003 · enchente</div>
+          <p class="summary">Recuperação de áreas úmidas + parque que aguenta a chuva</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb placeholder biodiversity">🌱</div>
+        <div class="card-body">
+          <div class="card-title"><h4>Várzea Lab · Vila Flores</h4></div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 2024 · misto</div>
+          <p class="summary">Hortas + jardins de chuva no 4º Distrito pós-enchente</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="screen">favorites mode · needs-help path</h2>
+  <p class="anno">Agent invites the user to save 1-2 examples. Saved cards get a green ring + filled bookmark. Saved IDs persist as <code>inspiration_picks[]</code> → E3's InterventionSelector pre-filters by them.</p>
+
+  <div class="scene">
+    <div class="agent-msg">
+      Vamos criar repertório antes do mapa. <strong>Salve 1 ou 2 que te chamam atenção</strong> — algum que parece que poderia funcionar no seu bairro.
+    </div>
+
+    <div class="strip">
+      <div class="card">
+        <div class="thumb barigui">
+          <div class="credit">A. C. Fonseca · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Parques do Barigui</h4>
+            <button class="save-btn" title="Salvar">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Curitiba, PR · 📅 1996 · enchente</div>
+          <p class="summary">Parques que viram retenção de água quando chove forte</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card saved">
+        <div class="thumb goncalo">
+          <div class="credit">Amigos da Rua · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Rua Gonçalo de Carvalho</h4>
+            <button class="save-btn active" title="Remover">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 1930 · calor</div>
+          <p class="summary">Túnel de copa formado por 100+ Tipuanas em 3 quarteirões</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb drenurbs">
+          <div class="credit">M. A. Dutra · CC-BY</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>DRENURBS — Primeiro de Maio</h4>
+            <button class="save-btn" title="Salvar">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Belo Horizonte, MG · 📅 2003 · enchente</div>
+          <p class="summary">Recuperação de áreas úmidas + parque que aguenta a chuva</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card saved">
+        <div class="thumb placeholder biodiversity">🌱</div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Várzea Lab · Vila Flores</h4>
+            <button class="save-btn active" title="Remover">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 2024 · misto</div>
+          <p class="summary">Hortas + jardins de chuva no 4º Distrito pós-enchente</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="screen">Photo curation</h2>
+  <div class="compare-grid">
+    <div class="compare-cell">
+      <p class="lbl">Verified photo</p>
+      <p>3 of 4 cards use verified-source photos from the manifest at <code>docs/photo-curation.md</code>. Photographer + license badge in the bottom-right corner — non-intrusive but always visible.</p>
+      <p>The cards above use SVG approximations because the live photos aren't embedded in this static HTML. In the app they render the real <code>/assets/interventions/*.jpg</code> files.</p>
+    </div>
+    <div class="compare-cell">
+      <p class="lbl">Placeholder (Vila Flores)</p>
+      <p>Vila Flores Várzea Lab doesn't yet have a verified photo, so it ships with a gradient + emoji placeholder. The card is still useful (text describes the case) — it just doesn't claim to show a specific image.</p>
+      <p>When a photo is sourced and verified, the manifest entry switches from <code>placeholder</code> to <code>photo</code> and the card flips automatically.</p>
+    </div>
+  </div>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 36px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Component: <code>client/src/core/components/cbo/NbsShowcaseCard.tsx</code> · Data: <code>shared/nbs-showcase-cards.ts</code> · Manifest: <code>docs/photo-curation.md</code>. Agent tool (<code>show_examples</code>) lands in a follow-up PR.
+  </p>
+</div>
+</body>
+</html>

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -6,7 +6,10 @@ import {
   cohorts,
   cohortMembers,
   DEFAULT_WORKSHOPS,
+  SUPPORT_REQUEST_TYPES,
   type CohortSettings,
+  type SupportRequest,
+  type SupportRequestType,
   type WorkshopConfig,
 } from '@shared/cohort-schema';
 
@@ -206,6 +209,9 @@ export function registerCohortRoutes(app: Express): void {
     const nextPhase = maxUnlocked + 1;
     const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
+    const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
+    const supportPending = supportRequests.filter(r => !r.resolvedAt);
+
     res.json({
       id: member.id,
       orgName: member.orgName,
@@ -216,7 +222,63 @@ export function registerCohortRoutes(app: Express): void {
       cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
       workshops,
       nextWorkshop,
+      supportRequests,
+      supportPendingCount: supportPending.length,
     });
+  }));
+
+  // CBO submits a support request. Returns the created entry (with id).
+  app.post('/api/cbo-member/:memberSlug/support-request', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    const { type, message } = req.body ?? {};
+    if (!SUPPORT_REQUEST_TYPES.includes(type as SupportRequestType)) {
+      res.status(400).json({ error: 'invalid support request type', allowed: SUPPORT_REQUEST_TYPES });
+      return;
+    }
+
+    const entry: SupportRequest = {
+      id: nanoid(12),
+      type: type as SupportRequestType,
+      message: typeof message === 'string' && message.trim() ? message.trim().slice(0, 2000) : null,
+      createdAt: new Date().toISOString(),
+      resolvedAt: null,
+      resolvedNote: null,
+    };
+    const existing = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
+    // Soft rate limit: cap a member's queue at 20. New requests drop the oldest
+    // resolved entry first; if no resolved entries, drop the oldest pending.
+    let next = [...existing, entry];
+    if (next.length > 20) {
+      const resolvedIdx = next.findIndex(r => !!r.resolvedAt);
+      next.splice(resolvedIdx >= 0 ? resolvedIdx : 0, 1);
+    }
+    await db.update(cohortMembers).set({ supportRequests: next }).where(eq(cohortMembers.id, member.id));
+    res.json({ entry });
+  }));
+
+  // Coordinator marks a request resolved. Optional resolvedNote.
+  app.patch('/api/cohort/:coordinatorSlug/support-request/:requestId/resolve', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const { resolvedNote } = req.body ?? {};
+    const note = typeof resolvedNote === 'string' && resolvedNote.trim() ? resolvedNote.trim().slice(0, 1000) : null;
+
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    for (const m of members) {
+      const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
+      const idx = arr.findIndex(r => r.id === req.params.requestId);
+      if (idx === -1) continue;
+      if (arr[idx].resolvedAt) { res.json({ ok: true, alreadyResolved: true }); return; }
+      const next = [...arr];
+      next[idx] = { ...next[idx], resolvedAt: new Date().toISOString(), resolvedNote: note };
+      await db.update(cohortMembers).set({ supportRequests: next }).where(eq(cohortMembers.id, m.id));
+      res.json({ ok: true, request: next[idx] });
+      return;
+    }
+    res.status(404).json({ error: 'request not found' });
   }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -19,6 +19,26 @@ export type CohortSettings = {
   workshops: WorkshopConfig[];
 };
 
+// RequestSupport — async escalation queue. CBO submits via chat-header button;
+// coordinator resolves from orchestrator dashboard. See
+// knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+export const SUPPORT_REQUEST_TYPES = [
+  'coordinator-chat',  // Conversa com a coordenadora
+  'oef-technical',     // Pergunta técnica pra equipe OEF
+  'cbo-connection',    // Conexão com outro CBO que já fez algo parecido
+  'finance-partners',  // Algo sobre finanças / parceiros
+] as const;
+export type SupportRequestType = typeof SUPPORT_REQUEST_TYPES[number];
+
+export type SupportRequest = {
+  id: string;
+  type: SupportRequestType;
+  message: string | null;
+  createdAt: string;          // ISO timestamp
+  resolvedAt: string | null;  // null while pending
+  resolvedNote: string | null;
+};
+
 export const cohorts = pgTable('cohorts', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
   coordinatorSlug: text('coordinator_slug').notNull().unique(),
@@ -41,6 +61,10 @@ export const cohortMembers = pgTable('cohort_members', {
   // mind; 'needs-help' = CBO wants help discovering one. Null until E1 asks.
   // See knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
   path: text('path').$type<'has-idea' | 'needs-help'>(),
+  // Cross-cutting RequestSupport queue. CBO submits via the chat-header button;
+  // coordinator resolves from the orchestrator dashboard. JSONB so we don't need
+  // a separate table for what is effectively a small per-member queue.
+  supportRequests: jsonb('support_requests').$type<SupportRequest[]>().default([]),
   unlockedPhases: jsonb('unlocked_phases').$type<number[]>().default([1]),
   invitedAt: timestamp('invited_at').defaultNow(),
   startedAt: timestamp('started_at'),

--- a/shared/nbs-showcase-cards.ts
+++ b/shared/nbs-showcase-cards.ts
@@ -1,0 +1,146 @@
+// NBS Showcase cards — Brazilian community-NBS examples shown inline in the E2
+// chat ("Vamos olhar exemplos antes do mapa"). Build vocabulary before the CBO
+// engages with the bairro map + intervention selector.
+//
+// Photo sources MUST be in the verified manifest (docs/photo-curation.md).
+// Cards without a verified photo render as a gradient + emoji placeholder —
+// no stock photography, no AI-generated images, no unattributed sources.
+//
+// Used by:
+//   - client: NbsShowcaseCard component (renders inline in chat)
+//   - server: show_examples MCP tool (filters by tag, returns the card payload)
+//   - E2 spec: knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/
+
+export type ShowcaseHazard = 'flood' | 'heat' | 'biodiversity' | 'mixed';
+
+export type ShowcasePhoto = {
+  path: string;
+  source: string;
+  photographer: string;
+  license: string;
+  verified: true;
+};
+
+export type ShowcasePlaceholder = {
+  /** Maps to a CSS gradient on the card. */
+  gradient: 'flood' | 'heat' | 'biodiversity';
+  emoji: string;
+};
+
+export type NbsShowcaseCard = {
+  id: string;
+  org: string;
+  city: string;
+  year: number;
+  hazard: ShowcaseHazard;
+  /** Which of the 6 NBS_INTERVENTION_TYPES this case represents. */
+  typeRefs: string[];
+  summaryPt: string;
+  summaryEn: string;
+  detailPt: string;
+  detailEn: string;
+  /** Either photo OR placeholder is set, not both. */
+  photo: ShowcasePhoto | null;
+  placeholder: ShowcasePlaceholder | null;
+};
+
+export const NBS_SHOWCASE_CARDS: NbsShowcaseCard[] = [
+  {
+    id: 'curitiba-barigui',
+    org: 'Parques do Barigui',
+    city: 'Curitiba, PR',
+    year: 1996,
+    hazard: 'flood',
+    typeRefs: ['flood-parks'],
+    summaryPt: 'Parques que viram retenção de água quando chove forte',
+    summaryEn: 'Parks that act as retention basins during heavy rain',
+    detailPt:
+      'Curitiba transformou várzeas inundáveis em parques públicos a partir de 1996. O Parque Barigui tem ~140 ha e funciona como pulmão urbano + reservatório natural durante enchentes. Modelo replicado em outros parques (Tanguá, Iguaçu, Tingui). 5% mais barato que canais de concreto.',
+    detailEn:
+      'Since 1996 Curitiba has turned flood-prone várzeas into public parks. Parque Barigui covers ~140 ha and works as an urban lung + natural reservoir during floods. Replicated across the city (Tanguá, Iguaçu, Tingui). 5% cheaper than concrete canals.',
+    photo: {
+      path: '/assets/interventions/flood-parks.jpg',
+      source: 'Wikimedia Commons',
+      photographer: 'Agrinaldo Caires Fonseca',
+      license: 'CC-BY-SA-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'poa-goncalo-de-carvalho',
+    org: 'Rua Gonçalo de Carvalho',
+    city: 'Porto Alegre, RS',
+    year: 1930,
+    hazard: 'heat',
+    typeRefs: ['urban-forests'],
+    summaryPt: 'Túnel de copa formado por 100+ Tipuanas em 3 quarteirões',
+    summaryEn: 'Canopy tunnel of 100+ Tipuana trees over 3 blocks',
+    detailPt:
+      'No bairro Independência, moradores defenderam por décadas o plantio dos anos 1930. Em 2006 conseguiram tombamento como Patrimônio Ambiental da América Latina, evitando a derrubada para um shopping. Hoje é uma das ruas mais frescas da cidade — diferença de até 4°C com ruas vizinhas.',
+    detailEn:
+      "In the Independência neighborhood, residents defended the 1930s plantings for decades. In 2006 they secured Environmental Heritage of Latin America status, blocking demolition for a mall. Today it's one of the coolest streets in the city — up to 4°C cooler than neighboring streets.",
+    photo: {
+      path: '/assets/interventions/urban-forests.jpg',
+      source: 'Amigos da Rua Gonçalo de Carvalho',
+      photographer: 'Amigos da Rua Gonçalo de Carvalho',
+      license: 'CC-BY-SA-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'bh-drenurbs',
+    org: 'DRENURBS — Parque Primeiro de Maio',
+    city: 'Belo Horizonte, MG',
+    year: 2003,
+    hazard: 'flood',
+    typeRefs: ['wetland-restoration', 'flood-parks'],
+    summaryPt: 'Recuperação de áreas úmidas + parque que aguenta a chuva',
+    summaryEn: 'Wetland recovery + a park that holds up to heavy rain',
+    detailPt:
+      'Programa de drenagem urbana sustentável da Prefeitura de BH, financiado pelo BID. Recupera córregos canalizados, restaura várzeas, cria parques lineares. Na enchente de 2020, a infraestrutura verde-azul se mostrou mais resiliente que a canalização tradicional. Modelo seguido por outras capitais.',
+    detailEn:
+      "Belo Horizonte's sustainable urban drainage program, IDB-financed. Recovers canalized streams, restores wetlands, creates linear parks. During the 2020 floods, the green-blue infrastructure outperformed traditional canalization. Now a model for other capitals.",
+    photo: {
+      path: '/assets/interventions/wetland-restoration.jpg',
+      source: 'Wikimedia Commons',
+      photographer: 'Marcio Adauto Dutra',
+      license: 'CC-BY-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'poa-varzea-lab',
+    org: 'Várzea Lab · Vila Flores',
+    city: 'Porto Alegre, RS',
+    year: 2024,
+    hazard: 'mixed',
+    typeRefs: ['wetland-restoration', 'bioswales-rain-gardens'],
+    summaryPt: 'Hortas + jardins de chuva no 4º Distrito pós-enchente',
+    summaryEn: 'Community gardens + rain gardens in the 4° Distrito post-flood',
+    detailPt:
+      'Iniciativa do Vila Flores no pós-enchente de maio de 2024. Articulou 5 laboratórios urbanos em 2 anos no 4º Distrito — incluindo hortas comunitárias, jardins de chuva, e oficinas com moradores. Captou recursos da Caixa Federal e do Fundo Casa RS. Referência regional pra adaptação climática liderada por OBCs.',
+    detailEn:
+      "Vila Flores' post-2024-flood initiative. Five urban labs in 2 years in the 4° Distrito — community gardens, rain gardens, and resident workshops. Funded by Caixa Federal and Fundo Casa RS. Regional reference for CBO-led climate adaptation.",
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '🌱',
+    },
+  },
+];
+
+export function getShowcaseCard(id: string): NbsShowcaseCard | undefined {
+  return NBS_SHOWCASE_CARDS.find(c => c.id === id);
+}
+
+/** Filter by tag — currently just hazard. Extend with more dimensions as we add cards. */
+export function filterShowcaseCards(opts?: { hazard?: ShowcaseHazard }): NbsShowcaseCard[] {
+  if (!opts) return NBS_SHOWCASE_CARDS;
+  return NBS_SHOWCASE_CARDS.filter(c => {
+    if (opts.hazard && c.hazard !== opts.hazard && c.hazard !== 'mixed') return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Foundation for **E2 Beat 1** — *\"Vamos olhar exemplos antes do mapa\"*. Renders 4 Brazilian community-NBS cases inline in chat as a horizontal-scroll strip. Two modes:

- **browse** (has-idea path) — read-only, scrollable, expandable detail
- **favorites** (needs-help path) — per-card save toggle, saved IDs persist as \`inspiration_picks[]\` which E3's InterventionSelector pre-filters by

**Stacks on PRs #147–#153.**

## Seed cards (all photo-curated)

| # | Org | City | Year | Hazard | Photo |
|---|---|---|---|---|---|
| 1 | Parques do Barigui | Curitiba, PR | 1996 | flood | verified (A. C. Fonseca · CC-BY-SA) |
| 2 | Rua Gonçalo de Carvalho | Porto Alegre, RS | 1930 | heat | verified (Amigos da Rua · CC-BY-SA) |
| 3 | DRENURBS Primeiro de Maio | Belo Horizonte, MG | 2003 | flood | verified (M. A. Dutra · CC-BY) |
| 4 | Várzea Lab · Vila Flores | Porto Alegre, RS | 2024 | mixed | placeholder (🌱 gradient — TBD) |

Photo curation compliance per \`docs/photo-curation.md\`: every photo has photographer + license + \`verified: true\`. Vila Flores ships with the spec-prescribed gradient + emoji fallback until a verified photo lands.

## What ships

| File | What |
|---|---|
| \`shared/nbs-showcase-cards.ts\` | Typed module with 4 cards (PT + EN copy), \`filterShowcaseCards()\` helper |
| \`client/src/core/components/cbo/NbsShowcaseCard.tsx\` | Inline strip component (~150 lines). Browse vs favorites mode. Expand-on-tap detail |
| \`knowledge/runs/.../E2-seu-territorio/showcase-mockup.html\` | Visual walkthrough |

## What's NOT in this PR (follow-ups)

- \`show_examples\` agent MCP tool (task #5) — agent triggers the strip with optional hazard filter
- \`inspiration_picks[]\` persistence — DB column + endpoint + cbo-profile event handler
- cbo-profile event stream wiring (\`show_examples\` CboEvent type)

These three land together in the next PR — they form a coherent wiring slice once we know the agent + cohort_members schema needs are stable.

## Test plan

- [ ] Open the mockup HTML — both modes render with expected styling
- [ ] Once the show_examples tool ships: agent says *\"vamos olhar exemplos\"* → strip appears inline → user expands detail on one → user saves 2 → page reload preserves saves (after persistence PR)
- [ ] Vila Flores card renders the 🌱 gradient placeholder until a verified photo lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)