### PR TITLE
fix(invite): language consistency on role hints

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -389,8 +389,8 @@ export function InviteCboDialog({
                   ? t('orchestrator.cohort.rolePriority', { defaultValue: 'Priority' })
                   : t('orchestrator.cohort.roleAlternate', { defaultValue: 'Alternate' });
                 const hint = r === 'priority'
-                  ? t('orchestrator.cohort.rolePriorityHint', { defaultValue: 'Rodando o piloto. Uma das 10 vagas ativas.' })
-                  : t('orchestrator.cohort.roleAlternateHint', { defaultValue: 'Lista de espera. Promovida se uma OBC priority desistir.' });
+                  ? t('orchestrator.cohort.rolePriorityHint', { defaultValue: 'Running the pilot. One of the 10 active seats.' })
+                  : t('orchestrator.cohort.roleAlternateHint', { defaultValue: 'Waitlist. Promotes to cohort if a priority CBO drops out.' });
                 return (
                   <button
                     key={r}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -77,6 +77,14 @@
     "subtitle": "Você poderá coordenar um portfólio de projetos comunitários aqui: acompanhar o status, ver o impacto agregado e orientá-los nos ciclos de financiamento.",
     "status": "Estamos desenhando isso junto com parceiros. Quer acesso antecipado? Entre em contato com a equipe.",
     "switchRole": "Voltar para seleção de perfil",
+    "cohort": {
+      "role": "Papel no grupo",
+      "roleAll": "Papel (aplica-se a todas)",
+      "rolePriority": "Prioridade",
+      "roleAlternate": "Suplente",
+      "rolePriorityHint": "Rodando o piloto. Uma das 10 vagas ativas.",
+      "roleAlternateHint": "Lista de espera. Promovida se uma OBC prioritária desistir."
+    },
     "demo": {
       "headerEyebrow": "Visão da articuladora",
       "headerTitle": "Portfólio de projetos comunitários",


### PR DESCRIPTION
## Summary

PR #163 set the role-hint \`defaultValue\` to Portuguese — that broke EN-mode users (they saw PT text inside an otherwise EN dialog).

**Stacks on PR #163.**

## Fix

1. \`defaultValue\` back to **English** — matches the rest of \`CohortDialogs.tsx\`, where every label uses EN as fallback and PT overrides come from \`pt.json\` keys.
2. Added a proper \`orchestrator.cohort\` block to \`pt.json\` with the 6 keys this surface needs:

| Key | PT |
|---|---|
| \`role\` | Papel no grupo |
| \`roleAll\` | Papel (aplica-se a todas) |
| \`rolePriority\` | Prioridade |
| \`roleAlternate\` | Suplente |
| \`rolePriorityHint\` | Rodando o piloto. Uma das 10 vagas ativas. |
| \`roleAlternateHint\` | Lista de espera. Promovida se uma OBC prioritária desistir. |

## Result

- **EN mode**: *\"Priority — Running the pilot. One of the 10 active seats.\"*
- **PT mode**: *\"Prioridade — Rodando o piloto. Uma das 10 vagas ativas.\"*

## Note

While in \`pt.json\` I noticed the rest of the dialog (createTitle, inviteTitle, cohortName, etc.) has no PT translations either — they all fall back to EN. Out of scope for this fix but worth a future cleanup pass if PT consistency matters for pilot launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)