### PR TITLE
fix(mobile): remove viewport-fit=cover (was creating empty bottom gap)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,12 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- viewport-fit=cover enables env(safe-area-inset-*) for notch/home-indicator
-         handling. maximum-scale removed so accessibility zoom works; inputs are
-         sized ≥16px in CSS to prevent iOS auto-zoom on focus. -->
+    <!-- maximum-scale removed so accessibility zoom works; inputs are sized
+         ≥16px in CSS to prevent iOS auto-zoom on focus.
+         Note: NOT using viewport-fit=cover — the system handles safe areas
+         automatically (page is constrained above the URL bar / below the
+         notch). Adding viewport-fit=cover would require us to manage all
+         safe-area-inset offsets, which created empty space below the mobile
+         tab bar where Safari's URL bar was overlaying. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0"
     />
     <!-- Brand tint for Safari/Chrome toolbar. Light + dark variants match the
          emerald-50 page bg the CBO flow uses; falls back to single value for

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -46,7 +46,7 @@ export function CboWelcome({
     : null;
 
   return (
-    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20 safe-top safe-bottom safe-x">
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
       {/* Top bar — quiet brand mark, no other chrome */}
       <header className="px-5 sm:px-8 py-5 flex items-center gap-2 text-emerald-700 dark:text-emerald-400">
         <Leaf className="w-4 h-4" strokeWidth={1.75} />

--- a/client/src/core/components/cbo/EncontroPreamble.tsx
+++ b/client/src/core/components/cbo/EncontroPreamble.tsx
@@ -37,7 +37,7 @@ export function EncontroPreamble({
   const { t } = useTranslation();
 
   return (
-    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20 safe-top safe-bottom safe-x">
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
       <main className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full px-5 sm:px-8 py-8">
         <motion.div
           initial={{ opacity: 0, y: 12 }}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -706,9 +706,8 @@ export default function CboProfilePage() {
           )}
           {/* Chat header — two-row layout. Row 1: back + org name + actions.
               Row 2: workshop progress strip, full width. Icon-only action
-              buttons keep the right side narrow even on small viewports.
-              safe-top pushes the row below the iPhone notch. */}
-          <div className="safe-top px-3 sm:px-4 pt-2.5 pb-2 border-b bg-background space-y-2">
+              buttons keep the right side narrow even on small viewports. */}
+          <div className="px-3 sm:px-4 pt-2.5 pb-2 border-b bg-background space-y-2">
             <div className="flex items-center gap-1.5">
               <Link href="/sample/project/sample-ada-1">
                 <Button variant="ghost" size="sm" className="h-8 w-8 p-0 shrink-0">
@@ -1204,7 +1203,7 @@ export default function CboProfilePage() {
       {/* MOBILE TAB BAR — visible only below md. Drives `mobileActiveTab` +
           (when on a non-Chat tab) `rightTab` so the right panel shows the
           right content. Hidden on desktop, where both panels render side-by-side. */}
-      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch safe-bottom">
+      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch">
         {(() => {
           // Compose the tabs available right now. Chat + Perfil are permanent.
           // Mapa / Intervenções appear only while the agent has those microapps active.


### PR DESCRIPTION
## Summary

PR #168 added \`viewport-fit=cover\` + safe-area padding so the page could extend behind the notch/home indicator. **On iPhone with Safari's bottom URL bar visible**, \`env(safe-area-inset-bottom)\` returns the URL-bar height + home indicator (~88px). The \`safe-bottom\` padding pushed the mobile tab bar up by that amount → **visible empty gap** between the tab bar and Safari's URL bar (in the reported screenshot).

## Fix

Go back to system-managed safe areas:

- Drop \`viewport-fit=cover\` from the viewport meta
- Remove \`safe-top\` from the chat header
- Remove \`safe-bottom\` from the mobile tab bar
- Remove \`safe-top safe-bottom safe-x\` from CboWelcome + EncontroPreamble

The system now constrains the page to the safe viewport automatically — above the URL bar, below the notch. No manual safe-area handling needed for the WhatsApp-link CBO flow.

## Kept from PR #168

The actually-useful mobile polish stays:
- \`100dvh\` on page root (still solves dynamic URL-bar clipping)
- \`theme-color\` + \`apple-mobile-web-app-*\` meta tags
- \`format-detection=telephone=no\`
- Global \`-webkit-tap-highlight-color: transparent\`
- Global \`overscroll-behavior-y: none\` (no pull-to-refresh on chat)
- Global \`input/textarea/select { font-size: 16px }\` (no iOS auto-zoom)

## Test plan

- [ ] iPhone Safari with bottom URL bar visible: mobile tab bar sits flush above URL bar, no empty gap
- [ ] Scroll to hide URL bar: tab bar still flush at bottom, no clipping
- [ ] Chat header sits cleanly below the URL bar (no clipping into notch zone)
- [ ] No regression in theme-color, font sizing, or tap behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)