### PR TITLE
feat(cbo): per-skill compute budget — Haiku for chip turns

### DIFF
--- a/knowledge/_skills/README.md
+++ b/knowledge/_skills/README.md
@@ -1,0 +1,111 @@
+# Encontro Skills — Authoring Guide
+
+Skills in this folder drive the CBO agent's behavior for each encontro (workshop) in the COUGAR/Vila Flores curriculum. One file per phase: `encontro-1.md` through `encontro-6.md`.
+
+When `state.phase = N`, `cboAgent.ts` loads `encontro-N.md` via `loadEncontroSkill(N)` and injects the markdown as the **CURRENT PHASE INSTRUCTIONS** block of the system prompt. If the file is missing, the agent falls back to the hardcoded `buildPhaseInstructions(N)` block in `cboAgent.ts` (less prescriptive — only use as a stopgap).
+
+## File format
+
+Every skill file MUST start with YAML frontmatter declaring the compute budget:
+
+```yaml
+---
+model: claude-haiku-4-5
+thinking_budget: 0
+---
+
+# /encontro-N-<slug> — Agent skill
+
+[rest of the skill markdown...]
+```
+
+### Fields
+
+| Field | Type | Values | Default |
+|---|---|---|---|
+| `model` | string | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-7` | SDK default (Sonnet) |
+| `thinking_budget` | int | `0` (off) or thinking-token budget (typically `1000`-`8000`) | `0` |
+
+Parsed by `server/services/encontroSkills.ts`. Cached for the process lifetime — restart the server to pick up edits.
+
+## Choosing the budget
+
+The right budget depends on what kind of work the encontro does turn-to-turn. Three archetypes:
+
+### Chip-heavy (Haiku, 0 thinking)
+
+> User picked a chip → call `update_section` → fire next `ask_user`. Repeat.
+
+Most turns are pure data capture with prescriptive chip lists declared in the skill. The agent doesn't need to reason about anything — it copies the chips from the skill, calls one or two tools, moves on.
+
+```yaml
+model: claude-haiku-4-5
+thinking_budget: 0
+```
+
+Expect ~1-1.5s turn latency, ~10× cheaper than Sonnet. **Use for E1, E2, E4.**
+
+### Synthesis-medium (Sonnet, ~4000 thinking)
+
+> Agent must reason about hazards/site/intervention combinations, read knowledge files, and propose with-vs-without confidence ranges.
+
+```yaml
+model: claude-sonnet-4-6
+thinking_budget: 4000
+```
+
+Expect ~4-8s turn latency. **Use for E3 (NBS selector reasoning), E6 (pitch composition).**
+
+### Synthesis-heavy (Sonnet, ~8000 thinking)
+
+> Final maturity scorecard — agent must score 9 metrics + 6 flags consistently across everything captured in E1-E4, justify each score, surface inconsistencies.
+
+```yaml
+model: claude-sonnet-4-6
+thinking_budget: 8000
+```
+
+Expect ~10-15s turn latency. **Use for E5.**
+
+### Per-encontro recommendation (May 2026)
+
+| Encontro | Profile | Suggested config |
+|---|---|---|
+| E1 — Who we are | Chips + a few free-text confirmations | `haiku-4-5`, `0` |
+| E2 — Where we work | Chips + map UI + small risk-rank synthesis | `haiku-4-5`, `0` |
+| E3 — What we build | Selector reasoning, hazard→NBS mapping | `sonnet-4-6`, `4000` |
+| E4 — What we need | Chips + free-text needs list | `haiku-4-5`, `0` |
+| E5 — Results | Full maturity scorecard synthesis | `sonnet-4-6`, `8000` |
+| E6 — Portfolio | Pitch composition, narrative weaving | `sonnet-4-6`, `4000` |
+
+## Automatic escalation
+
+The agent server overrides the skill's budget in one case: **file uploads** (user message starts with `"I'm uploading:"` or `"Estou enviando:"`). These contain parsed document content (up to 8KB) that needs real reasoning to map into sections. Forced to `sonnet-4-6` + `4000` thinking regardless of the encontro's default.
+
+See `streamWithSdk` in `server/services/cboAgent.ts` for the override.
+
+## How to tell if you picked wrong
+
+After running an encontro live, check `[cbo] Turn for ...` log lines:
+
+- **Too cheap (Haiku where Sonnet was needed):** agent drops tools, fails to call `update_section` after free-text answers, gives generic chip labels instead of the prescriptive ones declared in the skill, or hallucinates Brazilian context. → Bump to Sonnet.
+- **Too expensive (Sonnet where Haiku was enough):** turns regularly take >5s on chip selections that should be instant; agent over-explains in long paragraphs when the user expected to just see chips. → Drop to Haiku.
+- **Thinking wasted:** the assistant's text response is a one-liner ("Got it, next:") but thinking_budget was 4000 — the budget is being burned with no visible quality bump. → Drop thinking_budget toward 0.
+
+## Per-tool overrides (future)
+
+Not yet implemented. The current model is "skill declares default for the whole encontro." If we find we need targeted escalation inside a Haiku-default encontro (e.g. when `score_maturity` is called mid-E2), we'll add a tool-level override map in the agent. Don't put it in skill frontmatter — the skill author shouldn't have to think about tool internals.
+
+## When authoring a new encontro
+
+1. Pick the archetype above. Write frontmatter first.
+2. Copy the structure of `encontro-1.md` (most prescriptive existing skill): Identity → Voice → Read state → First action → Beat-by-beat instructions → Closing.
+3. **Be prescriptive about chips.** Spell out every `ask_user` chip list inline in the skill — don't expect the agent to invent them, especially on Haiku.
+4. Add an "Anti-patterns to AVOID" section near the bottom listing the specific failure modes you've seen the agent slip into (re-introducing, asking for exact numbers via free-text, bundling questions, etc.).
+5. After shipping, do a manual run-through and watch the logs. Adjust frontmatter once based on actual latency vs. quality.
+
+## Related files
+
+- `server/services/encontroSkills.ts` — frontmatter parser, skill cache
+- `server/services/cboAgent.ts` — `streamWithSdk`, budget application, file-upload escalation
+- `server/services/cboAgent.ts:buildPhaseInstructions` — hardcoded fallback when skill file is missing

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -1,3 +1,8 @@
+---
+model: claude-haiku-4-5
+thinking_budget: 0
+---
+
 # /encontro-1-quem-somos — Agent skill (first draft)
 
 > Loaded by `cboAgent.ts` when `member.unlockedPhases` includes 1 and the user hasn't completed Phase 1 yet. Replaces the Phase-1 section of the current monolithic `cbo-intervention.md` skill. Other phases keep loading the existing skill until they're split too.

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -1,3 +1,8 @@
+---
+model: claude-haiku-4-5
+thinking_budget: 0
+---
+
 # /encontro-2-seu-territorio — Agent skill
 
 Loaded by `cboAgent.ts` (via `loadEncontroSkill(2)`) when state.phase == 2.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -694,13 +694,33 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
 
   const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}\n\nUser message: ${userMessage}`;
 
-  console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
+  // Compute budget — read from skill frontmatter (cached). Chip-heavy encontros
+  // declare Haiku + 0 thinking for ~3× faster turns; synthesis-heavy ones
+  // declare Sonnet + 4-8k thinking. See knowledge/_skills/README.md.
+  const skill = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
+  let model = skill?.config.model;
+  let thinkingBudget = skill?.config.thinkingBudget ?? 0;
+
+  // Escalation hatch: file uploads contain parsed document content and need
+  // real reasoning to map into sections. Override the skill default to Sonnet
+  // + thinking regardless of which encontro we're in. Detected by the upload
+  // prompt prefix used by the file-drop handler (see cbo-profile.tsx).
+  const isFileUpload = /^(I'm uploading:|Estou enviando:|Uploaded ")/.test(userMessage);
+  if (isFileUpload) {
+    model = 'claude-sonnet-4-6';
+    thinkingBudget = 4000;
+  }
+
+  const sectionsFilled = Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length;
+  console.log(`[cbo] Turn for ${cboId} phase=${state.phase} sections=${sectionsFilled}/7 model=${model ?? 'sdk-default'} thinking=${thinkingBudget}${isFileUpload ? ' (file-upload escalation)' : ''}`);
 
   try {
     for await (const message of sdkQuery({
       prompt,
       options: {
         cwd: process.cwd(),
+        ...(model ? { model } : {}),
+        ...(thinkingBudget > 0 ? { maxThinkingTokens: thinkingBudget } : {}),
         allowedTools: [
           "Read", "Glob", "Grep",
           "mcp__cbo__update_section",
@@ -814,8 +834,10 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
   // Prefer encontro skill markdown from knowledge/_skills/encontro-{N}.md when
   // present (E1-E6 curriculum); fall back to the hardcoded block for phases
   // that haven't been migrated yet. Phase 0 = pre-onboarding, no encontro.
-  const encontroSkillMd = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
-  const phaseInstructions = encontroSkillMd ?? buildPhaseInstructions(state.phase, isPt);
+  // Compute budget (model + thinking) is read from skill frontmatter in
+  // streamWithSdk via the same loader (cached, so no double fs read).
+  const encontroSkill = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
+  const phaseInstructions = encontroSkill?.content ?? buildPhaseInstructions(state.phase, isPt);
 
   // ── City summary (condensed, always loaded) ──
   const citySummary = isPt

--- a/server/services/encontroSkills.ts
+++ b/server/services/encontroSkills.ts
@@ -5,29 +5,58 @@
 // `knowledge/_skills/encontro-{phase}.md` and overrides the hardcoded
 // per-phase instruction block in cboAgent.ts when present.
 //
-// Roll-out strategy: phases without a skill .md continue to use the existing
-// hardcoded instructions (full backwards compat). E1's skill ships first; E2-E6
-// remain on hardcoded instructions until their skills are wired.
+// Each skill file MAY declare a compute budget in YAML frontmatter:
+//   ---
+//   model: claude-haiku-4-5 | claude-sonnet-4-6 | claude-opus-4-7
+//   thinking_budget: 0 | <int>     # max thinking tokens; 0 = extended thinking off
+//   ---
+//
+// Chip-heavy encontros (E1, E2, E4) should use Haiku with no thinking — they
+// run ~3× faster and ~10× cheaper than Sonnet, and the work is mostly
+// "user picked a chip → call update_section + next ask_user." Synthesis-heavy
+// encontros (E3, E5, E6) want Sonnet + thinking. See knowledge/_skills/README.md
+// for the full rationale and per-encontro defaults.
+//
+// Roll-out: phases without a skill .md continue to use the hardcoded
+// per-phase block in cboAgent.ts (full backwards compat).
 
 import fs from 'fs/promises';
 import path from 'path';
 
-const skillCache = new Map<number, string | null>();
+export interface SkillConfig {
+  model?: string;
+  thinkingBudget: number;
+}
+
+export interface LoadedSkill {
+  content: string;
+  config: SkillConfig;
+}
+
+// Default config when the skill file omits frontmatter — matches pre-budget
+// behavior so existing skills don't regress when this lands.
+const DEFAULT_CONFIG: SkillConfig = {
+  model: undefined, // let the SDK pick its default (Sonnet)
+  thinkingBudget: 0,
+};
+
+const skillCache = new Map<number, LoadedSkill | null>();
 
 /**
- * Returns the skill markdown for a given phase, or null if no skill file
- * exists yet (caller should fall back to hardcoded instructions).
+ * Returns the loaded skill (markdown + parsed config) for a given phase, or
+ * null if no skill file exists yet. Caller falls back to hardcoded
+ * instructions when null.
  *
- * Cached for the lifetime of the process; restart to pick up edits. Cache is
- * keyed by phase number — skills change rarely and atomically per-phase.
+ * Cached for the lifetime of the process; restart to pick up edits.
  */
-export async function loadEncontroSkill(phase: number): Promise<string | null> {
+export async function loadEncontroSkill(phase: number): Promise<LoadedSkill | null> {
   if (skillCache.has(phase)) return skillCache.get(phase) ?? null;
   try {
     const filePath = path.join(process.cwd(), 'knowledge', '_skills', `encontro-${phase}.md`);
-    const content = await fs.readFile(filePath, 'utf-8');
-    skillCache.set(phase, content);
-    return content;
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const loaded = parseSkillFile(raw);
+    skillCache.set(phase, loaded);
+    return loaded;
   } catch {
     skillCache.set(phase, null);
     return null;
@@ -36,4 +65,34 @@ export async function loadEncontroSkill(phase: number): Promise<string | null> {
 
 export function invalidateEncontroSkillCache() {
   skillCache.clear();
+}
+
+// ── Frontmatter parsing ──────────────────────────────────────────────────────
+//
+// Tiny YAML subset — only `key: value` pairs, no nested objects or arrays.
+// This avoids a yaml dependency just to read two fields. If we need richer
+// frontmatter later, swap to gray-matter or js-yaml.
+
+function parseSkillFile(raw: string): LoadedSkill {
+  const fmMatch = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
+  if (!fmMatch) return { content: raw, config: { ...DEFAULT_CONFIG } };
+
+  const body = fmMatch[1];
+  const content = raw.slice(fmMatch[0].length);
+  const config: SkillConfig = { ...DEFAULT_CONFIG };
+
+  for (const line of body.split('\n')) {
+    const m = line.match(/^\s*([a-z_][a-z0-9_]*)\s*:\s*(.+?)\s*$/i);
+    if (!m) continue;
+    const key = m[1].toLowerCase();
+    const value = m[2].replace(/^["']|["']$/g, '').trim();
+    if (key === 'model') {
+      config.model = value;
+    } else if (key === 'thinking_budget' || key === 'thinkingbudget') {
+      const n = parseInt(value, 10);
+      if (Number.isFinite(n) && n >= 0) config.thinkingBudget = n;
+    }
+  }
+
+  return { content, config };
 }


### PR DESCRIPTION
## Summary
- Adds YAML frontmatter (`model`, `thinking_budget`) to encontro skill files. `loadEncontroSkill` parses it; `streamWithSdk` pipes the config into `sdkQuery` options.
- E1 + E2 declared as `claude-haiku-4-5` with `thinking_budget: 0` — these encontros are ~95% "user picked a chip → call update_section + next ask_user" and don't need extended thinking. Expected ~3× faster turns, ~10× cheaper.
- File-upload turns auto-escalate to Sonnet + 4000 thinking regardless of the encontro default (parsed document content needs real reasoning to map into sections).
- `knowledge/_skills/README.md` documents the pattern — per-encontro recommendations, when to use each archetype (chip-heavy / synthesis-medium / synthesis-heavy), and how to tell if a budget was set wrong. Reference doc for when E3-E6 skill files are authored.
- Default fallback (no frontmatter) matches pre-budget behavior — SDK-default model, no thinking. Backwards-compatible with any future skill that omits frontmatter.

## What changes in production
- E1/E2 chip turns log `model=claude-haiku-4-5 thinking=0` and complete faster
- File uploads log `model=claude-sonnet-4-6 thinking=4000 (file-upload escalation)`
- E3-E6 still hit the hardcoded `buildPhaseInstructions` fallback (no skill file yet) — no behavior change for those until skill files land

## Test plan
- [ ] Boot server, send a chip answer in E1, confirm log line shows `model=claude-haiku-4-5 thinking=0`
- [ ] Upload a document mid-E1, confirm log line shows the file-upload escalation
- [ ] Run E1→E2 transition end-to-end, watch for tool-call drops on Haiku (chip lists, update_section after free-text, set_path on close)
- [ ] Compare median chip-turn latency before/after (target: ≤1.5s, was ~3-5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)