### PR TITLE
fix(cbo): remove isNarration heuristic (re-apply post-revert)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -450,24 +450,40 @@ export default function CboProfilePage() {
   const processEvent = useCallback((event: CboEvent) => {
     switch (event.type) {
       case 'chat': {
-        const isNarration = /^(Let me |Good|Now |Starting |I'll |I can |Reading |Loading |Setting |Phase )/i.test(event.content.trim())
-          || (event.content.length < 300 && !event.content.includes('##') && !event.content.includes('**'));
-        const msgType = isNarration ? 'thinking' : 'content';
+        // All 'chat' events render as regular chat bubbles. The old
+        // isNarration heuristic (regex + length<300 fallback) hid brief
+        // agent responses behind the WORKING preview after PR #196 made
+        // the agent ≤8-word acks. Thinking content (extended-thinking
+        // output) arrives via a separate 'chat_thinking' event handled
+        // below — that's the only path that should produce a WORKING
+        // preview now.
+        //
         // Mobile-only: flag unread on the Chat tab if the user is currently
         // looking at the right panel (map / selector / perfil).
-        if (!isNarration && mobileActiveTabRef.current !== 'chat') {
+        if (mobileActiveTabRef.current !== 'chat') {
           setMobileChatUnread(true);
         }
         setMessages(prev => {
           const last = prev[prev.length - 1];
-          if (isNarration && last?.messageType === 'thinking') {
-            const bullets = event.content.split(/(?<=\.)\s*/).filter(s => s.trim()).map(s => `- ${s.trim()}`).join('\n');
-            return [...prev.slice(0, -1), { ...last, content: last.content + '\n' + bullets }];
-          }
-          if (!isNarration && last?.role === 'assistant' && last.messageType === 'content') {
+          // Concatenate consecutive assistant chat chunks into one bubble
+          // (the SSE stream emits the response in pieces as the model
+          // generates it).
+          if (last?.role === 'assistant' && last.messageType === 'content') {
             return [...prev.slice(0, -1), { ...last, content: last.content + event.content }];
           }
-          return [...prev, { role: 'assistant' as const, content: isNarration ? event.content.split(/(?<=\.)\s*/).filter(s => s.trim()).map(s => `- ${s.trim()}`).join('\n') : event.content, messageType: msgType as any, timestamp: new Date().toISOString() }];
+          return [...prev, { role: 'assistant' as const, content: event.content, messageType: 'content', timestamp: new Date().toISOString() }];
+        });
+        break;
+      }
+      case 'chat_thinking': {
+        // Legitimate extended-thinking output from the SDK. Renders as
+        // the dashed WORKING preview block, separate from chat bubbles.
+        setMessages(prev => {
+          const last = prev[prev.length - 1];
+          if (last?.role === 'assistant' && last.messageType === 'thinking') {
+            return [...prev.slice(0, -1), { ...last, content: last.content + event.content }];
+          }
+          return [...prev, { role: 'assistant' as const, content: event.content, messageType: 'thinking', timestamp: new Date().toISOString() }];
         });
         break;
       }

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -647,9 +647,19 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   const pushEvent = (event: CboEvent) => {
     res.write(`data: ${JSON.stringify(event)}\n\n`);
     if (event.type === 'chat') {
-      const isNarration = /^(Let me |Good[,. —]|Now |Starting |I'll |I can |I've |Reading |Loading |Setting |Creating |Phase )/i.test(event.content.trim())
-        || (event.content.length < 300 && !event.content.includes('##') && !event.content.includes('**'));
-      addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: isNarration ? 'thinking' : 'content', timestamp: new Date().toISOString() });
+      // ALL chat events store as messageType: 'content'. The previous
+      // heuristic (regex + length<300 fallback) was catastrophically
+      // over-aggressive after PR #196 made the agent brief: any agent
+      // response under 300 chars without markdown headers/bold was
+      // misclassified as 'thinking' and hidden behind the WORKING
+      // preview UI. This nuked acks ("Got it."), short questions
+      // ("And who am I speaking with — what's your name?"), and any
+      // closing message that followed the new ≤6-line cap.
+      //
+      // Real thinking content comes via the SDK's `chat_thinking`
+      // event (handled below) when extended thinking is enabled — that's
+      // the only path that should produce messageType: 'thinking' now.
+      addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: 'content', timestamp: new Date().toISOString() });
     } else if (event.type === 'chat_thinking') {
       addCboMessage(cboId, { role: 'assistant', content: event.content, messageType: 'thinking', timestamp: new Date().toISOString() });
     }


### PR DESCRIPTION
Re-applies PR #198 on top of the post-revert main. Cherry-picked clean.

## Why this is needed even after the revert
The Continue-from-Phase-1 bug is hitting on the reverted state because the agent's brief acks (\"Perfeito! Vamos começar.\" = 25 chars) trip the \`length < 300 && no markdown\` fallback in the isNarration heuristic at \`cboAgent.ts:650\`. The message is classified as \`'thinking'\`, rendered in the dashed WORKING preview, and excluded from the \`messageType === 'content'\` filter on the Continue button gate (\`cbo-profile.tsx:1170\`) → Continue button appears mid-conversation.

This bug predates today's afternoon work — the skill at \`b812dca3\` already said \"acknowledge with one or two words\" which always triggered the length fallback.

## What changes
- \`server/services/cboAgent.ts:streamCboChat.pushEvent\` — all \`'chat'\` events store as \`messageType: 'content'\`. The dedicated \`'chat_thinking'\` event handler still produces \`'thinking'\` (only fires when thinking_budget > 0).
- \`client/src/core/pages/cbo-profile.tsx:processEvent case 'chat'\` — same change. Adds a \`case 'chat_thinking'\` for explicit thinking content.

## What this does NOT touch
- Skill files (still post-#178 prescriptive chips)
- Bundling (still one-question-per-turn)
- Model selection (still SDK default = Sonnet)
- Decision log structure
- Banner gate / welcome screen / restart flow

Smallest possible PR for the immediate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)