### PR TITLE
fix(cbo): remove isNarration heuristic that hid agent chat behind WORKING preview

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -460,24 +460,40 @@ export default function CboProfilePage() {
   const processEvent = useCallback((event: CboEvent) => {
     switch (event.type) {
       case 'chat': {
-        const isNarration = /^(Let me |Good|Now |Starting |I'll |I can |Reading |Loading |Setting |Phase )/i.test(event.content.trim())
-          || (event.content.length < 300 && !event.content.includes('##') && !event.content.includes('**'));
-        const msgType = isNarration ? 'thinking' : 'content';
+        // All 'chat' events render as regular chat bubbles. The old
+        // isNarration heuristic (regex + length<300 fallback) hid brief
+        // agent responses behind the WORKING preview after PR #196 made
+        // the agent ≤8-word acks. Thinking content (extended-thinking
+        // output) arrives via a separate 'chat_thinking' event handled
+        // below — that's the only path that should produce a WORKING
+        // preview now.
+        //
         // Mobile-only: flag unread on the Chat tab if the user is currently
         // looking at the right panel (map / selector / perfil).
-        if (!isNarration && mobileActiveTabRef.current !== 'chat') {
+        if (mobileActiveTabRef.current !== 'chat') {
           setMobileChatUnread(true);
         }
         setMessages(prev => {
           const last = prev[prev.length - 1];
-          if (isNarration && last?.messageType === 'thinking') {
-            const bullets = event.content.split(/(?<=\.)\s*/).filter(s => s.trim()).map(s => `- ${s.trim()}`).join('\n');
-            return [...prev.slice(0, -1), { ...last, content: last.content + '\n' + bullets }];
-          }
-          if (!isNarration && last?.role === 'assistant' && last.messageType === 'content') {
+          // Concatenate consecutive assistant chat chunks into one bubble
+          // (the SSE stream emits the response in pieces as the model
+          // generates it).
+          if (last?.role === 'assistant' && last.messageType === 'content') {
             return [...prev.slice(0, -1), { ...last, content: last.content + event.content }];
           }
-          return [...prev, { role: 'assistant' as const, content: isNarration ? event.content.split(/(?<=\.)\s*/).filter(s => s.trim()).map(s => `- ${s.trim()}`).join('\n') : event.content, messageType: msgType as any, timestamp: new Date().toISOString() }];
+          return [...prev, { role: 'assistant' as const, content: event.content, messageType: 'content', timestamp: new Date().toISOString() }];
+        });
+        break;
+      }
+      case 'chat_thinking': {
+        // Legitimate extended-thinking output from the SDK. Renders as
+        // the dashed WORKING preview block, separate from chat bubbles.
+        setMessages(prev => {
+          const last = prev[prev.length - 1];
+          if (last?.role === 'assistant' && last.messageType === 'thinking') {
+            return [...prev.slice(0, -1), { ...last, content: last.content + event.content }];
+          }
+          return [...prev, { role: 'assistant' as const, content: event.content, messageType: 'thinking', timestamp: new Date().toISOString() }];
         });
         break;
       }

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -661,9 +661,19 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   const pushEvent = (event: CboEvent) => {
     res.write(`data: ${JSON.stringify(event)}\n\n`);
     if (event.type === 'chat') {
-      const isNarration = /^(Let me |Good[,. —]|Now |Starting |I'll |I can |I've |Reading |Loading |Setting |Creating |Phase )/i.test(event.content.trim())
-        || (event.content.length < 300 && !event.content.includes('##') && !event.content.includes('**'));
-      addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: isNarration ? 'thinking' : 'content', timestamp: new Date().toISOString() });
+      // ALL chat events store as messageType: 'content'. The previous
+      // heuristic (regex + length<300 fallback) was catastrophically
+      // over-aggressive after PR #196 made the agent brief: any agent
+      // response under 300 chars without markdown headers/bold was
+      // misclassified as 'thinking' and hidden behind the WORKING
+      // preview UI. This nuked acks ("Got it."), short questions
+      // ("And who am I speaking with — what's your name?"), and any
+      // closing message that followed the new ≤6-line cap.
+      //
+      // Real thinking content comes via the SDK's `chat_thinking`
+      // event (handled below) when extended thinking is enabled — that's
+      // the only path that should produce messageType: 'thinking' now.
+      addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: 'content', timestamp: new Date().toISOString() });
     } else if (event.type === 'chat_thinking') {
       addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: 'thinking', timestamp: new Date().toISOString() });
     }


### PR DESCRIPTION
Root cause of the bugs tonight (agent's question appearing only in the dashed WORKING preview, Continue button appearing mid-conversation instead of the agent's next question).

## The bug

Both \`cboAgent.ts:664\` and \`cbo-profile.tsx:463\` had identical heuristics:
\`\`\`ts
isNarration = /^(Let me |Now |...)/.test(content)
           || (content.length < 300 && !content.includes('##') && !content.includes('**'));
\`\`\`

The first clause is a defensible filter for tool-call narration. The **second clause was catastrophic**: it flagged every agent message under 300 chars without markdown headers/bold as \"thinking\" and routed it to the WORKING preview UI.

After PR #196 made the agent ≤8-word acks + plain-text questions, nearly every agent response got misclassified. Example from your screenshot: \"Got it. And who am I speaking with — what's your name?\" — 56 chars, no \`##\`, no \`**\` → hidden in WORKING preview → \`agentOwesResponse=true\` → Continue button rendered.

## Downstream symptoms all from this one root cause
- Agent's questions appearing only in the dashed WORKING block
- Continue button appearing mid-conversation
- \`buildDecisionLog\` filtering by \`content\` meant the agent's own questions were missing from its next-turn context — likely contributing to repeat-question loops earlier today
- The cleaner the skill made the agent, the more broken the UI got

## Fix
- All \`'chat'\` events → \`messageType: 'content'\` (no more guessing)
- Real thinking content comes through the SDK's \`'chat_thinking'\` event (extended thinking) — that's now the only path that produces \`messageType: 'thinking'\`
- Client gets a dedicated \`'chat_thinking'\` case in the SSE switch (wasn't there before)
- The narration regex is removed entirely; per PR #196, the agent is forbidden from narrating tool calls anyway

## Verified

| Call site | Behavior after fix |
|---|---|
| \`cboAgent.ts:839\` buildDecisionLog filters by content | Decision log now has the full conversation → better agent context |
| \`cbo-profile.tsx:481\` content bubble concatenation | Unchanged |
| \`cbo-profile.tsx:493\` thinking bubble concatenation (new) | Only fires when SDK emits real \`chat_thinking\` |
| \`cbo-profile.tsx:946-949\` UI styling by type | Thinking still gets WORKING preview |
| \`cbo-profile.tsx:1170\` agentOwesResponse | Now correctly reflects whether the agent has responded |

## Backwards compat
Existing 'thinking'-typed messages in the DB from prior sessions still render as WORKING preview blocks. Only NEW agent chat is reclassified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)