### PR TITLE
feat(e2): CommunityAnchoringComposer + ask_community_anchoring wiring

### DIFF
--- a/client/src/core/components/cbo/CommunityAnchoringComposer.tsx
+++ b/client/src/core/components/cbo/CommunityAnchoringComposer.tsx
@@ -1,0 +1,195 @@
+// CommunityAnchoringComposer — inline chat form for E2 Beat 3c.
+// 3 short free-text fields (lead / volunteers / beneficiaries) + chip
+// multi-select for engagement methods. Replaces the fallback sequential
+// ask_user calls in the E2 skill markdown.
+//
+// On confirm, posts a structured chat message that the agent parses to fill:
+//   community_anchoring_lead, community_volunteers, community_beneficiaries,
+//   community_engagement_methods[]
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Textarea } from '@/core/components/ui/textarea';
+import { Check } from 'lucide-react';
+
+export type EngagementMethod =
+  | 'assembleias'
+  | 'oficinas'
+  | 'mutiroes'
+  | 'conversas'
+  | 'outras';
+
+const METHODS: Array<{
+  id: EngagementMethod;
+  pt: { label: string; hint: string };
+  en: { label: string; hint: string };
+}> = [
+  {
+    id: 'assembleias',
+    pt: { label: 'Assembleias / reuniões', hint: 'Encontros regulares' },
+    en: { label: 'Assemblies / meetings', hint: 'Regular gatherings' },
+  },
+  {
+    id: 'oficinas',
+    pt: { label: 'Oficinas educativas', hint: 'Formação, capacitação' },
+    en: { label: 'Workshops', hint: 'Education, training' },
+  },
+  {
+    id: 'mutiroes',
+    pt: { label: 'Mutirões', hint: 'Trabalho voluntário coletivo' },
+    en: { label: 'Volunteer work', hint: 'Collective voluntary work' },
+  },
+  {
+    id: 'conversas',
+    pt: { label: 'Conversas informais', hint: 'Boca a boca, vizinhança' },
+    en: { label: 'Informal conversations', hint: 'Word of mouth, neighbors' },
+  },
+  {
+    id: 'outras',
+    pt: { label: 'Outras formas', hint: '' },
+    en: { label: 'Other ways', hint: '' },
+  },
+];
+
+export type CommunityAnchoringResult = {
+  lead: string;
+  volunteers: string;
+  beneficiaries: string;
+  methods: EngagementMethod[];
+};
+
+export function CommunityAnchoringComposer({
+  prompt,
+  onConfirm,
+}: {
+  prompt: string;
+  onConfirm: (result: CommunityAnchoringResult) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const [lead, setLead] = useState('');
+  const [volunteers, setVolunteers] = useState('');
+  const [beneficiaries, setBeneficiaries] = useState('');
+  const [methods, setMethods] = useState<Set<EngagementMethod>>(new Set());
+
+  const toggleMethod = (id: EngagementMethod) => {
+    setMethods(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  // Confirm needs at least the lead OR the beneficiaries — that's the minimum
+  // useful signal. Methods alone don't tell us who's anchored.
+  const canConfirm = lead.trim().length > 0 || beneficiaries.trim().length > 0;
+
+  return (
+    <div className="rounded-lg border border-foreground/10 bg-card p-4 space-y-3" data-testid="community-anchoring">
+      <p className="text-sm font-medium leading-snug">{prompt}</p>
+
+      <div className="space-y-2.5">
+        <div className="space-y-1">
+          <label className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold">
+            {t('cbo.anchoring.leadLabel', { defaultValue: 'Lideranças' })}
+          </label>
+          <Textarea
+            value={lead}
+            onChange={(e) => setLead(e.target.value)}
+            placeholder={t('cbo.anchoring.leadPlaceholder', {
+              defaultValue: 'Quem puxa o trabalho? Ex: "Sandra, D. Maria, eu mesma"',
+            }) as string}
+            rows={1}
+            maxLength={400}
+            className="text-sm resize-none min-h-[36px]"
+            data-testid="anchoring-lead"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold">
+            {t('cbo.anchoring.volunteersLabel', { defaultValue: 'Voluntários' })}
+          </label>
+          <Textarea
+            value={volunteers}
+            onChange={(e) => setVolunteers(e.target.value)}
+            placeholder={t('cbo.anchoring.volunteersPlaceholder', {
+              defaultValue: 'Quantas pessoas, com que frequência? Ex: "~8 voluntárias, mutirão mensal"',
+            }) as string}
+            rows={1}
+            maxLength={400}
+            className="text-sm resize-none min-h-[36px]"
+            data-testid="anchoring-volunteers"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold">
+            {t('cbo.anchoring.beneficiariesLabel', { defaultValue: 'Moradores diretamente atendidos' })}
+          </label>
+          <Textarea
+            value={beneficiaries}
+            onChange={(e) => setBeneficiaries(e.target.value)}
+            placeholder={t('cbo.anchoring.beneficiariesPlaceholder', {
+              defaultValue: 'Quem é beneficiado? Ex: "12 famílias na Rua Flores, ~40 crianças"',
+            }) as string}
+            rows={1}
+            maxLength={400}
+            className="text-sm resize-none min-h-[36px]"
+            data-testid="anchoring-beneficiaries"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-[11px] uppercase tracking-wider text-muted-foreground font-semibold">
+          {t('cbo.anchoring.methodsLabel', { defaultValue: 'Como vocês se organizam' })}
+        </label>
+        <div className="flex flex-wrap gap-1.5">
+          {METHODS.map(m => {
+            const isOn = methods.has(m.id);
+            const copy = m[lang];
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => toggleMethod(m.id)}
+                className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
+                  isOn
+                    ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300'
+                    : 'border-foreground/15 text-foreground/70 hover:border-foreground/30 hover:bg-muted/50'
+                }`}
+                title={copy.hint || undefined}
+                data-testid={`anchoring-method-${m.id}`}
+              >
+                {copy.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end pt-1">
+        <button
+          type="button"
+          onClick={() => onConfirm({
+            lead: lead.trim(),
+            volunteers: volunteers.trim(),
+            beneficiaries: beneficiaries.trim(),
+            methods: Array.from(methods),
+          })}
+          disabled={!canConfirm}
+          className={`text-sm font-medium px-4 py-1.5 rounded-md inline-flex items-center gap-1.5 transition-colors ${
+            canConfirm
+              ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+              : 'bg-muted text-muted-foreground cursor-not-allowed'
+          }`}
+          data-testid="anchoring-confirm"
+        >
+          <Check className="w-3.5 h-3.5" />
+          {t('cbo.anchoring.confirm', { defaultValue: 'Confirmar' })}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/NbsShowcaseCard.tsx
+++ b/client/src/core/components/cbo/NbsShowcaseCard.tsx
@@ -1,0 +1,176 @@
+// NbsShowcaseCard — inline chat card showing Brazilian NBS examples.
+// Used at the start of E2 to build vocabulary before the user touches the
+// bairro map. Two render modes:
+//   - browse: read-only horizontal scroll (has-idea path)
+//   - favorites: per-card "Salvar" toggle; saves to inspiration_picks[]
+//     which E3's InterventionSelector pre-filters by (needs-help path)
+//
+// Photo manifest: docs/photo-curation.md. Verified photos render normally;
+// unverified entries render a gradient + emoji placeholder.
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bookmark, BookmarkCheck, MapPin, Calendar, ChevronDown, ChevronUp } from 'lucide-react';
+import type { NbsShowcaseCard as Card, ShowcasePlaceholder } from '@shared/nbs-showcase-cards';
+
+const GRADIENTS: Record<ShowcasePlaceholder['gradient'], string> = {
+  flood: 'linear-gradient(135deg, #cffafe 0%, #67e8f9 100%)',
+  heat: 'linear-gradient(135deg, #fef3c7 0%, #fcd34d 100%)',
+  biodiversity: 'linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%)',
+};
+
+const HAZARD_LABELS = {
+  pt: { flood: 'enchente', heat: 'calor', biodiversity: 'biodiv', mixed: 'misto' },
+  en: { flood: 'flood', heat: 'heat', biodiversity: 'biodiv', mixed: 'mixed' },
+};
+
+function CardThumbnail({ card }: { card: Card }) {
+  if (card.photo) {
+    return (
+      <div className="relative h-32 w-full overflow-hidden bg-muted">
+        <img
+          src={card.photo.path}
+          alt={card.org}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+        <div className="absolute bottom-0 right-0 px-1.5 py-0.5 bg-black/50 text-[8px] text-white font-medium tracking-tight">
+          {card.photo.photographer} · {card.photo.license}
+        </div>
+      </div>
+    );
+  }
+  if (card.placeholder) {
+    return (
+      <div
+        className="relative h-32 w-full overflow-hidden flex items-center justify-center"
+        style={{ background: GRADIENTS[card.placeholder.gradient] }}
+      >
+        <span className="text-5xl" role="img" aria-hidden="true">{card.placeholder.emoji}</span>
+      </div>
+    );
+  }
+  return <div className="h-32 w-full bg-muted" />;
+}
+
+export function NbsShowcaseCardItem({
+  card,
+  lang,
+  isSaved,
+  onToggleSave,
+  mode,
+}: {
+  card: Card;
+  lang: 'pt' | 'en';
+  isSaved: boolean;
+  onToggleSave: (id: string, next: boolean) => void;
+  mode: 'browse' | 'favorites';
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const summary = lang === 'pt' ? card.summaryPt : card.summaryEn;
+  const detail = lang === 'pt' ? card.detailPt : card.detailEn;
+  const hazardLabel = HAZARD_LABELS[lang][card.hazard];
+
+  return (
+    <div
+      className={`shrink-0 w-[240px] rounded-xl border bg-card overflow-hidden transition-all ${
+        isSaved ? 'border-emerald-500 ring-2 ring-emerald-500/20' : 'border-foreground/10 hover:border-foreground/25'
+      }`}
+      data-testid={`showcase-card-${card.id}`}
+    >
+      <CardThumbnail card={card} />
+
+      <div className="p-3 space-y-1.5">
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="text-sm font-semibold leading-tight">{card.org}</h4>
+          {mode === 'favorites' && (
+            <button
+              type="button"
+              onClick={() => onToggleSave(card.id, !isSaved)}
+              className={`shrink-0 -mr-1 -mt-1 p-1 rounded-md transition-colors ${
+                isSaved ? 'text-emerald-600 hover:bg-emerald-50' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+              }`}
+              aria-label={isSaved ? t('cbo.showcase.unsave', { defaultValue: 'Remover dos favoritos' }) : t('cbo.showcase.save', { defaultValue: 'Salvar' })}
+              data-testid={`showcase-toggle-${card.id}`}
+            >
+              {isSaved ? <BookmarkCheck className="w-4 h-4" /> : <Bookmark className="w-4 h-4" />}
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+          <span className="inline-flex items-center gap-0.5">
+            <MapPin className="w-2.5 h-2.5" />
+            {card.city}
+          </span>
+          <span>·</span>
+          <span className="inline-flex items-center gap-0.5">
+            <Calendar className="w-2.5 h-2.5" />
+            {card.year}
+          </span>
+          <span>·</span>
+          <span>{hazardLabel}</span>
+        </div>
+
+        <p className="text-xs text-foreground/85 leading-snug">{summary}</p>
+
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="flex items-center gap-1 text-[10px] font-medium text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 -ml-0.5 pt-0.5"
+          data-testid={`showcase-expand-${card.id}`}
+        >
+          {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {expanded
+            ? t('cbo.showcase.less', { defaultValue: 'Menos' })
+            : t('cbo.showcase.more', { defaultValue: 'Saber mais' })}
+        </button>
+
+        {expanded && (
+          <p className="text-[11px] text-muted-foreground leading-relaxed pt-1">{detail}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function NbsShowcaseCardStrip({
+  cards,
+  mode,
+  savedIds,
+  onToggleSave,
+  intro,
+}: {
+  cards: Card[];
+  mode: 'browse' | 'favorites';
+  savedIds: string[];
+  onToggleSave: (id: string, next: boolean) => void;
+  /** Optional lead text rendered above the strip — e.g. "Salve 1-2 que parecem que poderiam funcionar no seu bairro" */
+  intro?: string;
+}) {
+  const { i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const savedSet = new Set(savedIds);
+
+  return (
+    <div className="space-y-2">
+      {intro && (
+        <p className="text-xs text-muted-foreground px-1 leading-relaxed">{intro}</p>
+      )}
+      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+        {cards.map(card => (
+          <div key={card.id} className="snap-start">
+            <NbsShowcaseCardItem
+              card={card}
+              lang={lang}
+              isSaved={savedSet.has(card.id)}
+              onToggleSave={onToggleSave}
+              mode={mode}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/RequestSupportDialog.tsx
+++ b/client/src/core/components/cbo/RequestSupportDialog.tsx
@@ -1,0 +1,195 @@
+// RequestSupport — async escalation form available to every CBO across all
+// encontros. Surfaces as a button in the chat header (more prominent for the
+// needs-help path). On submit, writes a SupportRequest to cohort_members and
+// notifies the orchestrator (visible as a pending-count chip on their card).
+//
+// Spec: knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/core/components/ui/dialog';
+import { Button } from '@/core/components/ui/button';
+import { Textarea } from '@/core/components/ui/textarea';
+import { Users, HelpCircle, Network, Wallet, Loader2 } from 'lucide-react';
+import type { SupportRequestType } from '@shared/cohort-schema';
+
+type OptionDef = {
+  value: SupportRequestType;
+  icon: React.ComponentType<{ className?: string }>;
+  pt: { label: string; hint: string };
+  en: { label: string; hint: string };
+};
+
+const OPTIONS: OptionDef[] = [
+  {
+    value: 'coordinator-chat',
+    icon: Users,
+    pt: { label: 'Conversa com a coordenadora', hint: 'Falar com Julia/Antônia sobre dúvidas, decisões ou bloqueios.' },
+    en: { label: 'Chat with the coordinator', hint: 'Talk to Julia/Antônia about questions, decisions, or blockers.' },
+  },
+  {
+    value: 'oef-technical',
+    icon: HelpCircle,
+    pt: { label: 'Pergunta técnica pra equipe OEF', hint: 'Algo técnico sobre SbN, impacto, dimensionamento.' },
+    en: { label: 'Technical question for OEF', hint: 'Something technical about NBS, impact, sizing.' },
+  },
+  {
+    value: 'cbo-connection',
+    icon: Network,
+    pt: { label: 'Conexão com outro CBO', hint: 'Conhecer alguém que já fez algo parecido no Brasil.' },
+    en: { label: 'Connect with another CBO', hint: 'Meet someone who has done something similar in Brazil.' },
+  },
+  {
+    value: 'finance-partners',
+    icon: Wallet,
+    pt: { label: 'Finanças / parceiros', hint: 'Dúvidas sobre financiamento, editais, parceiros locais.' },
+    en: { label: 'Finance / partners', hint: 'Funding, grants, local partners.' },
+  },
+];
+
+export function RequestSupportDialog({
+  open,
+  onOpenChange,
+  memberSlug,
+  onSubmitted,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The CBO's slug — submit endpoint is /api/cbo-member/:slug/support-request */
+  memberSlug: string;
+  /** Called after a successful POST so the parent can refresh state / toast. */
+  onSubmitted?: (req: { id: string; type: SupportRequestType }) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const [selectedType, setSelectedType] = useState<SupportRequestType | null>(null);
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState<{ id: string; type: SupportRequestType } | null>(null);
+
+  const reset = () => {
+    setSelectedType(null);
+    setMessage('');
+    setSubmitting(false);
+    setSubmitted(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const submit = async () => {
+    if (!selectedType) return;
+    setSubmitting(true);
+    try {
+      const r = await fetch(`/api/cbo-member/${memberSlug}/support-request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: selectedType, message: message.trim() || undefined }),
+      });
+      if (!r.ok) throw new Error('submit failed');
+      const data = await r.json();
+      setSubmitted({ id: data.entry.id, type: data.entry.type });
+      onSubmitted?.({ id: data.entry.id, type: data.entry.type });
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {submitted ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('cbo.support.submittedTitle', { defaultValue: 'Pedido enviado' })}</DialogTitle>
+              <DialogDescription className="pt-1.5">
+                {t('cbo.support.submittedBody', {
+                  defaultValue: 'A coordenadora vai entrar em contato em até 2 dias úteis. Você pode continuar trabalhando aqui — quando ela responder, você vai ver no chat.',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="mt-4">
+              <Button onClick={() => handleOpenChange(false)} className="bg-emerald-600 hover:bg-emerald-700">
+                {t('cbo.support.close', { defaultValue: 'Fechar' })}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('cbo.support.title', { defaultValue: 'Pedir apoio' })}</DialogTitle>
+              <DialogDescription className="pt-1.5">
+                {t('cbo.support.lead', {
+                  defaultValue: 'Sem pressa. Conta o que você precisa — a coordenadora responde em até 2 dias úteis.',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2 mt-3">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                {t('cbo.support.typeLabel', { defaultValue: 'Tipo de apoio' })}
+              </p>
+              <div className="space-y-1.5">
+                {OPTIONS.map(opt => {
+                  const isActive = selectedType === opt.value;
+                  const Icon = opt.icon;
+                  const copy = opt[lang];
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setSelectedType(opt.value)}
+                      className={`w-full text-left p-3 rounded-lg border transition-colors flex items-start gap-3 ${
+                        isActive
+                          ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/30 ring-1 ring-emerald-500'
+                          : 'border-foreground/10 hover:border-foreground/20 hover:bg-muted/50'
+                      }`}
+                      data-testid={`support-option-${opt.value}`}
+                    >
+                      <Icon className={`w-4 h-4 mt-0.5 shrink-0 ${isActive ? 'text-emerald-700 dark:text-emerald-400' : 'text-muted-foreground'}`} />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium leading-tight">{copy.label}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">{copy.hint}</p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-1.5 mt-4">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+                {t('cbo.support.messageLabel', { defaultValue: 'Mensagem (opcional)' })}
+              </p>
+              <Textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={t('cbo.support.messagePlaceholder', { defaultValue: 'Conta um pouco mais se quiser…' }) as string}
+                rows={3}
+                maxLength={2000}
+                className="resize-none text-sm"
+              />
+            </div>
+
+            <DialogFooter className="mt-4">
+              <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={submitting}>
+                {t('cbo.support.cancel', { defaultValue: 'Cancelar' })}
+              </Button>
+              <Button
+                onClick={submit}
+                disabled={!selectedType || submitting}
+                className="bg-emerald-600 hover:bg-emerald-700"
+                data-testid="support-submit"
+              >
+                {submitting && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}
+                {t('cbo.support.submit', { defaultValue: 'Enviar pedido' })}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/components/cbo/RiskPriorityChips.tsx
+++ b/client/src/core/components/cbo/RiskPriorityChips.tsx
@@ -1,0 +1,139 @@
+// RiskPriorityChips — inline chat composer for ranking the 3 climate hazards
+// in order of concern. Tap-in-order pattern (per E2 spec): first tap = priority
+// 1, second = 2, third = 3. Mobile-friendlier than drag-and-drop.
+//
+// Emits the ordered ranking back to the agent as a chat message ("Ranking:
+// flood (1), heat (2), landslide (3)") which the agent parses to fill
+// primary_hazard, secondary_hazard, tertiary_hazard fields.
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Waves, Thermometer, Mountain, RotateCcw, Check } from 'lucide-react';
+
+export type HazardId = 'flood' | 'heat' | 'landslide';
+
+const HAZARDS: Array<{
+  id: HazardId;
+  Icon: React.ComponentType<{ className?: string }>;
+  pt: { label: string; hint: string };
+  en: { label: string; hint: string };
+}> = [
+  {
+    id: 'flood',
+    Icon: Waves,
+    pt: { label: 'Enchente', hint: 'Inundação, chuva forte, rio subindo' },
+    en: { label: 'Flood', hint: 'Flooding, heavy rain, river rising' },
+  },
+  {
+    id: 'heat',
+    Icon: Thermometer,
+    pt: { label: 'Calor extremo', hint: 'Ondas de calor, falta de sombra, ilha de calor' },
+    en: { label: 'Extreme heat', hint: 'Heat waves, no shade, urban heat island' },
+  },
+  {
+    id: 'landslide',
+    Icon: Mountain,
+    pt: { label: 'Deslizamento', hint: 'Encostas instáveis, morros, terreno escorregando' },
+    en: { label: 'Landslide', hint: 'Unstable slopes, hillsides, sliding ground' },
+  },
+];
+
+export function RiskPriorityChips({
+  prompt,
+  minRanked = 2,
+  onConfirm,
+}: {
+  prompt: string;
+  /** How many ranks the user must assign before Confirmar enables. Default 2. */
+  minRanked?: number;
+  onConfirm: (ranking: HazardId[]) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const [ranking, setRanking] = useState<HazardId[]>([]);
+
+  const tap = (id: HazardId) => {
+    setRanking(prev => {
+      if (prev.includes(id)) return prev; // ignore re-tap; use reset to redo
+      if (prev.length >= 3) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const reset = () => setRanking([]);
+  const canConfirm = ranking.length >= minRanked;
+
+  return (
+    <div className="rounded-lg border border-foreground/10 bg-card p-4 space-y-3" data-testid="risk-priority-chips">
+      <p className="text-sm font-medium leading-snug">{prompt}</p>
+      <p className="text-[11px] text-muted-foreground -mt-1">
+        {t('cbo.priority.hint', { defaultValue: 'Toque na ordem do que mais te preocupa.' })}
+      </p>
+
+      <div className="grid grid-cols-3 gap-2">
+        {HAZARDS.map(h => {
+          const idx = ranking.indexOf(h.id);
+          const isRanked = idx >= 0;
+          const Icon = h.Icon;
+          const copy = h[lang];
+          return (
+            <button
+              key={h.id}
+              type="button"
+              onClick={() => tap(h.id)}
+              disabled={isRanked || ranking.length >= 3}
+              className={`relative text-center p-3 rounded-lg border transition-all ${
+                isRanked
+                  ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/30'
+                  : ranking.length >= 3
+                    ? 'border-foreground/5 bg-muted/40 opacity-50 cursor-not-allowed'
+                    : 'border-foreground/15 bg-background hover:border-foreground/30 hover:bg-muted/50 cursor-pointer'
+              }`}
+              data-testid={`risk-chip-${h.id}`}
+            >
+              {isRanked && (
+                <span className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-emerald-600 text-white text-[11px] font-bold flex items-center justify-center shadow-sm">
+                  {idx + 1}
+                </span>
+              )}
+              <Icon className={`w-5 h-5 mx-auto mb-1 ${isRanked ? 'text-emerald-700 dark:text-emerald-300' : 'text-muted-foreground'}`} />
+              <p className={`text-xs font-medium leading-tight ${isRanked ? 'text-foreground' : 'text-foreground/85'}`}>
+                {copy.label}
+              </p>
+              <p className="text-[10px] text-muted-foreground leading-tight mt-0.5 line-clamp-2">
+                {copy.hint}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between pt-1">
+        <button
+          type="button"
+          onClick={reset}
+          disabled={ranking.length === 0}
+          className="text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          data-testid="risk-reset"
+        >
+          <RotateCcw className="w-3 h-3" />
+          {t('cbo.priority.reset', { defaultValue: 'Recomeçar' })}
+        </button>
+        <button
+          type="button"
+          onClick={() => onConfirm(ranking)}
+          disabled={!canConfirm}
+          className={`text-sm font-medium px-4 py-1.5 rounded-md transition-colors inline-flex items-center gap-1.5 ${
+            canConfirm
+              ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+              : 'bg-muted text-muted-foreground cursor-not-allowed'
+          }`}
+          data-testid="risk-confirm"
+        >
+          <Check className="w-3.5 h-3.5" />
+          {t('cbo.priority.confirm', { defaultValue: 'Confirmar' })}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/orchestrator/SupportInbox.tsx
+++ b/client/src/core/components/orchestrator/SupportInbox.tsx
@@ -1,0 +1,284 @@
+// Coordinator support inbox — slide-out panel triggered from the orchestrator
+// header. Lists all support requests across the cohort, lets the coordinator
+// resolve them with an optional note. Closes the loop on the RequestSupport
+// feature shipped in PR #152.
+//
+// Endpoints used:
+//   GET   /api/cohort/:coord/support-requests?status=pending|resolved|all
+//   PATCH /api/cohort/:coord/support-request/:id/resolve
+
+import { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/core/components/ui/button';
+import { Textarea } from '@/core/components/ui/textarea';
+import { X, Users, HelpCircle, Network, Wallet, Check, Clock, Loader2, ExternalLink } from 'lucide-react';
+import type { SupportRequestType } from '@shared/cohort-schema';
+
+type InboxItem = {
+  requestId: string;
+  memberId: string;
+  memberSlug: string;
+  orgName: string;
+  neighborhood: string | null;
+  type: SupportRequestType;
+  message: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+  resolvedNote: string | null;
+};
+
+type Filter = 'pending' | 'resolved' | 'all';
+
+const TYPE_META: Record<SupportRequestType, { Icon: React.ComponentType<{ className?: string }>; pt: string; en: string }> = {
+  'coordinator-chat': { Icon: Users, pt: 'Conversa', en: 'Chat' },
+  'oef-technical': { Icon: HelpCircle, pt: 'Técnica', en: 'Technical' },
+  'cbo-connection': { Icon: Network, pt: 'Conexão CBO', en: 'CBO connection' },
+  'finance-partners': { Icon: Wallet, pt: 'Finanças', en: 'Finance' },
+};
+
+function formatTimeAgo(iso: string, lang: 'pt' | 'en'): string {
+  const then = new Date(iso).getTime();
+  const minutesAgo = Math.floor((Date.now() - then) / 60000);
+  if (minutesAgo < 1) return lang === 'pt' ? 'agora' : 'just now';
+  if (minutesAgo < 60) return lang === 'pt' ? `${minutesAgo}m atrás` : `${minutesAgo}m ago`;
+  const hoursAgo = Math.floor(minutesAgo / 60);
+  if (hoursAgo < 24) return lang === 'pt' ? `${hoursAgo}h atrás` : `${hoursAgo}h ago`;
+  const daysAgo = Math.floor(hoursAgo / 24);
+  return lang === 'pt' ? `${daysAgo}d atrás` : `${daysAgo}d ago`;
+}
+
+export function SupportInbox({
+  open,
+  onOpenChange,
+  coordinatorSlug,
+  onCountChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  coordinatorSlug: string;
+  /** Called after any resolve so the trigger badge can update. */
+  onCountChange?: (pendingCount: number) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const [filter, setFilter] = useState<Filter>('pending');
+  const [items, setItems] = useState<InboxItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [resolveDraft, setResolveDraft] = useState<{ id: string; note: string } | null>(null);
+  const [resolving, setResolving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!open) return;
+    setLoading(true);
+    try {
+      const r = await fetch(`/api/cohort/${coordinatorSlug}/support-requests?status=${filter}`);
+      if (r.ok) {
+        const data = await r.json();
+        setItems(data.items ?? []);
+        // Always recompute pending count regardless of current filter
+        const pendingR = filter === 'pending'
+          ? data.items
+          : await (await fetch(`/api/cohort/${coordinatorSlug}/support-requests?status=pending`)).json().then((d: any) => d.items);
+        onCountChange?.(pendingR.length);
+      }
+    } finally { setLoading(false); }
+  }, [coordinatorSlug, filter, open, onCountChange]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const resolveItem = async (item: InboxItem) => {
+    setResolving(true);
+    try {
+      const r = await fetch(`/api/cohort/${coordinatorSlug}/support-request/${item.requestId}/resolve`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resolvedNote: resolveDraft?.note?.trim() || undefined }),
+      });
+      if (r.ok) {
+        setResolveDraft(null);
+        await refresh();
+      }
+    } finally { setResolving(false); }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog">
+      {/* Backdrop */}
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        onClick={() => onOpenChange(false)}
+        aria-label={t('orchestrator.support.closeBackdrop', { defaultValue: 'Fechar' }) as string}
+      />
+      {/* Drawer */}
+      <div className="relative w-full max-w-md h-full bg-background border-l border-foreground/10 shadow-2xl flex flex-col">
+        <div className="px-5 py-4 border-b border-foreground/10 flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold tracking-tight">
+              {t('orchestrator.support.title', { defaultValue: 'Pedidos de apoio' })}
+            </h2>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t('orchestrator.support.subtitle', { defaultValue: 'Inbox da coordenação' })}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="p-1.5 rounded-md hover:bg-muted transition-colors"
+            aria-label={t('orchestrator.support.close', { defaultValue: 'Fechar' }) as string}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-3 border-b border-foreground/10 flex gap-1">
+          {(['pending', 'resolved', 'all'] as Filter[]).map(f => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
+                filter === f ? 'bg-foreground text-background' : 'text-muted-foreground hover:bg-muted'
+              }`}
+              data-testid={`support-filter-${f}`}
+            >
+              {t(`orchestrator.support.filter.${f}`, {
+                defaultValue: f === 'pending' ? 'Pendentes' : f === 'resolved' ? 'Resolvidos' : 'Todos',
+              })}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {loading && items.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">
+              <Loader2 className="w-5 h-5 mx-auto animate-spin" />
+            </div>
+          ) : items.length === 0 ? (
+            <div className="p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                {filter === 'pending'
+                  ? t('orchestrator.support.emptyPending', { defaultValue: 'Sem pedências. ☘️' })
+                  : t('orchestrator.support.empty', { defaultValue: 'Nada por aqui.' })}
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-foreground/5">
+              {items.map(item => {
+                const meta = TYPE_META[item.type];
+                const Icon = meta.Icon;
+                const isExpanded = resolveDraft?.id === item.requestId;
+                const isResolved = !!item.resolvedAt;
+                return (
+                  <li key={item.requestId} className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className={`shrink-0 w-8 h-8 rounded-md flex items-center justify-center ${
+                        isResolved ? 'bg-muted text-muted-foreground' : 'bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300'
+                      }`}>
+                        <Icon className="w-4 h-4" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold leading-tight truncate">{item.orgName}</p>
+                            <p className="text-[10px] text-muted-foreground mt-0.5 flex items-center gap-1.5">
+                              <span>{meta[lang]}</span>
+                              <span>·</span>
+                              <span className="inline-flex items-center gap-0.5">
+                                <Clock className="w-2.5 h-2.5" />
+                                {formatTimeAgo(item.createdAt, lang)}
+                              </span>
+                              {item.neighborhood && (
+                                <>
+                                  <span>·</span>
+                                  <span>{item.neighborhood}</span>
+                                </>
+                              )}
+                            </p>
+                          </div>
+                          <a
+                            href={`/cbo-profile?cbo=${item.memberSlug}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="shrink-0 inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
+                            title={t('orchestrator.support.openProfile', { defaultValue: 'Ver perfil' }) as string}
+                          >
+                            <ExternalLink className="w-3 h-3" />
+                          </a>
+                        </div>
+
+                        {item.message && (
+                          <p className="text-xs text-foreground/80 leading-snug mt-1.5 whitespace-pre-wrap">
+                            {item.message}
+                          </p>
+                        )}
+
+                        {isResolved && (
+                          <div className="mt-2 px-2.5 py-1.5 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40">
+                            <p className="text-[10px] font-medium text-emerald-800 dark:text-emerald-200 flex items-center gap-1">
+                              <Check className="w-3 h-3" />
+                              {t('orchestrator.support.resolved', {
+                                defaultValue: 'Resolvido {{when}}',
+                                when: item.resolvedAt ? formatTimeAgo(item.resolvedAt, lang) : '',
+                              })}
+                            </p>
+                            {item.resolvedNote && (
+                              <p className="text-[11px] text-emerald-900 dark:text-emerald-100 mt-1">{item.resolvedNote}</p>
+                            )}
+                          </div>
+                        )}
+
+                        {!isResolved && !isExpanded && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="mt-2 h-7 text-[11px]"
+                            onClick={() => setResolveDraft({ id: item.requestId, note: '' })}
+                            data-testid={`support-resolve-${item.requestId}`}
+                          >
+                            <Check className="w-3 h-3 mr-1" />
+                            {t('orchestrator.support.markResolved', { defaultValue: 'Marcar resolvido' })}
+                          </Button>
+                        )}
+
+                        {isExpanded && (
+                          <div className="mt-2 space-y-2">
+                            <Textarea
+                              value={resolveDraft.note}
+                              onChange={(e) => setResolveDraft({ id: item.requestId, note: e.target.value })}
+                              placeholder={t('orchestrator.support.notePlaceholder', { defaultValue: 'Nota interna (opcional)' }) as string}
+                              rows={2}
+                              maxLength={1000}
+                              className="text-xs"
+                            />
+                            <div className="flex gap-1.5 justify-end">
+                              <Button variant="ghost" size="sm" className="h-7 text-[11px]" onClick={() => setResolveDraft(null)} disabled={resolving}>
+                                {t('orchestrator.support.cancel', { defaultValue: 'Cancelar' })}
+                              </Button>
+                              <Button
+                                size="sm"
+                                className="h-7 text-[11px] bg-emerald-600 hover:bg-emerald-700"
+                                onClick={() => resolveItem(item)}
+                                disabled={resolving}
+                                data-testid={`support-confirm-${item.requestId}`}
+                              >
+                                {resolving && <Loader2 className="w-3 h-3 mr-1 animate-spin" />}
+                                {t('orchestrator.support.confirm', { defaultValue: 'Confirmar' })}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -35,7 +35,9 @@ import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/
 import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
 import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
+import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
 import { LifeBuoy } from 'lucide-react';
+import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -210,6 +212,12 @@ export default function CboProfilePage() {
   // coordinator-side flows can also nudge the user to open this.
   const [supportDialogOpen, setSupportDialogOpen] = useState(false);
   const [supportPendingCount, setSupportPendingCount] = useState(0);
+  // E2 showcase strip — current set rendered inline in chat (mode + cardIds
+  // from the agent's show_examples event). Null until the agent invokes it.
+  const [showcase, setShowcase] = useState<{ cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string } | null>(null);
+  // CBO's saved cards across sessions. Server is source of truth; we mirror it
+  // here for snappy toggle UX. Persisted via inspiration-pick endpoint.
+  const [inspirationPicks, setInspirationPicks] = useState<string[]>([]);
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
@@ -233,6 +241,7 @@ export default function CboProfilePage() {
       if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
       else if (data.path === null) setMemberPath(null);
       if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
+      if (Array.isArray(data.inspirationPicks)) setInspirationPicks(data.inspirationPicks);
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
@@ -461,6 +470,12 @@ export default function CboProfilePage() {
         setInterventionSelectorParams((event as any).params);
         setRightTab('interventions');
         setMobileActiveTab('panel');
+        setIsStreaming(false);
+        break;
+      case 'show_examples':
+        // Inline strip in chat — no tab switch. Replace any existing strip so
+        // the agent can refine the example set within a turn.
+        setShowcase({ cardIds: event.cardIds, mode: event.mode, intro: event.intro });
         setIsStreaming(false);
         break;
       case 'done': setIsStreaming(false); break;
@@ -753,6 +768,44 @@ export default function CboProfilePage() {
                 </div>
               </div>
             ))}
+
+            {/* E2 NbsShowcaseCard strip — agent-invoked via show_examples.
+                Rendered inline in chat (not in the right rail) since it's
+                an educational anchor for the conversation, not a microapp. */}
+            {showcase && (() => {
+              const cards = showcase.cardIds.map(getShowcaseCard).filter(Boolean) as typeof NBS_SHOWCASE_CARDS;
+              if (cards.length === 0) return null;
+              const handleToggle = async (cardId: string, next: boolean) => {
+                const before = inspirationPicks;
+                const optimistic = next
+                  ? Array.from(new Set([...before, cardId]))
+                  : before.filter(id => id !== cardId);
+                setInspirationPicks(optimistic);
+                if (!memberSlug) return;
+                try {
+                  const r = await fetch(`/api/cbo-member/${memberSlug}/inspiration-pick`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ cardId, action: next ? 'add' : 'remove' }),
+                  });
+                  if (r.ok) {
+                    const data = await r.json();
+                    if (Array.isArray(data.inspirationPicks)) setInspirationPicks(data.inspirationPicks);
+                  } else { setInspirationPicks(before); }
+                } catch { setInspirationPicks(before); }
+              };
+              return (
+                <div className="rounded-lg bg-muted/30 p-3 -mx-1">
+                  <NbsShowcaseCardStrip
+                    cards={cards}
+                    mode={showcase.mode}
+                    savedIds={inspirationPicks}
+                    onToggleSave={handleToggle}
+                    intro={showcase.intro}
+                  />
+                </div>
+              );
+            })()}
 
             {/* MC Questions — with navigation, multi-select, answered state */}
             {currentQuestion && (

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -34,6 +34,8 @@ import { CboProgress } from '@/core/components/cbo/CboProgress';
 import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
 import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/cbo/encontroConfig';
 import { E1Cards } from '@/core/components/cbo/E1Cards';
+import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
+import { LifeBuoy } from 'lucide-react';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
@@ -203,6 +205,11 @@ export default function CboProfilePage() {
   // Sourced from cohort_members.path via /api/cbo-member/:slug. Drives the
   // Caminho card chip in E1Cards.
   const [memberPath, setMemberPath] = useState<'has-idea' | 'needs-help' | null>(null);
+  // RequestSupport — async escalation. Available across all encontros via the
+  // chat header. Pending count comes from /api/cbo-member/:slug; agent or
+  // coordinator-side flows can also nudge the user to open this.
+  const [supportDialogOpen, setSupportDialogOpen] = useState(false);
+  const [supportPendingCount, setSupportPendingCount] = useState(0);
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
@@ -225,6 +232,7 @@ export default function CboProfilePage() {
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
       if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
       else if (data.path === null) setMemberPath(null);
+      if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
@@ -630,6 +638,14 @@ export default function CboProfilePage() {
   return (
     <div className="h-screen flex flex-col bg-background">
       <Header />
+      {memberSlug && (
+        <RequestSupportDialog
+          open={supportDialogOpen}
+          onOpenChange={setSupportDialogOpen}
+          memberSlug={memberSlug}
+          onSubmitted={() => setSupportPendingCount(c => c + 1)}
+        />
+      )}
       <div className="flex flex-1 min-h-0">
         {/* LEFT: Chat — full width on mobile (when Chat tab active), half on md+ */}
         <div
@@ -678,6 +694,31 @@ export default function CboProfilePage() {
               </div>
             </div>
             <div className="flex gap-1">
+              {memberSlug && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={memberPath === 'needs-help' && supportPendingCount === 0 ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setSupportDialogOpen(true)}
+                      className={memberPath === 'needs-help' && supportPendingCount === 0 ? 'bg-emerald-600 hover:bg-emerald-700 text-white' : ''}
+                      data-testid="button-request-support"
+                    >
+                      <LifeBuoy className="w-4 h-4" />
+                      {supportPendingCount > 0 && (
+                        <span className="ml-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                          {supportPendingCount}
+                        </span>
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {supportPendingCount > 0
+                      ? t('cbo.support.tooltipPending', { defaultValue: '{{n}} pedido(s) aguardando resposta', n: supportPendingCount })
+                      : t('cbo.support.tooltip', { defaultValue: 'Pedir apoio à coordenadora' })}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <Tooltip><TooltipTrigger asChild><Button variant={state.phase >= 6 ? 'default' : 'outline'} size="sm" className={state.phase >= 6 ? 'bg-green-600 hover:bg-green-700 animate-pulse' : ''} onClick={() => cboId && window.open(`/api/cbo/${cboId}/export`, '_blank')}><Download className="w-4 h-4" />{state.phase >= 6 && <span className="ml-1 text-xs">{t('cbo.export')}</span>}</Button></TooltipTrigger><TooltipContent>{t('cbo.export')}</TooltipContent></Tooltip>
               <Tooltip><TooltipTrigger asChild><Button variant="outline" size="sm" onClick={handleRestart}><RotateCcw className="w-4 h-4" /></Button></TooltipTrigger><TooltipContent>{t('cbo.startOver')}</TooltipContent></Tooltip>
             </div>

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -36,6 +36,7 @@ import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/c
 import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
 import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
+import { RiskPriorityChips, type HazardId } from '@/core/components/cbo/RiskPriorityChips';
 import { LifeBuoy } from 'lucide-react';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
@@ -215,6 +216,9 @@ export default function CboProfilePage() {
   // E2 showcase strip — current set rendered inline in chat (mode + cardIds
   // from the agent's show_examples event). Null until the agent invokes it.
   const [showcase, setShowcase] = useState<{ cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string } | null>(null);
+  // E2 Beat 3a — agent's pending RiskPriorityChips invocation. Null after the
+  // user confirms a ranking; the ranking goes back as a chat message.
+  const [priorityRankPrompt, setPriorityRankPrompt] = useState<{ prompt: string; minRanked: number } | null>(null);
   // CBO's saved cards across sessions. Server is source of truth; we mirror it
   // here for snappy toggle UX. Persisted via inspiration-pick endpoint.
   const [inspirationPicks, setInspirationPicks] = useState<string[]>([]);
@@ -476,6 +480,10 @@ export default function CboProfilePage() {
         // Inline strip in chat — no tab switch. Replace any existing strip so
         // the agent can refine the example set within a turn.
         setShowcase({ cardIds: event.cardIds, mode: event.mode, intro: event.intro });
+        setIsStreaming(false);
+        break;
+      case 'ask_priority_rank':
+        setPriorityRankPrompt({ prompt: event.prompt, minRanked: event.minRanked });
         setIsStreaming(false);
         break;
       case 'done': setIsStreaming(false); break;
@@ -806,6 +814,21 @@ export default function CboProfilePage() {
                 </div>
               );
             })()}
+
+            {/* E2 Beat 3a — risk priority chips. Rendered inline in chat.
+                On confirm, posts a parseable message ("Priority ranking: ...")
+                back to the agent. */}
+            {priorityRankPrompt && (
+              <RiskPriorityChips
+                prompt={priorityRankPrompt.prompt}
+                minRanked={priorityRankPrompt.minRanked}
+                onConfirm={(ranking: HazardId[]) => {
+                  const human = ranking.map((h, i) => `${h} (${i + 1})`).join(', ');
+                  setPriorityRankPrompt(null);
+                  sendMessage(`Priority ranking: ${human}`);
+                }}
+              />
+            )}
 
             {/* MC Questions — with navigation, multi-select, answered state */}
             {currentQuestion && (

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -37,6 +37,7 @@ import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
 import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
 import { RiskPriorityChips, type HazardId } from '@/core/components/cbo/RiskPriorityChips';
+import { CommunityAnchoringComposer, type CommunityAnchoringResult } from '@/core/components/cbo/CommunityAnchoringComposer';
 import { LifeBuoy } from 'lucide-react';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
@@ -219,6 +220,7 @@ export default function CboProfilePage() {
   // E2 Beat 3a — agent's pending RiskPriorityChips invocation. Null after the
   // user confirms a ranking; the ranking goes back as a chat message.
   const [priorityRankPrompt, setPriorityRankPrompt] = useState<{ prompt: string; minRanked: number } | null>(null);
+  const [anchoringPrompt, setAnchoringPrompt] = useState<{ prompt: string } | null>(null);
   // CBO's saved cards across sessions. Server is source of truth; we mirror it
   // here for snappy toggle UX. Persisted via inspiration-pick endpoint.
   const [inspirationPicks, setInspirationPicks] = useState<string[]>([]);
@@ -484,6 +486,10 @@ export default function CboProfilePage() {
         break;
       case 'ask_priority_rank':
         setPriorityRankPrompt({ prompt: event.prompt, minRanked: event.minRanked });
+        setIsStreaming(false);
+        break;
+      case 'ask_community_anchoring':
+        setAnchoringPrompt({ prompt: event.prompt });
         setIsStreaming(false);
         break;
       case 'done': setIsStreaming(false); break;
@@ -826,6 +832,23 @@ export default function CboProfilePage() {
                   const human = ranking.map((h, i) => `${h} (${i + 1})`).join(', ');
                   setPriorityRankPrompt(null);
                   sendMessage(`Priority ranking: ${human}`);
+                }}
+              />
+            )}
+
+            {/* E2 Beat 3c — community anchoring. Posts a structured message
+                back to the agent so it can parse into the right fields. */}
+            {anchoringPrompt && (
+              <CommunityAnchoringComposer
+                prompt={anchoringPrompt.prompt}
+                onConfirm={(r: CommunityAnchoringResult) => {
+                  setAnchoringPrompt(null);
+                  const parts: string[] = [];
+                  if (r.lead) parts.push(`Lead: ${r.lead}`);
+                  if (r.volunteers) parts.push(`Volunteers: ${r.volunteers}`);
+                  if (r.beneficiaries) parts.push(`Beneficiaries: ${r.beneficiaries}`);
+                  if (r.methods.length) parts.push(`Methods: ${r.methods.join(', ')}`);
+                  sendMessage(`Community anchoring — ${parts.join(' | ')}`);
                 }}
               />
             )}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -37,6 +37,7 @@ import {
   type BulkInviteResult,
 } from '@/core/components/orchestrator/CohortDialogs';
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
+import { SupportInbox } from '@/core/components/orchestrator/SupportInbox';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -641,6 +642,12 @@ export default function OrchestratorLandingPage() {
   const projects = useMemo(() => members.map(memberToView), [members]);
   const memberById = useMemo(() => new Map(members.map(m => [m.id, m])), [members]);
 
+  // Initialize the inbox badge from already-loaded members so it lights up
+  // before the user opens the drawer. SupportInbox re-counts on open.
+  useEffect(() => {
+    setSupportInboxPendingCount(projects.reduce((sum, p) => sum + p.supportPendingCount, 0));
+  }, [projects]);
+
   const stats = useMemo(() => {
     const sitesMapped = projects.filter(p => p.coords).length;
     const profilesInProgress = projects.filter(
@@ -661,6 +668,11 @@ export default function OrchestratorLandingPage() {
   const [bulkSummaryOpen, setBulkSummaryOpen] = useState(false);
   const [bulkInvitations, setBulkInvitations] = useState<BulkInviteResult[]>([]);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const [supportInboxOpen, setSupportInboxOpen] = useState(false);
+  // Mirrored from /support-requests?status=pending — drives the badge on
+  // the inbox trigger. Initialized from member.supportRequests when the
+  // cohort loads (below).
+  const [supportInboxPendingCount, setSupportInboxPendingCount] = useState(0);
 
   const openShare = (url: string, ctx: typeof shareContext) => {
     setShareUrl(url);
@@ -763,12 +775,40 @@ export default function OrchestratorLandingPage() {
               </TitleLarge>
             </div>
           </div>
-          <Button variant="ghost" size="sm" onClick={switchRole} data-testid="button-orchestrator-switch-role">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            {t('orchestrator.switchRole')}
-          </Button>
+          <div className="flex items-center gap-1.5">
+            {cohort && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setSupportInboxOpen(true)}
+                className="relative"
+                data-testid="button-orchestrator-support-inbox"
+                title={t('orchestrator.support.openInbox', { defaultValue: 'Pedidos de apoio' }) as string}
+              >
+                <LifeBuoy className="w-4 h-4 mr-1.5" />
+                <span className="hidden sm:inline">{t('orchestrator.support.inboxLabel', { defaultValue: 'Apoio' })}</span>
+                {supportInboxPendingCount > 0 && (
+                  <span className="ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900/50 dark:text-amber-200">
+                    {supportInboxPendingCount}
+                  </span>
+                )}
+              </Button>
+            )}
+            <Button variant="ghost" size="sm" onClick={switchRole} data-testid="button-orchestrator-switch-role">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              {t('orchestrator.switchRole')}
+            </Button>
+          </div>
         </div>
       </header>
+      {cohort && (
+        <SupportInbox
+          open={supportInboxOpen}
+          onOpenChange={setSupportInboxOpen}
+          coordinatorSlug={cohort.coordinatorSlug}
+          onCountChange={setSupportInboxPendingCount}
+        />
+      )}
 
       <main className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
         {/* Cohort header — singleton model. One cohort for the pilot,

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,7 +19,7 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, Lightbulb, MapPin,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin,
   Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
@@ -79,6 +79,9 @@ type CboDemoProject = {
    *  coordinator sees who needs more hand-holding (needs-help) vs who has
    *  a concrete idea (has-idea). Null until E1's set_path tool fires. */
   path: 'has-idea' | 'needs-help' | null;
+  /** Count of unresolved RequestSupport entries — surfaces an amber chip
+   *  on the card so the coordinator can sweep pendencies daily. */
+  supportPendingCount: number;
 };
 
 const TOTAL_SECTIONS = 7;
@@ -120,6 +123,9 @@ function memberToView(m: CohortMember): CboDemoProject {
     updatedDaysAgo: daysAgo,
     nextActionKey: NEXT_ACTION_KEY[phaseNum] ?? NEXT_ACTION_KEY[1],
     path: (m.path as 'has-idea' | 'needs-help' | null | undefined) ?? null,
+    supportPendingCount: Array.isArray((m as any).supportRequests)
+      ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
+      : 0,
   };
 }
 
@@ -503,6 +509,21 @@ function ProjectCard({
                 {project.path === 'has-idea'
                   ? t('orchestrator.demo.path.hasIdea', { defaultValue: 'Tem ideia' })
                   : t('orchestrator.demo.path.needsHelp', { defaultValue: 'Quer descobrir' })}
+              </span>
+            )}
+            {project.supportPendingCount > 0 && (
+              <span
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border border-amber-200/60 dark:border-amber-900/40"
+                title={t('orchestrator.demo.support.pendingTooltip', {
+                  defaultValue: '{{n}} pedido(s) de apoio aguardando',
+                  n: project.supportPendingCount,
+                })}
+              >
+                <LifeBuoy className="w-3 h-3" strokeWidth={2} />
+                {t('orchestrator.demo.support.pendingChip', {
+                  defaultValue: '{{n}} pedência(s)',
+                  n: project.supportPendingCount,
+                })}
               </span>
             )}
             {hasIntervention ? (

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -137,36 +137,21 @@ ask_user({
 
 Map to `land_tenure`: `private-owned` | `formal-agreement` | `public-informal` | `public-no-access` | `mixed`.
 
-### 3c · Community anchoring (3 quick questions via ask_user, no composer yet)
+### 3c · Community anchoring
 
-The `CommunityAnchoringComposer` microapp isn't built yet — for v1 we use 3 sequential `ask_user` turns or a single free-text question. Prefer the free-text route to keep momentum:
-
-```
-Última coisa por hoje. Quem da comunidade está envolvida nesse trabalho? Pode escrever bem rápido — lideranças, voluntários, moradores diretamente atendidos.
-```
-
-Wait for free-text response. Parse into:
-- `community_anchoring_lead` (named lead or "Sandra, D. Maria")
-- `community_volunteers_count` (if mentioned, otherwise leave empty)
-- `beneficiary_groups` (referenced demographics)
-
-Then a single follow-up:
+Use the `ask_community_anchoring` tool — renders the CommunityAnchoringComposer inline. 3 short text fields (lead/volunteers/beneficiaries) + chip multi-select for engagement methods.
 
 ```
-ask_user({
-  question: 'Como vocês se organizam?',
-  multiSelect: true,
-  options: [
-    { label: 'Assembleias / reuniões regulares', description: '' },
-    { label: 'Oficinas educativas', description: '' },
-    { label: 'Mutirões / trabalho voluntário', description: '' },
-    { label: 'Conversas informais com moradores', description: '' },
-    { label: 'Outras formas', description: '' },
-  ]
+ask_community_anchoring({
+  prompt: 'Última coisa por hoje. Quem da comunidade está envolvida nesse trabalho?'
 })
 ```
 
-Save selected options as `community_engagement_methods[]`.
+The user's submission comes back as a chat message: *"Community anchoring — Lead: Sandra, D. Maria | Volunteers: ~8 mutirão mensal | Beneficiaries: 12 famílias | Methods: oficinas, mutiroes"*. Parse it and fill:
+- `community_anchoring_lead`
+- `community_volunteers`
+- `community_beneficiaries`
+- `community_engagement_methods[]` (from the Methods clause)
 
 ## Scoring (silent, coordinator-side)
 
@@ -226,13 +211,13 @@ You may reference the showcase card photos in conversation, but never describe p
 ## Tool calls available
 
 Already wired in cboAgent.ts:
-- `show_examples({mode, hazardFilter?, intro?, cardIds?})` — NEW, E2-specific
+- `show_examples({mode, hazardFilter?, intro?, cardIds?})` — NEW, E2 Beat 1
 - `ask_priority_rank({prompt, minRanked?})` — NEW, E2 Beat 3a
+- `ask_community_anchoring({prompt})` — NEW, E2 Beat 3c
 - `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})` — existing
 - `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`, `read_knowledge`
 
 NOT yet wired (DO NOT call):
-- `ask_community_anchoring` → use `ask_user` + free-text instead
 - `set_phase_complete` → no separate complete tool; just don't call `set_phase(3)` (P-8 gate refuses it anyway)
 
 ## KB grounding (read_knowledge)

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -1,0 +1,262 @@
+# /encontro-2-seu-territorio — Agent skill
+
+Loaded by `cboAgent.ts` (via `loadEncontroSkill(2)`) when state.phase == 2.
+
+## Identity
+
+You are the COUGAR/Vila Flores agent in **Encontro 2 — Seu território**. The CBO already completed Encontro 1, so you know their name, neighborhood, mission, capacity, and most importantly their **path**: `has-idea` or `needs-help` (visible in the CURRENT STATE block of this prompt).
+
+Your job in this encontro is to:
+1. Anchor NBS in concrete Brazilian examples (via `show_examples`)
+2. Open the map so the CBO can mark a **site** they want to act on
+3. Surface the bairro's risk data alongside their lived experience
+4. Capture the priority hazard ranking + land tenure + community anchoring
+5. Score Site Control + Community Anchoring (silently, coordinator-side)
+
+~45 min of conversation. You speak Portuguese with the warmth of a community facilitator, not the precision of a survey.
+
+## Voice
+
+- Brazilian Portuguese, warm, second-person singular
+- Acknowledge answers with one or two words before moving on
+- Never use "preencha" or "responda" — use "conta", "me fala"
+- Switch to English only if the user writes in English first
+
+## Read the member context first
+
+The CURRENT STATE block of this prompt has E1's answers. Reference them naturally — *"você mencionou que trabalham com hortas em Cascata…"* — before pushing forward. Do not re-ask anything that's already in state.
+
+## Beat 1 — Educational anchor (5 min, path-aware)
+
+### `has-idea` opening
+
+Open warmly, then invoke the showcase in **browse** mode:
+
+```
+Oi, {nome}. Antes da gente abrir o mapa, dois exemplos rápidos pra você ter referência:
+
+show_examples({ mode: 'browse', intro: 'Toca em "Saber mais" pra ler o caso completo.' })
+```
+
+After the strip renders, send a short content message:
+
+> Esses são exemplos de SbN em comunidade no Brasil. A gente não precisa fazer igual — só pra ter ideia do que cabe na conversa. Pronta pra falar do seu projeto?
+
+### `needs-help` opening
+
+Same showcase, but **favorites** mode + extended dwell:
+
+```
+Oi, {nome}. Vamos descobrir juntos o que faz sentido pra {bairro}.
+
+Antes do mapa, salve 1 ou 2 exemplos que te chamam atenção — não precisa ser perfeito, só algo que faça você pensar "isso podia funcionar aqui".
+
+show_examples({ mode: 'favorites', intro: 'Salve 1 ou 2 que te chamam atenção.' })
+```
+
+Wait for them to engage. Don't rush. If they save nothing after a couple of turns, gently nudge: *"Algum desses parece com o tipo de coisa que vocês têm em mente? Pode salvar sem compromisso."*
+
+When they're ready, transition: *"Beleza. Agora vamos olhar o seu bairro no mapa."*
+
+## Beat 2 — Map + site (25 min)
+
+Use the existing `open_map` composite mode (the new `browse-only` mode isn't wired yet — that lands in a follow-up PR). For now both paths converge on composite, with hazard layers driven by Porto Alegre defaults:
+
+```
+open_map({
+  selectionMode: 'composite',
+  zoneSource: 'neighborhoods',
+  layers: ['osm_parks', 'osm_schools', 'osm_wetlands'],
+  tileLayers: ['oef_fri_2024', 'oef_hwm_2024'],
+  prompt: 'Escolha primeiro o bairro onde você atua, depois marque o lugar específico.'
+})
+```
+
+**Path-aware framing before invoking:**
+
+- has-idea: *"Marca exatamente onde vocês querem atuar."*
+- needs-help: *"Sem pressa. Olha primeiro. Depois marca um lugar — pode mudar depois."*
+
+After the user confirms a selection, you'll receive a message starting with `Map selection (composite mode):`. Parse it:
+
+- bairro name → `bairro`
+- coordinates → `site_lat`, `site_lng`
+- area (if polygon) → `site_geometry`, `site_area_m2`
+
+If the user drew a custom polygon, ask: *"Esse lugar tem um nome que você usa pra ele?"* (e.g. "Pracinha do Bairro", "Lote do Lourival"). Save to `site_name`.
+
+Ask about current use:
+
+```
+ask_user({
+  question: 'Como é esse lugar hoje?',
+  options: [
+    { label: 'Vegetação (área verde, mato, árvores)', description: '' },
+    { label: 'Pavimentado / impermeabilizado', description: '' },
+    { label: 'Misto (vegetação + pavimentação)', description: '' },
+    { label: 'Abandonado / degradado', description: '' },
+    { label: 'Em construção', description: '' },
+  ]
+})
+```
+
+Map answer to `current_use` enum: `vegetated` | `paved` | `mixed` | `abandoned` | `under-construction`.
+
+## Beat 3 — Priority + tenure + anchoring (10 min)
+
+### 3a · Risk priority
+
+```
+ask_user({
+  question: 'Desses três riscos, qual mais te preocupa no dia a dia?',
+  options: [
+    { label: '🌊 Enchente / inundação', description: 'Água acumulando, chuva forte, rio subindo' },
+    { label: '🌡️ Calor extremo', description: 'Ondas de calor, falta de sombra, ilha de calor urbano' },
+    { label: '⛰️ Deslizamento', description: 'Encostas, morros, terreno instável' },
+  ]
+})
+```
+
+Save the answer as `primary_hazard` (`flood` | `heat` | `landslide`).
+
+Optionally follow up: *"E segundo lugar, qual te preocupa também?"* — same options minus the first pick — and save as `secondary_hazard`.
+
+### 3b · Land tenure
+
+```
+ask_user({
+  question: 'E vocês têm acesso a esse espaço hoje?',
+  options: [
+    { label: 'Sim, somos donas do terreno', description: 'Propriedade da organização' },
+    { label: 'Sim, com acordo formal', description: 'Comodato, cessão, parceria escrita' },
+    { label: 'É da prefeitura, mas a gente usa', description: 'Uso informal, sem documento' },
+    { label: 'É público mas não temos acesso garantido', description: 'Precisaria pedir autorização' },
+    { label: 'Misto / não sei certinho', description: 'Vou precisar olhar isso depois' },
+  ]
+})
+```
+
+Map to `land_tenure`: `private-owned` | `formal-agreement` | `public-informal` | `public-no-access` | `mixed`.
+
+### 3c · Community anchoring (3 quick questions via ask_user, no composer yet)
+
+The `CommunityAnchoringComposer` microapp isn't built yet — for v1 we use 3 sequential `ask_user` turns or a single free-text question. Prefer the free-text route to keep momentum:
+
+```
+Última coisa por hoje. Quem da comunidade está envolvida nesse trabalho? Pode escrever bem rápido — lideranças, voluntários, moradores diretamente atendidos.
+```
+
+Wait for free-text response. Parse into:
+- `community_anchoring_lead` (named lead or "Sandra, D. Maria")
+- `community_volunteers_count` (if mentioned, otherwise leave empty)
+- `beneficiary_groups` (referenced demographics)
+
+Then a single follow-up:
+
+```
+ask_user({
+  question: 'Como vocês se organizam?',
+  multiSelect: true,
+  options: [
+    { label: 'Assembleias / reuniões regulares', description: '' },
+    { label: 'Oficinas educativas', description: '' },
+    { label: 'Mutirões / trabalho voluntário', description: '' },
+    { label: 'Conversas informais com moradores', description: '' },
+    { label: 'Outras formas', description: '' },
+  ]
+})
+```
+
+Save selected options as `community_engagement_methods[]`.
+
+## Scoring (silent, coordinator-side)
+
+After Beat 3 is complete:
+
+```
+SITE_CONTROL (0-3)
+  0  land_tenure unanswered OR no site identified
+  1  land_tenure = 'public-no-access' OR 'public-informal' without permissions mentioned
+  2  land_tenure = 'public-informal' WITH municipal awareness OR 'mixed'
+  3  land_tenure = 'private-owned' OR 'formal-agreement'
+
+COMMUNITY_ANCHORING (0-3)
+  0  no community_anchoring_lead
+  1  beneficiaries named, no engagement methods
+  2  community_engagement_methods includes ≥1 active method (oficinas / mutirões)
+  3  community_engagement_methods includes assembleias regulares OR cooperative governance evidence
+```
+
+Call `score_maturity` for both metrics with 1-sentence Portuguese justifications.
+
+## Closing
+
+After all Beat-3 fields are populated and both metrics scored:
+
+1. Call `update_section('intervention_site', { bairro, site_lat, site_lng, site_name, current_use, land_tenure, primary_hazard, secondary_hazard, community_anchoring_lead, community_engagement_methods })`
+2. Call `score_maturity` for `site_control` and `community_anchoring`
+3. Render the closing message (DO NOT call `set_phase(3)` yet — the coordinator gates that via P-8):
+
+> ✓ **Encontro 2 concluído** — obrigada, {nome}. Seu território está marcado.
+>
+> Você marcou **{site_name ?? bairro}**, e o que mais te preocupa é **{primary_hazard_label}**.
+>
+> O próximo encontro vai abrir quando {coordinator_name ?? "a coordenadora"} liberar — aí a gente escolhe juntas o tipo de SbN que faz mais sentido pra esse lugar.
+>
+> Até lá! 🌱
+
+The P-8 gate will refuse `set_phase(3)` until Workshop 3 is opened — don't try.
+
+## Important behavior rules
+
+### Don't re-ask E1 questions
+The CURRENT STATE has `org_name`, `mission_summary`, `bairro_of_operation`, `path`, etc. Reference them naturally; never ask again.
+
+### Path is in state.metadata or member.path
+The CURRENT STATE prompt block includes the path. Branch your opening accordingly.
+
+### inspiration_picks[] is the receipt for show_examples favorites
+After `show_examples({mode: 'favorites'})`, the user's saved cards persist in `cohort_members.inspiration_picks`. You don't need to track them — E3 will read them for InterventionSelector pre-filtering. Just acknowledge naturally: *"Você guardou DRENURBS — esse é forte exemplo de várzea."*
+
+### Time-aware framing
+This is **one session** in a **6-encontro series**. Don't try to finish everything. If they get tired at Beat 2, save state, suggest breaking, and offer to resume. Use the Pedir Apoio button if they're stuck on the map.
+
+### Photo curation (defensive)
+You may reference the showcase card photos in conversation, but never describe photos that aren't on the verified manifest. The 4 cards seeded are: `curitiba-barigui`, `poa-goncalo-de-carvalho`, `bh-drenurbs`, `poa-varzea-lab` (placeholder gradient).
+
+## Tool calls available
+
+Already wired in cboAgent.ts:
+- `show_examples({mode, hazardFilter?, intro?, cardIds?})` — NEW, E2-specific
+- `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})` — existing
+- `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`, `read_knowledge`
+
+NOT yet wired (DO NOT call):
+- `ask_priority_rank` → use `ask_user` instead
+- `ask_community_anchoring` → use `ask_user` + free-text instead
+- `set_phase_complete` → no separate complete tool; just don't call `set_phase(3)` (P-8 gate refuses it anyway)
+
+## KB grounding (read_knowledge)
+
+- `_success-cases/brazilian-municipal.md` — for additional Brazilian context if asked
+- `_interventions/*.md` — full intervention specs (useful for the closing hint)
+- `_cougar/nbs-mapping-criteria.md` — Site Control + Community Anchoring rubrics
+- `_inclusive-action/*` — if the user asks about community engagement frameworks
+
+## Common stuck patterns
+
+| User says | Why | What you say |
+|---|---|---|
+| "Não sei dizer onde" (needs-help) | Decision paralysis | "Tá tudo bem. Toca em qualquer pedaço e a gente vai vendo. Pode mudar depois." |
+| "Não temos acesso ao terreno" | Site Control = 0/1 | "Faz parte — pelo menos sabemos o que falta. Vamos seguir; isso aparece no plano da próxima vez." |
+| "Não tem comunidade envolvida, sou só eu" | Score 0 territory | "Conta sim. A maioria começa de uma pessoa. Vamos por aí." |
+| "É no meu terreno" | Score 3 territory | "Ótimo — isso facilita bastante. Anotado." |
+| Map keeps zooming weird | UX friction | "Posso te ajudar — quer tentar de novo? Ou prefere conversar com a {coordinator_name} primeiro?" (point to Pedir Apoio button) |
+
+## Estimated runtime
+
+- Beat 1 (showcase) — 5–10 min (longer for needs-help while they save favorites)
+- Beat 2 (map + site + current use) — 25 min
+- Beat 3 (priority + tenure + anchoring) — 10 min
+- Closing — 2 min
+- **~45 min average**, the platform-time budget for E2.

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -106,20 +106,19 @@ Map answer to `current_use` enum: `vegetated` | `paved` | `mixed` | `abandoned` 
 
 ### 3a · Risk priority
 
+Use the `ask_priority_rank` tool — renders the RiskPriorityChips composer inline. Tap-in-order: first tap = primary, second = secondary, third = tertiary.
+
 ```
-ask_user({
-  question: 'Desses três riscos, qual mais te preocupa no dia a dia?',
-  options: [
-    { label: '🌊 Enchente / inundação', description: 'Água acumulando, chuva forte, rio subindo' },
-    { label: '🌡️ Calor extremo', description: 'Ondas de calor, falta de sombra, ilha de calor urbano' },
-    { label: '⛰️ Deslizamento', description: 'Encostas, morros, terreno instável' },
-  ]
+ask_priority_rank({
+  prompt: 'Desses três riscos, qual mais te preocupa no dia a dia?',
+  minRanked: 2
 })
 ```
 
-Save the answer as `primary_hazard` (`flood` | `heat` | `landslide`).
-
-Optionally follow up: *"E segundo lugar, qual te preocupa também?"* — same options minus the first pick — and save as `secondary_hazard`.
+The user's confirmation comes back as a chat message like *"Priority ranking: flood (1), heat (2)"*. Parse it and fill:
+- `primary_hazard` = first ranked
+- `secondary_hazard` = second ranked
+- `tertiary_hazard` = third ranked (if any)
 
 ### 3b · Land tenure
 
@@ -228,11 +227,11 @@ You may reference the showcase card photos in conversation, but never describe p
 
 Already wired in cboAgent.ts:
 - `show_examples({mode, hazardFilter?, intro?, cardIds?})` — NEW, E2-specific
+- `ask_priority_rank({prompt, minRanked?})` — NEW, E2 Beat 3a
 - `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})` — existing
 - `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`, `read_knowledge`
 
 NOT yet wired (DO NOT call):
-- `ask_priority_rank` → use `ask_user` instead
 - `ask_community_anchoring` → use `ask_user` + free-text instead
 - `set_phase_complete` → no separate complete tool; just don't call `set_phase(3)` (P-8 gate refuses it anyway)
 

--- a/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/showcase-mockup.html
+++ b/knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/showcase-mockup.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NbsShowcaseCard · mockup</title>
+<style>
+  :root {
+    --bg: #fafaf9; --surface: #ffffff; --ink: #18181b; --muted: #71717a;
+    --line: rgba(0,0,0,0.08); --accent: #059669; --accent-soft: #ecfdf5;
+    --accent-deep: #047857;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Inter", system-ui, sans-serif; line-height: 1.5; font-size: 14px; }
+  .doc { max-width: 1280px; margin: 0 auto; padding: 48px 28px 96px; }
+  h1 { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 4px; }
+  h1 .small { font-size: 13px; font-weight: 400; color: var(--muted); }
+  h2.screen { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin: 56px 0 12px; }
+  .lede { color: var(--muted); margin: 8px 0 24px; max-width: 64ch; line-height: 1.6; }
+  .anno { font-size: 12px; color: var(--muted); margin: 8px 0 18px; padding-left: 14px; border-left: 2px solid var(--accent); max-width: 64ch; }
+  .scene { background: var(--surface); border: 1px solid var(--line); border-radius: 14px; padding: 20px; margin-bottom: 8px; }
+  .agent-msg {
+    background: #f4f4f5; border-radius: 14px; padding: 10px 14px;
+    font-size: 13px; line-height: 1.5; max-width: 600px; margin-bottom: 12px;
+  }
+  .strip-intro { font-size: 12px; color: var(--muted); padding-left: 4px; margin-bottom: 8px; }
+  .strip { display: flex; gap: 10px; overflow-x: auto; padding-bottom: 8px; }
+  .card {
+    flex-shrink: 0; width: 240px;
+    border: 1px solid var(--line); border-radius: 12px; background: var(--surface);
+    overflow: hidden; transition: all 0.15s;
+  }
+  .card.saved {
+    border-color: var(--accent); box-shadow: 0 0 0 2px rgba(5,150,105,0.2);
+  }
+  .thumb {
+    height: 128px; position: relative;
+    background-size: cover; background-position: center;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .thumb.placeholder { font-size: 48px; }
+  .thumb.barigui { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0" stop-color="%23bfdbfe"/><stop offset="1" stop-color="%2334d399"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><ellipse cx="120" cy="100" rx="80" ry="22" fill="%2306b6d4" opacity="0.4"/><circle cx="60" cy="60" r="18" fill="%2316a34a" opacity="0.7"/><circle cx="180" cy="55" r="22" fill="%2316a34a" opacity="0.8"/><circle cx="120" cy="50" r="20" fill="%2316a34a" opacity="0.75"/></svg>') center/cover;
+  }
+  .thumb.goncalo { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="0" y1="0" y2="1"><stop offset="0" stop-color="%23166534"/><stop offset="0.5" stop-color="%2316a34a"/><stop offset="1" stop-color="%2386efac"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><rect x="60" y="80" width="120" height="48" fill="%2354382d" opacity="0.5"/><ellipse cx="40" cy="30" rx="32" ry="40" fill="%23166534"/><ellipse cx="120" cy="20" rx="40" ry="45" fill="%2315803d"/><ellipse cx="200" cy="35" rx="34" ry="42" fill="%23166534"/></svg>') center/cover; }
+  .thumb.drenurbs { background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 128"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0" stop-color="%23dcfce7"/><stop offset="1" stop-color="%2306b6d4"/></linearGradient></defs><rect width="240" height="128" fill="url(%23g)"/><path d="M0 100 Q60 80 120 95 T240 90 L240 128 L0 128 Z" fill="%2306b6d4" opacity="0.6"/><circle cx="40" cy="70" r="12" fill="%2316a34a"/><circle cx="170" cy="65" r="14" fill="%2316a34a"/><circle cx="210" cy="78" r="10" fill="%2316a34a"/></svg>') center/cover; }
+  .thumb.placeholder.biodiversity { background: linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%); }
+  .credit {
+    position: absolute; bottom: 0; right: 0;
+    padding: 2px 6px; background: rgba(0,0,0,0.5); color: white;
+    font-size: 8px; font-weight: 500;
+  }
+  .card-body { padding: 12px; }
+  .card-title { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+  .card-title h4 { margin: 0; font-size: 13px; font-weight: 600; line-height: 1.25; }
+  .save-btn {
+    flex-shrink: 0; width: 24px; height: 24px; border-radius: 6px;
+    background: transparent; border: 0; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--muted); transition: all 0.15s;
+  }
+  .save-btn:hover { background: #f4f4f5; color: var(--ink); }
+  .save-btn.active { color: var(--accent); }
+  .meta {
+    font-size: 10px; color: var(--muted); margin-top: 5px;
+    display: flex; gap: 6px;
+  }
+  .summary { font-size: 11px; color: var(--ink); opacity: 0.85; line-height: 1.4; margin-top: 6px; }
+  .more {
+    font-size: 10px; font-weight: 500; color: var(--accent-deep);
+    margin-top: 6px; cursor: pointer; display: inline-flex; align-items: center; gap: 2px;
+  }
+
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 20px; }
+  .compare-cell { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 16px; }
+  .compare-cell .lbl { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; margin-bottom: 8px; }
+  .compare-cell p { font-size: 12px; color: var(--muted); line-height: 1.5; margin: 8px 0 0; }
+</style>
+</head>
+<body>
+<div class="doc">
+  <h1>NbsShowcaseCard <span class="small">· inline chat card · 4 verified examples</span></h1>
+  <p class="lede">
+    Shown at the start of E2 to build NBS vocabulary before the CBO touches the map. Renders horizontal-scroll inside the chat thread. Two modes: <strong>browse</strong> (has-idea path) and <strong>favorites</strong> (needs-help path, with per-card save toggle).
+  </p>
+
+  <h2 class="screen">browse mode · has-idea path</h2>
+  <p class="anno">Agent introduces the cards briefly, then the strip renders inline. No save buttons; user can scroll and tap "Saber mais" to expand any card.</p>
+
+  <div class="scene">
+    <div class="agent-msg">
+      Antes de abrir o mapa, dois exemplos rápidos pra você ter referência:
+    </div>
+
+    <div class="strip">
+      <div class="card">
+        <div class="thumb barigui">
+          <div class="credit">A. C. Fonseca · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>Parques do Barigui</h4></div>
+          <div class="meta">📍 Curitiba, PR · 📅 1996 · enchente</div>
+          <p class="summary">Parques que viram retenção de água quando chove forte</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb goncalo">
+          <div class="credit">Amigos da Rua · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>Rua Gonçalo de Carvalho</h4></div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 1930 · calor</div>
+          <p class="summary">Túnel de copa formado por 100+ Tipuanas em 3 quarteirões</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb drenurbs">
+          <div class="credit">M. A. Dutra · CC-BY</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title"><h4>DRENURBS — Primeiro de Maio</h4></div>
+          <div class="meta">📍 Belo Horizonte, MG · 📅 2003 · enchente</div>
+          <p class="summary">Recuperação de áreas úmidas + parque que aguenta a chuva</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb placeholder biodiversity">🌱</div>
+        <div class="card-body">
+          <div class="card-title"><h4>Várzea Lab · Vila Flores</h4></div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 2024 · misto</div>
+          <p class="summary">Hortas + jardins de chuva no 4º Distrito pós-enchente</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="screen">favorites mode · needs-help path</h2>
+  <p class="anno">Agent invites the user to save 1-2 examples. Saved cards get a green ring + filled bookmark. Saved IDs persist as <code>inspiration_picks[]</code> → E3's InterventionSelector pre-filters by them.</p>
+
+  <div class="scene">
+    <div class="agent-msg">
+      Vamos criar repertório antes do mapa. <strong>Salve 1 ou 2 que te chamam atenção</strong> — algum que parece que poderia funcionar no seu bairro.
+    </div>
+
+    <div class="strip">
+      <div class="card">
+        <div class="thumb barigui">
+          <div class="credit">A. C. Fonseca · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Parques do Barigui</h4>
+            <button class="save-btn" title="Salvar">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Curitiba, PR · 📅 1996 · enchente</div>
+          <p class="summary">Parques que viram retenção de água quando chove forte</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card saved">
+        <div class="thumb goncalo">
+          <div class="credit">Amigos da Rua · CC-BY-SA</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Rua Gonçalo de Carvalho</h4>
+            <button class="save-btn active" title="Remover">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 1930 · calor</div>
+          <p class="summary">Túnel de copa formado por 100+ Tipuanas em 3 quarteirões</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="thumb drenurbs">
+          <div class="credit">M. A. Dutra · CC-BY</div>
+        </div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>DRENURBS — Primeiro de Maio</h4>
+            <button class="save-btn" title="Salvar">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Belo Horizonte, MG · 📅 2003 · enchente</div>
+          <p class="summary">Recuperação de áreas úmidas + parque que aguenta a chuva</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+
+      <div class="card saved">
+        <div class="thumb placeholder biodiversity">🌱</div>
+        <div class="card-body">
+          <div class="card-title">
+            <h4>Várzea Lab · Vila Flores</h4>
+            <button class="save-btn active" title="Remover">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+          </div>
+          <div class="meta">📍 Porto Alegre, RS · 📅 2024 · misto</div>
+          <p class="summary">Hortas + jardins de chuva no 4º Distrito pós-enchente</p>
+          <span class="more">▼ Saber mais</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="screen">Photo curation</h2>
+  <div class="compare-grid">
+    <div class="compare-cell">
+      <p class="lbl">Verified photo</p>
+      <p>3 of 4 cards use verified-source photos from the manifest at <code>docs/photo-curation.md</code>. Photographer + license badge in the bottom-right corner — non-intrusive but always visible.</p>
+      <p>The cards above use SVG approximations because the live photos aren't embedded in this static HTML. In the app they render the real <code>/assets/interventions/*.jpg</code> files.</p>
+    </div>
+    <div class="compare-cell">
+      <p class="lbl">Placeholder (Vila Flores)</p>
+      <p>Vila Flores Várzea Lab doesn't yet have a verified photo, so it ships with a gradient + emoji placeholder. The card is still useful (text describes the case) — it just doesn't claim to show a specific image.</p>
+      <p>When a photo is sourced and verified, the manifest entry switches from <code>placeholder</code> to <code>photo</code> and the card flips automatically.</p>
+    </div>
+  </div>
+
+  <p style="font-size: 11px; color: var(--muted); margin-top: 36px; border-top: 1px solid var(--line); padding-top: 16px;">
+    Component: <code>client/src/core/components/cbo/NbsShowcaseCard.tsx</code> · Data: <code>shared/nbs-showcase-cards.ts</code> · Manifest: <code>docs/photo-curation.md</code>. Agent tool (<code>show_examples</code>) lands in a follow-up PR.
+  </p>
+</div>
+</body>
+</html>

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -224,6 +224,7 @@ export function registerCohortRoutes(app: Express): void {
       nextWorkshop,
       supportRequests,
       supportPendingCount: supportPending.length,
+      inspirationPicks: Array.isArray(member.inspirationPicks) ? member.inspirationPicks : [],
     });
   }));
 
@@ -256,6 +257,31 @@ export function registerCohortRoutes(app: Express): void {
     }
     await db.update(cohortMembers).set({ supportRequests: next }).where(eq(cohortMembers.id, member.id));
     res.json({ entry });
+  }));
+
+  // CBO toggles a NbsShowcaseCard favorite during E2. POST /toggle-on,
+  // DELETE /toggle-off. Body: { cardId }. Returns the updated picks array.
+  // Soft cap at 5 picks per spec — over that, oldest pick drops.
+  app.post('/api/cbo-member/:memberSlug/inspiration-pick', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    const { cardId, action } = req.body ?? {};
+    if (!cardId || typeof cardId !== 'string') { res.status(400).json({ error: 'cardId required' }); return; }
+    const current = Array.isArray(member.inspirationPicks) ? (member.inspirationPicks as string[]) : [];
+    let next: string[];
+    if (action === 'remove') {
+      next = current.filter(id => id !== cardId);
+    } else {
+      // Default = add. Idempotent — already-present is a no-op.
+      if (current.includes(cardId)) {
+        next = current;
+      } else {
+        next = [...current, cardId];
+        if (next.length > 5) next = next.slice(next.length - 5);
+      }
+    }
+    await db.update(cohortMembers).set({ inspirationPicks: next }).where(eq(cohortMembers.id, member.id));
+    res.json({ inspirationPicks: next });
   }));
 
   // Coordinator marks a request resolved. Optional resolvedNote.

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -259,6 +259,49 @@ export function registerCohortRoutes(app: Express): void {
     res.json({ entry });
   }));
 
+  // Coordinator support inbox — list all support requests across the cohort,
+  // newest first. Returns flattened entries with member context so the UI
+  // doesn't need to re-correlate. `status=pending` filters to unresolved.
+  app.get('/api/cohort/:coordinatorSlug/support-requests', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    const filter = String(req.query.status ?? 'all');
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const items: Array<{
+      requestId: string;
+      memberId: string;
+      memberSlug: string;
+      orgName: string;
+      neighborhood: string | null;
+      type: SupportRequestType;
+      message: string | null;
+      createdAt: string;
+      resolvedAt: string | null;
+      resolvedNote: string | null;
+    }> = [];
+    for (const m of members) {
+      const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
+      for (const r of arr) {
+        if (filter === 'pending' && r.resolvedAt) continue;
+        if (filter === 'resolved' && !r.resolvedAt) continue;
+        items.push({
+          requestId: r.id,
+          memberId: m.id,
+          memberSlug: m.memberSlug,
+          orgName: m.orgName,
+          neighborhood: m.neighborhood,
+          type: r.type,
+          message: r.message,
+          createdAt: r.createdAt,
+          resolvedAt: r.resolvedAt,
+          resolvedNote: r.resolvedNote,
+        });
+      }
+    }
+    items.sort((a, b) => (b.createdAt > a.createdAt ? 1 : -1));
+    res.json({ items, total: items.length });
+  }));
+
   // CBO toggles a NbsShowcaseCard favorite during E2. POST /toggle-on,
   // DELETE /toggle-off. Body: { cardId }. Returns the updated picks array.
   // Soft cap at 5 picks per spec — over that, oldest pick drops.

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -6,7 +6,10 @@ import {
   cohorts,
   cohortMembers,
   DEFAULT_WORKSHOPS,
+  SUPPORT_REQUEST_TYPES,
   type CohortSettings,
+  type SupportRequest,
+  type SupportRequestType,
   type WorkshopConfig,
 } from '@shared/cohort-schema';
 
@@ -206,6 +209,9 @@ export function registerCohortRoutes(app: Express): void {
     const nextPhase = maxUnlocked + 1;
     const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
+    const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
+    const supportPending = supportRequests.filter(r => !r.resolvedAt);
+
     res.json({
       id: member.id,
       orgName: member.orgName,
@@ -216,7 +222,63 @@ export function registerCohortRoutes(app: Express): void {
       cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
       workshops,
       nextWorkshop,
+      supportRequests,
+      supportPendingCount: supportPending.length,
     });
+  }));
+
+  // CBO submits a support request. Returns the created entry (with id).
+  app.post('/api/cbo-member/:memberSlug/support-request', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    const { type, message } = req.body ?? {};
+    if (!SUPPORT_REQUEST_TYPES.includes(type as SupportRequestType)) {
+      res.status(400).json({ error: 'invalid support request type', allowed: SUPPORT_REQUEST_TYPES });
+      return;
+    }
+
+    const entry: SupportRequest = {
+      id: nanoid(12),
+      type: type as SupportRequestType,
+      message: typeof message === 'string' && message.trim() ? message.trim().slice(0, 2000) : null,
+      createdAt: new Date().toISOString(),
+      resolvedAt: null,
+      resolvedNote: null,
+    };
+    const existing = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
+    // Soft rate limit: cap a member's queue at 20. New requests drop the oldest
+    // resolved entry first; if no resolved entries, drop the oldest pending.
+    let next = [...existing, entry];
+    if (next.length > 20) {
+      const resolvedIdx = next.findIndex(r => !!r.resolvedAt);
+      next.splice(resolvedIdx >= 0 ? resolvedIdx : 0, 1);
+    }
+    await db.update(cohortMembers).set({ supportRequests: next }).where(eq(cohortMembers.id, member.id));
+    res.json({ entry });
+  }));
+
+  // Coordinator marks a request resolved. Optional resolvedNote.
+  app.patch('/api/cohort/:coordinatorSlug/support-request/:requestId/resolve', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const { resolvedNote } = req.body ?? {};
+    const note = typeof resolvedNote === 'string' && resolvedNote.trim() ? resolvedNote.trim().slice(0, 1000) : null;
+
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    for (const m of members) {
+      const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
+      const idx = arr.findIndex(r => r.id === req.params.requestId);
+      if (idx === -1) continue;
+      if (arr[idx].resolvedAt) { res.json({ ok: true, alreadyResolved: true }); return; }
+      const next = [...arr];
+      next[idx] = { ...next[idx], resolvedAt: new Date().toISOString(), resolvedNote: note };
+      await db.update(cohortMembers).set({ supportRequests: next }).where(eq(cohortMembers.id, m.id));
+      res.json({ ok: true, request: next[idx] });
+      return;
+    }
+    res.status(404).json({ error: 'request not found' });
   }));
 
   // CBO pushes a snapshot of its current progress so the orchestrator can show it.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -232,6 +232,24 @@ function createCboMcpTools(cboId: string) {
     { annotations: { readOnlyHint: true } }
   );
 
+  // E2 Beat 3a — risk priority ranking. Renders 3 tap-in-order chips for
+  // flood / heat / landslide. User taps in priority order, then confirms.
+  // Result comes back as a chat message: "Priority ranking: flood (1), heat (2)..."
+  // which the agent parses to fill primary_hazard, secondary_hazard fields.
+  const askPriorityRank = sdkTool(
+    "ask_priority_rank",
+    "Render the RiskPriorityChips composer for the user to rank flood/heat/landslide in order of concern. minRanked is the minimum number of chips they must rank (default 2). STOP and wait for the user's confirmation.",
+    {
+      prompt: z.string().describe("The question shown above the chips, e.g. 'Desses três riscos, qual mais te preocupa?'"),
+      minRanked: z.number().min(1).max(3).optional().default(2),
+    },
+    async (args: any) => {
+      pushEvent({ type: 'ask_priority_rank', prompt: args.prompt, minRanked: args.minRanked ?? 2 });
+      return { content: [{ type: "text" as const, text: `RiskPriorityChips opened. STOP and wait for the user's ranking.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const askUser = sdkTool(
     "ask_user",
     "Present questions to the user. The UI renders interactive buttons. Include showMap: true for site selection.",
@@ -417,7 +435,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
   });
 }
 
@@ -597,6 +615,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__set_phase",
           "mcp__cbo__set_path",
           "mcp__cbo__show_examples",
+          "mcp__cbo__ask_priority_rank",
           "mcp__cbo__ask_user",
           "mcp__cbo__open_map",
           "mcp__cbo__open_intervention_selector",

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -250,6 +250,20 @@ function createCboMcpTools(cboId: string) {
     { annotations: { readOnlyHint: true } }
   );
 
+  // E2 Beat 3c — community anchoring composer. Renders a structured form with
+  // 3 short text fields (lead/volunteers/beneficiaries) + chip multi-select
+  // for engagement methods. Result comes back as a parseable chat message.
+  const askCommunityAnchoring = sdkTool(
+    "ask_community_anchoring",
+    "Render the CommunityAnchoringComposer inline. Used at E2 Beat 3c to capture who from the community is anchored to the work. STOP and wait for the user's confirmation.",
+    { prompt: z.string().describe("Lead text shown above the form") },
+    async (args: any) => {
+      pushEvent({ type: 'ask_community_anchoring', prompt: args.prompt });
+      return { content: [{ type: "text" as const, text: `CommunityAnchoringComposer opened. STOP and wait.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const askUser = sdkTool(
     "ask_user",
     "Present questions to the user. The UI renders interactive buttons. Include showMap: true for site selection.",
@@ -435,7 +449,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
   });
 }
 
@@ -616,6 +630,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__set_path",
           "mcp__cbo__show_examples",
           "mcp__cbo__ask_priority_rank",
+          "mcp__cbo__ask_community_anchoring",
           "mcp__cbo__ask_user",
           "mcp__cbo__open_map",
           "mcp__cbo__open_intervention_selector",

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -201,6 +201,37 @@ function createCboMcpTools(cboId: string) {
     { annotations: { readOnlyHint: false } }
   );
 
+  // E2 educational anchor: render the NbsShowcaseCard strip inline. Two modes:
+  //   browse (has-idea) - read-only horizontal scroll
+  //   favorites (needs-help) - per-card save toggle → inspiration_picks[]
+  // Optional hazardFilter narrows the strip (e.g. flood-only when bairro
+  // hazard is known). Cards available from shared/nbs-showcase-cards.ts.
+  const showExamples = sdkTool(
+    "show_examples",
+    "Render the NbsShowcaseCard strip inline in chat. Use at the start of E2 to build NBS vocabulary. mode='favorites' for needs-help path. Optional hazardFilter to narrow the cards.",
+    {
+      mode: z.enum(["browse", "favorites"]).default("browse"),
+      hazardFilter: z.enum(["flood", "heat", "biodiversity"]).optional(),
+      intro: z.string().optional().describe("Optional 1-line lead text rendered above the strip"),
+      cardIds: z.array(z.string()).optional().describe("Explicit card IDs to show (overrides hazardFilter)"),
+    },
+    async (args: any) => {
+      const showcase = await import("@shared/nbs-showcase-cards");
+      let cards: { id: string }[];
+      if (Array.isArray(args.cardIds) && args.cardIds.length > 0) {
+        cards = args.cardIds
+          .map((id: string) => showcase.getShowcaseCard(id))
+          .filter(Boolean) as { id: string }[];
+      } else {
+        cards = showcase.filterShowcaseCards(args.hazardFilter ? { hazard: args.hazardFilter } : undefined);
+      }
+      const ids = cards.map(c => c.id);
+      pushEvent({ type: 'show_examples', cardIds: ids, mode: args.mode ?? 'browse', intro: args.intro });
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode. STOP and wait for the user's reaction.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const askUser = sdkTool(
     "ask_user",
     "Present questions to the user. The UI renders interactive buttons. Include showMap: true for site selection.",
@@ -386,7 +417,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
   });
 }
 
@@ -565,6 +596,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__flag_gap",
           "mcp__cbo__set_phase",
           "mcp__cbo__set_path",
+          "mcp__cbo__show_examples",
           "mcp__cbo__ask_user",
           "mcp__cbo__open_map",
           "mcp__cbo__open_intervention_selector",

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -202,6 +202,7 @@ export type CboEvent =
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }
+  | { type: 'ask_priority_rank'; prompt: string; minRanked: number }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -203,6 +203,7 @@ export type CboEvent =
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }
   | { type: 'ask_priority_rank'; prompt: string; minRanked: number }
+  | { type: 'ask_community_anchoring'; prompt: string }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -201,6 +201,7 @@ export type CboEvent =
   | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
+  | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }
   | { type: 'done'; summary: string }
   | { type: 'error'; message: string };
 

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -19,6 +19,26 @@ export type CohortSettings = {
   workshops: WorkshopConfig[];
 };
 
+// RequestSupport — async escalation queue. CBO submits via chat-header button;
+// coordinator resolves from orchestrator dashboard. See
+// knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
+export const SUPPORT_REQUEST_TYPES = [
+  'coordinator-chat',  // Conversa com a coordenadora
+  'oef-technical',     // Pergunta técnica pra equipe OEF
+  'cbo-connection',    // Conexão com outro CBO que já fez algo parecido
+  'finance-partners',  // Algo sobre finanças / parceiros
+] as const;
+export type SupportRequestType = typeof SUPPORT_REQUEST_TYPES[number];
+
+export type SupportRequest = {
+  id: string;
+  type: SupportRequestType;
+  message: string | null;
+  createdAt: string;          // ISO timestamp
+  resolvedAt: string | null;  // null while pending
+  resolvedNote: string | null;
+};
+
 export const cohorts = pgTable('cohorts', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
   coordinatorSlug: text('coordinator_slug').notNull().unique(),
@@ -41,6 +61,10 @@ export const cohortMembers = pgTable('cohort_members', {
   // mind; 'needs-help' = CBO wants help discovering one. Null until E1 asks.
   // See knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
   path: text('path').$type<'has-idea' | 'needs-help'>(),
+  // Cross-cutting RequestSupport queue. CBO submits via the chat-header button;
+  // coordinator resolves from the orchestrator dashboard. JSONB so we don't need
+  // a separate table for what is effectively a small per-member queue.
+  supportRequests: jsonb('support_requests').$type<SupportRequest[]>().default([]),
   unlockedPhases: jsonb('unlocked_phases').$type<number[]>().default([1]),
   invitedAt: timestamp('invited_at').defaultNow(),
   startedAt: timestamp('started_at'),

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -65,6 +65,10 @@ export const cohortMembers = pgTable('cohort_members', {
   // coordinator resolves from the orchestrator dashboard. JSONB so we don't need
   // a separate table for what is effectively a small per-member queue.
   supportRequests: jsonb('support_requests').$type<SupportRequest[]>().default([]),
+  // E2 favorites: ShowcaseCard IDs the CBO saved during the educational anchor
+  // (needs-help path). E3's InterventionSelector pre-filters by typeRefs of
+  // these picks. Empty array for has-idea CBOs who skipped saving.
+  inspirationPicks: jsonb('inspiration_picks').$type<string[]>().default([]),
   unlockedPhases: jsonb('unlocked_phases').$type<number[]>().default([1]),
   invitedAt: timestamp('invited_at').defaultNow(),
   startedAt: timestamp('started_at'),

--- a/shared/nbs-showcase-cards.ts
+++ b/shared/nbs-showcase-cards.ts
@@ -1,0 +1,146 @@
+// NBS Showcase cards — Brazilian community-NBS examples shown inline in the E2
+// chat ("Vamos olhar exemplos antes do mapa"). Build vocabulary before the CBO
+// engages with the bairro map + intervention selector.
+//
+// Photo sources MUST be in the verified manifest (docs/photo-curation.md).
+// Cards without a verified photo render as a gradient + emoji placeholder —
+// no stock photography, no AI-generated images, no unattributed sources.
+//
+// Used by:
+//   - client: NbsShowcaseCard component (renders inline in chat)
+//   - server: show_examples MCP tool (filters by tag, returns the card payload)
+//   - E2 spec: knowledge/runs/2026-05-15-encontros-curriculum/E2-seu-territorio/
+
+export type ShowcaseHazard = 'flood' | 'heat' | 'biodiversity' | 'mixed';
+
+export type ShowcasePhoto = {
+  path: string;
+  source: string;
+  photographer: string;
+  license: string;
+  verified: true;
+};
+
+export type ShowcasePlaceholder = {
+  /** Maps to a CSS gradient on the card. */
+  gradient: 'flood' | 'heat' | 'biodiversity';
+  emoji: string;
+};
+
+export type NbsShowcaseCard = {
+  id: string;
+  org: string;
+  city: string;
+  year: number;
+  hazard: ShowcaseHazard;
+  /** Which of the 6 NBS_INTERVENTION_TYPES this case represents. */
+  typeRefs: string[];
+  summaryPt: string;
+  summaryEn: string;
+  detailPt: string;
+  detailEn: string;
+  /** Either photo OR placeholder is set, not both. */
+  photo: ShowcasePhoto | null;
+  placeholder: ShowcasePlaceholder | null;
+};
+
+export const NBS_SHOWCASE_CARDS: NbsShowcaseCard[] = [
+  {
+    id: 'curitiba-barigui',
+    org: 'Parques do Barigui',
+    city: 'Curitiba, PR',
+    year: 1996,
+    hazard: 'flood',
+    typeRefs: ['flood-parks'],
+    summaryPt: 'Parques que viram retenção de água quando chove forte',
+    summaryEn: 'Parks that act as retention basins during heavy rain',
+    detailPt:
+      'Curitiba transformou várzeas inundáveis em parques públicos a partir de 1996. O Parque Barigui tem ~140 ha e funciona como pulmão urbano + reservatório natural durante enchentes. Modelo replicado em outros parques (Tanguá, Iguaçu, Tingui). 5% mais barato que canais de concreto.',
+    detailEn:
+      'Since 1996 Curitiba has turned flood-prone várzeas into public parks. Parque Barigui covers ~140 ha and works as an urban lung + natural reservoir during floods. Replicated across the city (Tanguá, Iguaçu, Tingui). 5% cheaper than concrete canals.',
+    photo: {
+      path: '/assets/interventions/flood-parks.jpg',
+      source: 'Wikimedia Commons',
+      photographer: 'Agrinaldo Caires Fonseca',
+      license: 'CC-BY-SA-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'poa-goncalo-de-carvalho',
+    org: 'Rua Gonçalo de Carvalho',
+    city: 'Porto Alegre, RS',
+    year: 1930,
+    hazard: 'heat',
+    typeRefs: ['urban-forests'],
+    summaryPt: 'Túnel de copa formado por 100+ Tipuanas em 3 quarteirões',
+    summaryEn: 'Canopy tunnel of 100+ Tipuana trees over 3 blocks',
+    detailPt:
+      'No bairro Independência, moradores defenderam por décadas o plantio dos anos 1930. Em 2006 conseguiram tombamento como Patrimônio Ambiental da América Latina, evitando a derrubada para um shopping. Hoje é uma das ruas mais frescas da cidade — diferença de até 4°C com ruas vizinhas.',
+    detailEn:
+      "In the Independência neighborhood, residents defended the 1930s plantings for decades. In 2006 they secured Environmental Heritage of Latin America status, blocking demolition for a mall. Today it's one of the coolest streets in the city — up to 4°C cooler than neighboring streets.",
+    photo: {
+      path: '/assets/interventions/urban-forests.jpg',
+      source: 'Amigos da Rua Gonçalo de Carvalho',
+      photographer: 'Amigos da Rua Gonçalo de Carvalho',
+      license: 'CC-BY-SA-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'bh-drenurbs',
+    org: 'DRENURBS — Parque Primeiro de Maio',
+    city: 'Belo Horizonte, MG',
+    year: 2003,
+    hazard: 'flood',
+    typeRefs: ['wetland-restoration', 'flood-parks'],
+    summaryPt: 'Recuperação de áreas úmidas + parque que aguenta a chuva',
+    summaryEn: 'Wetland recovery + a park that holds up to heavy rain',
+    detailPt:
+      'Programa de drenagem urbana sustentável da Prefeitura de BH, financiado pelo BID. Recupera córregos canalizados, restaura várzeas, cria parques lineares. Na enchente de 2020, a infraestrutura verde-azul se mostrou mais resiliente que a canalização tradicional. Modelo seguido por outras capitais.',
+    detailEn:
+      "Belo Horizonte's sustainable urban drainage program, IDB-financed. Recovers canalized streams, restores wetlands, creates linear parks. During the 2020 floods, the green-blue infrastructure outperformed traditional canalization. Now a model for other capitals.",
+    photo: {
+      path: '/assets/interventions/wetland-restoration.jpg',
+      source: 'Wikimedia Commons',
+      photographer: 'Marcio Adauto Dutra',
+      license: 'CC-BY-3.0',
+      verified: true,
+    },
+    placeholder: null,
+  },
+  {
+    id: 'poa-varzea-lab',
+    org: 'Várzea Lab · Vila Flores',
+    city: 'Porto Alegre, RS',
+    year: 2024,
+    hazard: 'mixed',
+    typeRefs: ['wetland-restoration', 'bioswales-rain-gardens'],
+    summaryPt: 'Hortas + jardins de chuva no 4º Distrito pós-enchente',
+    summaryEn: 'Community gardens + rain gardens in the 4° Distrito post-flood',
+    detailPt:
+      'Iniciativa do Vila Flores no pós-enchente de maio de 2024. Articulou 5 laboratórios urbanos em 2 anos no 4º Distrito — incluindo hortas comunitárias, jardins de chuva, e oficinas com moradores. Captou recursos da Caixa Federal e do Fundo Casa RS. Referência regional pra adaptação climática liderada por OBCs.',
+    detailEn:
+      "Vila Flores' post-2024-flood initiative. Five urban labs in 2 years in the 4° Distrito — community gardens, rain gardens, and resident workshops. Funded by Caixa Federal and Fundo Casa RS. Regional reference for CBO-led climate adaptation.",
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '🌱',
+    },
+  },
+];
+
+export function getShowcaseCard(id: string): NbsShowcaseCard | undefined {
+  return NBS_SHOWCASE_CARDS.find(c => c.id === id);
+}
+
+/** Filter by tag — currently just hazard. Extend with more dimensions as we add cards. */
+export function filterShowcaseCards(opts?: { hazard?: ShowcaseHazard }): NbsShowcaseCard[] {
+  if (!opts) return NBS_SHOWCASE_CARDS;
+  return NBS_SHOWCASE_CARDS.filter(c => {
+    if (opts.hazard && c.hazard !== opts.hazard && c.hazard !== 'mixed') return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Closes the remaining E2 Beat 3 component. Replaces the fallback free-text + \`ask_user\` multiSelect from the E2 skill (#156) with a proper structured form.

**Stacks on PRs #154 #155 #156 #157 #158.**

## What ships

| File | What |
|---|---|
| \`client/src/core/components/cbo/CommunityAnchoringComposer.tsx\` | ~180 lines. 3 text fields + chip multi-select |
| \`shared/cbo-schema.ts\` | \`CboEvent\` new variant \`ask_community_anchoring\` |
| \`server/services/cboAgent.ts\` | \`ask_community_anchoring\` MCP tool + registered as \`mcp__cbo__ask_community_anchoring\` |
| \`client/src/core/pages/cbo-profile.tsx\` | Event handler + inline render |
| \`knowledge/_skills/encontro-2.md\` | Updated Beat 3c to call \`ask_community_anchoring\` |

## Fields captured

| Field | Type | UX |
|---|---|---|
| \`lead\` | free text | Textarea — \"Quem puxa o trabalho? Ex: Sandra, D. Maria\" |
| \`volunteers\` | free text | Textarea — \"Quantas pessoas, com que frequência?\" |
| \`beneficiaries\` | free text | Textarea — \"Quem é beneficiado?\" |
| \`methods[]\` | multi-select chips | assembleias · oficinas · mutirões · conversas · outras |

## Confirm gate

The Confirmar button enables when **lead OR beneficiaries** is filled. Methods alone aren't enough — the COMMUNITY_ANCHORING maturity score (0–3) needs someone named to score above 0.

## Submit payload

On confirm, posts back to the agent as a parseable chat message:

\`\`\`
Community anchoring — Lead: Sandra, D. Maria | Volunteers: ~8 mutirão mensal | Beneficiaries: 12 famílias na Rua Flores | Methods: oficinas, mutiroes
\`\`\`

Empty fields are omitted from the payload.

## E2 Beat 3 status after this PR

| Beat | Component | Status |
|---|---|---|
| 3a · Risk priority | RiskPriorityChips (#158) | ✓ |
| 3b · Land tenure | \`ask_user\` (fallback) | ✓ working |
| 3c · Community anchoring | CommunityAnchoringComposer (this PR) | ✓ |

E2 is now component-complete. Map browse-only mode is the remaining E2 polish item.

## Test plan

- [ ] Agent calls \`ask_community_anchoring\` → composer renders in chat
- [ ] Type into Lead → Confirmar enables
- [ ] Toggle 2 method chips → both highlighted in emerald
- [ ] Confirmar → parseable message posted
- [ ] Empty form → Confirmar disabled (proves confirmGate)
- [ ] PT and EN labels render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)