### PR TITLE
fix(cbo): advance phase server-side before Start Encontro N message

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1003,12 +1003,30 @@ export default function CboProfilePage() {
                     <Button
                       size="sm"
                       className="bg-emerald-600 hover:bg-emerald-700 mt-1"
-                      onClick={() => sendMessage(
-                        lang === 'pt'
-                          ? `Vamos começar o Encontro ${nextUnlockedPhase}.`
-                          : `Let's start Encontro ${nextUnlockedPhase}.`,
-                        true,
-                      )}
+                      onClick={async () => {
+                        if (!cboId) return;
+                        // Advance the phase SERVER-SIDE first. Without this,
+                        // the agent's next turn loads encontro-1.md (skill
+                        // is keyed on state.phase) and the banner re-fires
+                        // because nextUnlockedPhase stays > state.phase.
+                        try {
+                          const r = await fetch(`/api/cbo/${cboId}/advance-phase`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ phase: nextUnlockedPhase }),
+                          });
+                          if (r.ok) {
+                            const data = await r.json();
+                            if (data?.state) setState(migrateCboState(data.state));
+                          }
+                        } catch {}
+                        sendMessage(
+                          lang === 'pt'
+                            ? `Vamos começar o Encontro ${nextUnlockedPhase}.`
+                            : `Let's start Encontro ${nextUnlockedPhase}.`,
+                          true,
+                        );
+                      }}
                       data-testid={`button-start-encontro-${nextUnlockedPhase}`}
                     >
                       {lang === 'pt' ? `Começar Encontro ${nextUnlockedPhase}` : `Start Encontro ${nextUnlockedPhase}`}

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -26,6 +26,18 @@ Your job in this encontro is to:
 
 The CURRENT STATE block of this prompt has E1's answers. Reference them naturally — *"você mencionou que trabalham com hortas em Cascata…"* — before pushing forward. Do not re-ask anything that's already in state.
 
+## ⚠️ First action on entering E2 — non-negotiable
+
+When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's start Encontro 2"* and state.phase = 2 (already advanced server-side), your **FIRST tool call MUST be `show_examples`**. Do NOT ask free-text intro questions about their site before showing examples + opening the map.
+
+Order of tool calls when entering E2:
+1. `show_examples({mode: 'browse'|'favorites'})` — path-aware (see below)
+2. Short content message acknowledging the examples
+3. `open_map({selectionMode: 'composite'|'browse-only'})` — path-aware
+4. After site confirmed: `ask_user` for `current_use`, then `ask_priority_rank`, then `ask_user` for `land_tenure`, then `ask_community_anchoring`
+
+Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen with that framing. Skip straight to the showcase.
+
 ## Beat 1 — Educational anchor (5 min, path-aware)
 
 ### `has-idea` opening

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -138,6 +138,48 @@ export function registerCboRoutes(app: Express): void {
     res.json({ ok: true, changed, state });
   });
 
+  // Advance phase server-side (called by the Start-Next-Workshop banner).
+  //
+  // The CBO can't rely on the agent to call set_phase() when entering a new
+  // encontro — without explicit instruction, the agent generated E2-flavored
+  // text but left state.phase at 1, leaving the banner in a re-trigger loop.
+  //
+  // This endpoint advances state authoritatively, checking the P-8 gate so
+  // CBOs can't skip past workshops the coordinator hasn't opened.
+  app.post("/api/cbo/:id/advance-phase", async (req: Request, res: Response) => {
+    const { getPhasePolicyForCbo, isPhaseAllowed } = await import("../services/phaseGating");
+    let state = getCboState(req.params.id);
+    if (!state) {
+      const persisted = await loadPersistedCboState(req.params.id);
+      if (persisted) { setCboState(req.params.id, persisted.state); state = persisted.state; }
+    }
+    if (!state) return res.status(404).json({ error: "Not found" });
+
+    const target = Number(req.body?.phase);
+    if (!Number.isInteger(target) || target < 0 || target > 6) {
+      return res.status(400).json({ error: "phase must be an integer 0-6" });
+    }
+
+    // P-8 gate — same rule the agent's set_phase tool enforces. Phase 6
+    // (wrap/export) is always allowed; phases 1-5 must be in unlockedPhases
+    // for cohort members.
+    if (target >= 1 && target <= 5) {
+      const policy = await getPhasePolicyForCbo(req.params.id);
+      if (policy.gated && !isPhaseAllowed(policy, target)) {
+        return res.status(409).json({
+          error: "phase_locked",
+          requestedPhase: target,
+          unlockedPhases: policy.unlockedPhases,
+        });
+      }
+    }
+
+    state.phase = target;
+    setCboState(req.params.id, state);
+    debouncedPersist(req.params.id);
+    res.json({ ok: true, phase: target, state });
+  });
+
   // User edit
   app.post("/api/cbo/:id/edit", async (req: Request, res: Response) => {
     const { sectionId, field, value } = req.body;


### PR DESCRIPTION
## Reported loop

User clicked **Start Encontro 2** → agent intros E2 in text → banner still shows → user clicks again → same intro → loop forever. \`state.phase\` never advanced.

## Root cause

Implicit contract: \"click Start → agent figures out it should advance the phase.\" Too fragile. The agent generated E2-flavored text in response to *\"Vamos começar o Encontro 2\"* but never called \`set_phase(2)\`. Because:

- The skill loader is keyed on \`state.phase\` → loaded \`encontro-1.md\` → no E2 prescriptive guidance
- The banner's condition (\`nextUnlockedPhase > state.phase\`) stayed true
- The user's only affordance was Start again → same loop

## Three changes (defense in depth)

### 1. Server endpoint — \`POST /api/cbo/:id/advance-phase\`

Authoritative phase advance. Body: \`{ phase: N }\`. Enforces the **P-8 gate** (same rule as the \`set_phase\` tool — CBO can't skip past workshops the coordinator hasn't opened). Returns the updated state.

### 2. Banner button now advances before messaging

\`\`\`ts
// onClick:
await fetch(`/api/cbo/${cboId}/advance-phase`, { body: { phase: N } });
setState(updated);  // state.phase = N now
sendMessage(`Vamos começar o Encontro ${N}.`, true);
// agent's next turn loads encontro-N.md
\`\`\`

Banner hides immediately because \`nextUnlockedPhase\` no longer \`> state.phase\`.

### 3. encontro-2.md prescriptive opening

Added an explicit *\"First action on entering E2 — non-negotiable\"* block:

> First tool call **MUST** be \`show_examples\`, then \`open_map\`. Do NOT generate free-text intro paragraphs — the user already saw the E2 preamble.

Same fix concept as PR #177 (E1 prescriptive chips): make implicit defaults explicit.

## Resulting flow

\`\`\`
E1 wraps → coordinator opens W2 → banner appears →
User clicks Start Encontro 2 →
  POST /advance-phase { phase: 2 } → state.phase=2 → banner hides →
  sendMessage(\"Vamos começar o Encontro 2\") →
  Agent prompt has state.phase=2 → loads encontro-2.md →
  First tool call: show_examples → strip renders →
  open_map → site selection → ... full E2 flow
\`\`\`

## Test plan

- [ ] Complete E1, get banner
- [ ] Click Start Encontro 2 → progress bar updates to \"Section 2 of 5 · Where We Work\"
- [ ] Banner disappears
- [ ] Agent's first response includes the NbsShowcaseCard strip (not free-text intro)
- [ ] Map opens after showcase
- [ ] /_inspect shows phase=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)