### PR TITLE
refactor(cboAgent): pin model + split system from user prompt (PR A of 5)

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-6
+---
+
 # /encontro-1-quem-somos — Agent skill (first draft)
 
 > Loaded by `cboAgent.ts` when `member.unlockedPhases` includes 1 and the user hasn't completed Phase 1 yet. Replaces the Phase-1 section of the current monolithic `cbo-intervention.md` skill. Other phases keep loading the existing skill until they're split too.

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-6
+---
+
 # /encontro-2-seu-territorio — Agent skill
 
 Loaded by `cboAgent.ts` (via `loadEncontroSkill(2)`) when state.phase == 2.

--- a/knowledge/runs/2026-05-19-cbo-chat-refactor/plan.md
+++ b/knowledge/runs/2026-05-19-cbo-chat-refactor/plan.md
@@ -1,0 +1,206 @@
+# CBO chat refactor — fold cboAgent into the CT (concept-note) pattern
+
+**Date:** 2026-05-19
+**Goal:** Stop the CBO chat from being "stupid" before the June 8 Vila Flores convening series.
+**Owner:** JVP + Claude
+
+---
+
+## Why this exists
+
+The CBO chat used to be a chip-driven, MCQ-first conversation modeled on the CityCatalyst (CT) concept-note agent. Over the last several weeks of iteration it has degraded: the agent asks open-text questions where chips exist, re-asks things it already knows, ends turns without a follow-up (stranding the user behind a "Continue from Phase X" button), and has no graceful state for "you finished this workshop, the next isn't open yet."
+
+We diagnosed the root causes against the working `server/services/conceptNoteAgent.ts` (the CT pattern) and decided on a **structural refactor** (not symptom patches) plus **Playwright E2E coverage**.
+
+This document is the per-encontro plan: what the refactor means for E1 now, what changes for E2 (next), and the placeholders for E3+ (we'll fill these as we get there).
+
+---
+
+## Diagnostic — five root causes
+
+| # | Cause | Location | Effect |
+|---|---|---|---|
+| 1 | No `model:` passed to `sdkQuery` — SDK picks default | `server/services/cboAgent.ts:710-732` | Drifty model = unreliable tool-following |
+| 2 | Skill cache is process-lifetime, no mtime check | `server/services/encontroSkills.ts:24-35` | Skill edits don't reach the running server until restart |
+| 3 | Skill markdown stuffed into the user-side prompt | `server/services/cboAgent.ts:705` | Weaker steering than a system prompt or tool-description |
+| 4 | "Continue from Phase X" button fires whenever the agent ends a turn without text | `client/src/core/pages/cbo-profile.tsx:1107` | Skill-violating turn → hand-grenade button mid-conversation |
+| 5 | No UI branch for "finished current workshop, next not yet unlocked" | `client/src/core/pages/cbo-profile.tsx:1043` (returns `null`) | Blank screen, no "waiting for coordinator" cue |
+
+Cross-cutting: **no automated tests.** Every regression is caught live by JVP.
+
+---
+
+## Target architecture (CT pattern)
+
+The `conceptNoteAgent.ts` codifies what we want:
+
+- **Explicit model per call** (`claude-opus-4-6` / `claude-sonnet-4-20250514`) — `conceptNoteAgent.ts:374`, `:543`
+- **System prompt separated from user message** — proper SDK shape, not a concatenated string
+- **Batching encoded in the `ask_user` tool description**, not just in the skill: *"ALWAYS batch ALL questions for the current phase in a SINGLE call"* — `conceptNoteAgent.ts:191`, `:532`
+- **Tool catalog appears in the system prompt** so the model treats tools as first-class
+
+The cboAgent will adopt all four.
+
+---
+
+## Refactor — five PRs
+
+Each is its own branch off fresh `origin/main`, its own PR. Per JVP standing rule: never push to an existing PR branch.
+
+### PR A — Pin model + system-prompt separation
+
+**Scope:**
+- `server/services/cboAgent.ts:710` — add `model:` to `sdkQuery` options
+- Split the assembled prompt at `cboAgent.ts:705` into `system` (`sysCtx` + state + skill + tool catalog) and `user` (just the user message + decision log)
+- `server/services/encontroSkills.ts` — parse YAML frontmatter and return `{ markdown, model }`
+- Default model: `claude-sonnet-4-6` for E1/E2 (matches CT's working choice), `claude-opus-4-6` for E3+ (more complex multi-tool turns); both overridable per skill via frontmatter
+
+**Acceptance:**
+- Server log on every turn shows the model used
+- Skill frontmatter `model:` overrides default
+- No regressions: a full E1 walk still completes
+
+### PR B — Encode MCQ + turn-ender rules in the tool layer
+
+**Scope:**
+- `server/services/cboAgent.ts:342-356` (the `askUser` SDK tool) — rewrite description to mirror `conceptNoteAgent.ts:191`:
+  > *"Present multiple-choice questions to the user. The UI renders interactive buttons. ALWAYS use this for any question with 2-7 natural buckets. Pair every `update_section` call with an `ask_user` in the same turn unless ending the encontro (the closing tool calls handle that case)."*
+- Add a **post-turn guard** in `streamWithSdk`: after the SDK loop exits, if no `ask_user` / `open_map` / `ask_priority_rank` / `ask_community_anchoring` / `score_maturity` (closing) tool fired AND `state.phase < 6`, log a counter event + emit a fallback `chat` event telling the user to re-prompt
+- The post-turn guard is the structural defense against the silent-turn → Continue-button class of bug
+
+**Acceptance:**
+- The Playwright E2E (PR E) never sees the Continue button mid-flow
+- Server logs the `silent_turn_fallback` counter; baseline should be < 5% of turns
+
+### PR C — mtime-based skill cache
+
+**Scope:**
+- `server/services/encontroSkills.ts:24-35` — replace process-lifetime `Map<number, string|null>` with `Map<number, { mtimeMs: number; content: string | null }>`
+- On each call, stat the file; reload if `mtimeMs` changed
+- Drop the now-lying comment that says "restart to pick up edits"
+
+**Acceptance:**
+- Edit `knowledge/_skills/encontro-1.md`, hit the chat, see the new instruction take effect within one turn — no Replit restart
+
+### PR D — Waiting-for-coordinator UI + hardened Continue gate
+
+**Scope:**
+- `client/src/core/pages/cbo-profile.tsx:1043` — replace the `return null` (when no next phase is unlocked) with a "Próximo encontro ainda não foi aberto — sua coordenadora vai te avisar quando estiver pronta" card, parallel to the unlocked-next card above it
+- `client/src/core/pages/cbo-profile.tsx:1104-1108` — tighten the Continue button gate: require **(a)** the last user message timestamp to be > 30 min old, OR **(b)** the page to have been freshly loaded with no in-flight stream this session. Drops the case where the agent simply violated its turn-ender rule
+
+**Acceptance:**
+- After finishing E1 with no E2 unlocked, the CBO sees the waiting card (not a blank space, not a Continue button)
+- Continue button appears on a fresh page load after a real session loss — but not after a same-session agent silent-turn
+
+### PR E — Playwright E2E for Encontro 1
+
+**Scope:**
+- `npm i -D @playwright/test`
+- `playwright.config.ts` pointed at `localhost:5000`
+- `tests/e2e/encontro-1.spec.ts`:
+  - Creates a coordinator + cohort via the test endpoint (or seeds via API)
+  - Invites a CBO, opens `/cbo/:memberSlug`
+  - Walks the 10-question E1 flow: click chip / type free-text / submit, for each question
+  - **Asserts:**
+    - Every non-unique question presents chips (`[data-testid^="chip-"]` present)
+    - Continue button (`[data-testid="continue-phase"]`) never appears between questions
+    - On completion, the E2-unlocked banner is visible
+    - Total turn count is within `[10, 14]` (allowing for one or two clarification turns; if higher, the agent is re-asking)
+- Add `npm run test:e2e` script
+- GH Action: `npm run dev &; wait-on http://localhost:5000; npm run test:e2e`
+
+**Acceptance:**
+- Test runs locally and in CI, passes deterministically across 5 consecutive runs
+
+---
+
+## Per-encontro impact
+
+### E1 — Quem Somos (refactor target — first to ship)
+
+**What changes for E1 specifically:**
+
+| Aspect | Before | After |
+|---|---|---|
+| Model | SDK default (drifty) | Pinned `claude-sonnet-4-6` via skill frontmatter |
+| Skill delivery | Embedded in user-side prompt string | System prompt + tool catalog |
+| `ask_user` enforcement | Skill says "use chips" | Skill says it AND tool description says it AND post-turn guard catches violations |
+| Pre-filled values | Skill says "check CURRENT STATE first" | Skill prescription unchanged, but better-followed because the state appears in the **system** prompt |
+| Closing turn (after Q10) | Skill says "fire `score_maturity` × 2 + `set_path`" | Same — but the post-turn guard recognises closing-tool calls as a valid turn-ender |
+| Continue button | Appears any time agent ends silently | Only appears on legitimate session-loss (PR D) |
+| Test coverage | None | Playwright walks all 10 questions, asserts chip presence and no Continue button |
+
+**E1 question shape after refactor** (from `knowledge/_skills/encontro-1.md`):
+
+1. Confirm org name (free-text — unique input)
+2. Contact name (free-text)
+3. Contact role (free-text)
+4. Mission summary (free-text — unique)
+5. Legal form (chips: ONG/Coop/Coletivo/Empresa social/Outra)
+6. Year founded (free-text — number)
+7. Team size (chips: 1-2 / 3-5 / 6-15 / 16+)
+8. Paid vs volunteer (chips: 5 buckets)
+9. Prior project scale (chips: 5 buckets)
+10. NBS experience (chips: 4 buckets)
+11. Bairro of operation (chips: POA bairros, or pre-filled)
+12. Groups served (multi-select chips)
+13. Path triage (chips: has-idea / needs-help) — **most important**
+14. Proud moment (optional free-text)
+
+**Closing:** `score_maturity('org_delivery_capacity')` + `score_maturity('team_technical_experience')` + `set_path` + closing chat.
+
+### E2 — Onde Atuamos (next encontro to migrate after E1 lands)
+
+**Scheduled to migrate:** week of 2026-05-26 (assuming E1 refactor ships clean by 2026-05-22).
+
+**What's different vs E1:**
+- Adds **micro-app turns**: `open_map`, `ask_priority_rank`, `ask_community_anchoring`, `show_examples`
+- Path-aware: `has-idea` CBOs skip the educational anchor (`show_examples`); `needs-help` CBOs go through it
+- Closing scores: `site_control` + `community_anchoring`
+
+**Refactor delta from E1 plan:**
+- The post-turn guard in PR B must already recognise `open_map`, `ask_priority_rank`, `ask_community_anchoring`, `show_examples` as valid turn-enders — landing this in PR B (not PR E1-only) avoids re-touching the file
+- Playwright test for E2 (`tests/e2e/encontro-2.spec.ts`) needs to mock or auto-dismiss the map micro-app — write a thin Playwright helper `dismissMap()` that closes the map after a fake site selection so the E2E doesn't depend on real OSM/tile fetches
+- Skill model pin: `claude-sonnet-4-6` (same as E1 — E2 is still mostly chip-driven)
+
+**Risks specific to E2:**
+- Map micro-app currently posts coordinates back via a side channel — verify it still works under the system/user prompt split. Likely fine but worth a manual run before declaring done.
+- Path-aware branching: ensure the path field (set in E1) is in the system-prompt state summary so the agent reliably branches without re-asking
+
+### E3+ — What We Build / What We Need / Results & Evidence (placeholder)
+
+**To be filled when we get there.** Targets:
+- **E3 (week of 2026-06-02)** — Intervention selection. Adds `open_intervention_selector`. Probably needs `claude-opus-4-6` (more complex multi-tool reasoning across hazards × types × sizing). Add an "intervention selector dismiss helper" to the Playwright suite.
+- **E4 (week of 2026-06-09)** — Needs assessment + funder matching. Refactor pattern should hold; verify `read_knowledge` works under system-prompt split (it reads from `_financing-sources/`).
+- **E5 (week of 2026-06-16)** — Results & evidence. Lots of file upload turns; verify `ask_user` post-turn guard doesn't false-positive on upload-driven turns (an upload usually arrives mid-turn; the guard should already handle this because uploads go through the user message path, not the agent tool path — confirm).
+- **E6 (week of 2026-06-23)** — Wrap-up & review. Read-mostly; consider whether `set_phase(6)` should automatically suppress the Continue button entirely.
+
+For each, write a section here mirroring the E2 structure (delta vs E1, micro-app considerations, Playwright helper needs, model pin) **before** opening the PR for that encontro.
+
+---
+
+## Risks (cross-cutting)
+
+- **Model pin breaks `update_section` quality on cheaper models** → mitigated by per-phase override in skill frontmatter
+- **Post-turn guard masks real bugs by always firing a fallback** → log every fallback to a counter; if it fires in >10% of turns, the skill or model is wrong (treat as P0)
+- **Playwright nondeterminism from LLM variance** → assertions are structural (event types, chip presence), not semantic (exact wording)
+- **Refactor lands too close to June 8** → land PRs A + B + D by 2026-05-26, leaving 13 days of soak time; PR E (tests) can land in parallel; PR C is independent and low-risk
+
+---
+
+## Success criteria
+
+- [ ] An agent turn that fills a section never ends without an `ask_user` (asserted in test)
+- [ ] "Continue from Phase X" button does not appear while a CBO is mid-conversation in their unlocked workshop
+- [ ] After finishing the unlocked workshop with no next unlocked, the CBO sees a "waiting for coordinator" card
+- [ ] Skill edits to `knowledge/_skills/encontro-*.md` are picked up without a Replit restart
+- [ ] `npm run test:e2e` runs the full E1 walk-through and passes deterministically across 5 consecutive runs
+- [ ] By 2026-06-01: PRs A, B, C, D, E merged. E2 refactored. E3+ plan sections drafted but not necessarily shipped.
+
+---
+
+## Open questions
+
+1. Does the Agent SDK currently honor a `model:` override, or do we need to call the Anthropic API directly (like `conceptNoteAgent.ts:543`'s fallback)? Verify in PR A.
+2. Should the "waiting for coordinator" card include a "request to open early" button that posts to a coordinator inbox? Out of scope for now; revisit if Ana asks.
+3. The skill currently includes hardcoded language ("Brazilian Portuguese, warm, second-person") — should this move to a shared `voice.md` that every encontro skill imports? Defer.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -694,6 +694,11 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   res.end();
 }
 
+// Default model for the CBO chat. Mirrors the conceptNoteAgent (CT) choice that
+// proved reliable at sequential chip-first ask_user turns. Per-phase overrides
+// live in the encontro skill's YAML frontmatter (`model:` field).
+const DEFAULT_CBO_MODEL = 'claude-sonnet-4-6';
+
 async function streamWithSdk(cboId: string, userMessage: string, state: CboState, pushEvent: EventPusher, lang: string = 'en') {
   const mcpServer = getMcpServer(cboId);
   const sysCtx = await buildSystemContext(state, lang);
@@ -702,15 +707,28 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const policy = await getPhasePolicyForCbo(cboId);
   const accessPolicy = buildAccessPolicyPrompt(policy);
 
-  const prompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}\n\nUser message: ${userMessage}`;
+  // Pull the per-phase model from skill frontmatter, fall back to default.
+  // loadEncontroSkill is cached so this is free when buildSystemContext also
+  // called it. Phase 0 (pre-onboarding) has no skill — use default.
+  const skill = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
+  const model = skill?.model ?? DEFAULT_CBO_MODEL;
 
-  console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
+  // System prompt = the durable facts the agent needs (persona, tools, skill,
+  // state, recent conversation, access policy). User prompt = just the new
+  // turn. This mirrors conceptNoteAgent and is the SDK's expected shape;
+  // tool-use rules placed in the system prompt are followed more reliably
+  // than rules concatenated into the user message string.
+  const systemPrompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}`;
+
+  console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, model ${model}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 
   try {
     for await (const message of sdkQuery({
-      prompt,
+      prompt: userMessage,
       options: {
         cwd: process.cwd(),
+        model,
+        systemPrompt,
         allowedTools: [
           "Read", "Glob", "Grep",
           "mcp__cbo__update_section",
@@ -824,8 +842,8 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
   // Prefer encontro skill markdown from knowledge/_skills/encontro-{N}.md when
   // present (E1-E6 curriculum); fall back to the hardcoded block for phases
   // that haven't been migrated yet. Phase 0 = pre-onboarding, no encontro.
-  const encontroSkillMd = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
-  const phaseInstructions = encontroSkillMd ?? buildPhaseInstructions(state.phase, isPt);
+  const encontroSkill = state.phase >= 1 ? await loadEncontroSkill(state.phase) : null;
+  const phaseInstructions = encontroSkill?.markdown ?? buildPhaseInstructions(state.phase, isPt);
 
   // ── City summary (condensed, always loaded) ──
   const citySummary = isPt

--- a/server/services/encontroSkills.ts
+++ b/server/services/encontroSkills.ts
@@ -5,29 +5,45 @@
 // `knowledge/_skills/encontro-{phase}.md` and overrides the hardcoded
 // per-phase instruction block in cboAgent.ts when present.
 //
-// Roll-out strategy: phases without a skill .md continue to use the existing
-// hardcoded instructions (full backwards compat). E1's skill ships first; E2-E6
-// remain on hardcoded instructions until their skills are wired.
+// Each skill file may optionally start with YAML frontmatter that pins
+// per-phase configuration the agent loop honors — e.g. `model:` to lock the
+// SDK to a specific Claude model regardless of CLI defaults:
+//
+//     ---
+//     model: claude-sonnet-4-6
+//     ---
+//     # /encontro-1-quem-somos — Agent skill
+//     ...
+//
+// Skills without frontmatter still work (model falls back to the cboAgent
+// default).
 
 import fs from 'fs/promises';
 import path from 'path';
 
-const skillCache = new Map<number, string | null>();
+export type EncontroSkill = {
+  markdown: string;
+  model?: string;
+};
+
+const skillCache = new Map<number, EncontroSkill | null>();
 
 /**
- * Returns the skill markdown for a given phase, or null if no skill file
- * exists yet (caller should fall back to hardcoded instructions).
+ * Returns the parsed skill for a given phase, or null if no skill file exists
+ * (caller falls back to hardcoded instructions).
  *
  * Cached for the lifetime of the process; restart to pick up edits. Cache is
  * keyed by phase number — skills change rarely and atomically per-phase.
+ * (An mtime-based reload is planned in a follow-up PR.)
  */
-export async function loadEncontroSkill(phase: number): Promise<string | null> {
+export async function loadEncontroSkill(phase: number): Promise<EncontroSkill | null> {
   if (skillCache.has(phase)) return skillCache.get(phase) ?? null;
   try {
     const filePath = path.join(process.cwd(), 'knowledge', '_skills', `encontro-${phase}.md`);
     const content = await fs.readFile(filePath, 'utf-8');
-    skillCache.set(phase, content);
-    return content;
+    const skill = parseFrontmatter(content);
+    skillCache.set(phase, skill);
+    return skill;
   } catch {
     skillCache.set(phase, null);
     return null;
@@ -36,4 +52,28 @@ export async function loadEncontroSkill(phase: number): Promise<string | null> {
 
 export function invalidateEncontroSkillCache() {
   skillCache.clear();
+}
+
+// ── Frontmatter parser ──────────────────────────────────────────────────────
+// Minimal YAML subset: `key: value` lines between leading `---` fences. Values
+// are treated as strings; quotes are stripped. We deliberately avoid pulling in
+// a yaml dependency since the schema is this small.
+function parseFrontmatter(content: string): EncontroSkill {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return { markdown: content };
+  const [, frontmatter, markdown] = match;
+  const fields: Record<string, string> = {};
+  for (const rawLine of frontmatter.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let value = m[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    fields[key] = value;
+  }
+  return { markdown, model: fields.model || undefined };
 }


### PR DESCRIPTION
## Why

The CBO chat has degraded — agent asks open text where chips should appear, re-asks things it already knows, ends turns silently (stranding the user behind a 'Continue from Phase X' button). Diagnosed against \`conceptNoteAgent.ts\` (the CT flow that works) and laid out a 5-PR plan at \`knowledge/runs/2026-05-19-cbo-chat-refactor/plan.md\`.

This is **PR A of 5**, addressing the two foundational root causes.

## What changed

**1. Pin model per phase.** \`cboAgent.ts:streamWithSdk\` was calling \`sdkQuery\` with no \`model:\` option — the SDK picked whatever default, drifting between runs. Now pinned via \`DEFAULT_CBO_MODEL = 'claude-sonnet-4-6'\` (matches the CT default), overridable per phase via skill YAML frontmatter. Logged on every turn so we can see what's running.

**2. Split system from user prompt.** Previously the entire \`sysCtx + state + conversation + access policy + 'User message: X'\` was one concatenated string passed as \`prompt\`. Now:
- \`systemPrompt\` = persona, voice, tool catalog, skill markdown, rules, city context, scoring criteria, knowledge listing, **current state, recent conversation, access policy**
- \`prompt\` = just the new user message

This mirrors \`conceptNoteAgent.ts:374,543\`. The SDK treats system-prompt rules as durable instructions weighted more heavily than user-prompt content — the lever for making the chip-first rule stick.

**3. Skill frontmatter parser.** \`encontroSkills.ts\` now parses optional \`---\nmodel: …\n---\` YAML at the top of each \`encontro-N.md\`. Returns \`{ markdown, model? }\`. Backward-compat: skills without frontmatter still work (model falls back to the cboAgent default). No yaml dep added — the schema is tiny.

**4. E1 + E2 pinned to \`claude-sonnet-4-6\`.** Same model the CT flow uses, proven reliable for chip-first sequential turns.

## What does NOT change

- Chat streaming output (still emits \`text\` blocks as \`chat\` events)
- Tool invocations (allowedTools list, MCP server, push events all unchanged)
- The skill content itself (only frontmatter added)
- The cbo-profile.tsx UI — none of the five UI-side issues are addressed here

## What this fixes vs doesn't

**Should improve immediately:** model no longer drifts, skill rules (including \"ALWAYS use ask_user with chips\") are followed more reliably because they sit in the system prompt instead of the user message body.

**Does NOT fix on its own:** the Continue-button hand-grenade, the missing 'waiting for coordinator' UI, the silent-turn class of bug, or the no-tests gap. Those land in PRs B–E.

## Risk + verification

- **Risk**: SDK rejects \`claude-sonnet-4-6\` as a model name. → Mitigation: \`conceptNoteAgent.ts:374\` already pins \`claude-opus-4-6\` (same shape), so the SDK accepts \`claude-X-4-N\` IDs. If sonnet-4-6 isn't recognized on Replit's SDK version, the failure surfaces immediately on first chat turn — easy to roll back via a frontmatter edit, no code change.
- **Risk**: state moving from user-prompt body into systemPrompt changes how the agent reads it. → Verified that buildSystemContext still produces identical content; the split is purely positional.
- **Risk**: \`loadEncontroSkill\` return-type change breaks an unknown caller. → \`grep\` confirms only \`cboAgent.ts\` calls it (two sites, both updated).

\`npx tsc --noEmit\` produces no new errors in changed files (pre-existing errors unrelated).

## Test plan

- [ ] Hit chat on a fresh CBO; verify the \`[cbo] Turn for X (phase Y, model claude-sonnet-4-6, …)\` log line appears
- [ ] Walk through E1 question 1–5; verify chips appear for legal_form, team_size, paid_vs_volunteer (all should be \`ask_user\` chip turns, not free text)
- [ ] Hit reload mid-E1; verify the chat resumes correctly with state intact
- [ ] Verify other agents (concept-note, etc.) unaffected — the only file change to a non-CBO file is the SDK type contract which is shared

Plan doc: \`knowledge/runs/2026-05-19-cbo-chat-refactor/plan.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)