### PR TITLE
fix(cbo): next-workshop banner gates on maturity-scoring completion

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -981,9 +981,41 @@ export default function CboProfilePage() {
                 When the coordinator opens a workshop higher than the user's
                 current phase, this card appears so the CBO knows the next
                 encontro is available + has a clear CTA to enter it. Without
-                this, the user has no signal that anything changed. */}
+                this, the user has no signal that anything changed.
+
+                Gates (in order):
+                1. Not streaming, has messages, phase > 0 — basic readiness.
+                2. No active ask_user — answer the current question first.
+                3. Current phase complete — defined as: every maturity metric
+                   the agent is supposed to score during this phase has a
+                   score recorded. The explicit completion signal matches
+                   the user's mental model ("I haven't finished E1, why is
+                   E2 being offered?"). Mapping below mirrors the per-phase
+                   scoring instructions in the skill markdown +
+                   buildPhaseInstructions fallback. */}
             {(() => {
               if (isStreaming || messages.length === 0 || state.phase === 0) return null;
+              if (currentQuestion) return null;
+
+              // Phase → required maturity metrics. Source of truth: the
+              // "Score: …" lines in each phase's instruction block in
+              // server/services/cboAgent.ts:buildPhaseInstructions and the
+              // matching skill markdown. Keep in sync when scoring rules
+              // change in either place.
+              const PHASE_COMPLETION_METRICS: Record<number, string[]> = {
+                1: ['org_delivery_capacity', 'team_technical_experience'],
+                2: ['site_control', 'community_anchoring'],
+                3: ['problem_clarity', 'solution_clarity', 'climate_nbs_impact', 'financial_thinking'],
+                4: ['regulatory_awareness'],
+                5: [], // E5 produces the full scorecard then advances to phase 6 — no banner needed
+              };
+              const required = PHASE_COMPLETION_METRICS[state.phase] ?? [];
+              if (required.length > 0) {
+                const scored = new Set((state.maturityScores ?? []).map(s => s.metric));
+                const allScored = required.every(m => scored.has(m));
+                if (!allScored) return null;
+              }
+
               const nextUnlockedPhase = unlockedPhases.find(p => p > state.phase);
               if (nextUnlockedPhase == null) return null;
               const ws = workshops.find(w => w.unlocksPhase === nextUnlockedPhase);


### PR DESCRIPTION
Re-applies PR #189 on top of post-revert main. Conflict resolved (the revert had no \`currentQuestion\` / \`userReplies\` guards, so the new gate is added cleanly without the intermediate heuristic).

## Why
Without this gate, the next-workshop banner appears whenever \`unlockedPhases.find(p => p > state.phase)\` is truthy. Since workshops are cohort-wide, a coordinator opening W2 for any CBO means EVERY member of the cohort sees \"Start Encontro 2\" — even ones still mid-E1. The user reported this directly: *\"why workshop 2 if they haven't done workshop 1 yet?\"*

## What this changes
Single block in \`cbo-profile.tsx\` (~33 lines added). Banner now hides unless:
1. Not streaming + has messages + phase > 0 (existing gate)
2. No active \`ask_user\` (don't compete with a pending question)
3. **Every maturity metric the agent is supposed to score in the current phase has a score recorded.** Mapping inline (phase 1 = org_delivery_capacity + team_technical_experience; phase 2 = site_control + community_anchoring; etc.) — source of truth is the \"Score:\" lines in \`buildPhaseInstructions\`.

## Risk
If the agent forgets to call \`score_maturity\` at end-of-phase, the banner won't appear and the user will get stuck. The skill already mandates scoring at end-of-encontro. If pilot logs show \"phase looks done by chat content but maturityScores is empty,\" the fix is in the skill markdown, not here.

## What this does NOT touch
- Skill files
- Chat/SSE pipeline
- isNarration heuristic
- Welcome screen
- Restart flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)