### PR TITLE
fix(dates): off-by-one in workshop date pills (UTC vs local)

### DIFF
--- a/client/src/core/components/cbo/CboProgress.tsx
+++ b/client/src/core/components/cbo/CboProgress.tsx
@@ -4,6 +4,7 @@ import {
   Popover, PopoverContent, PopoverTrigger,
 } from '@/core/components/ui/popover';
 import type { WorkshopConfig } from '@shared/cohort-schema';
+import { formatCalendarDate } from '@/lib/dateHelpers';
 
 // ---------------------------------------------------------------------------
 // CboProgress — friendly progress display that replaces the
@@ -89,7 +90,7 @@ export function CboProgress({
           if (!isUnlocked) {
             const workshop = workshops.find(w => w.unlocksPhase === p.num);
             const workshopDate = workshop?.date
-              ? new Date(workshop.date).toLocaleDateString(isPt ? 'pt-BR' : 'en-US', { weekday: 'long', day: 'numeric', month: 'short' })
+              ? formatCalendarDate(workshop.date, isPt ? 'pt-BR' : 'en-US', { weekday: 'long', day: 'numeric', month: 'short' })
               : null;
             return (
               <Popover key={p.num}>

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Calendar, Clock, Leaf, Sprout } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
 import type { WorkshopConfig } from '@shared/cohort-schema';
+import { formatCalendarDate } from '@/lib/dateHelpers';
 
 // ---------------------------------------------------------------------------
 // CBO welcome screen — the first thing a community leader sees after tapping
@@ -34,7 +35,7 @@ export function CboWelcome({
   const phasesUnlockedCount = unlockedPhases.length;
 
   const workshopDateLabel = nextWorkshop?.date
-    ? new Date(nextWorkshop.date).toLocaleDateString(isPt ? 'pt-BR' : 'en-US', {
+    ? formatCalendarDate(nextWorkshop.date, isPt ? 'pt-BR' : 'en-US', {
         weekday: 'long', day: 'numeric', month: 'long',
       })
     : null;

--- a/client/src/core/components/orchestrator/WorkshopCadence.tsx
+++ b/client/src/core/components/orchestrator/WorkshopCadence.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Calendar, Check, ChevronRight, Lock, Pencil, Unlock } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
+import { formatCalendarDate } from '@/lib/dateHelpers';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 
 // ---------------------------------------------------------------------------
@@ -35,12 +36,7 @@ function computeState(workshops: WorkshopConfig[]): WorkshopState[] {
 }
 
 function formatShortDate(iso: string, locale: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' });
-  } catch {
-    return iso;
-  }
+  return formatCalendarDate(iso, locale);
 }
 
 // ---------------------------------------------------------------------------

--- a/client/src/lib/dateHelpers.ts
+++ b/client/src/lib/dateHelpers.ts
@@ -1,0 +1,32 @@
+// Frontend date helpers.
+//
+// `<input type="date">` returns YYYY-MM-DD strings. Passing those to
+// `new Date()` parses them as **UTC midnight** per the ISO 8601 spec for
+// date-only strings — which then formats one day earlier in any negative-
+// offset timezone (e.g. America/Sao_Paulo, UTC-3). For workshop dates we
+// want the *calendar day* to be preserved regardless of timezone.
+//
+// `parseLocalCalendarDate` accepts either a date-only string (YYYY-MM-DD)
+// or a full ISO timestamp and always returns a Date that represents the
+// intended calendar day in the user's local timezone.
+
+/** Returns a local-midnight Date for a YYYY-MM-DD string, or `new Date(iso)`
+ *  for any other ISO format. Always safe to feed to toLocaleDateString. */
+export function parseLocalCalendarDate(iso: string): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (m) return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return new Date(iso);
+}
+
+/** Format a workshop date for display — always tz-safe. */
+export function formatCalendarDate(
+  iso: string,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = { weekday: 'short', day: 'numeric', month: 'short' },
+): string {
+  try {
+    return parseLocalCalendarDate(iso).toLocaleDateString(locale, options);
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
## Summary

Coordinator picks **18/05/2026** in the workshop date picker → it renders back as **17/05**. Classic UTC-vs-local-timezone bug.

\`<input type=\"date\">\` emits YYYY-MM-DD strings. \`new Date(\"2026-05-18\")\` parses that as **UTC midnight** per the ISO 8601 spec for date-only strings — which then formats one day earlier in any negative-offset timezone. São Paulo is UTC-3, so the calendar day shifts back.

## Fix

Parse YYYY-MM-DD strings as **local midnight** instead of UTC. Full ISO timestamps with time components flow through unchanged.

| File | Change |
|---|---|
| \`client/src/lib/dateHelpers.ts\` (new) | \`parseLocalCalendarDate()\` + \`formatCalendarDate()\` |
| \`WorkshopCadence.tsx\` | \`formatShortDate\` uses the new helper — fixes DatePill + HeldOnPill |
| \`CboProgress.tsx\` | Locked-phase popover workshopDate |
| \`CboWelcome.tsx\` | Next-workshop card on the welcome screen |

## Test plan

- [ ] Open orchestrator in BR timezone, pick \"18/05/2026\" → pill renders \"18/5\" not \"17/5\"
- [ ] Same in en-US timezone (UTC+ also affected, but inverted): pick a date → pill matches
- [ ] CBO welcome screen → next-workshop card shows correct date
- [ ] CBO progress chips → locked phase popover shows correct workshop date

🤖 Generated with [Claude Code](https://claude.com/claude-code)