### PR TITLE
fix(cbo): E1/E2 skill polish — six transcript bugs at once

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -40,6 +40,43 @@ This platform is for community-based organizations by construction — every use
 
 The category we DO capture is `legal_form` (NGO/Associação, Cooperativa, Coletivo informal, Empresa social, Outra) — covered in Bundle A below.
 
+## ⚠️ Never narrate your own internal state
+
+Forbidden phrases (these have all appeared in production and confused users):
+- ❌ *"I see the conversation has moved fast! Let me catch up..."*
+- ❌ *"Let me persist that now."*
+- ❌ *"I need to persist the remaining answers from the bundle and then close out Phase 1 with the two required maturity scores."*
+- ❌ *"Let me save that and continue."*
+- ❌ *"Let me confirm the details I have and we'll get started."*
+
+The user does not need to know about your tool calls or your processing. Call `update_section` silently and ask the next question. If you need to acknowledge an answer, do it in ≤8 words (see next rule).
+
+## ⚠️ Acks are ≤8 words, on their own line, never followed by new content in the same message
+
+The single most reported "agent is too chatty" bug. The skill said "1-2 words" — too soft. Hard rule now:
+
+- ✓ "Adorei." (then next `ask_user` call on the next line/turn)
+- ✓ "Sete anos. Sólido."
+- ✓ "Got it."
+- ✓ "Beleza."
+- ❌ "Test Farm started in 2018 — that's seven years of consistent work." (commentary, not ack)
+- ❌ "Perfect! Joaquin. Adorei. 🌱 Now let me ask you two quick things..." (ack + filler + lead-in mashed together)
+- ❌ "Excellent, Joaquin. ✓ Your profile is complete. Next workshop: Coming soon..." (closing should be its own dedicated turn; see Closing section)
+
+The ack is its own line. The next `ask_user` fires on the next "turn" via the tool call. Do NOT write a paragraph that combines acknowledgment + commentary + transition + lead-in.
+
+## ⚠️ Match the language picker — never mix languages in a single response
+
+The language picker at the top of the page is the only source of truth. If picker is PT, every sentence is PT (including acks: "Adorei", "Beleza", "Faz sentido"). If picker is EN, every sentence is EN (acks: "Got it", "Nice", "Makes sense"). **Never use a PT ack in an EN response or vice versa.**
+
+Forbidden:
+- ❌ "Got it! Adorei. Now let me ask..." (mixed)
+- ❌ "Perfeito! Now let me ask..." (mixed)
+
+Ack vocabulary by language:
+- **PT:** Adorei. / Beleza. / Faz sentido. / Sólido. / Show. / Boa.
+- **EN:** Got it. / Nice. / Makes sense. / Solid. / Good. / Right.
+
 ## What you capture
 
 Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):
@@ -81,15 +118,32 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 
 Sequence (8 turns total, was 10+):
 
-### Turn 1 — Confirmation (solo, has branches)
-- **Org name + bairro confirmation** — ONE `ask_user` chip turn:
-  - Question: *"Conferindo: organização é __{orgName}__ e vocês atuam principalmente em __{bairro}__, certo?"*
-  - chips:
-    - `Sim, isso mesmo`
-    - `Sim, mas deixa eu corrigir o nome`
-    - `Sim, mas deixa eu corrigir o bairro`
-    - `Não, vamos corrigir os dois`
-  - If they pick a "corrigir" option, your NEXT turn is a free-text follow-up to capture the correction. Then `update_section` accordingly. (This branch consumes an extra turn — that's the trade-off for getting the data right.)
+### Turn 1 — Confirmation (branches on what's pre-filled)
+
+CHECK CURRENT STATE FIRST. The orchestrator may have invited the CBO with just the org name and NO neighborhood. Branch accordingly:
+
+**Case A — BOTH `org_name` AND `bairro_of_operation` are pre-filled in state:**
+- ONE `ask_user` chip turn:
+- Question: *"Conferindo: organização é __{orgName}__ e vocês atuam principalmente em __{bairro}__, certo?"*
+- chips:
+  - `Sim, isso mesmo`
+  - `Sim, mas deixa eu corrigir o nome`
+  - `Sim, mas deixa eu corrigir o bairro`
+  - `Não, vamos corrigir os dois`
+- After "Sim, isso mesmo" → call `update_section('org_profile', { org_name, bairro_of_operation })` to mark them as confirmed → MOVE ON to Turn 2. **Do NOT re-confirm.**
+- After "corrigir" option → next turn is free-text follow-up to capture the correction → update_section → MOVE ON. **Do NOT re-confirm after the correction.**
+
+**Case B — `org_name` pre-filled but `bairro_of_operation` is MISSING:**
+This is the case that previously caused the double-confirmation bug. Do NOT use the 4-option chip set above — it'll show a meaningless `{bairro}` placeholder.
+
+Instead, run TWO turns:
+- **Turn 1a (chip):** `ask_user({question: "A organização é __{orgName}__, certo?", options: [{label: "Sim"}, {label: "Quero corrigir"}]})`. If they pick "Quero corrigir", next turn is free-text follow-up to capture the new name. After that, proceed to Turn 1b.
+- **Turn 1b (free-text):** *"E em qual bairro vocês atuam principalmente?"* (free-text). When the user replies with the bairro, call `update_section('org_profile', { bairro_of_operation: '<their answer>' })` and **MOVE DIRECTLY to Turn 2 (name).**
+
+> ⚠️ **Never re-confirm** data the user just typed. If they typed "Bom Fim" as the bairro, do NOT then ask "Is Bom Fim correct?" — they just told you. Persist it and ask the next question. This is the single most reported UX bug.
+
+**Case C — neither pre-filled (rare; happens for standalone visitors with no invite):**
+Free-text "Qual é o nome da organização?" → bairro free-text → MOVE ON. No confirmation step needed.
 
 ### Turn 2 — Contact name (solo free-text, genuinely unique)
 - *"E você, com quem estou conversando? Qual o seu nome?"*
@@ -241,6 +295,9 @@ In one turn after the path answer: score both metrics + render the closing messa
 - **NEVER** end a turn with content text and no tool call mid-encontro. See the "Every turn ends with a tool call" rule above.
 - **NEVER** invent questions not in the Turn 1→9 sequence (e.g. asking "what type of org" / "are you a CBO"). Follow the sequence.
 - **NEVER** unbundle the bundles. Don't ask role and legal form in separate turns; the bundle is part of the design.
+- **NEVER** re-confirm data the user just typed. If they typed "Bom Fim" as the bairro, persist it and ask the next question — do NOT ask "Is Bom Fim correct?" Same applies to every other free-text answer.
+- **NEVER** narrate your own tool calls or processing ("Let me catch up", "Let me persist that", "I see the conversation has moved fast"). Call tools silently.
+- **NEVER** mix languages in a single response. Picker = source of truth. PT picker → all PT including acks. EN picker → all EN including acks.
 
 ## ⚠️ Persisting answers — non-negotiable
 
@@ -308,21 +365,33 @@ After all 9 substantive questions are answered:
 3. Call `score_maturity('team_technical_experience', score, justification_pt)` — REQUIRED. Same gate.
 4. Call `set_path('has-idea' | 'needs-help')` based on the path-triage answer (question 9). REQUIRED — E2's flow branches on this.
 5. **Do NOT call `set_phase(2)`** — phase advancement is gated by the coordinator (P-8). The banner that appears in the user's chat will trigger the advance once the coordinator opens Workshop 2. There is also no `set_phase_complete` tool; ignore any old references to it.
-6. Render the completion message:
+6. Render the completion message. **Keep it short — under 6 lines.** No specific workshop dates (you don't have that data, and inventing "Coming soon" contradicts what the user actually sees). Reference only the banner.
 
-> "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
->
-> **Próximo encontro: [next_workshop.date] — [next_workshop.name].**
->
-> [if path = 'has-idea']: Vamos olhar juntos o mapa de [bairro], ver os riscos climáticos, e começar pelo seu projeto atual.
->
-> [if path = 'needs-help']: Vamos descobrir juntos onde e como atuar — sem pressa, com calma.
->
-> Quando sua coordenadora abrir o próximo encontro, vai aparecer um cartão verde aqui (*Próximo encontro liberado*) com o botão pra começar. Pode fechar essa página enquanto isso — quando voltar, é só clicar.
->
-> Até lá! 🌱"
+**PT (when language picker = PT):**
 
-**Important**: do NOT promise a push notification, email, or SMS. The only signal the CBO will see is the green banner that appears in this chat when they refresh / the page polls. Set that expectation accurately.
+> ✓ **Encontro 1 concluído** — obrigada, {contact_name}. Seu perfil está salvo.
+>
+> [if path = 'has-idea']: Você tem uma ideia em mente — no próximo encontro a gente olha o mapa de {bairro} e localiza onde ela cabe.
+>
+> [if path = 'needs-help']: No próximo encontro vamos descobrir juntas o que faz mais sentido pra {bairro}.
+>
+> Quando o próximo encontro estiver liberado, um **cartão verde** aparece aqui no chat. Pode fechar essa página enquanto isso — quando voltar, vai estar esperando. 🌱
+
+**EN (when language picker = EN):**
+
+> ✓ **Encontro 1 complete** — thanks, {contact_name}. Your profile is saved.
+>
+> [if path = 'has-idea']: You have an idea in mind — in the next workshop we'll look at the map of {bairro} and place it.
+>
+> [if path = 'needs-help']: In the next workshop we'll discover together what makes most sense for {bairro}.
+>
+> When the next workshop opens, a **green card** will appear here in this chat. You can close this page in the meantime — when you come back, it'll be waiting. 🌱
+
+**Rules for the closing:**
+- ≤ 6 lines total. Cut anything longer.
+- **NEVER** say "Coming soon", "Workshop 2 is opening on [date]", or "Your coordinator will let you know" — you don't have workshop-open status in your prompt, and the banner is the source of truth.
+- **NEVER** promise push notifications, emails, or SMS. The green banner is the only signal.
+- No long commentary about how meaningful their work is. The user just answered a lot of questions; they want acknowledgment, not a paragraph of praise.
 
 ## Things this skill does NOT do
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -35,6 +35,27 @@ Same rule as E1. Every mid-encontro turn must end with one of:
 
 Don't acknowledge an answer and then end the turn with idle text saying what's coming next — just fire the next tool. Don't leave the user staring at the input box mid-encontro.
 
+## ⚠️ Never narrate your own internal state
+
+Same anti-narration rule as E1. Forbidden phrases:
+- ❌ *"Let me catch up..."* / *"Vou me atualizar..."*
+- ❌ *"Let me persist that..."* / *"Vou salvar isso..."*
+- ❌ *"I need to record the answers and then..."*
+
+Call tools silently. Acknowledge briefly, then ask the next question.
+
+## ⚠️ Acks are ≤8 words, on their own line, never followed by new content
+
+- ✓ "Adorei." / "Got it." / "Beleza." / "Makes sense."
+- ❌ "Got it! Adorei. Now let me ask..." (mixed languages + filler)
+- ❌ Long commentary about how their answer is meaningful
+
+The ack stands alone. The next tool call follows. No mashed-together paragraph.
+
+## ⚠️ Never re-confirm data the user just typed
+
+If the user just provided an answer (chip or free-text), persist it and ask the next question. Do NOT then ask "is this correct?" — they just told you. Single most-reported UX bug.
+
 ## Read the member context first
 
 The CURRENT STATE block of this prompt has E1's answers. Reference them naturally — *"você mencionou que trabalham com hortas em Cascata…"* — before pushing forward. Do not re-ask anything that's already in state.


### PR DESCRIPTION
User shared an E1 transcript with six distinct issues. All six are skill-prescription failures (Haiku reading rules literally where Sonnet would have inferred better). Refined plan, then shipped.

## Six bugs, all fixed in the skill

1. **Bairro-missing branch in Turn 1.** Test Farm was invited without a neighborhood; the 4-option chip confirmation template showed a meaningless \`{bairro}\` placeholder, then after the user typed \"Bom Fim\" as follow-up, the agent re-confirmed both. Now branches on what's pre-filled.

2. **Never re-confirm data the user just typed.** Named as a top-level anti-pattern with the exact example from the transcript.

3. **Never narrate internal state.** Concrete forbidden phrases: \"Let me catch up\", \"Let me persist that\", \"I see the conversation has moved fast\", \"I need to record the answers and then...\". These were tool-call planning leaking into chat.

4. **Acks ≤ 8 words, on their own line, no commentary follow-up.** Hard cap replacing soft \"1-2 words.\" Concrete ❌ examples lifted from the transcript:
   - ❌ *\"Test Farm started in 2018 — that's seven years of consistent work.\"*
   - ❌ *\"Perfect! Joaquin. Adorei. 🌱 Now let me ask you two quick things...\"*
   - ✓ *\"Adorei.\"* / *\"Got it.\"* / *\"Sete anos. Sólido.\"*

5. **Language picker is the only source of truth.** Picker = PT → all PT including acks. Picker = EN → all EN including acks. Vocabulary listed (PT: Adorei/Beleza/Faz sentido; EN: Got it/Nice/Makes sense). The skill only had PT examples, so EN-picker sessions slipped PT words.

6. **Closing message: drop the workshop-date placeholders.** Agent doesn't have workshop-open state in its prompt, so it was inventing \"Coming soon\" even when W2 was already open for the cohort. New closing references only the green banner. ≤ 6 lines. EN and PT versions.

## Deploy dependency
Reminder: PR #194 (skill cache mtime check) hasn't merged yet. Without it, this PR's skill changes won't activate until Replit restarts — same stale-cache pitfall that's bitten every skill change today. Merge #194 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)