### PR TITLE
fix(cbo): double-init guard + DB error surfacing

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -335,8 +335,18 @@ export default function CboProfilePage() {
     return () => clearTimeout(timer);
   }, [currentQuestionIdx, activeQuestions]);
 
-  // Init session
+  // Init session.
+  // Critical guard: React 18 StrictMode (and dev HMR remounts) fire useEffect
+  // twice. Without the ref, the second invocation races the first and creates
+  // a second CBO state via POST /api/cbo before localStorage is written from
+  // the first — producing duplicate sessions, one with prefill and one without.
+  // The active id ends up being the second (no-prefill) CBO and the prefilled
+  // one orphans. Symptoms: agent re-asks org_name despite the doc panel showing
+  // it, "starting fresh" messages, language flipping, etc.
+  const initRef = useRef(false);
   useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
     async function init() {
       const saved = getSavedId();
       if (saved) {
@@ -350,6 +360,11 @@ export default function CboProfilePage() {
             if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) setMessages(msgs); }
             return;
           }
+          // 404 means the cached id points at a CBO that no longer exists on the
+          // server (DB wiped, container recycled, etc). Clear the stale id so
+          // we don't keep pointing at a phantom across reloads — fall through
+          // to creating a fresh session.
+          if (res.status === 404) clearId();
         } catch {}
       }
       const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,7 +72,16 @@ app.use((req, res, next) => {
     },
     async () => {
       log(`serving on port ${port}`);
-      
+
+      // Probe for CBO tables — logs a loud message if `npm run db:push`
+      // hasn't been run yet so the dev catches it on boot, not on first chat.
+      try {
+        const { checkCboTablesExist } = await import('./services/cboPersistence');
+        await checkCboTablesExist();
+      } catch (error) {
+        console.error('[cbo] table check failed', error);
+      }
+
       // Auto-seed knowledge base on startup (seeds only missing documents)
       try {
         await autoSeedKnowledgeBase();

--- a/server/services/cboPersistence.ts
+++ b/server/services/cboPersistence.ts
@@ -16,6 +16,22 @@ import { cboStates, cboMessages } from '@shared/cbo-db-schema';
 import { eq, asc } from 'drizzle-orm';
 import type { CboState, CboChatMessage } from '@shared/cbo-schema';
 
+// Detect "relation does not exist" and log a clear, actionable message.
+// Postgres error code 42P01 means the table is missing — almost always
+// because `npm run db:push` hasn't been run after schema changes.
+function logDbError(op: string, id: string, e: any) {
+  if (e?.code === '42P01') {
+    console.error(
+      `[cbo] ${op}(${id}) — DB TABLE MISSING (code 42P01).\n` +
+      `      The cbo_states / cbo_messages tables don't exist yet.\n` +
+      `      Run \`npm run db:push\` on Replit shell to create them.\n` +
+      `      Until then, state is in-memory only and will be lost on restart.`
+    );
+  } else {
+    console.error(`[cbo] ${op}(${id}) error`, e);
+  }
+}
+
 function rowToState(row: any): CboState {
   return {
     id: row.id,
@@ -41,7 +57,7 @@ export async function loadCboState(id: string): Promise<CboState | null> {
     const [row] = await db.select().from(cboStates).where(eq(cboStates.id, id)).limit(1);
     return row ? rowToState(row) : null;
   } catch (e) {
-    console.error(`[cbo] loadCboState(${id}) error`, e);
+    logDbError('loadCboState', id, e);
     return null;
   }
 }
@@ -60,7 +76,7 @@ export async function loadCboMessages(id: string): Promise<CboChatMessage[]> {
       timestamp: r.timestamp?.toISOString?.() ?? new Date().toISOString(),
     }));
   } catch (e) {
-    console.error(`[cbo] loadCboMessages(${id}) error`, e);
+    logDbError('loadCboMessages', id, e);
     return [];
   }
 }
@@ -92,7 +108,7 @@ export async function upsertCboState(state: CboState): Promise<void> {
       set: values,
     });
   } catch (e) {
-    console.error(`[cbo] upsertCboState(${state.id}) error`, e);
+    logDbError('upsertCboState', state.id, e);
   }
 }
 
@@ -117,7 +133,37 @@ export async function appendCboMessages(
       timestamp: m.timestamp ? new Date(m.timestamp) : new Date(),
     })));
   } catch (e) {
-    console.error(`[cbo] appendCboMessages(${cboStateId}, ${msgs.length} msgs) error`, e);
+    logDbError(`appendCboMessages[${msgs.length} msgs]`, cboStateId, e);
+  }
+}
+
+/**
+ * Self-check at boot — probes for the cbo_states table. If it doesn't exist,
+ * log a single LOUD line so the dev sees the fix immediately instead of
+ * chasing the symptom (re-introducing agent, 404s on cold load, etc).
+ */
+export async function checkCboTablesExist(): Promise<boolean> {
+  try {
+    await db.select().from(cboStates).limit(1);
+    return true;
+  } catch (e: any) {
+    if (e?.code === '42P01') {
+      console.error('\n' +
+        '╔══════════════════════════════════════════════════════════════════════╗\n' +
+        '║  ⚠️  CBO DB TABLES MISSING                                           ║\n' +
+        '║                                                                      ║\n' +
+        '║  The cbo_states and cbo_messages tables do not exist yet.            ║\n' +
+        '║  Run `npm run db:push` on the Replit shell to create them.           ║\n' +
+        '║                                                                      ║\n' +
+        '║  Until then, CBO state survives only in process memory and will be   ║\n' +
+        '║  lost on restart. The agent will see empty state every cold load     ║\n' +
+        '║  and may re-ask questions it already asked.                          ║\n' +
+        '╚══════════════════════════════════════════════════════════════════════╝\n'
+      );
+    } else {
+      console.error('[cbo] checkCboTablesExist unexpected error', e);
+    }
+    return false;
   }
 }
 
@@ -129,6 +175,6 @@ export async function deleteCboState(id: string): Promise<void> {
     await db.delete(cboMessages).where(eq(cboMessages.cboStateId, id));
     await db.delete(cboStates).where(eq(cboStates.id, id));
   } catch (e) {
-    console.error(`[cbo] deleteCboState(${id}) error`, e);
+    logDbError('deleteCboState', id, e);
   }
 }


### PR DESCRIPTION
## Diagnosis

User reported a chaotic chat: agent re-asking org_name (despite the doc panel showing it filled), language flipping mid-sentence, \"Continue from Phase 1\" button firing on its own, agent saying *\"I see we're starting fresh\"*. **Three compounding bugs traced from the server logs.**

### Bug 1 (root cause): DB tables don't exist

Every state write threw \`relation \"cbo_states\" does not exist\` (Postgres code 42P01). PR #172 added the schema but \`npm run db:push\` was never run on Replit after merge. Every UPSERT silently failed; every cold GET 404'd; every reload created a brand new CBO; the agent re-introduced itself each session because state was empty.

**Resolution**: you run \`npm run db:push\` on Replit shell. This PR adds a boot-time check that logs a LOUD banner if the tables are missing, so you catch it on next deploy.

### Bug 2: React StrictMode double-init

Logs showed two simultaneous POST /api/cbo:
\`\`\`
3:16:41 PM POST /api/cbo 200 → 2721be1c... 
3:16:41 PM POST /api/cbo 200 → e4937fff...  ← race
3:16:41 PM POST /api/cbo/2721be1c.../prefill 200  ← prefilled
[chat fires on e4937fff — the orphan, no prefill]
\`\`\`

React 18 StrictMode (and dev HMR) double-mount components. The init effect fires twice before localStorage gets written from the first call, so both POSTs race. The active id ends up being the second (orphan) CBO. The agent sees empty state and re-asks.

**Fix**: useRef guard on the init effect so the second mount short-circuits.

### Bug 3: 404 keeps stale localStorage id

When the saved cboId points at a CBO that no longer exists (DB wiped, etc), GET returns 404 and the client falls through to POST. But localStorage still points at the phantom — next reload hits 404 again. Fix: \`clearId()\` on 404 before the POST.

## What ships

| File | What |
|---|---|
| \`client/src/core/pages/cbo-profile.tsx\` | useRef init guard + clearId on 404 |
| \`server/services/cboPersistence.ts\` | \`logDbError()\` detects 42P01 → actionable message. \`checkCboTablesExist()\` boot-time probe |
| \`server/index.ts\` | Calls \`checkCboTablesExist()\` after \`listen()\` so the banner fires on every startup |

## Boot output if tables are missing

\`\`\`
╔══════════════════════════════════════════════════════════════════════╗
║  ⚠️  CBO DB TABLES MISSING                                           ║
║                                                                      ║
║  The cbo_states and cbo_messages tables do not exist yet.            ║
║  Run `npm run db:push` on the Replit shell to create them.           ║
║                                                                      ║
║  Until then, CBO state survives only in process memory and will be   ║
║  lost on restart. The agent will see empty state every cold load     ║
║  and may re-ask questions it already asked.                          ║
╚══════════════════════════════════════════════════════════════════════╝
\`\`\`

## Test plan

After merge AND running \`npm run db:push\` on Replit:

- [ ] Boot banner says no missing tables
- [ ] Fresh tab → only ONE POST /api/cbo in logs (StrictMode guard works)
- [ ] Prefill lands on the same cboId that chat uses
- [ ] Agent confirms the prefilled name instead of asking again
- [ ] Reload preserves the conversation (DB persistence working)
- [ ] Hit /_inspect endpoint (PR #173) — \`statesMatch: true, messagesMatch: true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)