### PR TITLE
feat(e1): pre-fill org_name + bairro from invite, don't re-ask

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -290,6 +290,30 @@ export default function CboProfilePage() {
     }).catch(() => {});
   }, [memberSlug, cboId]);
 
+  // Seed E1 fields from the invite. The orchestrator already collected
+  // orgName + neighborhood at invite time — re-asking on the first chat
+  // turn is bad UX. The server-side prefill is idempotent (won't overwrite
+  // userEdited fields), so firing it repeatedly is safe.
+  const prefillSentRef = useRef(false);
+  useEffect(() => {
+    if (prefillSentRef.current) return;
+    if (!cboId || !memberInfo) return;
+    prefillSentRef.current = true;
+    fetch(`/api/cbo/${cboId}/prefill`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        orgName: memberInfo.orgName,
+        neighborhood: memberInfo.neighborhood ?? undefined,
+      }),
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.state) setState(migrateCboState(data.state));
+      })
+      .catch(() => {});
+  }, [cboId, memberInfo]);
+
   // Hide Replit chat widget on this page
   useEffect(() => {
     const style = document.createElement('style');

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -43,17 +43,26 @@ Plus on `state.maturityScores`:
 - `org_delivery_capacity` (0-3) — you infer this; see the rubric below
 - `team_technical_experience` (0-3) — you infer this
 
+## Pre-filled from invite — check CURRENT STATE first
+
+The orchestrator collected the org name (and often the neighborhood) at invite time. Those are pre-seeded into state with `source: 'invite'`. **Always check CURRENT STATE before asking** — if you see:
+
+- `org_profile.org_name` already populated → **do NOT ask the name again.** Open with a confirmation: *"Conferindo: organização é __{orgName}__, certo? Pode corrigir se eu peguei errado."* If the user confirms or stays silent, move on. If they correct, call `update_section('org_profile', { org_name: '<corrected>' })`.
+- `org_profile.bairro_of_operation` already populated → skip question 7 (Bairro), just confirm inside the flow naturally (*"E vocês atuam principalmente em {bairro}, certo?"*) — don't make it a separate ask_user turn.
+
+Treat pre-filled values as **starting points the user can edit**, never as final answers.
+
 ## Question sequence
 
 You're not strict about order — read the room. But default flow:
 
-1. **Identity** — name, contact, role
+1. **Identity** — confirm org name (pre-filled, see above) + ask contact name + role
 2. **Mission** — one-sentence what they do
 3. **Form + age** — legal_form (chips) + year_founded
 4. **Team** — team_size (chips) + paid/volunteer split
 5. **Prior work** — prior_project_scale (chips); offer file drop after
 6. **NBS experience** — nbs_experience (chips)
-7. **Bairro** — where do you mainly work (suggest from POA list, accept free text)
+7. **Bairro** — confirm pre-filled value if any, otherwise ask (suggest from POA list)
 8. **Groups served** — multi-select chips
 9. **Path triage** — has-idea / needs-help (chips with distinct colors)
 10. **Optional**: "Tem algo que sua organização fez que vocês têm orgulho? Pode contar?"

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -107,6 +107,56 @@ export function registerCboRoutes(app: Express): void {
     debouncedPersist(req.params.id);
   });
 
+  // Seed from invite — when a CBO is part of a cohort, the orchestrator
+  // already collected org name (and sometimes neighborhood) at invite time.
+  // Re-asking on E1 is bad UX. This endpoint pre-fills those values into
+  // the state so the agent confirms instead of asking. Idempotent: won't
+  // overwrite fields the user has already edited.
+  app.post("/api/cbo/:id/prefill", async (req: Request, res: Response) => {
+    let state = getCboState(req.params.id);
+    if (!state) {
+      const persisted = await loadPersistedCboState(req.params.id);
+      if (persisted) { setCboState(req.params.id, persisted.state); state = persisted.state; }
+    }
+    if (!state) return res.status(404).json({ error: "Not found" });
+
+    const { orgName, neighborhood } = req.body ?? {};
+    const orgProfile: any = state.sections.org_profile;
+    if (!orgProfile) return res.status(500).json({ error: "org_profile section missing" });
+
+    let changed = false;
+
+    if (typeof orgName === 'string' && orgName.trim()) {
+      const existing = orgProfile.fields?.org_name;
+      // Don't overwrite if the user has already edited the name in chat or
+      // inline. Source 'invite' lets the agent know the value came from the
+      // orchestrator, not the user themselves — so it'll confirm.
+      if (!existing || (!existing.userEdited && (!existing.value || existing.source === 'invite'))) {
+        orgProfile.fields = orgProfile.fields || {};
+        orgProfile.fields.org_name = { value: orgName.trim(), confidence: 'high', source: 'invite', userEdited: false };
+        if (!state.orgName) state.orgName = orgName.trim();
+        changed = true;
+      }
+    }
+
+    if (typeof neighborhood === 'string' && neighborhood.trim()) {
+      const existing = orgProfile.fields?.bairro_of_operation;
+      if (!existing || (!existing.userEdited && (!existing.value || existing.source === 'invite'))) {
+        orgProfile.fields = orgProfile.fields || {};
+        orgProfile.fields.bairro_of_operation = { value: neighborhood.trim(), confidence: 'medium', source: 'invite', userEdited: false };
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      orgProfile.lastUpdatedBy = 'agent';
+      setCboState(req.params.id, state);
+      debouncedPersist(req.params.id);
+    }
+
+    res.json({ ok: true, changed, state });
+  });
+
   // User edit
   app.post("/api/cbo/:id/edit", async (req: Request, res: Response) => {
     const { sectionId, field, value } = req.body;


### PR DESCRIPTION
## Summary

The orchestrator already collected the org name (and often the neighborhood) at invite time. Asking again as the first question of E1 was redundant and broke the *\"no formulário longo\"* promise of the welcome screen.

Now the agent **confirms** instead of asking.

## Flow

**Before**
\`\`\`
Agent: Bem-vindo! Qual o nome da sua organização e tipo?
[Buttons: Community association | NGO | Cooperative | …]
\`\`\`
*(but the URL slug + welcome screen already showed \"Horta Comunitária Cascata\")*

**After**
\`\`\`
Agent: Conferindo rápido — organização é Horta Comunitária Cascata,
       certo? Pode corrigir se eu peguei errado.
[User confirms or corrects]
Agent: Quem está conversando com a gente?
\`\`\`

## What ships

| File | What |
|---|---|
| \`server/routes/cboRoutes.ts\` | New \`POST /api/cbo/:id/prefill\` endpoint — idempotent, source-aware. Writes \`state.orgName\` + \`org_profile.fields.{org_name, bairro_of_operation}\` with \`source: 'invite'\` |
| \`client/src/core/pages/cbo-profile.tsx\` | New effect fires \`/prefill\` once when \`cboId\` + \`memberInfo\` both ready. Updates local state with the response so the doc panel reflects the seed immediately |
| \`knowledge/_skills/encontro-1.md\` | New \"Pre-filled from invite\" section. Question 1 reframed to confirm-not-ask; question 7 (bairro) same treatment if pre-filled |

## Editability preserved

Pre-filled values are starting points the user can change:
- **In chat**: \"Atualmente chamamos 'Horta Comunitária do Bairro' — pode mudar?\" → agent calls \`update_section\` → overwrites
- **Doc panel inline edit**: ✏️ on the \"Quem somos\" card → user types directly → overwrites
- The endpoint never overwrites a field with \`userEdited: true\`

## Test plan

- [ ] Invite \"Horta Comunitária Cascata\" with neighborhood \"Cascata\" → CBO opens link → \"Quem somos\" doc-panel card already shows both values before first chat turn
- [ ] Agent's first turn: confirmation message, NOT a \"what's your name?\" question
- [ ] User corrects org name in chat → \`update_section\` overrides → doc panel updates → subsequent agent turns reference the corrected value
- [ ] Invite without neighborhood → only org_name pre-filled, agent still asks bairro in question 7
- [ ] Standalone CBO (no slug param, no memberInfo) → prefill effect doesn't fire → agent asks org_name normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)