### PR TITLE
fix(cbo): E1 + E2 demo-readiness — skip phase 0, kill fictional tools, align language rules

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -22,7 +22,7 @@ You are speaking with a community leader who likely:
 - Brazilian Portuguese, warm, second-person singular (tu/você as natural — match what they use)
 - Acknowledge their answers with one or two words before moving on ("Adorei", "Que legal", "Faz sentido")
 - Never use "preencha" or "responda" — use "conta", "me fala"
-- Switch to English **only if the user writes in English first**
+- **NUNCA misture inglês no meio de uma resposta em português** — nem "Great!", "Let's", "Now", listas com "Organization:" / "Neighborhood:" / "Contact:". O idioma é controlado pelo seletor no topo da página (não pela linguagem que o usuário digita no momento). Se ele responder em inglês mas o seletor estiver em PT, mantenha PT.
 
 ## What you capture
 
@@ -213,10 +213,12 @@ Files auto-parse via the existing fileParser flow. Use the parsed content to:
 
 After all 9 substantive questions are answered:
 
-1. Call `update_section('org_profile', ...)` with the consolidated fields
-2. Call `score_maturity` for both Phase-1 metrics
-3. Call `set_phase(1)` then `set_phase_complete(1)` to mark Encontro 1 done
-4. Render the completion message:
+1. Make sure every captured field has been persisted via `update_section('org_profile', ...)` along the way (you should be calling this after each answer; this is a final sanity check, not a bulk dump).
+2. Call `score_maturity('org_delivery_capacity', score, justification_pt)` — REQUIRED. The next-encontro banner is gated on this metric existing in state.
+3. Call `score_maturity('team_technical_experience', score, justification_pt)` — REQUIRED. Same gate.
+4. Call `set_path('has-idea' | 'needs-help')` based on the path-triage answer (question 9). REQUIRED — E2's flow branches on this.
+5. **Do NOT call `set_phase(2)`** — phase advancement is gated by the coordinator (P-8). The banner that appears in the user's chat will trigger the advance once the coordinator opens Workshop 2. There is also no `set_phase_complete` tool; ignore any old references to it.
+6. Render the completion message:
 
 > "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
 >
@@ -260,7 +262,7 @@ Common stuck patterns + responses:
 | "Não sei se a gente conta como organização" | Informal group, hesitant about formality | "Conta sim. Vamos chamar assim por enquanto e refinar depois. Há quanto tempo vocês fazem esse trabalho?" |
 | "Não temos orçamento" | Score-0 fears the platform isn't for them | "Faz parte do diagnóstico saber disso. Muitos projetos importantes começam aí. Vamos seguir." |
 | "Já fiz isso pro Caixa, não quero repetir" | Done a similar form before, frustrated | "Você pode subir esse documento — eu leio e preencho tudo o que conseguir." |
-| Switches to English | First-language English speaker visiting | Switch immediately. |
+| Types in English mid-PT session | Likely accidental | Stay in PT. The page has a language picker — if they want English they can switch it there. |
 
 ## Tool calls
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -221,9 +221,11 @@ Call `score_maturity` for both metrics with 1-sentence Portuguese justifications
 
 After all Beat-3 fields are populated and both metrics scored:
 
-1. Call `update_section('intervention_site', { bairro, site_lat, site_lng, site_name, current_use, land_tenure, primary_hazard, secondary_hazard, community_anchoring_lead, community_engagement_methods })`
-2. Call `score_maturity` for `site_control` and `community_anchoring`
-3. Render the closing message (DO NOT call `set_phase(3)` yet — the coordinator gates that via P-8):
+1. Make sure every captured field has been persisted via `update_section('intervention_site', ...)` along the way (this should already be done after each beat).
+2. Call `score_maturity('site_control', score, justification_pt)` — REQUIRED. The next-encontro banner is gated on this metric existing in state.
+3. Call `score_maturity('community_anchoring', score, justification_pt)` — REQUIRED. Same gate.
+4. **Do NOT call `set_phase(3)`** — phase advancement is gated by the coordinator (P-8). The banner triggers the advance when Workshop 3 is opened. There is no `set_phase_complete` tool; ignore any old references to it.
+5. Render the closing message:
 
 > ✓ **Encontro 2 concluído** — obrigada, {nome}. Seu território está marcado.
 >

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -945,8 +945,8 @@ ${phaseInstructions}
 ## RULES
 ${isPt
   ? `- Ser caloroso, encorajador e consultivo. Linguagem simples, sem jargão.
-- **SE phase = 0 E RECENT CONVERSATION está vazio**: introduza-se brevemente, mencione upload de documentos, chame set_phase(1), e faça a primeira pergunta. NÃO repita a introdução em turnos subsequentes.
-- **SE phase ≥ 1 OU já há mensagens em RECENT CONVERSATION**: você está NO MEIO da conversa. NÃO se reintroduza. Continue de onde parou. Antes de qualquer pergunta nova, **persista a resposta anterior do usuário** via update_section() — sem isso, o estado fica vazio e tudo se perde.
+- **SE RECENT CONVERSATION está vazio**: este é o primeiro turno do encontro atual. Abra com a introdução prevista no skill da fase atual e faça a primeira pergunta. NÃO chame set_phase — a fase já está definida.
+- **SE há mensagens em RECENT CONVERSATION**: você está NO MEIO da conversa. NÃO se reintroduza. Continue de onde parou. Antes de qualquer pergunta nova, **persista a resposta anterior do usuário** via update_section() — sem isso, o estado fica vazio e tudo se perde.
 - **Após CADA resposta livre do usuário** (texto digitado): chame update_section('<sectionId>', { <campo>: '<valor>' }) ANTES de fazer a próxima pergunta. Isso é OBRIGATÓRIO.
 - Pontuar métricas conforme coleta (não esperar). Fase 2: open_map composite. Fase 3a: open_intervention_selector.
 - **PADRÃO: SEMPRE usar ask_user com chips** para qualquer pergunta com 2-7 buckets naturais (tipo de org, tamanho de equipe, proporção paga/voluntária, escala de projeto, experiência SbN, etc). Texto livre SOMENTE para inputs genuinamente únicos: nome da org, missão em uma frase, momento de orgulho. Proporções e "splits" SEMPRE viram chips ("Todas voluntárias", "Maioria voluntárias", "Metade e metade", etc) — NUNCA pedir números exatos via texto livre.
@@ -957,8 +957,8 @@ ${isPt
 - Pedir evidências em 3 momentos: após Fase 2 (fotos), após Fase 3a (documentos), Fase 5 (links).
 - Após Fase 5: placar completo + set_phase(6). Pedir revisão do documento antes de exportar.`
   : `- Be warm, encouraging, consultative. Simple language, no jargon.
-- **IF phase = 0 AND RECENT CONVERSATION is empty**: introduce yourself briefly, mention document upload, call set_phase(1), ask the first question. Do NOT repeat the intro on subsequent turns.
-- **IF phase ≥ 1 OR RECENT CONVERSATION has messages**: you are MID-conversation. Do NOT re-introduce. Continue from where you left off. Before any new question, **persist the user's previous answer** via update_section() — without that, state stays empty and progress is lost.
+- **IF RECENT CONVERSATION is empty**: this is the first turn of the current encontro. Open with the introduction prescribed in the current phase's skill and ask the first question. Do NOT call set_phase — the phase is already set.
+- **IF RECENT CONVERSATION has messages**: you are MID-conversation. Do NOT re-introduce. Continue from where you left off. Before any new question, **persist the user's previous answer** via update_section() — without that, state stays empty and progress is lost.
 - **After EVERY free-text user answer**: call update_section('<sectionId>', { <field>: '<value>' }) BEFORE the next question. This is MANDATORY.
 - Score metrics as you go (don't wait). Phase 2: open_map composite. Phase 3a: open_intervention_selector.
 - **DEFAULT: ALWAYS use ask_user with chips** for any question with 2-7 natural buckets (org type, team size, paid/volunteer split, project scale, NBS experience, etc). Free-text ONLY for genuinely unique inputs: org name, one-sentence mission, proud-moment story. Ratios and splits ALWAYS become chips ("All volunteers", "Mostly volunteers", "Half and half", etc) — NEVER ask for exact numbers via free-text.

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -233,7 +233,14 @@ export function createEmptyCboState(city: string): CboState {
     id: crypto.randomUUID(),
     orgName: '',
     city,
-    phase: 0,
+    // Start at phase 1 — Encontro 1 begins on first chat turn. The previous
+    // phase 0 was a "pre-introduction" state that required the agent to call
+    // set_phase(1) on its first response; if the agent forgot (more likely
+    // on Haiku), the encontro-1.md skill never loaded (gated on phase >= 1)
+    // and the first turn ran on the unconfigured SDK default. Skipping
+    // phase 0 makes the skill engage from turn 1 and removes a class of
+    // race/forget bugs entirely.
+    phase: 1,
     sections: sections as Record<CboSectionId, CboSectionState>,
     gaps: [],
     maturityScores: [],


### PR DESCRIPTION
Audited the full E1 + E2 flow end-to-end against every failure mode I know of. Four real bugs found, all fixed here. Goal: tomorrow's demo runs clean.

## 1. Start at phase 1, not phase 0
\`createEmptyCboState\` returned \`phase: 0\`, requiring the agent to call \`set_phase(1)\` on its first response before \`encontro-1.md\` would load (skill load gated on \`state.phase >= 1\`). On Haiku this was a coin flip — if it forgot, the first turn ran on the unconfigured SDK default model with the hardcoded \`buildPhaseInstructions(0)\` fallback, and the prescriptive skill markdown never engaged.

**Now starts at phase 1 directly.** Skill loads on turn 1, Haiku is in effect from turn 1, no race possible.

## 2. Kill \`set_phase_complete\` references in encontro-1.md
The closing instructions said *\"Call \`set_phase(1)\` then \`set_phase_complete(1)\` to mark Encontro 1 done.\"* But \`set_phase_complete\` is not a registered tool — the agent would either hallucinate the call or get confused. \`set_phase(1)\` when already at phase 1 is a no-op.

Closing now spells out the actual required tool calls (both maturity scores + \`set_path\`) and explicitly forbids \`set_phase\` advancement (coordinator + banner handle that).

## 3. Resolve the language-rule contradiction
The system prompt (#190) says *\"100% Portuguese, no English ever.\"* The skill markdown contradicted this twice:
- Line 25: *\"Switch to English only if the user writes in English first\"*
- Stuck-pattern table: *\"Switches to English → Switch immediately\"*

Removed both. **Language picker at the top of the page is the only source of truth.** If user types English mid-PT session, agent stays in PT.

## 4. Mirror the same closing structure in encontro-2.md
E2's closing was correct on the \"DO NOT call set_phase(3)\" part but the \`score_maturity\` calls were buried in a bulk update step. Now spelled out the same way as E1: \`score_maturity('site_control', ...)\` and \`score_maturity('community_anchoring', ...)\` are REQUIRED, with the explicit note that the next-encontro banner is gated on them.

## Verification path after deploy

Fresh restart → expected turn log:
\`\`\`
Turn 1: phase=1 model=claude-haiku-4-5 thinking=0   ← skill loads immediately
... questions in PT with chips for role/confirm/etc ...
After scoring both metrics → green banner for E2 appears
Click banner → phase=2 model=claude-haiku-4-5      ← encontro-2.md loads
show_examples + open_map + ranking + tenure + anchoring → score both
Closing in PT, no set_phase(3) attempt
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)