### PR TITLE
fix(cbo): new invitees see Start + W1, not Resume + W2

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -703,7 +703,14 @@ export default function CboProfilePage() {
   // single-CTA first-impression. Tapping Start (or Continue) flips
   // welcomeMode off and reveals either the encontro preamble or the chat.
   if (welcomeMode && memberInfo) {
-    const hasExistingProgress = messages.length > 0 || (state?.phase ?? 0) > 0;
+    // hasExistingProgress = the user has actually engaged. Previously we also
+    // checked (state?.phase ?? 0) > 0, but PR #191 changed the initial CBO
+    // state phase from 0 to 1 (to skip the slow phase-0 turn). After that
+    // change, every freshly-created CBO has phase=1 from the moment the row
+    // exists — so the phase check fired for brand-new invitees and they saw
+    // "Continue where I left off" on their first visit. messages.length is
+    // the only signal that actually means "they typed/clicked something."
+    const hasExistingProgress = messages.length > 0;
     // Show preamble for current phase if not yet seen. Fires for both
     // first-time Start and Resume — the seen flag handles dedup so the same
     // CBO doesn't see E1's preamble twice, but they DO see E2's the first

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -209,16 +209,27 @@ export function registerCohortRoutes(app: Express): void {
     const nextPhase = maxUnlocked + 1;
     const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
-    // The "focus workshop" is what the CBO welcome card should highlight.
-    // If the coordinator has opened any workshop, the most-recently opened one
-    // is the *current* workshop (the user is actively in it). Otherwise the
-    // first one in the sequence is the *next* (upcoming) workshop. This
-    // matches the CBO's mental model: "which workshop am I in/about to do?"
-    const openedWorkshops = workshops.filter(w => w.openedAt);
-    const focusWorkshop = openedWorkshops.length > 0
-      ? openedWorkshops[openedWorkshops.length - 1]
-      : (workshops[0] ?? null);
-    const focusWorkshopIsCurrent = openedWorkshops.length > 0;
+    // The "focus workshop" is what the CBO welcome card should highlight —
+    // it must reflect THIS member's progress, not the cohort's global state.
+    // Workshops are cohort-wide (one `openedAt` per workshop shared by all
+    // members), so a late-joining member inherited the most-recently-opened
+    // workshop as their "current" — pushing Test Farm to W2 before they'd
+    // done W1. Fix: pick the earliest workshop the member hasn't completed
+    // (= the workshop whose `unlocksPhase` equals their current snapshot
+    // phase). Fall back to the first workshop in the sequence for brand-new
+    // members with no snapshot yet.
+    const memberPhase = typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0
+      ? member.snapshotPhase
+      : 1; // brand-new member → start at W1 (unlocks phase 1)
+    const focusWorkshop =
+      workshops.find(w => w.unlocksPhase === memberPhase) ??
+      workshops[0] ??
+      null;
+    // "Current" if the member has actually started (any opened workshop AND
+    // the member has at least passed the welcome screen, i.e. snapshotPhase
+    // moved past null). For brand-new invitees, the workshop is "upcoming."
+    const focusWorkshopIsCurrent =
+      !!focusWorkshop?.openedAt && typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0;
 
     const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
     const supportPending = supportRequests.filter(r => !r.resolvedAt);


### PR DESCRIPTION
Two bugs from inviting Test Farm into a cohort where the coordinator had already opened Workshop 2 for a prior member.

## Bug 1: \"Continue where I left off\" shown for brand-new CBO
\`cbo-profile.tsx:665\` checked \`hasExistingProgress = messages.length > 0 || (state?.phase ?? 0) > 0\`.

PR #191 changed the initial phase from 0 → 1 (to skip the slow phase-0 turn). After that change, EVERY freshly-created CBO has \`phase=1\` from the moment its DB row exists — so the phase check fired for brand-new invitees and they saw \"Continue where I left off\" on their first visit instead of \"Start.\"

**Fix:** drop the phase check. \`messages.length\` is the only reliable signal that the user actually engaged.

## Bug 2: Workshop 2 shown as \"current\" for a new CBO who hasn't done W1
\`cohortRoutes.ts:217-221\` set \`focusWorkshop\` to the most-recently-opened workshop cohort-wide. Workshop config is shared across the cohort (one \`openedAt\` per workshop, not per-member), so a late-joining member inherited the cohort's current state.

The right behavior for a new member: focus on the workshop they're currently in (= the workshop whose \`unlocksPhase\` equals their snapshot phase). For brand-new members with no snapshot yet, fall back to phase 1 (W1).

**Fix:** compute \`focusWorkshop\` from \`member.snapshotPhase\`, with \`workshops.find(w => w.unlocksPhase === memberPhase)\` and W1 fallback. \`focusWorkshopIsCurrent\` now also gates on the member having actually started (snapshotPhase > 0).

## Test plan
- [ ] Invite a brand-new CBO into an existing cohort with W2 already opened → welcome shows \"Start\" CTA + Workshop 1 card
- [ ] After they finish E1 (score both metrics) and advance to phase 2 → welcome shows Workshop 2
- [ ] Returning member mid-session sees \"Continue where I left off\" + correct workshop

🤖 Generated with [Claude Code](https://claude.com/claude-code)