### PR TITLE
feat(mobile): native-feel polish across the CBO flow

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,10 +2,25 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- viewport-fit=cover enables env(safe-area-inset-*) for notch/home-indicator
+         handling. maximum-scale removed so accessibility zoom works; inputs are
+         sized ≥16px in CSS to prevent iOS auto-zoom on focus. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
+    <!-- Brand tint for Safari/Chrome toolbar. Light + dark variants match the
+         emerald-50 page bg the CBO flow uses; falls back to single value for
+         browsers that don't support media queries on theme-color. -->
+    <meta name="theme-color" content="#ecfdf5" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#022c22" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ecfdf5" />
+    <!-- iOS PWA cosmetics — even without a manifest, these tighten up the
+         add-to-home-screen experience if a CBO chooses to do it. -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="COUGAR" />
+    <meta name="format-detection" content="telephone=no" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -41,7 +41,7 @@ export function CboWelcome({
     : null;
 
   return (
-    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20 safe-top safe-bottom safe-x">
       {/* Top bar — quiet brand mark, no other chrome */}
       <header className="px-5 sm:px-8 py-5 flex items-center gap-2 text-emerald-700 dark:text-emerald-400">
         <Leaf className="w-4 h-4" strokeWidth={1.75} />

--- a/client/src/core/components/cbo/EncontroPreamble.tsx
+++ b/client/src/core/components/cbo/EncontroPreamble.tsx
@@ -37,7 +37,7 @@ export function EncontroPreamble({
   const { t } = useTranslation();
 
   return (
-    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20 safe-top safe-bottom safe-x">
       <main className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full px-5 sm:px-8 py-8">
         <motion.div
           initial={{ opacity: 0, y: 12 }}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -601,7 +601,7 @@ export default function CboProfilePage() {
 
   const filledCount = useMemo(() => state ? Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length : 0, [state]);
 
-  if (!state) return <div className="flex items-center justify-center h-screen"><Loader2 className="w-8 h-8 animate-spin text-muted-foreground" /></div>;
+  if (!state) return <div className="flex items-center justify-center h-[100dvh]"><Loader2 className="w-8 h-8 animate-spin text-muted-foreground" /></div>;
 
   // Cohort welcome screen — only when the user arrived via an invite and
   // hasn't dismissed the welcome. Replaces the entire chrome with a calm,
@@ -665,7 +665,7 @@ export default function CboProfilePage() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-background">
+    <div className="h-[100dvh] flex flex-col bg-background">
       <Header />
       {memberSlug && (
         <RequestSupportDialog
@@ -692,7 +692,7 @@ export default function CboProfilePage() {
               </div>
             </div>
           )}
-          <div className="px-4 py-3 border-b bg-background flex items-start justify-between gap-3">
+          <div className="safe-top px-4 py-3 border-b bg-background flex items-start justify-between gap-3">
             <div className="flex items-center gap-2 min-w-0 flex-1">
               <Link href="/sample/project/sample-ada-1"><Button variant="ghost" size="sm" className="h-7 px-2 shrink-0"><ArrowLeft className="w-4 h-4" /></Button></Link>
               <div className="min-w-0 flex-1">
@@ -1166,7 +1166,7 @@ export default function CboProfilePage() {
       {/* MOBILE TAB BAR — visible only below md. Drives `mobileActiveTab` +
           (when on a non-Chat tab) `rightTab` so the right panel shows the
           right content. Hidden on desktop, where both panels render side-by-side. */}
-      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch">
+      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch safe-bottom">
         {(() => {
           // Compose the tabs available right now. Chat + Perfil are permanent.
           // Mapa / Intervenções appear only while the agent has those microapps active.

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -315,3 +315,40 @@
   image-rendering: auto;
   filter: blur(0.5px);
 }
+
+/* ─── Mobile-native polish ──────────────────────────────────────────────────
+   Applied app-wide. Critical for the WhatsApp-link CBO flow where users open
+   the platform in Safari/Chrome on iPhone and Android. */
+
+html {
+  /* No gray flash on tap. iOS-native pattern; web defaults to a 5% gray overlay
+     which feels old-school next to native apps. */
+  -webkit-tap-highlight-color: transparent;
+  /* Prevent iOS from auto-resizing text when rotating to landscape. */
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  /* Kill iOS pull-to-refresh on the app shell. Chat threads have their own
+     scrollers; pull-to-refresh in chat re-loaded the page mid-conversation. */
+  overscroll-behavior-y: none;
+}
+
+/* Prevent iOS auto-zoom on input focus. iOS Safari zooms into any input with
+   computed font-size < 16px. Bumping to 16px keeps the viewport stable. */
+@media (max-width: 767px) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+/* Safe-area utilities — apply to elements that sit at the edge of the viewport
+   (chat header below the notch, mobile tab bar above the home indicator). */
+.safe-top    { padding-top: env(safe-area-inset-top); }
+.safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+.safe-x      {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}


### PR DESCRIPTION
## Summary

Pilot ships via WhatsApp link → CBOs open the platform in mobile Safari/Chrome. This PR makes it feel as native as possible **inside the browser** (no PWA install required).

## What ships

### \`client/index.html\` — viewport + native meta

| Change | Why |
|---|---|
| \`viewport-fit=cover\` | Enables \`env(safe-area-inset-*)\` so notch + home indicator don't cover content |
| Removed \`maximum-scale=1\` | Accessibility zoom works; global CSS keeps inputs ≥16px so iOS doesn't auto-zoom |
| \`theme-color\` (light/dark) | Safari/Chrome toolbar tints emerald to match brand |
| \`apple-mobile-web-app-capable\` + status-bar-style + title | Add-to-home-screen experience tightened |
| \`format-detection=telephone=no\` | Stops chat content from getting auto-linked as phone numbers |

### \`client/src/index.css\` — global polish

- \`-webkit-tap-highlight-color: transparent\` — no gray flash on tap
- \`-webkit-text-size-adjust: 100%\` — no font resize on rotate
- \`body overscroll-behavior-y: none\` — kills iOS pull-to-refresh on the app shell (was re-loading the page mid-chat)
- \`@media (max-width: 767px) input/textarea/select { font-size: 16px }\` — prevents iOS auto-zoom on focus
- New utility classes: \`.safe-top\`, \`.safe-bottom\`, \`.safe-x\`

### \`cbo-profile.tsx\` — viewport sizing

- \`h-screen\` → \`h-[100dvh]\` on page root + loading state. \`100dvh\` accounts for dynamic mobile browser chrome; \`vh\` was getting clipped behind Safari's URL bar
- Chat header gets \`safe-top\` (sits below notch)
- Mobile tab bar gets \`safe-bottom\` (sits above home indicator)

### CboWelcome + EncontroPreamble

Already used \`min-h-[100dvh]\`; added \`safe-top safe-bottom safe-x\`.

## Test plan

- [ ] iPhone with notch in portrait: chat header sits below notch, tab bar sits above home indicator
- [ ] No content clips behind Safari URL bar as it auto-hides on scroll
- [ ] Tapping the chat input doesn't trigger iOS auto-zoom
- [ ] No gray flash on tap (any button)
- [ ] Pull down on chat thread doesn't re-load the page
- [ ] Safari toolbar tints emerald (light mode)
- [ ] Android Chrome: same — \`theme-color\` works there too
- [ ] Desktop layout unchanged (utilities return 0 padding when no safe-area inset exists)

## Out of scope

- PWA manifest + icons + service worker (the \"installable app\" layer) — per scope choice, browser polish only

🤖 Generated with [Claude Code](https://claude.com/claude-code)