### PR TITLE
Flood Risk → validated catalog H×E×V + Flood Indices row

### DIFF
--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -36,7 +36,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS } from '@shared/geospatial-layers';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS } from '@shared/geospatial-layers';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
 import ValueTooltip from '@/core/components/concept-note/ValueTooltip';
 
@@ -78,7 +78,7 @@ interface CityInfo {
 }
 
 type LayerSource = 'geojson' | 'tiles';
-type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
+type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'flood_indices' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
 
 interface LayerState {
   id: string;
@@ -142,6 +142,19 @@ const LAYER_CONFIGS: LayerConfig[] = [
     hasValueTiles: l.hasValueTiles,
     valueEncoding: l.valueEncoding,
   })),
+  // Flood component indices (catalog poa_flood_* — hazard / exposure / vulnerability)
+  ...FLOOD_INDEX_LAYERS.map(l => ({
+    id: l.id,
+    name: l.name,
+    icon: AlertTriangle,
+    color: l.color,
+    source: 'tiles' as LayerSource,
+    group: 'flood_indices' as LayerGroupId,
+    available: true,
+    tileLayerId: l.tileLayerId,
+    hasValueTiles: l.hasValueTiles,
+    valueEncoding: l.valueEncoding,
+  })),
   // OEF tile layers — generated from shared catalog (48 layers)
   ...TILE_LAYERS.filter(l => l.available).map(l => ({
     id: l.id,
@@ -159,6 +172,7 @@ const LAYER_CONFIGS: LayerConfig[] = [
 
 const LAYER_GROUPS: readonly { id: LayerGroupId; label: string }[] = [
   { id: 'risk_250m', label: 'Risk Analysis (250m)' },
+  { id: 'flood_indices', label: 'Flood Indices' },
   { id: 'reference_data', label: 'Reference Data' },
   { id: 'analysis', label: 'Intervention Zones' },
   { id: 'environment', label: 'Environment' },

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -109,6 +109,12 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
   fri_2050s_585: { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/nbs/porto_alegre/climate_hazards/floods/flood_risk_index/oef_calculation/2050s_ssp585/tiles_visual/{z}/{x}/{y}.png" },
   fri_2100s_245: { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/nbs/porto_alegre/climate_hazards/floods/flood_risk_index/oef_calculation/2100s_ssp245/tiles_visual/{z}/{x}/{y}.png" },
   fri_2100s_585: { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/nbs/porto_alegre/climate_hazards/floods/flood_risk_index/oef_calculation/2100s_ssp585/tiles_visual/{z}/{x}/{y}.png" },
+
+  // ── Flood Risk (H×E×V) + component indices — catalog poa_flood_* (validated) ──
+  poa_flood_risk:          { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/risk/tiles_visual/{z}/{x}/{y}.png" },
+  poa_flood_hazard:        { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/hazard/tiles_visual/{z}/{x}/{y}.png" },
+  poa_flood_exposure:      { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/exposure/tiles_visual/{z}/{x}/{y}.png" },
+  poa_flood_vulnerability: { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/vulnerability/tiles_visual/{z}/{x}/{y}.png" },
 };
 
 // Track failed tile URLs to avoid repeated 404s (cache for 1 hour)

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -6,6 +6,7 @@
 export type LayerSource = 'geojson' | 'tiles';
 export type LayerGroup =
   | 'risk_analysis'    // Existing: flood/heat/landslide from grid
+  | 'flood_indices'    // Catalog poa_flood_* components: hazard / exposure / vulnerability
   | 'environment'      // Existing: elevation, landcover, water, rivers, forest
   | 'urban_land'       // New: Dynamic World, GHSL, VIIRS
   | 'ecology'          // New: NDVI, Hansen, Solar
@@ -43,10 +44,12 @@ export interface TileLayerDef {
 // Decode: value = (R + 256*G) / 1000 (scale=1000, offset=0, unit="index 0–1")
 export const LOCAL_RISK_LAYERS: TileLayerDef[] = [
   {
-    id: 'risk_flood_250m', name: 'Flood Risk (250m)', group: 'risk_analysis', color: '#1d4ed8',
-    tileLayerId: '_local_flood_risk', available: true, hasValueTiles: true,
-    valueEncoding: { type: 'numeric', scale: 1000, offset: 0, unit: 'index 0–1',
-      urlTemplate: '/tiles_values/flood_risk/{z}/{x}/{y}.png' },
+    // Catalog poa_flood_risk — validated H×E×V composite (S3, 24-bit, scale 10000).
+    // Replaces the old locally-computed flood_score (_local_flood_risk).
+    id: 'risk_flood_250m', name: 'Flood Risk (H×E×V)', group: 'risk_analysis', color: '#1d4ed8',
+    tileLayerId: 'poa_flood_risk', available: true, hasValueTiles: true,
+    valueEncoding: { type: 'numeric', scale: 10000, offset: 0, unit: 'index 0–1',
+      urlTemplate: 'https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/risk/tiles_values/{z}/{x}/{y}.png' },
   },
   {
     id: 'risk_heat_250m', name: 'Heat Risk (250m)', group: 'risk_analysis', color: '#dc2626',
@@ -63,6 +66,34 @@ export const LOCAL_RISK_LAYERS: TileLayerDef[] = [
   {
     id: 'risk_composite_hotspot', name: 'Risk Hotspots (all)', group: 'risk_analysis', color: '#8b5cf6',
     tileLayerId: '_local_composite_hotspot', available: true,
+  },
+];
+
+// Flood component indices from the catalog (poa_flood_* H/E/V), S3-backed.
+// Rendered as their own "Flood Indices" row. Heat/landslide get parallel arrays later.
+// Value tiles: 24-bit RGB, scale 10000 → value = (R + 256*G + 65536*B) / 10000.
+const FLOOD_INDEX_BASE =
+  'https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods';
+const floodIndexEncoding = (component: string): ValueTileEncoding => ({
+  type: 'numeric', scale: 10000, offset: 0, unit: 'index 0–1',
+  urlTemplate: `${FLOOD_INDEX_BASE}/${component}/tiles_values/{z}/{x}/{y}.png`,
+});
+
+export const FLOOD_INDEX_LAYERS: TileLayerDef[] = [
+  {
+    id: 'poa_flood_hazard', name: 'Flood Hazard', group: 'flood_indices', color: '#2563eb',
+    tileLayerId: 'poa_flood_hazard', available: true, hasValueTiles: true,
+    valueEncoding: floodIndexEncoding('hazard'),
+  },
+  {
+    id: 'poa_flood_exposure', name: 'Flood Exposure', group: 'flood_indices', color: '#7c3aed',
+    tileLayerId: 'poa_flood_exposure', available: true, hasValueTiles: true,
+    valueEncoding: floodIndexEncoding('exposure'),
+  },
+  {
+    id: 'poa_flood_vulnerability', name: 'Flood Vulnerability', group: 'flood_indices', color: '#db2777',
+    tileLayerId: 'poa_flood_vulnerability', available: true, hasValueTiles: true,
+    valueEncoding: floodIndexEncoding('vulnerability'),
   },
 ];
 


### PR DESCRIPTION
## Phase 1 — swap flood risk to the validated catalog dataset

Replaces the old locally-computed flood layer with the validated catalog composite and exposes its components.

### What changed
- **Flood Risk card repointed + renamed** — "Flood Risk (250m)" (`_local_flood_risk`, old `flood_score`) → **"Flood Risk (H×E×V)"** backed by catalog `poa_flood_risk` (S3, 24-bit, `scale 10000`). Matches Mau's audit §2.6 terminology fix (true IPCC-style Hazard × Exposure × Vulnerability, not hazard-mislabeled-as-risk).
- **New "Flood Indices" row** under RISK ANALYSIS — `poa_flood_hazard` / `poa_flood_exposure` / `poa_flood_vulnerability`, each with value-on-hover. Pattern is reusable for heat/landslide.

### Files
- `server/routes/tileProxyRoutes.ts` — 4 visual-tile proxy entries for catalog `poa_flood_*`
- `shared/geospatial-layers.ts` — repoint+rename flood risk card; add `flood_indices` group + `FLOOD_INDEX_LAYERS`
- `client/src/core/pages/site-explorer.tsx` — register group + render the new row

### Verification
- All 8 S3 endpoints (visual + value × 4 datasets) return **200** on a POA tile
- Value decode already handles the 24-bit blue channel (`decodePixelNumeric`)
- No new typecheck errors in touched files; `npm run build` passes

### Notes / follow-ups (Phase 2)
- Old local flood tiles (`client/public/tiles/flood_risk/`) are now dead but left in place — they still feed `risk_composite_hotspot` until that's re-sourced in Phase 2.
- Phase 2 (separate) handles the downstream recompute: catalog-led zone prioritization (drop app vulnerabilityFactor), agent/CBO context, spatial-query thresholds, and deprecating app-side risk math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)