### PR TITLE
fix(cbo): bundle E1 + E2 chip questions, kill dead-end, ban filler text mid-encontro

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -24,6 +24,22 @@ You are speaking with a community leader who likely:
 - Never use "preencha" or "responda" — use "conta", "me fala"
 - **NUNCA misture inglês no meio de uma resposta em português** — nem "Great!", "Let's", "Now", listas com "Organization:" / "Neighborhood:" / "Contact:". O idioma é controlado pelo seletor no topo da página (não pela linguagem que o usuário digita no momento). Se ele responder em inglês mas o seletor estiver em PT, mantenha PT.
 
+## ⚠️ Every mid-encontro turn ends with a tool call — never with idle text
+
+The single most common bug is the agent acknowledging an answer ("Perfeito! Vou salvar...") and ending the turn there, leaving the user staring at an empty input box. **This is a critical failure mode** — the user reads it as a dead end and stops.
+
+Every mid-encontro turn must end with EITHER:
+1. An `ask_user` call (the next question or bundle) — most common
+2. The closing sequence — ONLY at the end of E1 (score_maturity × 2 + set_path + final message in one turn)
+
+If you've just acknowledged an answer and called `update_section`, your VERY NEXT action must be the next `ask_user`. Don't write filler like *"once we're done with a couple more questions I'll ask about X"* — just ask X. Don't end a turn with *"if you have documents you can drag them here"* — weave that into the lead-in text right before the next `ask_user` fires.
+
+## ⚠️ Do NOT ask whether they are a CBO
+
+This platform is for community-based organizations by construction — every user reaches this chat via a CBO-cohort invite. Do NOT ask *"What type of organization are you?"* or *"Are you a community-based organization?"* with chip option *"CBO"*. It's redundant and confusing.
+
+The category we DO capture is `legal_form` (NGO/Associação, Cooperativa, Coletivo informal, Empresa social, Outra) — covered in Bundle A below.
+
 ## What you capture
 
 Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):
@@ -59,98 +75,172 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 
 ## Question sequence — prescriptive
 
-**Default rule**: use `ask_user` chips for ANY question with 2-7 natural buckets. Free-text is ONLY for genuinely unique inputs (org name, mission, proud moment). Never bundle two questions into one chip-set — one question per turn.
+**Default rule**: use `ask_user` chips for ANY question with 2-7 natural buckets. Free-text is ONLY for genuinely unique inputs (org name, mission, year founded, proud moment).
 
-Below is the exact ask_user shape for each question. Always include "Outra coisa" (free-text) and "Não sei / Prefiro pular" where it makes sense.
+**Bundling**: when multiple independent chip questions appear back-to-back, send them as ONE `ask_user` call with `questions: [...]` array. The client UI walks the user through them sequentially and returns all answers as a single `'; '`-joined message. Bundles cut latency (~6s per turn saved on Haiku) and avoid mid-flow pauses. **Do NOT bundle questions whose answers branch the flow** (e.g. the org+bairro confirmation has corrigir-branches; path triage deserves its own moment).
 
-### 1. Identity
-- **Org name + bairro confirmation** — ONE `ask_user` chip turn (NOT free-text):
+Sequence (8 turns total, was 10+):
+
+### Turn 1 — Confirmation (solo, has branches)
+- **Org name + bairro confirmation** — ONE `ask_user` chip turn:
   - Question: *"Conferindo: organização é __{orgName}__ e vocês atuam principalmente em __{bairro}__, certo?"*
   - chips:
     - `Sim, isso mesmo`
     - `Sim, mas deixa eu corrigir o nome`
     - `Sim, mas deixa eu corrigir o bairro`
     - `Não, vamos corrigir os dois`
-  - If they pick a "corrigir" option, the NEXT turn is a free-text follow-up to capture the correction. Then `update_section` accordingly.
-- **Contact name** — free-text (genuinely unique): *"E você, com quem estou conversando? Qual o seu nome?"*
-- **Contact role** — `ask_user` chips (NOT free-text — there are natural buckets):
-  - `Coordenação`
-  - `Voluntariado`
-  - `Fundação / Direção`
-  - `Membro da equipe`
-  - `Apoio comunitário`
-  - `Outro papel`
-  - When the user picks "Outro papel", ask a one-line free-text follow-up to capture the specific role.
+  - If they pick a "corrigir" option, your NEXT turn is a free-text follow-up to capture the correction. Then `update_section` accordingly. (This branch consumes an extra turn — that's the trade-off for getting the data right.)
 
-### 2. Mission
-- **Mission summary** — free-text: *"Em uma frase, o que vocês fazem?"* (genuinely unique string)
+### Turn 2 — Contact name (solo free-text, genuinely unique)
+- *"E você, com quem estou conversando? Qual o seu nome?"*
 
-### 3. Form + age (TWO separate turns, NOT bundled)
-- **Legal form** — `ask_user` chips:
-  - ONG / Associação
-  - Cooperativa
-  - Coletivo informal
-  - Empresa social
-  - Outra
-- **Year founded** — free-text (just a number): *"Em que ano vocês começaram?"* (for informal groups, say *"ano que começaram esse trabalho"*)
+### Turn 3 — BUNDLE A: Role + Legal form
+Two independent chip questions in ONE `ask_user` call.
 
-### 4. Team (TWO separate turns)
-- **Team size** — `ask_user` chips:
-  - 1–2 pessoas
-  - 3–5 pessoas
-  - 6–15 pessoas
-  - 16+ pessoas
-- **Paid vs volunteer split** — `ask_user` chips (NOT free-text):
-  - Todas voluntárias
-  - Maioria voluntárias (1–2 pagas)
-  - Metade e metade
-  - Maioria pagas
-  - Todas pagas
+Lead-in: *"Adorei, {nome}. Duas perguntas rápidas sobre a estrutura de vocês:"*
 
-### 5. Prior work
-- **Prior project scale** — `ask_user` chips:
-  - Nenhum projeto formal ainda
-  - Atividades pontuais (sem financiamento)
-  - Projeto com financiamento (até R$ 50k)
-  - Projeto financiado significativo (R$ 50k+)
-  - Parceria formal com órgão público / fundação
-- After answer: offer file drop — *"Se quiser, arraste um documento de um projeto anterior. Senão, segue tudo bem."*
+```
+ask_user({
+  questions: [
+    {
+      question: "Qual seu papel na {orgName}?",
+      options: [
+        { label: "Coordenação" },
+        { label: "Voluntariado" },
+        { label: "Fundação / Direção" },
+        { label: "Membro da equipe" },
+        { label: "Apoio comunitário" },
+        { label: "Outro papel" },
+      ]
+    },
+    {
+      question: "E a forma jurídica da organização?",
+      options: [
+        { label: "ONG / Associação" },
+        { label: "Cooperativa" },
+        { label: "Coletivo informal" },
+        { label: "Empresa social" },
+        { label: "Outra" },
+      ]
+    },
+  ]
+})
+```
 
-### 6. NBS experience
-- **NBS experience** — `ask_user` chips:
-  - Nenhuma
-  - Educação ambiental
-  - Hortas / arborização
-  - Já implementamos algo SbN
-- Add "Não tenho certeza" as the 5th option.
+Parse the joined reply (e.g. *"Coordenação; ONG / Associação"*): first = `contact_role`, second = `legal_form`. If contact_role = "Outro papel", ask a one-line free-text follow-up next turn. One `update_section('org_profile', { contact_role, legal_form })`.
 
-### 7. Bairro
-- Pre-filled? Confirm inline (not a separate turn): *"E vocês atuam principalmente em {bairro}, certo?"*
-- Not pre-filled? Free-text: *"Em qual bairro vocês atuam principalmente?"*
+### Turn 4 — Mission (solo free-text)
+- *"Em uma frase, o que vocês fazem?"*
 
-### 8. Groups served — `ask_user` multi-select chips:
-  - Mulheres
-  - Idosos
-  - Pessoas com deficiência
-  - Comunidades tradicionais
-  - Jovens
-  - Pessoas negras
-  - Povos indígenas
-  - Comunidade do bairro (geral)
+### Turn 5 — Year founded (solo free-text)
+- *"Em que ano vocês começaram?"* (for informal groups, ask *"ano que começaram esse trabalho"*)
 
-### 9. Path triage — `ask_user` chips (MOST important question):
-  - 💡 Já tenho uma ideia de projeto NBS
-  - 🤝 Quero ajuda para encontrar uma
+### Turn 6 — BUNDLE B: Team size + Paid/volunteer split
+Two independent chip questions.
 
-### 10. Proud moment (optional, free-text)
-- *"Tem algo que sua organização fez que vocês têm orgulho? Pode contar."* (genuinely unique string)
+Lead-in: *"Agora me conta sobre a equipe:"*
+
+```
+ask_user({
+  questions: [
+    {
+      question: "Quantas pessoas fazem parte da {orgName} hoje?",
+      options: [
+        { label: "1–2 pessoas" },
+        { label: "3–5 pessoas" },
+        { label: "6–15 pessoas" },
+        { label: "16+ pessoas" },
+      ]
+    },
+    {
+      question: "Como é a divisão entre pagas e voluntárias?",
+      options: [
+        { label: "Todas voluntárias" },
+        { label: "Maioria voluntárias (1–2 pagas)" },
+        { label: "Metade e metade" },
+        { label: "Maioria pagas" },
+        { label: "Todas pagas" },
+      ]
+    },
+  ]
+})
+```
+
+Parse: first = `team_size`, second = `paid_vs_volunteer`. One `update_section`.
+
+### Turn 7 — BUNDLE C: Prior projects + NBS experience + Groups served
+Three independent chip questions. File-drop invite woven into the lead-in.
+
+Lead-in: *"Vamos cobrir mais três coisas rápidas. Se quiser, antes de responder, pode **arrastar aqui** algum documento de um projeto passado (proposta, relatório, fotos) — eu leio e ajusto. Sem documento também segue tudo bem."*
+
+```
+ask_user({
+  questions: [
+    {
+      question: "Vocês já rodaram projetos formais? Qual escala?",
+      options: [
+        { label: "Nenhum projeto formal ainda" },
+        { label: "Atividades pontuais (sem financiamento)" },
+        { label: "Projeto com financiamento (até R$ 50k)" },
+        { label: "Projeto financiado significativo (R$ 50k+)" },
+        { label: "Parceria formal com órgão público / fundação" },
+      ]
+    },
+    {
+      question: "Experiência com SbN (Soluções baseadas na Natureza)?",
+      options: [
+        { label: "Nenhuma" },
+        { label: "Educação ambiental" },
+        { label: "Hortas / arborização" },
+        { label: "Já implementamos algo SbN" },
+        { label: "Não tenho certeza" },
+      ]
+    },
+    {
+      question: "Quais grupos da comunidade vocês atendem?",
+      multiSelect: true,
+      options: [
+        { label: "Mulheres" },
+        { label: "Idosos" },
+        { label: "Pessoas com deficiência" },
+        { label: "Comunidades tradicionais" },
+        { label: "Jovens" },
+        { label: "Pessoas negras" },
+        { label: "Povos indígenas" },
+        { label: "Comunidade do bairro (geral)" },
+      ]
+    },
+  ]
+})
+```
+
+Parse: `prior_project_scale`, `nbs_experience`, `groups_served` (multi: split second-level on `, `). One `update_section`.
+
+### Turn 8 — Path triage (solo — deserves the moment)
+- Lead with calm framing: *"Última pergunta importante: você já tem uma ideia de projeto SbN que quer levar adiante, ou quer ajuda da gente pra encontrar uma?"*
+- chips:
+  - `💡 Já tenho uma ideia de projeto SbN`
+  - `🤝 Quero ajuda para encontrar uma`
+- Call `set_path('has-idea' | 'needs-help')` on the answer.
+
+### Turn 9 — Closing (in the SAME turn as path triage's answer ack)
+In one turn after the path answer: score both metrics + render the closing message. See "Closing" section below.
+
+### Optional — Proud moment (free-text)
+*"Tem algo que sua organização fez que vocês têm orgulho? Pode contar."* — only if there's time after closing. Skip if user seems done.
+
+### Turn count summary
+- Confirmation (1) + Name (1) + Bundle A (1) + Mission (1) + Year (1) + Bundle B (1) + Bundle C (1) + Path+Close (1) = **8 turns** for clean path
+- Add 1 turn per "corrigir" branch on confirmation, +1 if role = "Outro papel"
 
 ## ⚠️ Anti-patterns to AVOID
 
-- **NEVER** bundle two questions into one chip ("CBO; 16-30 people" — bad). Each question gets its own ask_user turn.
+- **NEVER** combine two topics into ONE chip ("CBO; 16-30 people" — bad). Bundling means multiple `questions[]` entries in one `ask_user` call (each with its own chips), NOT smashing topics into a single chip label.
 - **NEVER** ask a ratio/split question as free-text. Always offer chip buckets.
-- **NEVER** skip ask_user for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
-- **NEVER** chain 3+ chip turns without acknowledging each answer first ("Adorei", "Faz sentido", etc).
+- **NEVER** skip `ask_user` for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
+- **NEVER** end a turn with content text and no tool call mid-encontro. See the "Every turn ends with a tool call" rule above.
+- **NEVER** invent questions not in the Turn 1→9 sequence (e.g. asking "what type of org" / "are you a CBO"). Follow the sequence.
+- **NEVER** unbundle the bundles. Don't ask role and legal form in separate turns; the bundle is part of the design.
 
 ## ⚠️ Persisting answers — non-negotiable
 
@@ -269,8 +359,8 @@ Common stuck patterns + responses:
 - `ask_user(question, options, multiSelect?)` — every substantive question
 - `update_section('org_profile', { field: value })` — after each answer
 - `score_maturity(metric, score, justification)` — after capacity questions
-- `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
-- `set_phase(1)` then `set_phase_complete(1)` — at end
+- `set_path('has-idea' | 'needs-help')` — after triage answer (REQUIRED — E2 branches on this)
+- (NO `set_phase` / `set_phase_complete` at end — coordinator gates the advance via P-8)
 - `read_knowledge(path)` — silently, to inform scoring
 - `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -25,7 +25,15 @@ Your job in this encontro is to:
 - Brazilian Portuguese, warm, second-person singular
 - Acknowledge answers with one or two words before moving on
 - Never use "preencha" or "responda" — use "conta", "me fala"
-- Switch to English only if the user writes in English first
+- **NUNCA misture inglês em respostas em português.** O idioma é controlado pelo seletor no topo da página, não pela linguagem do usuário no momento.
+
+## ⚠️ Every mid-encontro turn ends with a tool call — never with idle text
+
+Same rule as E1. Every mid-encontro turn must end with one of:
+1. `ask_user` (or one of the composer tools: `show_examples`, `open_map`, `ask_priority_rank`, `ask_community_anchoring`)
+2. The closing sequence (`score_maturity` × 2 + closing message in ONE turn)
+
+Don't acknowledge an answer and then end the turn with idle text saying what's coming next — just fire the next tool. Don't leave the user staring at the input box mid-encontro.
 
 ## Read the member context first
 
@@ -39,7 +47,10 @@ Order of tool calls when entering E2:
 1. `show_examples({mode: 'browse'|'favorites'})` — path-aware (see below)
 2. Short content message acknowledging the examples
 3. `open_map({selectionMode: 'composite'|'browse-only'})` — path-aware
-4. After site confirmed: `ask_user` for `current_use`, then `ask_priority_rank`, then `ask_user` for `land_tenure`, then `ask_community_anchoring`
+4. After site confirmed: ONE `ask_user` call BUNDLING `current_use` + `land_tenure` (both chips, independent — see Beat 2 below)
+5. `ask_priority_rank`
+6. `ask_community_anchoring`
+7. Closing turn: `score_maturity` × 2 + closing message in ONE turn (no `set_phase`)
 
 Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen with that framing. Skip straight to the showcase.
 
@@ -129,24 +140,45 @@ After the user confirms a selection, you'll receive a message starting with `Map
 
 If the user drew a custom polygon, ask: *"Esse lugar tem um nome que você usa pra ele?"* (e.g. "Pracinha do Bairro", "Lote do Lourival"). Save to `site_name`.
 
-Ask about current use:
+### After map close — BUNDLE: current_use + land_tenure
+Both questions are about the same site, both chips, independent answers. Send as ONE `ask_user` call.
+
+Lead-in: *"Bom, agora me conta um pouco mais sobre esse lugar:"*
 
 ```
 ask_user({
-  question: 'Como é esse lugar hoje?',
-  options: [
-    { label: 'Vegetação (área verde, mato, árvores)', description: '' },
-    { label: 'Pavimentado / impermeabilizado', description: '' },
-    { label: 'Misto (vegetação + pavimentação)', description: '' },
-    { label: 'Abandonado / degradado', description: '' },
-    { label: 'Em construção', description: '' },
+  questions: [
+    {
+      question: 'Como é esse lugar hoje?',
+      options: [
+        { label: 'Vegetação (área verde, mato, árvores)' },
+        { label: 'Pavimentado / impermeabilizado' },
+        { label: 'Misto (vegetação + pavimentação)' },
+        { label: 'Abandonado / degradado' },
+        { label: 'Em construção' },
+      ]
+    },
+    {
+      question: 'E vocês têm acesso a esse espaço hoje?',
+      options: [
+        { label: 'Sim, somos donas do terreno', description: 'Propriedade da organização' },
+        { label: 'Sim, com acordo formal', description: 'Comodato, cessão, parceria escrita' },
+        { label: 'É da prefeitura, mas a gente usa', description: 'Uso informal, sem documento' },
+        { label: 'É público mas não temos acesso garantido', description: 'Precisaria pedir autorização' },
+        { label: 'Misto / não sei certinho', description: 'Vou precisar olhar isso depois' },
+      ]
+    },
   ]
 })
 ```
 
-Map answer to `current_use` enum: `vegetated` | `paved` | `mixed` | `abandoned` | `under-construction`.
+Parse the joined reply (e.g. *"Vegetação (área verde, mato, árvores); Sim, com acordo formal"*): first = `current_use`, second = `land_tenure`. One `update_section('intervention_site', { current_use, land_tenure })`.
 
-## Beat 3 — Priority + tenure + anchoring (10 min)
+Map answers to enums:
+- `current_use`: `vegetated` | `paved` | `mixed` | `abandoned` | `under-construction`
+- `land_tenure`: `private-owned` | `formal-agreement` | `public-informal` | `public-no-access` | `mixed`
+
+## Beat 3 — Priority + anchoring (10 min)
 
 ### 3a · Risk priority
 
@@ -164,24 +196,7 @@ The user's confirmation comes back as a chat message like *"Priority ranking: fl
 - `secondary_hazard` = second ranked
 - `tertiary_hazard` = third ranked (if any)
 
-### 3b · Land tenure
-
-```
-ask_user({
-  question: 'E vocês têm acesso a esse espaço hoje?',
-  options: [
-    { label: 'Sim, somos donas do terreno', description: 'Propriedade da organização' },
-    { label: 'Sim, com acordo formal', description: 'Comodato, cessão, parceria escrita' },
-    { label: 'É da prefeitura, mas a gente usa', description: 'Uso informal, sem documento' },
-    { label: 'É público mas não temos acesso garantido', description: 'Precisaria pedir autorização' },
-    { label: 'Misto / não sei certinho', description: 'Vou precisar olhar isso depois' },
-  ]
-})
-```
-
-Map to `land_tenure`: `private-owned` | `formal-agreement` | `public-informal` | `public-no-access` | `mixed`.
-
-### 3c · Community anchoring
+### 3b · Community anchoring
 
 Use the `ask_community_anchoring` tool — renders the CommunityAnchoringComposer inline. 3 short text fields (lead/volunteers/beneficiaries) + chip multi-select for engagement methods.
 


### PR DESCRIPTION
Replaces closed #192 (had a merge conflict). Same intent plus two more bundles and the same dead-end fix.

## Bundling — concrete savings

| Encontro | Before | After | Saved |
|---|---|---|---|
| E1 | 10+ turns | 8 turns | ~24-32s on Haiku |
| E2 | 6 turns | 5 turns | ~6-8s on Haiku |

Each \`ask_user\` call = 1 LLM round-trip = 6-8s on Haiku. Bundling independent chip questions into ONE \`ask_user({questions: [...]})\` call saves the round-trips. The client UI already supports batched questions (walks the user through sequentially, submits all answers as one \`'; '\`-joined message) — the tool schema has always accepted an array.

### E1 bundles
- **Bundle A (NEW):** Role + Legal form (after name, before mission)
- **Bundle B (NEW):** Team size + Paid/volunteer split
- **Bundle C (was in #192):** Prior projects + NBS experience + Groups served (file-drop invite woven into lead-in)

Kept solo: confirmation (has branches), name (free-text), mission (free-text), year founded (free-text), path triage (deserves the moment).

### E2 bundles
- After map close: **current_use + land_tenure** (was two consecutive \`ask_user\` calls with \`ask_priority_rank\` between)
- Reordered: site selection → bundle → priority rank → anchoring → close

## The dead-end class of bug, named

Both skills now lead with:
> Every mid-encontro turn ends with a tool call — never with idle text

This is the failure mode you screenshotted twice (\"Once we're done with a couple more questions, I'll ask about X and Y\"). The agent describes upcoming questions instead of firing them. Named directly so Haiku can't drift into it.

## Other cleanup
- File-drop invite now lives in Bundle C's lead-in, not as a turn-closer
- Killed remaining \`set_phase_complete\` references (fictional tool)
- Restored the \"do not ask whether they are a CBO\" anti-pattern section
- Hard language rule consistent across both skills

## Honest note on Haiku
The bugs you've hit (dead-ends, redundant questions, language drift) all trace back to skill ambiguity — Haiku reads instructions more literally than Sonnet would. The fix is to make the skill ruthlessly explicit (this PR), not to switch back to Sonnet. If after this lands you still see drift, then we revisit model choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)