### PR TITLE
fix(cbo): restart flow — cohort wipe, stale-closure 404, banner gates

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -235,6 +235,12 @@ export default function CboProfilePage() {
   // When arriving via ?cbo=<slug>, render the premium welcome screen until
   // the user taps Start / Continue. Flipped to true once member-fetch lands.
   const [welcomeMode, setWelcomeMode] = useState(false);
+  // Flag set by handleRestart so the kickoff fires AFTER the new cboId has
+  // flushed into state. Calling kickoffChat inline right after handleRestart
+  // races with React's batching — the kickoffChat closure captures the old
+  // (deleted) cboId and POSTs /api/cbo/<old>/chat → 404. The effect below
+  // watches [pendingKickoff, cboId] and only fires when both are true.
+  const [pendingKickoff, setPendingKickoff] = useState(false);
   // Per-encontro preamble — once dismissed, the encontro's first session reveals
   // the chat. State is encontro number 1-6 OR null (no preamble showing).
   const [preambleEncontro, setPreambleEncontro] = useState<number | null>(null);
@@ -629,13 +635,28 @@ export default function CboProfilePage() {
   }, [cboId, processEvent]);
 
   const handleRestart = useCallback(async () => {
+    // Two stores hold the user's session: the CBO state row (sections,
+    // maturity, messages) and the cohort-member row (path, inspirationPicks,
+    // supportRequests, snapshot fields). Wiping only the first leaves the
+    // second leaking into the fresh session — the agent's earlier set_path
+    // call sticks, the saved NBS showcase cards re-appear, etc. Reset both.
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
+    if (memberSlug) { try { await fetch(`/api/cbo-member/${memberSlug}/reset-session`, { method: 'POST' }); } catch {} }
+
     clearId(); saveMapParams(null); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
+    // Cohort-member-derived React state — server is wiped above; mirror that
+    // locally so the UI doesn't keep rendering the stale path / picks / count
+    // until the next polling refresh.
+    setMemberPath(null);
+    setInspirationPicks([]);
+    setSupportPendingCount(0);
+    setShowcase(null);
+
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
     setCboId(data.cboId); setState(data.state); saveId(data.cboId);
-  }, [cboId]);
+  }, [cboId, memberSlug]);
 
   // Kick off the agent chat with the standard intake prompt. Hidden from the
   // visible message stream — the agent's first response is what the user sees.
@@ -647,6 +668,14 @@ export default function CboProfilePage() {
       : "Start the CBO intervention profile for Porto Alegre. Use the /cbo-intervention skill flow. Always use the ask_user tool for multiple-choice questions. In your first message, mention that the user can drop existing documents (proposals, reports, plans, photos) into the chat at any time — you'll extract info and auto-fill sections.";
     sendMessage(text, true);
   }, [lang, sendMessage]);
+
+  // Fire a pending kickoff once the new cboId has flushed into state and
+  // kickoffChat has been re-built with the fresh closure. Set by handleRestart.
+  useEffect(() => {
+    if (!pendingKickoff || !cboId) return;
+    setPendingKickoff(false);
+    kickoffChat();
+  }, [pendingKickoff, cboId, kickoffChat]);
 
   // File drop handler
   const { isDragging, isUploading, dragHandlers } = useFileDrop({
@@ -703,14 +732,14 @@ export default function CboProfilePage() {
               : 'Starting over will erase your current conversation and answers. Are you sure?';
             if (!window.confirm(confirmMsg)) return;
             setWelcomeMode(false);
+            // Defer kickoff to the effect — calling kickoffChat() inline here
+            // would race with React's batching: the closure has captured the
+            // old (now-deleted) cboId. The effect fires once cboId has
+            // flushed to the new value, kickoffChat re-built with the fresh
+            // closure. Skip the preamble — user already saw it before
+            // restarting, and localStorage's seen-flag would suppress it.
+            setPendingKickoff(true);
             await handleRestart();
-            // After restart: new cboId, state.phase = 0, empty messages.
-            // The prefill effect re-fires on the new cboId, and we kick off
-            // the chat the same way a first-time visitor would. Skip the
-            // preamble — the user already saw it before they decided to
-            // restart, and the localStorage seen-flag would suppress it
-            // anyway. Going straight to chat is the cleaner intent.
-            kickoffChat();
             return;
           }
           setWelcomeMode(false);
@@ -1007,9 +1036,22 @@ export default function CboProfilePage() {
                 When the coordinator opens a workshop higher than the user's
                 current phase, this card appears so the CBO knows the next
                 encontro is available + has a clear CTA to enter it. Without
-                this, the user has no signal that anything changed. */}
+                this, the user has no signal that anything changed.
+
+                Gates (in order):
+                1. Not streaming, has messages, phase > 0 — basic readiness.
+                2. No active ask_user — the user has a pending question and
+                   the banner would compete for attention. Answer first.
+                3. ≥3 user replies in the conversation — keeps the banner from
+                   appearing immediately after a restart (or a fresh start
+                   where the coordinator already had W2+ open). The user
+                   should engage with the current encontro before being
+                   nudged out of it. */}
             {(() => {
               if (isStreaming || messages.length === 0 || state.phase === 0) return null;
+              if (currentQuestion) return null;
+              const userReplies = messages.filter(m => m.role === 'user' && m.messageType === 'content').length;
+              if (userReplies < 3) return null;
               const nextUnlockedPhase = unlockedPhases.find(p => p > state.phase);
               if (nextUnlockedPhase == null) return null;
               const ws = workshops.find(w => w.unlocksPhase === nextUnlockedPhase);

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -402,4 +402,37 @@ export function registerCohortRoutes(app: Express): void {
     }).where(eq(cohortMembers.id, member.id));
     res.json({ ok: true });
   }));
+
+  // CBO resets its session — clears everything the user/agent accumulated
+  // during the run, but keeps coordinator-owned and invite-time data so the
+  // restart lands cleanly back at E1 with the same seed.
+  //
+  // Cleared:        path, inspirationPicks, supportRequests, all snapshot
+  //                 fields, startedAt, cboStateId pointer.
+  // Preserved:      orgName, neighborhood, memberSlug, cohortId, unlockedPhases
+  //                 (coordinator-driven), contact info.
+  //
+  // Called from cbo-profile.tsx's handleRestart so the cohort-member row
+  // doesn't leak path/picks/support requests across a fresh start.
+  app.post('/api/cbo-member/:memberSlug/reset-session', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    await db.update(cohortMembers).set({
+      path: null,
+      inspirationPicks: [],
+      supportRequests: [],
+      cboStateId: null,
+      startedAt: null,
+      snapshotPhase: 0,
+      snapshotSectionsComplete: 0,
+      snapshotMaturityScore: 0,
+      snapshotFlagsMet: 0,
+      snapshotIntervention: null,
+      snapshotUpdatedAt: new Date(),
+    }).where(eq(cohortMembers.id, member.id));
+
+    console.log(`[cohort] Reset session for member ${member.memberSlug} (${member.orgName})`);
+    res.json({ ok: true });
+  }));
 }


### PR DESCRIPTION
Three symptoms from the same restart pathway, all visible in the last test run:

## 1. \"Has an NBS project idea\" persisted across Start Over
The user's path lives on \`cohortMembers.path\` (written by the agent's \`set_path\` tool), not on the CBO state. \`handleRestart\` only deleted \`cbo_states\`, leaving path / inspirationPicks / supportRequests / snapshot fields intact. Adds \`POST /api/cbo-member/:slug/reset-session\` that nulls these while keeping coordinator-owned data (\`unlockedPhases\`, \`orgName\`, \`neighborhood\`). Wires it into \`handleRestart\` and mirrors the wipe in local React state.

## 2. \`POST /api/cbo/<old-cboId>/chat → 404\` after Start Over
The log showed:
\`\`\`
7:18:52 DELETE /api/cbo/38095163... 200
7:18:52 POST /api/cbo → new cboId 6c0c414a
7:18:52 POST /api/cbo/38095163.../chat 404   ← stale closure
\`\`\`
\`onStart\` called \`kickoffChat()\` immediately after \`handleRestart\`, but the \`useCallback\` closure had captured the old (deleted) \`cboId\` because React's state hadn't flushed yet. Added a \`pendingKickoff\` state + effect that fires \`kickoffChat\` after \`cboId\` has updated AND \`kickoffChat\` has been re-built with the fresh closure.

## 3. \"Start Encontro 2\" banner appearing mid-E1
The banner condition was *\"any unlocked phase > current phase\"*. After a restart, \`unlockedPhases\` still includes [1, 2, 3...] from the coordinator's earlier actions, so the banner appeared the moment \`state.phase\` advanced to 1 — while the user was still answering E1's first question. Two new gates:
- **No active ask_user** — don't compete with a pending question
- **userReplies ≥ 3** — user must engage with the current encontro before being nudged into the next

## Test plan
- [ ] Click \"Or start over\" → confirm → fresh chat starts, no \"NBS project idea\" tag, no immediate \"Start Encontro 2\" banner, no 404 in network tab
- [ ] After 3 user replies in the new E1, banner appears if W2 is open
- [ ] During an active ask_user (chips visible), banner is hidden
- [ ] First-time visitor (no progress) — flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)