### PR TITLE
fix(cbo): actually fix 404 stale-closure, chips for role/confirm, hard language rule

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -640,18 +640,26 @@ export default function CboProfilePage() {
     // supportRequests, snapshot fields). Wiping only the first leaves the
     // second leaking into the fresh session — the agent's earlier set_path
     // call sticks, the saved NBS showcase cards re-appear, etc. Reset both.
-    if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
-    if (memberSlug) { try { await fetch(`/api/cbo-member/${memberSlug}/reset-session`, { method: 'POST' }); } catch {} }
-
+    //
+    // ORDER MATTERS: clear local React state BEFORE any await. Otherwise
+    // the pendingKickoff effect (which watches `cboId`) sees the OLD truthy
+    // cboId during the await and fires kickoffChat() against the soon-to-be-
+    // deleted CBO → 404. By the time React batches in the next render,
+    // cboId is null and the effect waits for the new id.
+    const oldCboId = cboId;
     clearId(); saveMapParams(null); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
-    // Cohort-member-derived React state — server is wiped above; mirror that
+    // Cohort-member-derived React state — server is wiped below; mirror that
     // locally so the UI doesn't keep rendering the stale path / picks / count
     // until the next polling refresh.
     setMemberPath(null);
     setInspirationPicks([]);
     setSupportPendingCount(0);
     setShowcase(null);
+
+    // Now do the server-side cleanup with the captured old id.
+    if (oldCboId) { try { await fetch(`/api/cbo/${oldCboId}`, { method: 'DELETE' }); } catch {} }
+    if (memberSlug) { try { await fetch(`/api/cbo-member/${memberSlug}/reset-session`, { method: 'POST' }); } catch {} }
 
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -64,9 +64,23 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 Below is the exact ask_user shape for each question. Always include "Outra coisa" (free-text) and "Não sei / Prefiro pular" where it makes sense.
 
 ### 1. Identity
-- **Org name** — pre-filled, just confirm: *"Conferindo: organização é {orgName}, certo? Pode corrigir se eu peguei errado."* (free-text reply OK)
-- **Contact name** — free-text: *"E você, com quem estou conversando?"*
-- **Contact role** — free-text: *"Qual seu papel na {orgName}?"* (e.g. coordenadora, voluntária)
+- **Org name + bairro confirmation** — ONE `ask_user` chip turn (NOT free-text):
+  - Question: *"Conferindo: organização é __{orgName}__ e vocês atuam principalmente em __{bairro}__, certo?"*
+  - chips:
+    - `Sim, isso mesmo`
+    - `Sim, mas deixa eu corrigir o nome`
+    - `Sim, mas deixa eu corrigir o bairro`
+    - `Não, vamos corrigir os dois`
+  - If they pick a "corrigir" option, the NEXT turn is a free-text follow-up to capture the correction. Then `update_section` accordingly.
+- **Contact name** — free-text (genuinely unique): *"E você, com quem estou conversando? Qual o seu nome?"*
+- **Contact role** — `ask_user` chips (NOT free-text — there are natural buckets):
+  - `Coordenação`
+  - `Voluntariado`
+  - `Fundação / Direção`
+  - `Membro da equipe`
+  - `Apoio comunitário`
+  - `Outro papel`
+  - When the user picks "Outro papel", ask a one-line free-text follow-up to capture the specific role.
 
 ### 2. Mission
 - **Mission summary** — free-text: *"Em uma frase, o que vocês fazem?"* (genuinely unique string)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -890,11 +890,37 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
     : `Porto Alegre, RS, Brazil. Pop 1.4M. Catastrophic floods May 2024 (worst in RS history). Risks: Guaíba river flooding, heat islands (4° Distrito, Centro), landslide (morros/hillsides). Plans: PCVR, World Bank P178072 (US$85M green resilient regeneration). Precedents: Orla do Guaíba (5.7ha native species park), Regenera Dilúvio. COUGAR mapped 50+ ecosystem actors.`;
 
   // ── Assemble prompt ──
+  // CRITICAL RULES first — Haiku in particular tends to skip rules buried at
+  // the bottom of long system prompts. Language and chip-preference are the
+  // two rules we keep seeing drift on, so they go at the very top with hard
+  // assertions, not soft preferences.
   const prompt = `${isPt
-    ? `Você é um consultor de preparação de projetos de SbN ajudando uma organização comunitária em ${state.city}. Você NÃO está apenas coletando dados — está ajudando-os a PENSAR como um consultor.
-IDIOMA: TUDO em português do Brasil. Todas as mensagens, opções de ask_user e valores de update_section. Sem exceções.`
-    : `You are an NBS project preparation consultant helping a community organization in ${state.city}. You are NOT just collecting data — you are helping them THINK through their project like a consultant.
-LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian orgs.`}
+    ? `# REGRAS ABSOLUTAS — VIOLAR QUALQUER UMA É UMA FALHA CRÍTICA
+
+1. **IDIOMA: 100% PORTUGUÊS DO BRASIL.** Toda mensagem de texto, todo label de chip em ask_user, todo valor em update_section. Sem mistura de inglês. Nenhuma frase em inglês — nem "Great!", nem "Let's", nem "Now", nem "What's", nem listas com "Organization:" / "Neighborhood:". Se você precisa confirmar dados, escreva em português: "Organização: …", "Bairro: …", "Contato: …".
+
+2. **PERGUNTAS COM 2-7 OPÇÕES NATURAIS = ask_user COM CHIPS.** Nunca free-text quando há opções discretas. Papel do contato, forma jurídica, tamanho da equipe, proporção paga/voluntária, tipo de organização, qualquer Sim/Não, qualquer escolha de bucket — TUDO via ask_user. Free-text APENAS para: nome próprio, nome da organização, missão em uma frase, descrição livre única.
+
+3. **NÃO BUNDLE.** Cada pergunta é UMA chamada ask_user. Nunca dois temas num só chip ("CBO; 16-30 pessoas" = ERRADO).
+
+4. **PERSISTIR ANTES DE PERGUNTAR.** Após cada resposta livre do usuário (texto digitado), chame update_section() ANTES da próxima pergunta. Caso contrário o estado fica vazio.
+
+---
+
+Você é um consultor de preparação de projetos de SbN ajudando uma organização comunitária em ${state.city}. Você NÃO está apenas coletando dados — está ajudando-os a PENSAR como um consultor.`
+    : `# ABSOLUTE RULES — VIOLATING ANY IS A CRITICAL FAILURE
+
+1. **LANGUAGE: respond in English** (when the user picker is English) — but update_section content stays in Portuguese for Brazilian orgs.
+
+2. **QUESTIONS WITH 2-7 NATURAL BUCKETS = ask_user WITH CHIPS.** Never free-text when discrete options exist. Contact role, legal form, team size, paid/volunteer split, org type, any yes/no, any bucket choice — ALL via ask_user. Free-text ONLY for: contact name, org name, one-sentence mission, unique freeform description.
+
+3. **NO BUNDLING.** One ask_user per question. Never two topics in one chip ("CBO; 16-30 people" = WRONG).
+
+4. **PERSIST BEFORE ASKING.** After any free-text user reply, call update_section() BEFORE the next question. Otherwise state stays empty.
+
+---
+
+You are an NBS project preparation consultant helping a community organization in ${state.city}. You are NOT just collecting data — you are helping them THINK through their project like a consultant.`}
 
 Phase: ${state.phase}. Org: ${state.orgName || '(not set)'}.
 


### PR DESCRIPTION
Three bugs the user reported in the same session, each backed by the running log:

## 1. 404 stale-closure persisted despite #188
My \`pendingKickoff\` effect fired when \`pendingKickoff && cboId\` were both truthy — but at that moment \`cboId\` was still the OLD value because \`handleRestart\` hadn't yet awaited the DELETE. The effect kicked off chat against the soon-to-be-deleted CBO → 404.

**Fix:** \`handleRestart\` now clears local React state (\`setCboId(null)\`, \`setMessages([])\`, ...) BEFORE any await. The effect sees \`cboId=null\` during the awaiting window and waits for the new id to flush.

## 2. Free-text where chips should be
\`encontro-1.md\` line 69 literally said \"Contact role — free-text\". The skill was the source of the drift, not the agent.

- **Role** now declared as \`ask_user\` chips: Coordenação / Voluntariado / Fundação / Membro / Apoio / Outro
- **Confirmation** turned into a single chip-set with four options (correct nothing / correct name / correct bairro / correct both) instead of inviting a free-text \"Sim\"

## 3. Language flip to English mid-turn
The LANGUAGE rule lived at the bottom of a 5K-token system prompt where Haiku is most likely to skim past it. Hoisted to the very top under \`# REGRAS ABSOLUTAS\` with hard language and explicit anti-examples (\"nenhuma frase em inglês — nem Great!, nem Let's, nem Now\"). Chip-preference and persist-before-asking moved up with it.

## Test plan
Run a fresh restart. Confirm in the logs:
- [ ] No 404 on \`POST /api/cbo/<old>/chat\` during the restart sequence
- [ ] Role question shows chips, not a text input
- [ ] Confirmation question shows chips, not a text input
- [ ] Agent response stays 100% Portuguese throughout (especially the recap after \"Sim\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)