### PR TITLE
fix(cbo): welcome's "Or start over" actually starts over

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -303,11 +303,15 @@ export default function CboProfilePage() {
   // orgName + neighborhood at invite time — re-asking on the first chat
   // turn is bad UX. The server-side prefill is idempotent (won't overwrite
   // userEdited fields), so firing it repeatedly is safe.
-  const prefillSentRef = useRef(false);
+  //
+  // Track the cboId that was prefilled (not just a boolean) so that
+  // handleRestart's new cboId triggers a fresh prefill instead of being
+  // skipped by a sticky guard.
+  const prefilledCboIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (prefillSentRef.current) return;
     if (!cboId || !memberInfo) return;
-    prefillSentRef.current = true;
+    if (prefilledCboIdRef.current === cboId) return;
+    prefilledCboIdRef.current = cboId;
     fetch(`/api/cbo/${cboId}/prefill`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -686,9 +690,31 @@ export default function CboProfilePage() {
         focusWorkshopIsCurrent={focusWorkshopIsCurrent}
         unlockedPhases={unlockedPhases}
         hasExistingProgress={hasExistingProgress}
-        onStart={() => {
+        onStart={async () => {
+          // CboWelcome fires onStart from two places:
+          //   1. The primary CTA when there is no existing progress (first
+          //      visit) — kick off the chat fresh.
+          //   2. The secondary "Or start over" link when there IS existing
+          //      progress — the user wants to wipe and begin from zero.
+          // The two cases need different side effects, so branch here.
+          if (hasExistingProgress) {
+            const confirmMsg = lang === 'pt'
+              ? 'Começar de novo apaga toda sua conversa e respostas anteriores. Tem certeza?'
+              : 'Starting over will erase your current conversation and answers. Are you sure?';
+            if (!window.confirm(confirmMsg)) return;
+            setWelcomeMode(false);
+            await handleRestart();
+            // After restart: new cboId, state.phase = 0, empty messages.
+            // The prefill effect re-fires on the new cboId, and we kick off
+            // the chat the same way a first-time visitor would. Skip the
+            // preamble — the user already saw it before they decided to
+            // restart, and the localStorage seen-flag would suppress it
+            // anyway. Going straight to chat is the cleaner intent.
+            kickoffChat();
+            return;
+          }
           setWelcomeMode(false);
-          if (!tryShowPreamble() && !hasExistingProgress) kickoffChat();
+          if (!tryShowPreamble()) kickoffChat();
         }}
         onResume={() => {
           setWelcomeMode(false);


### PR DESCRIPTION
## Summary
The \"Or start over\" link on the CBO welcome screen was a no-op — it dismissed the welcome and landed back on the existing session instead of wiping state. Two bugs:

1. **\`onStart\` didn't wipe state when \`hasExistingProgress\`.** The handler ignored the existing-progress branch entirely and never called \`handleRestart\` (which already exists at line 627 and does the right thing — DELETE the CBO state, create a fresh one). Now branches: confirm + handleRestart + kickoff if has progress; plain kickoff otherwise.

2. **\`prefillSentRef\` was a sticky boolean.** Once set to \`true\` on first mount, it stayed true forever. After \`handleRestart\` created a new \`cboId\`, the prefill effect was skipped — so the new CBO didn't get the invite's \`orgName\` + \`neighborhood\` seeded. Now tracks the \`cboId\` that was prefilled, so a new \`cboId\` triggers a fresh prefill (server-side prefill is idempotent and respects \`userEdited\`).

Also adds a \`window.confirm\` before the wipe — destructive action shouldn't be one misclick away.

## Test plan
- [ ] Welcome screen with existing progress → \"Or start over\" → confirm dialog appears
- [ ] Confirm → state wipes, fresh CBO created, chat kicks off with empty history
- [ ] Cancel → still on welcome screen, no change
- [ ] After restart, org name + neighborhood from invite are seeded into the new CBO (check via /api/cbo/:id state)
- [ ] First-time visitor (no existing progress) → primary CTA still works as before, no confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)