### PR TITLE
fix(cbo): kill silent-turn bug + ban redundant CBO question

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -19,6 +19,27 @@ You are speaking with a community leader who likely:
 - Never use "preencha" or "responda" — use "conta", "me fala"
 - Switch to English **only if the user writes in English first**
 
+## ⚠️ Every mid-encontro turn ends with a tool call — never silent, never idle
+
+Each turn you take MUST end with one of these:
+
+1. An `ask_user` tool call (the next question in the sequence). This is the most common case.
+2. A composer tool call: `open_map`, `ask_priority_rank`, `ask_community_anchoring`, `show_examples` (N/A in E1, used in E2+).
+3. The closing message + closing tool calls (`score_maturity` × 2 + `set_path`) — ONLY at the end of E1 after all questions answered.
+
+**If you respond to a user answer with only silent tool calls (e.g. `update_section` and nothing else), the user sees an empty screen with a "Continue" button instead of the next question.** That is a critical failure. Always pair an `update_section` with the next `ask_user` in the same turn.
+
+Forbidden patterns:
+- Calling `update_section` and ending the turn with no further tool call — leaves the user stranded.
+- Acknowledging an answer in plain text and ending the turn without firing the next `ask_user`.
+- Generating a paragraph saying *"once we're done with a few more questions, I'll ask about X"* instead of just asking X.
+
+## ⚠️ Do NOT ask "what type of organization?" / "are you a CBO?"
+
+This platform is for community-based organizations by construction — every user reaches this chat via a CBO-cohort invite. Asking *"What type of organization are you?"* with a chip option *"Community-based organization (CBO)"* is **redundant and confusing** — like asking *"Are you a person?"* on a signup form.
+
+The category we DO capture is `legal_form` (NGO/Associação, Cooperativa, Coletivo informal, Empresa social, Outra) — that's question 3 in the sequence below. Start with question 1 (the org+bairro confirmation, see below); do NOT insert any preliminary "are you a CBO" question.
+
 ## What you capture
 
 Per the spec, these fields land in the CBO profile (`state.sections.org_profile`):

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -22,6 +22,16 @@ Your job in this encontro is to:
 - Never use "preencha" or "responda" — use "conta", "me fala"
 - Switch to English only if the user writes in English first
 
+## ⚠️ Every mid-encontro turn ends with a tool call — never silent, never idle
+
+Same rule as E1. Each turn must end with one of:
+
+1. An `ask_user` call (the next question)
+2. A composer: `show_examples`, `open_map`, `ask_priority_rank`, `ask_community_anchoring`
+3. The closing sequence (`score_maturity` × 2 + closing message in ONE turn)
+
+If you call `update_section` and end the turn with no further tool call, the user sees a Continue button instead of the next question. Critical failure. Always pair `update_section` with the next prescribed tool in the same turn.
+
 ## Read the member context first
 
 The CURRENT STATE block of this prompt has E1's answers. Reference them naturally — *"você mencionou que trabalham com hortas em Cascata…"* — before pushing forward. Do not re-ask anything that's already in state.


### PR DESCRIPTION
Two targeted skill additions, **zero code changes**. Both are precise subsets of the reverted #196 polish, applied without the brief-ack/bundling/Haiku noise that caused problems earlier.

## Bug 1: \"Why does the agent always ask 'what type of org?' first?\"

The reverted skill says \"use chips for substantive questions\" but doesn't explicitly ban the redundant *\"What type of organization are you?\"* opener. Sonnet sees a fresh survey-like context and naturally opens with that question, with CBO/NGO/Cooperative/etc. as chips.

Useless — every user reaches this chat via a CBO-cohort invite. We already know they're a CBO.

**Fix:** explicit anti-pattern naming the question with the chip option \"CBO\" and pointing the agent to start with question 1 (org+bairro confirmation). Skill now begins the question sequence with the legitimate first question.

## Bug 2: Continue button appears with no agent response

When the agent responds to a chip answer by calling \`update_section\` silently and ending the turn with no further tool call, the user sees: their chip → empty space → Continue button. The Continue gate at \`cbo-profile.tsx:1170\` correctly identifies that the last \`content\` message is the user's — and since the agent didn't produce content OR fire ask_user, it shows Continue.

**Fix:** skill rule \"Every mid-encontro turn ends with a tool call.\" Names the silent-update_section pattern as a critical failure. Mirrors into E2 for parity.

## What this PR does NOT do
- Doesn't touch any code (server, client, schema, routes)
- Doesn't add brief-ack rules (those interacted badly with isNarration; not needed now)
- Doesn't add bundling
- Doesn't change models
- Doesn't change the question sequence (still one question per turn, prescriptive chips from #177)

Pure skill rule additions. 31 lines total across both skill files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)