### PR TITLE
fix(welcome): show current workshop, not just "next"

### DIFF
--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -15,7 +15,8 @@ export function CboWelcome({
   orgName,
   neighborhood,
   cohortName,
-  nextWorkshop,
+  focusWorkshop,
+  focusWorkshopIsCurrent,
   unlockedPhases,
   onStart,
   onResume,
@@ -24,7 +25,11 @@ export function CboWelcome({
   orgName: string;
   neighborhood: string | null;
   cohortName: string | null;
-  nextWorkshop: WorkshopConfig | null;
+  /** The workshop to feature on the welcome card. Either the currently-active
+   *  one (if the coordinator has opened any) or the first upcoming one. */
+  focusWorkshop: WorkshopConfig | null;
+  /** When true, label as "current workshop"; when false, label as "next". */
+  focusWorkshopIsCurrent: boolean;
   unlockedPhases: number[];
   onStart: () => void;
   onResume: () => void;
@@ -34,8 +39,8 @@ export function CboWelcome({
   const isPt = i18n.language?.startsWith('pt');
   const phasesUnlockedCount = unlockedPhases.length;
 
-  const workshopDateLabel = nextWorkshop?.date
-    ? formatCalendarDate(nextWorkshop.date, isPt ? 'pt-BR' : 'en-US', {
+  const workshopDateLabel = focusWorkshop?.date
+    ? formatCalendarDate(focusWorkshop.date, isPt ? 'pt-BR' : 'en-US', {
         weekday: 'long', day: 'numeric', month: 'long',
       })
     : null;
@@ -90,8 +95,8 @@ export function CboWelcome({
             </p>
           </div>
 
-          {/* Next workshop card */}
-          {nextWorkshop && (
+          {/* Focus workshop card — current (active) or next (upcoming). */}
+          {focusWorkshop && (
             <motion.div
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
@@ -99,9 +104,11 @@ export function CboWelcome({
               className="rounded-xl border border-emerald-200/60 bg-white/70 dark:border-emerald-900/40 dark:bg-emerald-950/30 px-4 py-3 backdrop-blur-sm"
             >
               <p className="text-[10px] uppercase tracking-wider text-emerald-700/70 dark:text-emerald-400/70 font-semibold mb-1.5">
-                {t('cbo.welcome.nextWorkshopLabel', { defaultValue: 'Next workshop' })}
+                {focusWorkshopIsCurrent
+                  ? t('cbo.welcome.currentWorkshopLabel', { defaultValue: 'Current workshop' })
+                  : t('cbo.welcome.nextWorkshopLabel', { defaultValue: 'Next workshop' })}
               </p>
-              <p className="text-sm font-medium text-foreground/90">{nextWorkshop.name}</p>
+              <p className="text-sm font-medium text-foreground/90">{focusWorkshop.name}</p>
               {workshopDateLabel && (
                 <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
                   <Calendar className="w-3 h-3" />

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -227,6 +227,11 @@ export default function CboProfilePage() {
   const [cohortName, setCohortName] = useState<string | null>(null);
   const [workshops, setWorkshops] = useState<WorkshopConfig[]>([]);
   const [nextWorkshop, setNextWorkshop] = useState<WorkshopConfig | null>(null);
+  // CboWelcome's "focus workshop" — the one to highlight on the welcome card.
+  // Either the currently-active workshop (most-recently opened) or the first
+  // upcoming one. focusWorkshopIsCurrent picks which label to show.
+  const [focusWorkshop, setFocusWorkshop] = useState<WorkshopConfig | null>(null);
+  const [focusWorkshopIsCurrent, setFocusWorkshopIsCurrent] = useState(false);
   const [unlockedPhases, setUnlockedPhases] = useState<number[]>([1, 2, 3, 4, 5]); // ungated by default
   // When arriving via ?cbo=<slug>, render the premium welcome screen until
   // the user taps Start / Continue. Flipped to true once member-fetch lands.
@@ -251,6 +256,8 @@ export default function CboProfilePage() {
       if (data.cohort?.name) setCohortName(data.cohort.name);
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
+      setFocusWorkshop(data.focusWorkshop ?? null);
+      setFocusWorkshopIsCurrent(!!data.focusWorkshopIsCurrent);
     };
     fetch(`/api/cbo-member/${slug}`)
       .then(r => r.ok ? r.json() : null)
@@ -628,7 +635,8 @@ export default function CboProfilePage() {
         orgName={memberInfo.orgName}
         neighborhood={memberInfo.neighborhood}
         cohortName={cohortName}
-        nextWorkshop={nextWorkshop}
+        focusWorkshop={focusWorkshop ?? nextWorkshop}
+        focusWorkshopIsCurrent={focusWorkshopIsCurrent}
         unlockedPhases={unlockedPhases}
         hasExistingProgress={hasExistingProgress}
         onStart={() => {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1831,6 +1831,7 @@
       "invitationLead": "You've been invited to the {{cohort}} platform — a quiet space to share what your organization does, where you work, and what you need to move your project forward.",
       "invitationFraming": "We'll build this together, one part at a time. Each section opens after the workshop where we cover it.",
       "nextWorkshopLabel": "Next workshop",
+      "currentWorkshopLabel": "Current workshop",
       "whatWeWillDoLabel": "What we'll do together",
       "step1": "Who you are",
       "step2": "Where you work",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1818,6 +1818,7 @@
       "invitationLead": "Você foi convidado(a) para a plataforma do {{cohort}} — um espaço tranquilo para contar o que a sua organização faz, onde trabalha, e do que precisa para tirar o seu projeto do papel.",
       "invitationFraming": "Vamos construir isso juntos, uma parte de cada vez. Cada seção abre depois do encontro em que tratamos do tema.",
       "nextWorkshopLabel": "Próximo encontro",
+      "currentWorkshopLabel": "Encontro atual",
       "whatWeWillDoLabel": "O que vamos fazer juntos",
       "step1": "Quem somos",
       "step2": "Onde trabalhamos",

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -209,6 +209,17 @@ export function registerCohortRoutes(app: Express): void {
     const nextPhase = maxUnlocked + 1;
     const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
+    // The "focus workshop" is what the CBO welcome card should highlight.
+    // If the coordinator has opened any workshop, the most-recently opened one
+    // is the *current* workshop (the user is actively in it). Otherwise the
+    // first one in the sequence is the *next* (upcoming) workshop. This
+    // matches the CBO's mental model: "which workshop am I in/about to do?"
+    const openedWorkshops = workshops.filter(w => w.openedAt);
+    const focusWorkshop = openedWorkshops.length > 0
+      ? openedWorkshops[openedWorkshops.length - 1]
+      : (workshops[0] ?? null);
+    const focusWorkshopIsCurrent = openedWorkshops.length > 0;
+
     const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
     const supportPending = supportRequests.filter(r => !r.resolvedAt);
 
@@ -222,6 +233,8 @@ export function registerCohortRoutes(app: Express): void {
       cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
       workshops,
       nextWorkshop,
+      focusWorkshop,
+      focusWorkshopIsCurrent,
       supportRequests,
       supportPendingCount: supportPending.length,
       inspirationPicks: Array.isArray(member.inspirationPicks) ? member.inspirationPicks : [],


### PR DESCRIPTION
## Summary

The welcome card always showed \`maxUnlocked + 1\` ("next workshop") which was wrong when the user is still inside the active workshop. A CBO mid-E1 saw **\"Next workshop: Workshop 2 — May 20\"** before they'd even finished W1, implying W1 wasn't a thing they were doing.

## Fix

The card now shows whichever workshop the CBO should be **focused on**:

| State | What's shown | Label |
|---|---|---|
| Coordinator has opened a workshop | Most-recently opened | **Current workshop** |
| No workshop opened yet | First in sequence | **Next workshop** |

## What ships

**Server** — \`/api/cbo-member/:slug\` returns 2 new fields:
- \`focusWorkshop: WorkshopConfig | null\`
- \`focusWorkshopIsCurrent: boolean\`

Existing \`nextWorkshop\` kept for backwards compatibility (no other callers, but no reason to remove).

**Client** — \`CboWelcome\` takes \`focusWorkshop\` + \`focusWorkshopIsCurrent\`; label picks between \`currentWorkshopLabel\` and \`nextWorkshopLabel\` keys.

**i18n** — \`currentWorkshopLabel\` added to both locales:
- PT: *"Encontro atual"*
- EN: *"Current workshop"*

## Test plan

- [ ] Fresh invite, coordinator has NOT opened W1 → card reads "NEXT WORKSHOP · Workshop 1"
- [ ] Coordinator opens W1 → CBO refreshes → card reads "CURRENT WORKSHOP · Workshop 1"
- [ ] CBO mid-E1 → still "CURRENT WORKSHOP · Workshop 1"
- [ ] Coordinator opens W2 → "CURRENT WORKSHOP · Workshop 2"
- [ ] Both EN and PT render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)