### PR TITLE
fix(cbo): hide Continue button when agent just asked a free-text question

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -968,8 +968,22 @@ export default function CboProfilePage() {
 
             {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
 
-            {/* Resume / Completion */}
-            {!isStreaming && state.phase > 0 && !currentQuestion && messages.length > 0 && (
+            {/* Resume / Completion.
+                Structural rule: only show this block when the agent owes the
+                next message — i.e. the last content-type chat message is
+                from the user, OR phase 6 is reached (completion).
+                Previously this fired whenever there was no ask_user chip
+                active, which broke free-text questions: the agent asks
+                "how many paid vs volunteers?" → no currentQuestion (free
+                text expected) → "Continue from Phase X" button appears
+                competing with the typing input → user confused, clicks it,
+                sends a directive that derails the agent. */}
+            {(() => {
+              if (isStreaming || state.phase === 0 || currentQuestion || messages.length === 0) return null;
+              const lastContent = [...messages].reverse().find(m => m.messageType === 'content');
+              const agentOwesResponse = !lastContent || lastContent.role === 'user';
+              if (state.phase < 6 && !agentOwesResponse) return null;
+              return (
               <div className="text-center py-4">
                 {state.phase >= 6 ? (
                   <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-green-400 bg-green-50">
@@ -998,7 +1012,8 @@ export default function CboProfilePage() {
                   </div>
                 )}
               </div>
-            )}
+              );
+            })()}
 
             <div ref={chatEndRef} />
           </div>


### PR DESCRIPTION
## Reported

Agent ends a turn with a free-text question (\"how many paid staff versus volunteers?\") and a **\"Phase 1/5, 1 sections filled · Continue\"** button appears competing with the typing input. Clicking it sends \`Continue from Phase X.\` to the agent — a directive that derails the conversation.

## Root cause (structural)

The Resume/Completion block at line 957 fired whenever:
- not streaming
- phase > 0
- **no active \`currentQuestion\` (ask_user chips)**
- has messages

It didn't check **who owes the next message**. For free-text questions the agent ends its turn without calling \`ask_user\` → no \`currentQuestion\` → the button shows even though the user is the one who should respond next.

## Structural fix

Gate the block on whether the agent owes the next message:

\`\`\`ts
const lastContent = [...messages].reverse().find(m => m.messageType === 'content');
const agentOwesResponse = !lastContent || lastContent.role === 'user';

// Show Continue button only if phase < 6 AND agent owes response
// Show Profile-complete card always at phase ≥ 6 (terminal state)
\`\`\`

| Scenario | Last content msg | Button shown? |
|---|---|---|
| Agent asks free-text question | assistant | ❌ (was bug — now fixed) |
| User types, agent thinking | user (mid-stream) | streaming → hidden |
| User reloads tab after typing, no reply yet | user | ✅ (legit resume) |
| Phase 6 reached | either | ✅ (Profile complete card) |
| Fresh session, no messages | — | ❌ (was already correct) |

## Why this matters

Free-text questions are deliberate in the E1 skill (\"qual é o nome da organização?\" is type-it-in, not chips). The Continue button was a remnant from when chat flow could stall mid-turn. With the new agent + DB persistence, the agent always ends a turn with a clear ask — the user just needs to respond.

## Test plan

- [ ] Agent asks free-text → no Continue button shows, typing input is the only affordance
- [ ] User types reply, agent streams response, ends in another free-text → still no button
- [ ] User clicks ask_user chip → button correctly hidden during streaming, stays hidden after agent responds
- [ ] User closes tab mid-conversation, reopens → button appears IF last content was their message (resume case)
- [ ] Phase 6 reached → Profile complete card shows + export buttons (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)