### PR TITLE
fix(e1): prescriptive ask_user chips per question — kill free-text drift

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -52,22 +52,86 @@ The orchestrator collected the org name (and often the neighborhood) at invite t
 
 Treat pre-filled values as **starting points the user can edit**, never as final answers.
 
-## Question sequence
+## Question sequence — prescriptive
 
-You're not strict about order — read the room. But default flow:
+**Default rule**: use `ask_user` chips for ANY question with 2-7 natural buckets. Free-text is ONLY for genuinely unique inputs (org name, mission, proud moment). Never bundle two questions into one chip-set — one question per turn.
 
-1. **Identity** — confirm org name (pre-filled, see above) + ask contact name + role
-2. **Mission** — one-sentence what they do
-3. **Form + age** — legal_form (chips) + year_founded
-4. **Team** — team_size (chips) + paid/volunteer split
-5. **Prior work** — prior_project_scale (chips); offer file drop after
-6. **NBS experience** — nbs_experience (chips)
-7. **Bairro** — confirm pre-filled value if any, otherwise ask (suggest from POA list)
-8. **Groups served** — multi-select chips
-9. **Path triage** — has-idea / needs-help (chips with distinct colors)
-10. **Optional**: "Tem algo que sua organização fez que vocês têm orgulho? Pode contar?"
+Below is the exact ask_user shape for each question. Always include "Outra coisa" (free-text) and "Não sei / Prefiro pular" where it makes sense.
 
-Use the `ask_user` tool for every multiple-choice question. Always include a free-text option ("Outra coisa") and a "Não sei / Prefiro pular" option where appropriate.
+### 1. Identity
+- **Org name** — pre-filled, just confirm: *"Conferindo: organização é {orgName}, certo? Pode corrigir se eu peguei errado."* (free-text reply OK)
+- **Contact name** — free-text: *"E você, com quem estou conversando?"*
+- **Contact role** — free-text: *"Qual seu papel na {orgName}?"* (e.g. coordenadora, voluntária)
+
+### 2. Mission
+- **Mission summary** — free-text: *"Em uma frase, o que vocês fazem?"* (genuinely unique string)
+
+### 3. Form + age (TWO separate turns, NOT bundled)
+- **Legal form** — `ask_user` chips:
+  - ONG / Associação
+  - Cooperativa
+  - Coletivo informal
+  - Empresa social
+  - Outra
+- **Year founded** — free-text (just a number): *"Em que ano vocês começaram?"* (for informal groups, say *"ano que começaram esse trabalho"*)
+
+### 4. Team (TWO separate turns)
+- **Team size** — `ask_user` chips:
+  - 1–2 pessoas
+  - 3–5 pessoas
+  - 6–15 pessoas
+  - 16+ pessoas
+- **Paid vs volunteer split** — `ask_user` chips (NOT free-text):
+  - Todas voluntárias
+  - Maioria voluntárias (1–2 pagas)
+  - Metade e metade
+  - Maioria pagas
+  - Todas pagas
+
+### 5. Prior work
+- **Prior project scale** — `ask_user` chips:
+  - Nenhum projeto formal ainda
+  - Atividades pontuais (sem financiamento)
+  - Projeto com financiamento (até R$ 50k)
+  - Projeto financiado significativo (R$ 50k+)
+  - Parceria formal com órgão público / fundação
+- After answer: offer file drop — *"Se quiser, arraste um documento de um projeto anterior. Senão, segue tudo bem."*
+
+### 6. NBS experience
+- **NBS experience** — `ask_user` chips:
+  - Nenhuma
+  - Educação ambiental
+  - Hortas / arborização
+  - Já implementamos algo SbN
+- Add "Não tenho certeza" as the 5th option.
+
+### 7. Bairro
+- Pre-filled? Confirm inline (not a separate turn): *"E vocês atuam principalmente em {bairro}, certo?"*
+- Not pre-filled? Free-text: *"Em qual bairro vocês atuam principalmente?"*
+
+### 8. Groups served — `ask_user` multi-select chips:
+  - Mulheres
+  - Idosos
+  - Pessoas com deficiência
+  - Comunidades tradicionais
+  - Jovens
+  - Pessoas negras
+  - Povos indígenas
+  - Comunidade do bairro (geral)
+
+### 9. Path triage — `ask_user` chips (MOST important question):
+  - 💡 Já tenho uma ideia de projeto NBS
+  - 🤝 Quero ajuda para encontrar uma
+
+### 10. Proud moment (optional, free-text)
+- *"Tem algo que sua organização fez que vocês têm orgulho? Pode contar."* (genuinely unique string)
+
+## ⚠️ Anti-patterns to AVOID
+
+- **NEVER** bundle two questions into one chip ("CBO; 16-30 people" — bad). Each question gets its own ask_user turn.
+- **NEVER** ask a ratio/split question as free-text. Always offer chip buckets.
+- **NEVER** skip ask_user for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
+- **NEVER** chain 3+ chip turns without acknowledging each answer first ("Adorei", "Faz sentido", etc).
 
 ## ⚠️ Persisting answers — non-negotiable
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -856,6 +856,8 @@ ${isPt
 - **SE phase ≥ 1 OU já há mensagens em RECENT CONVERSATION**: você está NO MEIO da conversa. NÃO se reintroduza. Continue de onde parou. Antes de qualquer pergunta nova, **persista a resposta anterior do usuário** via update_section() — sem isso, o estado fica vazio e tudo se perde.
 - **Após CADA resposta livre do usuário** (texto digitado): chame update_section('<sectionId>', { <campo>: '<valor>' }) ANTES de fazer a próxima pergunta. Isso é OBRIGATÓRIO.
 - Pontuar métricas conforme coleta (não esperar). Fase 2: open_map composite. Fase 3a: open_intervention_selector.
+- **PADRÃO: SEMPRE usar ask_user com chips** para qualquer pergunta com 2-7 buckets naturais (tipo de org, tamanho de equipe, proporção paga/voluntária, escala de projeto, experiência SbN, etc). Texto livre SOMENTE para inputs genuinamente únicos: nome da org, missão em uma frase, momento de orgulho. Proporções e "splits" SEMPRE viram chips ("Todas voluntárias", "Maioria voluntárias", "Metade e metade", etc) — NUNCA pedir números exatos via texto livre.
+- **NUNCA juntar duas perguntas em um chip** ("CBO; 16-30 pessoas" é errado). Cada pergunta é uma chamada ask_user separada.
 - TODA pergunta substantiva DEVE ter opção "Não sei / Me ajude". Quando selecionada: read_knowledge, dar exemplos brasileiros, recomendar.
 - NÃO repetir perguntas já respondidas. Checar ESTADO ATUAL antes de perguntar. Referenciar respostas anteriores.
 - Upload de documentos: extrair tudo, preencher com update_section, pontuar maturidade, pular perguntas respondidas.
@@ -866,6 +868,8 @@ ${isPt
 - **IF phase ≥ 1 OR RECENT CONVERSATION has messages**: you are MID-conversation. Do NOT re-introduce. Continue from where you left off. Before any new question, **persist the user's previous answer** via update_section() — without that, state stays empty and progress is lost.
 - **After EVERY free-text user answer**: call update_section('<sectionId>', { <field>: '<value>' }) BEFORE the next question. This is MANDATORY.
 - Score metrics as you go (don't wait). Phase 2: open_map composite. Phase 3a: open_intervention_selector.
+- **DEFAULT: ALWAYS use ask_user with chips** for any question with 2-7 natural buckets (org type, team size, paid/volunteer split, project scale, NBS experience, etc). Free-text ONLY for genuinely unique inputs: org name, one-sentence mission, proud-moment story. Ratios and splits ALWAYS become chips ("All volunteers", "Mostly volunteers", "Half and half", etc) — NEVER ask for exact numbers via free-text.
+- **NEVER bundle two questions into one chip** ("CBO; 16-30 people" is wrong). Each question is its own separate ask_user call.
 - EVERY substantive question MUST have "I don't know / Help me" option. When selected: read_knowledge, give Brazilian examples, recommend.
 - DO NOT repeat questions already answered. Check CURRENT STATE before asking. Reference earlier answers.
 - File drops: extract all, fill with update_section, score maturity, skip answered questions.


### PR DESCRIPTION
## Reported

Agent asked *\"how many paid staff versus volunteers? You can give me a rough split — for example, '2 paid, 14 volunteers' or 'all volunteers.'\"* — as free-text. User expected chips.

Same agent earlier bundled \"org type + team size\" into ONE chip (*\"Community-based organization (CBO); 16-30 people\"*) — also wrong.

## Structural cause

\`encontro-1.md\` said:
> 4. **Team** — team_size (chips) + paid/volunteer split

It told the agent to use chips for \`team_size\` but said nothing about how to ask the split. Free-text drift fills the gap. The global system prompt also says \"Use ask_user for every multiple-choice question\" — but the agent reasonably reads \"split\" as numeric, not multiple-choice.

The agent has too much latitude on how to ask each question.

## Two-layer fix

### Layer 1 — encontro-1.md prescriptive chips

Every question now spells out the exact ask_user shape:

| Field | Shape |
|---|---|
| team_size | chips: 1–2, 3–5, 6–15, 16+ |
| paid_vs_volunteer | chips: Todas voluntárias / Maioria voluntárias / Metade e metade / Maioria pagas / Todas pagas |
| prior_project_scale | chips: Nenhum / Pontuais / Até R$ 50k / R$ 50k+ / Parceria pública |
| nbs_experience | chips: Nenhuma / Educação ambiental / Hortas / Já implementamos SbN |
| legal_form | chips: ONG / Cooperativa / Coletivo informal / Empresa social / Outra |
| groups_served | multi-select chips |
| path | chips: 💡 Já tenho ideia / 🤝 Quero ajuda |
| org_name, contact_name, mission, year_founded, bairro, proud_moment | free-text (genuinely unique) |

Plus a new explicit **\"Anti-patterns to AVOID\"** section:
- NEVER bundle two questions into one chip
- NEVER ask ratios as free-text
- NEVER skip ask_user for questions with 2-7 buckets

### Layer 2 — global cboAgent.ts rules (PT + EN)

\`\`\`
- DEFAULT: ALWAYS use ask_user with chips for any 2-7 bucket question.
  Free-text ONLY for genuinely unique inputs.
- Ratios and splits ALWAYS become chips ("All volunteers", "Mostly
  volunteers", "Half and half", etc) — NEVER ask for exact numbers.
- NEVER bundle two questions into one chip.
\`\`\`

## Test plan

After deploy, run a fresh CBO and verify:

- [ ] team_size asked with 4 chips
- [ ] paid_vs_volunteer asked with 5 chips (not free-text)
- [ ] prior_project_scale asked with 5 chips
- [ ] nbs_experience asked with 4-5 chips
- [ ] legal_form asked with 5 chips
- [ ] No combined chips like \"X; Y\"
- [ ] org_name, contact_name, mission, proud_moment still free-text

🤖 Generated with [Claude Code](https://claude.com/claude-code)