### PR TITLE
feat(cbo): Start-Next-Workshop banner + polling for unlock detection

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -258,6 +258,8 @@ export default function CboProfilePage() {
       setFocusWorkshop(data.focusWorkshop ?? null);
       setFocusWorkshopIsCurrent(!!data.focusWorkshopIsCurrent);
     };
+    const refetch = () => fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
+
     fetch(`/api/cbo-member/${slug}`)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
@@ -265,12 +267,19 @@ export default function CboProfilePage() {
         if (data) setWelcomeMode(true);
       })
       .catch(() => {});
-    // Re-fetch on focus so coordinator unlocks propagate without a hard reload.
-    const onFocus = () => {
-      fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
+
+    // Re-fetch on tab focus so coordinator unlocks propagate without a manual reload.
+    window.addEventListener('focus', refetch);
+    // Also poll every 30s while the page is visible — catches the case where
+    // the CBO is sitting in the tab waiting for the coordinator to open the
+    // next workshop. Pause when the tab is hidden to be polite.
+    const poll = setInterval(() => {
+      if (document.visibilityState === 'visible') refetch();
+    }, 30000);
+    return () => {
+      window.removeEventListener('focus', refetch);
+      clearInterval(poll);
     };
-    window.addEventListener('focus', onFocus);
-    return () => window.removeEventListener('focus', onFocus);
   }, []);
 
   const isPhaseUnlocked = useCallback(
@@ -967,6 +976,47 @@ export default function CboProfilePage() {
             )}
 
             {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
+
+            {/* Start Next Workshop banner.
+                When the coordinator opens a workshop higher than the user's
+                current phase, this card appears so the CBO knows the next
+                encontro is available + has a clear CTA to enter it. Without
+                this, the user has no signal that anything changed. */}
+            {(() => {
+              if (isStreaming || messages.length === 0 || state.phase === 0) return null;
+              const nextUnlockedPhase = unlockedPhases.find(p => p > state.phase);
+              if (nextUnlockedPhase == null) return null;
+              const ws = workshops.find(w => w.unlocksPhase === nextUnlockedPhase);
+              const wsName = ws?.name ?? `Workshop ${nextUnlockedPhase}`;
+              return (
+                <div className="text-center py-4">
+                  <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-700 max-w-md">
+                    <span className="text-[10px] uppercase tracking-wider text-emerald-700 dark:text-emerald-300 font-semibold">
+                      {lang === 'pt' ? '🌱 Próximo encontro liberado' : '🌱 Next workshop unlocked'}
+                    </span>
+                    <p className="text-sm font-medium text-emerald-900 dark:text-emerald-100">{wsName}</p>
+                    <p className="text-xs text-emerald-800/80 dark:text-emerald-200/80 leading-snug">
+                      {lang === 'pt'
+                        ? 'Sua coordenadora abriu esse encontro. Quando estiver pronta, podemos começar.'
+                        : 'Your coordinator opened this workshop. When you\'re ready, we can begin.'}
+                    </p>
+                    <Button
+                      size="sm"
+                      className="bg-emerald-600 hover:bg-emerald-700 mt-1"
+                      onClick={() => sendMessage(
+                        lang === 'pt'
+                          ? `Vamos começar o Encontro ${nextUnlockedPhase}.`
+                          : `Let's start Encontro ${nextUnlockedPhase}.`,
+                        true,
+                      )}
+                      data-testid={`button-start-encontro-${nextUnlockedPhase}`}
+                    >
+                      {lang === 'pt' ? `Começar Encontro ${nextUnlockedPhase}` : `Start Encontro ${nextUnlockedPhase}`}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })()}
 
             {/* Resume / Completion.
                 Structural rule: only show this block when the agent owes the

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -207,7 +207,11 @@ After all 9 substantive questions are answered:
 >
 > [if path = 'needs-help']: Vamos descobrir juntos onde e como atuar — sem pressa, com calma.
 >
+> Quando sua coordenadora abrir o próximo encontro, vai aparecer um cartão verde aqui (*Próximo encontro liberado*) com o botão pra começar. Pode fechar essa página enquanto isso — quando voltar, é só clicar.
+>
 > Até lá! 🌱"
+
+**Important**: do NOT promise a push notification, email, or SMS. The only signal the CBO will see is the green banner that appears in this chat when they refresh / the page polls. Set that expectation accurately.
 
 ## Things this skill does NOT do
 


### PR DESCRIPTION
## What user reported

After completing E1, coordinator clicked \"Open Workshop 2\". CBO refreshed. **Nothing visible changed.** Progress bar still showed \"Section 1 of 5\". No banner, no button, no signal. They asked: *\"how does the cbo know? what should happen from e1 to e2?\"*

## Structural cause

The only thing that advances \`state.phase\` is the agent calling \`set_phase()\`. After E1 wraps, the agent (correctly) refuses to advance past \`max(unlockedPhases)\`. When the coordinator later unlocks phase 2:

- Server: \`cohort_members.unlockedPhases\` becomes \`[1, 2]\`
- Client refresh: \`unlockedPhases\` state updates
- \`state.phase\` stays at 1 — agent never re-evaluates
- Progress bar reads \`state.phase\` → still shows phase 1
- **No banner, no CTA, no prompt to advance**
- The agent had even promised *\"you'll get a notification\"* — but nothing was built

## Three fixes

### 1. Start-Next-Workshop banner

When \`unlockedPhases\` contains a value greater than \`state.phase\`, render an emerald card in the chat:

\`\`\`
┌─────────────────────────────────────┐
│ 🌱 PRÓXIMO ENCONTRO LIBERADO        │
│                                     │
│   Workshop 2 — Where We Work        │
│                                     │
│   Sua coordenadora abriu esse       │
│   encontro. Quando estiver pronta,  │
│   podemos começar.                  │
│                                     │
│         [ Começar Encontro 2 ]      │
└─────────────────────────────────────┘
\`\`\`

Click → \`sendMessage(\"Vamos começar o Encontro N.\", hidden=true)\` → agent calls \`set_phase(N)\` → \`encontro-N.md\` skill loads → flow begins.

### 2. 30s polling

Previously \`/api/cbo-member/:slug\` only re-fetched on tab focus. Added \`setInterval(refetch, 30000)\` that pauses when the tab is hidden. Now a CBO sitting on the page sees the banner appear within 30s of the coordinator's click — no manual refresh needed.

### 3. Accurate skill closing message

\`encontro-1.md\`'s wrap-up no longer says \"you'll get a notification\". It tells the CBO specifically what to look for:

> *\"Quando sua coordenadora abrir o próximo encontro, vai aparecer um cartão verde aqui (Próximo encontro liberado) com o botão pra começar.\"*

Plus an explicit rule: *\"do NOT promise push / email / SMS — the only signal is the in-chat banner.\"*

## Test plan

- [ ] CBO completes E1 → wrap-up message mentions the green banner
- [ ] Coordinator opens W2
- [ ] CBO tab in focus → banner appears within 30s
- [ ] CBO tab in background → banner appears on next focus
- [ ] CBO taps Start → agent advances + runs E2 flow
- [ ] Banner disappears once state.phase advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)