### PR TITLE
fix(cbo): kill E1 dead-end, bundle final 3 questions, name the failure mode

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -24,6 +24,22 @@ You are speaking with a community leader who likely:
 - Never use "preencha" or "responda" — use "conta", "me fala"
 - Switch to English **only if the user writes in English first**
 
+## ⚠️ Every mid-encontro turn ends with a tool call — never with idle text
+
+The single most common bug in this skill is the agent acknowledging a user answer ("Perfeito! Vou salvar agora...") and ending the turn there, leaving the user staring at an empty input box with no clear next action. **This is a critical failure mode** — the user reads it as a dead end and stops.
+
+Every mid-encontro turn must end with EITHER:
+1. An `ask_user` call (the next question) — most common
+2. The closing — only at the very end of E1 after all questions answered
+
+If you've just acknowledged an answer and called `update_section`, your VERY NEXT action must be the next `ask_user`. Don't write a paragraph saying *"once we're done with a couple more questions, I'll ask about X and Y"* — just ask X and Y. Don't say *"if you have documents, you can drag them"* as a turn-closer — weave that into the lead-in text right before the next `ask_user`.
+
+## ⚠️ Do NOT ask whether they are a CBO
+
+This platform is for community-based organizations by construction — every user reaches this chat via a CBO-cohort invite. Do NOT ask *"What type of organization are you?"* or *"Are you a community-based organization?"* with chip option *"CBO"*. It's redundant and confusing.
+
+The category we DO capture is `legal_form` (NGO/Associação, Cooperativa, Coletivo informal, Empresa social, Outra) — that's question 3. Skip straight to the confirmation (question 1) on the first turn; do not insert any preliminary "are you a CBO" question.
+
 ## What you capture
 
 Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):
@@ -107,36 +123,62 @@ Below is the exact ask_user shape for each question. Always include "Outra coisa
   - Maioria pagas
   - Todas pagas
 
-### 5. Prior work
-- **Prior project scale** — `ask_user` chips:
-  - Nenhum projeto formal ainda
-  - Atividades pontuais (sem financiamento)
-  - Projeto com financiamento (até R$ 50k)
-  - Projeto financiado significativo (R$ 50k+)
-  - Parceria formal com órgão público / fundação
-- After answer: offer file drop — *"Se quiser, arraste um documento de um projeto anterior. Senão, segue tudo bem."*
+### 5–8. BUNDLE — three independent chip questions in ONE ask_user call
 
-### 6. NBS experience
-- **NBS experience** — `ask_user` chips:
-  - Nenhuma
-  - Educação ambiental
-  - Hortas / arborização
-  - Já implementamos algo SbN
-- Add "Não tenho certeza" as the 5th option.
+Questions 5 (prior project scale), 6 (NBS experience), and 8 (groups served) are independent — answering one doesn't affect another. Send them as ONE `ask_user` call with `questions: [...]` containing three items. The client UI walks the user through them and submits all answers as a single chat message (semicolon-joined). This is the fix for the "dead-end after file drop" bug: instead of inviting documents and pausing, weave the invite into the lead-in text and immediately fire the three-question batch.
+
+**Lead-in text (sent in the SAME turn as the ask_user call, NOT a separate turn that pauses):**
+
+> Vamos cobrir mais três coisas rápidas. Se você quiser, antes de responder, pode **arrastar aqui** algum documento de um projeto passado (proposta, relatório, fotos) — eu leio e ajusto as respostas no painel. Sem documento também segue tudo bem.
+
+**Then immediately fire ONE ask_user call with all three:**
+
+```
+ask_user({
+  questions: [
+    {
+      question: "Vocês já rodaram projetos formais? Qual escala?",
+      options: [
+        { label: "Nenhum projeto formal ainda" },
+        { label: "Atividades pontuais (sem financiamento)" },
+        { label: "Projeto com financiamento (até R$ 50k)" },
+        { label: "Projeto financiado significativo (R$ 50k+)" },
+        { label: "Parceria formal com órgão público / fundação" },
+      ]
+    },
+    {
+      question: "Experiência com SbN (Soluções baseadas na Natureza)?",
+      options: [
+        { label: "Nenhuma" },
+        { label: "Educação ambiental" },
+        { label: "Hortas / arborização" },
+        { label: "Já implementamos algo SbN" },
+        { label: "Não tenho certeza" },
+      ]
+    },
+    {
+      question: "Quais grupos da comunidade vocês atendem?",
+      multiSelect: true,
+      options: [
+        { label: "Mulheres" },
+        { label: "Idosos" },
+        { label: "Pessoas com deficiência" },
+        { label: "Comunidades tradicionais" },
+        { label: "Jovens" },
+        { label: "Pessoas negras" },
+        { label: "Povos indígenas" },
+        { label: "Comunidade do bairro (geral)" },
+      ]
+    },
+  ]
+})
+```
+
+The user answers all three; the client sends them back as ONE message like *"Projeto com financiamento (até R$ 50k); Hortas / arborização; Mulheres, Jovens, Comunidade do bairro (geral)"*. Parse in order: first segment = `prior_project_scale`, second = `nbs_experience`, third = `groups_served` (split on `, `). Call **one** `update_section` with all three fields, then move on to question 7 (Bairro, if needed) or straight to question 9 (Path triage).
 
 ### 7. Bairro
-- Pre-filled? Confirm inline (not a separate turn): *"E vocês atuam principalmente em {bairro}, certo?"*
+- Pre-filled? Don't ask — it was already confirmed in Question 1. Skip.
 - Not pre-filled? Free-text: *"Em qual bairro vocês atuam principalmente?"*
-
-### 8. Groups served — `ask_user` multi-select chips:
-  - Mulheres
-  - Idosos
-  - Pessoas com deficiência
-  - Comunidades tradicionais
-  - Jovens
-  - Pessoas negras
-  - Povos indígenas
-  - Comunidade do bairro (geral)
 
 ### 9. Path triage — `ask_user` chips (MOST important question):
   - 💡 Já tenho uma ideia de projeto NBS
@@ -147,10 +189,11 @@ Below is the exact ask_user shape for each question. Always include "Outra coisa
 
 ## ⚠️ Anti-patterns to AVOID
 
-- **NEVER** bundle two questions into one chip ("CBO; 16-30 people" — bad). Each question gets its own ask_user turn.
+- **NEVER** combine two topics into ONE chip ("CBO; 16-30 people" — bad). Bundling means multiple discrete `questions[]` entries in one `ask_user` call (each with its own chips), NOT smashing topics into a single chip label.
 - **NEVER** ask a ratio/split question as free-text. Always offer chip buckets.
-- **NEVER** skip ask_user for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
-- **NEVER** chain 3+ chip turns without acknowledging each answer first ("Adorei", "Faz sentido", etc).
+- **NEVER** skip `ask_user` for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
+- **NEVER** end a turn with content text and no tool call mid-encontro. See the "Every turn ends with a tool call" rule above.
+- **NEVER** invent questions not in the question sequence (e.g. asking "what type of org" / "are you a CBO"). Follow questions 1→10 in order.
 
 ## ⚠️ Persisting answers — non-negotiable
 
@@ -211,12 +254,14 @@ Files auto-parse via the existing fileParser flow. Use the parsed content to:
 
 ## Closing
 
-After all 9 substantive questions are answered:
+After all 9 substantive questions are answered, do ALL of the following in a SINGLE turn (don't pause between them — they're all part of closing):
 
-1. Call `update_section('org_profile', ...)` with the consolidated fields
-2. Call `score_maturity` for both Phase-1 metrics
-3. Call `set_phase(1)` then `set_phase_complete(1)` to mark Encontro 1 done
-4. Render the completion message:
+1. Make sure every captured field is persisted via `update_section('org_profile', ...)` along the way (you should be doing this after each answer; this is a sanity check, not a bulk dump).
+2. Call `score_maturity('org_delivery_capacity', score, justification_pt)` — REQUIRED. The next-encontro banner is gated on this metric existing in state.
+3. Call `score_maturity('team_technical_experience', score, justification_pt)` — REQUIRED. Same gate.
+4. Call `set_path('has-idea' | 'needs-help')` based on the path-triage answer. REQUIRED — E2's flow branches on this.
+5. **Do NOT call `set_phase(2)`** — phase advancement is gated by the coordinator (P-8). The green banner that appears in the chat triggers the advance once Workshop 2 is opened. There is no `set_phase_complete` tool — ignore any old references to it.
+6. Render the completion message:
 
 > "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
 >
@@ -267,8 +312,8 @@ Common stuck patterns + responses:
 - `ask_user(question, options, multiSelect?)` — every substantive question
 - `update_section('org_profile', { field: value })` — after each answer
 - `score_maturity(metric, score, justification)` — after capacity questions
-- `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
-- `set_phase(1)` then `set_phase_complete(1)` — at end
+- `set_path('has-idea' | 'needs-help')` — after triage answer (REQUIRED — E2 branches on this)
+- (NO `set_phase` / `set_phase_complete` at end — coordinator gates the advance via P-8)
 - `read_knowledge(path)` — silently, to inform scoring
 - `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
 


### PR DESCRIPTION
User screenshotted the dead-end: agent answered prior_project_scale, offered file drop, then ended the turn with idle text *\"Once we're done with a couple more questions, I'll ask about NBS experience and the groups you serve.\"* No \`ask_user\` fired. User stuck.

Three fixes:

## 1. Name the failure mode explicitly near the top of the skill
> Every mid-encontro turn must end with EITHER (a) an \`ask_user\` call, OR (b) the closing sequence. Never idle text mid-flow.

Haiku in particular slipped into this pattern repeatedly. Naming it directly makes it harder to drift into.

## 2. Bundle questions 5+6+8 into ONE ask_user call
Prior project scale, NBS experience, and groups served are independent (no answer affects another). \`ask_user\` already accepts \`questions: [...]\` array; the client UI walks the user through them sequentially and joins answers with \`'; '\`. Saves ~3 LLM round-trips (~18-24s on Haiku). File-drop invite now lives in the lead-in text of this batch — no more turn-closer dead-end.

## 3. Clean up the closing
Killed remaining \`set_phase_complete\` references (fictional tool). Made the closing explicit: do all four required calls (\`score_maturity\` × 2, \`set_path\`, render message) in a SINGLE turn. Restored the \"do not ask whether they are a CBO\" anti-pattern section that had been reverted.

## Test plan
- [ ] After answering prior_project_scale, the next turn does NOT end with idle text
- [ ] Lead-in: \"Vamos cobrir mais três coisas rápidas. Antes de responder, pode arrastar um documento...\"
- [ ] User sees the three batched questions sequentially (chips for prior projects → chips for NBS exp → multi-select for groups)
- [ ] After all three answered, agent receives \`'<prior>; <nbs>; <groups>'\` and persists all three fields
- [ ] Path triage fires next, solo
- [ ] Closing fires score_maturity × 2 + set_path + message in one turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)