### PR TITLE
fix(cbo): new invitees see their own current workshop, not the cohort's last-opened

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -662,7 +662,14 @@ export default function CboProfilePage() {
   // single-CTA first-impression. Tapping Start (or Continue) flips
   // welcomeMode off and reveals either the encontro preamble or the chat.
   if (welcomeMode && memberInfo) {
-    const hasExistingProgress = messages.length > 0 || (state?.phase ?? 0) > 0;
+    // hasExistingProgress = the user has actually engaged. Previously we also
+    // checked (state?.phase ?? 0) > 0, but PR #191 changed the initial CBO
+    // state phase from 0 to 1 (to skip the slow phase-0 turn). After that
+    // change, every freshly-created CBO has phase=1 from the moment the row
+    // exists — so the phase check fired for brand-new invitees and they saw
+    // "Continue where I left off" on their first visit. messages.length is
+    // the only signal that actually means "they typed/clicked something."
+    const hasExistingProgress = messages.length > 0;
     // Show preamble for current phase if not yet seen. Fires for both
     // first-time Start and Resume — the seen flag handles dedup so the same
     // CBO doesn't see E1's preamble twice, but they DO see E2's the first

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -209,16 +209,27 @@ export function registerCohortRoutes(app: Express): void {
     const nextPhase = maxUnlocked + 1;
     const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
-    // The "focus workshop" is what the CBO welcome card should highlight.
-    // If the coordinator has opened any workshop, the most-recently opened one
-    // is the *current* workshop (the user is actively in it). Otherwise the
-    // first one in the sequence is the *next* (upcoming) workshop. This
-    // matches the CBO's mental model: "which workshop am I in/about to do?"
-    const openedWorkshops = workshops.filter(w => w.openedAt);
-    const focusWorkshop = openedWorkshops.length > 0
-      ? openedWorkshops[openedWorkshops.length - 1]
-      : (workshops[0] ?? null);
-    const focusWorkshopIsCurrent = openedWorkshops.length > 0;
+    // The "focus workshop" is what the CBO welcome card should highlight —
+    // it must reflect THIS member's progress, not the cohort's global state.
+    // Workshops are cohort-wide (one `openedAt` per workshop shared by all
+    // members), so a late-joining member inherited the most-recently-opened
+    // workshop as their "current" — pushing Test Farm to W2 before they'd
+    // done W1. Fix: pick the earliest workshop the member hasn't completed
+    // (= the workshop whose `unlocksPhase` equals their current snapshot
+    // phase). Fall back to the first workshop in the sequence for brand-new
+    // members with no snapshot yet.
+    const memberPhase = typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0
+      ? member.snapshotPhase
+      : 1; // brand-new member → start at W1 (unlocks phase 1)
+    const focusWorkshop =
+      workshops.find(w => w.unlocksPhase === memberPhase) ??
+      workshops[0] ??
+      null;
+    // "Current" if the member has actually started (any opened workshop AND
+    // the member has at least passed the welcome screen, i.e. snapshotPhase
+    // moved past null). For brand-new invitees, the workshop is "upcoming."
+    const focusWorkshopIsCurrent =
+      !!focusWorkshop?.openedAt && typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0;
 
     const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
     const supportPending = supportRequests.filter(r => !r.resolvedAt);


### PR DESCRIPTION
Re-applies PR #195 on top of post-revert main. Clean cherry-pick.

## The bug
Workshop config (\`openedAt\`) is cohort-wide. When the coordinator opens W2 for any prior CBO, the cohort's workshops list shows W2 as opened. \`/api/cbo-member/:slug\` used \`workshops.filter(w => w.openedAt).last\` for \`focusWorkshop\` — so EVERY member of the cohort, including brand-new invitees, saw \"Current workshop: Workshop 2.\"

You reported this earlier today: *\"why workshop 2 if they haven't done workshop 1 yet?\"*

## Fix
\`cohortRoutes.ts:200\` — \`focusWorkshop\` now uses \`member.snapshotPhase\` (the THIS-MEMBER's phase), with W1 fallback for brand-new members with no snapshot. \`focusWorkshopIsCurrent\` gates on the member having actually started.

## Note on the hasExistingProgress change
This PR also touches \`cbo-profile.tsx:665\` to change \`hasExistingProgress = messages.length > 0 || (state.phase ?? 0) > 0\` to just \`messages.length > 0\`. At the current reverted state, both produce the same result for new CBOs (phase is 0 again). The change is defensive — if anyone re-applies the phase=1 initial state, this PR already handles it correctly.

## What this does NOT touch
- Skill files
- Chat / SSE pipeline
- Banner gate
- isNarration

🤖 Generated with [Claude Code](https://claude.com/claude-code)