### PR TITLE
Per-layer inline legends for evidence layers

### DIFF
--- a/client/public/sample-data/layer-legends.json
+++ b/client/public/sample-data/layer-legends.json
@@ -1,0 +1,1285 @@
+{
+  "risk_flood_250m": {
+    "layerId": "risk_flood_250m",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.12,
+        "color": "#3b3470"
+      },
+      {
+        "value": 0.155,
+        "color": "#37457b"
+      },
+      {
+        "value": 0.19,
+        "color": "#364c7e"
+      },
+      {
+        "value": 0.224,
+        "color": "#335e89"
+      },
+      {
+        "value": 0.259,
+        "color": "#316a8e"
+      },
+      {
+        "value": 0.294,
+        "color": "#327a89"
+      },
+      {
+        "value": 0.329,
+        "color": "#327b89"
+      }
+    ],
+    "min": 0.12,
+    "max": 0.329,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "risk_heat_250m": {
+    "layerId": "risk_heat_250m",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.15,
+        "color": "#fecdcd"
+      },
+      {
+        "value": 0.3,
+        "color": "#fca5a5"
+      },
+      {
+        "value": 0.5,
+        "color": "#dc2626"
+      },
+      {
+        "value": 0.7,
+        "color": "#991b1b"
+      }
+    ],
+    "min": 0.15,
+    "max": 0.7,
+    "source": "code",
+    "note": "screening index 0–1"
+  },
+  "risk_landslide_250m": {
+    "layerId": "risk_landslide_250m",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.15,
+        "color": "#eab308"
+      },
+      {
+        "value": 0.3,
+        "color": "#ca8a04"
+      },
+      {
+        "value": 0.5,
+        "color": "#a16207"
+      },
+      {
+        "value": 0.7,
+        "color": "#78350f"
+      }
+    ],
+    "min": 0.15,
+    "max": 0.7,
+    "source": "code",
+    "note": "screening index 0–1"
+  },
+  "poa_flood_hazard": {
+    "layerId": "poa_flood_hazard",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.119,
+        "color": "#3c2f6e"
+      },
+      {
+        "value": 0.203,
+        "color": "#355080"
+      },
+      {
+        "value": 0.286,
+        "color": "#32768a"
+      },
+      {
+        "value": 0.37,
+        "color": "#339482"
+      },
+      {
+        "value": 0.453,
+        "color": "#34aa7c"
+      },
+      {
+        "value": 0.537,
+        "color": "#3cba75"
+      },
+      {
+        "value": 0.62,
+        "color": "#4ec16a"
+      }
+    ],
+    "min": 0.119,
+    "max": 0.62,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "poa_flood_exposure": {
+    "layerId": "poa_flood_exposure",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.025,
+        "color": "#420b5a"
+      },
+      {
+        "value": 0.108,
+        "color": "#3d286a"
+      },
+      {
+        "value": 0.191,
+        "color": "#37477b"
+      },
+      {
+        "value": 0.274,
+        "color": "#316c8d"
+      },
+      {
+        "value": 0.357,
+        "color": "#338786"
+      },
+      {
+        "value": 0.44,
+        "color": "#34a67d"
+      },
+      {
+        "value": 0.523,
+        "color": "#3ab976"
+      }
+    ],
+    "min": 0.025,
+    "max": 0.523,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "poa_flood_vulnerability": {
+    "layerId": "poa_flood_vulnerability",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.091,
+        "color": "#3d2669"
+      },
+      {
+        "value": 0.176,
+        "color": "#37467b"
+      },
+      {
+        "value": 0.262,
+        "color": "#316e8c"
+      },
+      {
+        "value": 0.348,
+        "color": "#328387"
+      },
+      {
+        "value": 0.433,
+        "color": "#34a17f"
+      },
+      {
+        "value": 0.519,
+        "color": "#35b779"
+      },
+      {
+        "value": 0.605,
+        "color": "#4dc16b"
+      }
+    ],
+    "min": 0.091,
+    "max": 0.605,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_dynamic_world": {
+    "layerId": "oef_dynamic_world",
+    "kind": "classes",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#62B0CC",
+        "label": "Water"
+      },
+      {
+        "value": 1,
+        "color": "#488C5F",
+        "label": "Trees"
+      },
+      {
+        "value": 2,
+        "color": "#98B982",
+        "label": "Grass"
+      },
+      {
+        "value": 3,
+        "color": "#A0AAC3",
+        "label": "Flooded veg"
+      },
+      {
+        "value": 4,
+        "color": "#D7A55F",
+        "label": "Crops"
+      },
+      {
+        "value": 5,
+        "color": "#CDB982",
+        "label": "Shrub"
+      },
+      {
+        "value": 6,
+        "color": "#B45F55",
+        "label": "Built"
+      },
+      {
+        "value": 7,
+        "color": "#AFA89E",
+        "label": "Bare"
+      },
+      {
+        "value": 8,
+        "color": "#B9CDE1",
+        "label": "Snow"
+      }
+    ],
+    "source": "classes"
+  },
+  "oef_ghsl_built_up": {
+    "layerId": "oef_ghsl_built_up",
+    "kind": "gradient",
+    "unit": "m²",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#fffaf0"
+      },
+      {
+        "value": 1000,
+        "color": "#ffe6c8"
+      },
+      {
+        "value": 2000,
+        "color": "#fac8a0"
+      },
+      {
+        "value": 4000,
+        "color": "#e6966e"
+      },
+      {
+        "value": 6000,
+        "color": "#be6450"
+      },
+      {
+        "value": 8000,
+        "color": "#8c3c32"
+      }
+    ],
+    "min": 0,
+    "max": 8000,
+    "source": "file"
+  },
+  "oef_ghsl_urbanization": {
+    "layerId": "oef_ghsl_urbanization",
+    "kind": "gradient",
+    "stops": [
+      {
+        "value": -200,
+        "color": "#000000"
+      },
+      {
+        "value": 10,
+        "color": "#7ab6f5"
+      },
+      {
+        "value": 11,
+        "color": "#cdf57a"
+      },
+      {
+        "value": 12,
+        "color": "#abcd66"
+      },
+      {
+        "value": 13,
+        "color": "#375623"
+      },
+      {
+        "value": 21,
+        "color": "#ffff00"
+      },
+      {
+        "value": 22,
+        "color": "#a87000"
+      },
+      {
+        "value": 23,
+        "color": "#732600"
+      },
+      {
+        "value": 30,
+        "color": "#ff0000"
+      }
+    ],
+    "min": -200,
+    "max": 30,
+    "source": "file"
+  },
+  "oef_viirs_nightlights": {
+    "layerId": "oef_viirs_nightlights",
+    "kind": "gradient",
+    "unit": "nW/cm²/sr",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#080818"
+      },
+      {
+        "value": 5,
+        "color": "#0f1937"
+      },
+      {
+        "value": 10,
+        "color": "#142d5a"
+      },
+      {
+        "value": 25,
+        "color": "#194682"
+      },
+      {
+        "value": 50,
+        "color": "#3278b4"
+      },
+      {
+        "value": 75,
+        "color": "#50b4dc"
+      },
+      {
+        "value": 100,
+        "color": "#8cdcff"
+      },
+      {
+        "value": 150,
+        "color": "#e6f5c8"
+      },
+      {
+        "value": 200,
+        "color": "#ffffe6"
+      },
+      {
+        "value": 300,
+        "color": "#ffffff"
+      }
+    ],
+    "min": 0,
+    "max": 300,
+    "source": "file"
+  },
+  "oef_solar_tiles": {
+    "layerId": "oef_solar_tiles",
+    "kind": "gradient",
+    "unit": "kWh/kWp",
+    "stops": [
+      {
+        "value": 3,
+        "color": "#2166ac"
+      },
+      {
+        "value": 3.5,
+        "color": "#3b82f6"
+      },
+      {
+        "value": 3.75,
+        "color": "#22c55e"
+      },
+      {
+        "value": 4,
+        "color": "#facc15"
+      },
+      {
+        "value": 4.25,
+        "color": "#f97316"
+      },
+      {
+        "value": 4.5,
+        "color": "#ef4444"
+      },
+      {
+        "value": 5,
+        "color": "#b71c1c"
+      }
+    ],
+    "min": 3,
+    "max": 5,
+    "source": "file"
+  },
+  "oef_modis_ndvi": {
+    "layerId": "oef_modis_ndvi",
+    "kind": "gradient",
+    "unit": "NDVI",
+    "stops": [
+      {
+        "value": -0.2,
+        "color": "#8b5a2b"
+      },
+      {
+        "value": 0,
+        "color": "#d2b48c"
+      },
+      {
+        "value": 0.2,
+        "color": "#ffff99"
+      },
+      {
+        "value": 0.4,
+        "color": "#addd8e"
+      },
+      {
+        "value": 0.6,
+        "color": "#78c679"
+      },
+      {
+        "value": 0.8,
+        "color": "#31a354"
+      },
+      {
+        "value": 1,
+        "color": "#006837"
+      }
+    ],
+    "min": -0.2,
+    "max": 1,
+    "source": "file"
+  },
+  "oef_hansen_forest": {
+    "layerId": "oef_hansen_forest",
+    "kind": "gradient",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 1,
+        "color": "#ff0000"
+      }
+    ],
+    "min": 0,
+    "max": 1,
+    "source": "file"
+  },
+  "oef_ghsl_population": {
+    "layerId": "oef_ghsl_population",
+    "kind": "gradient",
+    "unit": "people",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#fffcf0"
+      },
+      {
+        "value": 16,
+        "color": "#fff5dc"
+      },
+      {
+        "value": 33,
+        "color": "#ffe4b5"
+      },
+      {
+        "value": 50,
+        "color": "#ffc87c"
+      },
+      {
+        "value": 66,
+        "color": "#ffa500"
+      },
+      {
+        "value": 83,
+        "color": "#ff6347"
+      },
+      {
+        "value": 100,
+        "color": "#b22222"
+      }
+    ],
+    "min": 0,
+    "max": 100,
+    "source": "file"
+  },
+  "oef_copernicus_dem": {
+    "layerId": "oef_copernicus_dem",
+    "kind": "gradient",
+    "unit": "m",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#0000ff"
+      },
+      {
+        "value": 250,
+        "color": "#00ffff"
+      },
+      {
+        "value": 500,
+        "color": "#ffff00"
+      },
+      {
+        "value": 750,
+        "color": "#ff0000"
+      },
+      {
+        "value": 1000,
+        "color": "#ffffff"
+      }
+    ],
+    "min": 0,
+    "max": 1000,
+    "source": "file"
+  },
+  "oef_merit_elv": {
+    "layerId": "oef_merit_elv",
+    "kind": "gradient",
+    "unit": "m",
+    "stops": [
+      {
+        "value": -50,
+        "color": "#0000b4"
+      },
+      {
+        "value": 0,
+        "color": "#0078ff"
+      },
+      {
+        "value": 100,
+        "color": "#00ffff"
+      },
+      {
+        "value": 300,
+        "color": "#ffff00"
+      },
+      {
+        "value": 700,
+        "color": "#ff8c00"
+      },
+      {
+        "value": 1200,
+        "color": "#ffffff"
+      }
+    ],
+    "min": -50,
+    "max": 1200,
+    "source": "file"
+  },
+  "oef_merit_upa": {
+    "layerId": "oef_merit_upa",
+    "kind": "gradient",
+    "unit": "cells",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 10,
+        "color": "#add8e6"
+      },
+      {
+        "value": 100,
+        "color": "#0078ff"
+      },
+      {
+        "value": 1000,
+        "color": "#00008b"
+      }
+    ],
+    "min": 0,
+    "max": 1000,
+    "source": "file"
+  },
+  "oef_merit_hydro": {
+    "layerId": "oef_merit_hydro",
+    "kind": "gradient",
+    "unit": "m",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 5,
+        "color": "#ffff99"
+      },
+      {
+        "value": 20,
+        "color": "#ffcc66"
+      },
+      {
+        "value": 50,
+        "color": "#ff8000"
+      },
+      {
+        "value": 100,
+        "color": "#cc0000"
+      }
+    ],
+    "min": 0,
+    "max": 100,
+    "source": "file"
+  },
+  "oef_emsn194": {
+    "layerId": "oef_emsn194",
+    "kind": "gradient",
+    "unit": "m",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 0.5,
+        "color": "#add8e6"
+      },
+      {
+        "value": 1,
+        "color": "#87cefa"
+      },
+      {
+        "value": 2,
+        "color": "#4682b4"
+      },
+      {
+        "value": 3,
+        "color": "#6495ed"
+      },
+      {
+        "value": 4,
+        "color": "#ffd700"
+      },
+      {
+        "value": 5,
+        "color": "#ffa500"
+      },
+      {
+        "value": 6,
+        "color": "#ff8c00"
+      },
+      {
+        "value": 7,
+        "color": "#ff6347"
+      },
+      {
+        "value": 8,
+        "color": "#dc143c"
+      },
+      {
+        "value": 10,
+        "color": "#8b0000"
+      }
+    ],
+    "min": 0,
+    "max": 10,
+    "source": "file"
+  },
+  "oef_jrc_occurrence": {
+    "layerId": "oef_jrc_occurrence",
+    "kind": "gradient",
+    "unit": "%",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 50,
+        "color": "#ffbbbb"
+      },
+      {
+        "value": 100,
+        "color": "#0000ff"
+      }
+    ],
+    "min": 0,
+    "max": 100,
+    "source": "file"
+  },
+  "oef_jrc_seasonality": {
+    "layerId": "oef_jrc_seasonality",
+    "kind": "gradient",
+    "unit": "months",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 6,
+        "color": "#add8e6"
+      },
+      {
+        "value": 12,
+        "color": "#0000ff"
+      }
+    ],
+    "min": 0,
+    "max": 12,
+    "source": "file"
+  },
+  "oef_jrc_change": {
+    "layerId": "oef_jrc_change",
+    "kind": "gradient",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 1,
+        "color": "#0000ff"
+      },
+      {
+        "value": 2,
+        "color": "#22b14c"
+      },
+      {
+        "value": 3,
+        "color": "#d1102d"
+      },
+      {
+        "value": 4,
+        "color": "#99d9ea"
+      },
+      {
+        "value": 5,
+        "color": "#b5e61d"
+      },
+      {
+        "value": 6,
+        "color": "#e6a1aa"
+      },
+      {
+        "value": 7,
+        "color": "#ff7f27"
+      },
+      {
+        "value": 8,
+        "color": "#ffc90e"
+      },
+      {
+        "value": 9,
+        "color": "#7f7f7f"
+      },
+      {
+        "value": 10,
+        "color": "#c3c3c3"
+      }
+    ],
+    "min": 0,
+    "max": 10,
+    "source": "file"
+  },
+  "oef_hansen_treecover": {
+    "layerId": "oef_hansen_treecover",
+    "kind": "gradient",
+    "unit": "%",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#ffffff"
+      },
+      {
+        "value": 50,
+        "color": "#90ee90"
+      },
+      {
+        "value": 100,
+        "color": "#006400"
+      }
+    ],
+    "min": 0,
+    "max": 100,
+    "source": "file"
+  },
+  "oef_chirps_r90p_2024": {
+    "layerId": "oef_chirps_r90p_2024",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 525.34,
+        "color": "#065497"
+      },
+      {
+        "value": 560.97,
+        "color": "#019aec"
+      },
+      {
+        "value": 596.6,
+        "color": "#15b1f4"
+      },
+      {
+        "value": 632.23,
+        "color": "#69cdc8"
+      },
+      {
+        "value": 667.86,
+        "color": "#15b1f4"
+      },
+      {
+        "value": 703.49,
+        "color": "#2bb8e8"
+      },
+      {
+        "value": 739.12,
+        "color": "#ffaa1f"
+      }
+    ],
+    "min": 525.34,
+    "max": 739.12,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_r90p_clim": {
+    "layerId": "oef_chirps_r90p_clim",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 377.37,
+        "color": "#0290df"
+      },
+      {
+        "value": 379.612,
+        "color": "#27b7ea"
+      },
+      {
+        "value": 381.853,
+        "color": "#2bb8e8"
+      },
+      {
+        "value": 384.095,
+        "color": "#96dcb0"
+      },
+      {
+        "value": 386.337,
+        "color": "#ace3a4"
+      },
+      {
+        "value": 388.578,
+        "color": "#ffdb52"
+      },
+      {
+        "value": 390.82,
+        "color": "#ffdb52"
+      }
+    ],
+    "min": 377.37,
+    "max": 390.82,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_r95p_2024": {
+    "layerId": "oef_chirps_r95p_2024",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 422.7,
+        "color": "#99ddae"
+      },
+      {
+        "value": 437.502,
+        "color": "#cbee93"
+      },
+      {
+        "value": 452.303,
+        "color": "#fffa73"
+      },
+      {
+        "value": 467.105,
+        "color": "#fffa73"
+      },
+      {
+        "value": 481.907,
+        "color": "#ffd84f"
+      },
+      {
+        "value": 496.708,
+        "color": "#ffab20"
+      },
+      {
+        "value": 511.51,
+        "color": "#ffab20"
+      }
+    ],
+    "min": 422.7,
+    "max": 511.51,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_r95p_clim": {
+    "layerId": "oef_chirps_r95p_clim",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 223.35,
+        "color": "#00a4f7"
+      },
+      {
+        "value": 224.91,
+        "color": "#00a7fb"
+      },
+      {
+        "value": 226.47,
+        "color": "#33bbe4"
+      },
+      {
+        "value": 228.03,
+        "color": "#18b2f2"
+      },
+      {
+        "value": 229.59,
+        "color": "#33bbe4"
+      },
+      {
+        "value": 231.15,
+        "color": "#f9fd7b"
+      },
+      {
+        "value": 232.71,
+        "color": "#ffda51"
+      }
+    ],
+    "min": 223.35,
+    "max": 232.71,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_r99p_2024": {
+    "layerId": "oef_chirps_r99p_2024",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 134.38,
+        "color": "#064d8e"
+      },
+      {
+        "value": 156.823,
+        "color": "#055fa4"
+      },
+      {
+        "value": 179.267,
+        "color": "#00a6fa"
+      },
+      {
+        "value": 201.71,
+        "color": "#00a6fa"
+      },
+      {
+        "value": 224.153,
+        "color": "#00a6fa"
+      },
+      {
+        "value": 246.597,
+        "color": "#fff26a"
+      },
+      {
+        "value": 269.04,
+        "color": "#ffbe34"
+      }
+    ],
+    "min": 134.38,
+    "max": 269.04,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_r99p_clim": {
+    "layerId": "oef_chirps_r99p_clim",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 93.82,
+        "color": "#0faff7"
+      },
+      {
+        "value": 98.262,
+        "color": "#53c6d3"
+      },
+      {
+        "value": 102.703,
+        "color": "#e1f588"
+      },
+      {
+        "value": 107.145,
+        "color": "#53c6d3"
+      },
+      {
+        "value": 111.587,
+        "color": "#e1f588"
+      },
+      {
+        "value": 116.028,
+        "color": "#df5100"
+      },
+      {
+        "value": 120.47,
+        "color": "#df5100"
+      }
+    ],
+    "min": 93.82,
+    "max": 120.47,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_rx1day_2024": {
+    "layerId": "oef_chirps_rx1day_2024",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 66.01,
+        "color": "#074382"
+      },
+      {
+        "value": 68.132,
+        "color": "#055da1"
+      },
+      {
+        "value": 70.253,
+        "color": "#05589c"
+      },
+      {
+        "value": 72.375,
+        "color": "#0467ad"
+      },
+      {
+        "value": 74.497,
+        "color": "#65ccca"
+      },
+      {
+        "value": 76.618,
+        "color": "#65ccca"
+      },
+      {
+        "value": 78.74,
+        "color": "#8fdab3"
+      }
+    ],
+    "min": 66.01,
+    "max": 78.74,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_rx1day_clim": {
+    "layerId": "oef_chirps_rx1day_clim",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 58.36,
+        "color": "#037ac5"
+      },
+      {
+        "value": 58.868,
+        "color": "#028bda"
+      },
+      {
+        "value": 59.377,
+        "color": "#037ac5"
+      },
+      {
+        "value": 59.885,
+        "color": "#028bda"
+      },
+      {
+        "value": 60.393,
+        "color": "#71d0c3"
+      },
+      {
+        "value": 60.902,
+        "color": "#71d0c3"
+      },
+      {
+        "value": 61.41,
+        "color": "#f1fa7f"
+      }
+    ],
+    "min": 58.36,
+    "max": 61.41,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_rx5day_2024": {
+    "layerId": "oef_chirps_rx5day_2024",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 178.37,
+        "color": "#064d8e"
+      },
+      {
+        "value": 180.45,
+        "color": "#046bb2"
+      },
+      {
+        "value": 182.53,
+        "color": "#0473bc"
+      },
+      {
+        "value": 184.61,
+        "color": "#0196e6"
+      },
+      {
+        "value": 186.69,
+        "color": "#00a5f9"
+      },
+      {
+        "value": 188.77,
+        "color": "#00a5f9"
+      },
+      {
+        "value": 190.85,
+        "color": "#36bce2"
+      }
+    ],
+    "min": 178.37,
+    "max": 190.85,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_chirps_rx5day_clim": {
+    "layerId": "oef_chirps_rx5day_clim",
+    "kind": "gradient",
+    "unit": "mm",
+    "stops": [
+      {
+        "value": 111.05,
+        "color": "#055ea3"
+      },
+      {
+        "value": 111.432,
+        "color": "#046ab1"
+      },
+      {
+        "value": 111.813,
+        "color": "#037fcb"
+      },
+      {
+        "value": 112.195,
+        "color": "#3bbee0"
+      },
+      {
+        "value": 112.577,
+        "color": "#0daef8"
+      },
+      {
+        "value": 112.958,
+        "color": "#3bbee0"
+      },
+      {
+        "value": 113.34,
+        "color": "#52c5d4"
+      }
+    ],
+    "min": 111.05,
+    "max": 113.34,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_fri_2024": {
+    "layerId": "oef_fri_2024",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.14,
+        "color": "#05579a"
+      },
+      {
+        "value": 0.19,
+        "color": "#0378c2"
+      },
+      {
+        "value": 0.24,
+        "color": "#0288d6"
+      },
+      {
+        "value": 0.29,
+        "color": "#14b1f4"
+      },
+      {
+        "value": 0.34,
+        "color": "#0288d6"
+      },
+      {
+        "value": 0.39,
+        "color": "#15b1f4"
+      },
+      {
+        "value": 0.44,
+        "color": "#b4e6a0"
+      }
+    ],
+    "min": 0.14,
+    "max": 0.44,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "oef_fri_2030s_245": {
+    "layerId": "oef_fri_2030s_245",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.05,
+        "color": "#055fa4"
+      },
+      {
+        "value": 0.208,
+        "color": "#0474bd"
+      },
+      {
+        "value": 0.367,
+        "color": "#0473bc"
+      },
+      {
+        "value": 0.525,
+        "color": "#0473bc"
+      },
+      {
+        "value": 0.683,
+        "color": "#ffbb32"
+      },
+      {
+        "value": 0.842,
+        "color": "#c92700"
+      },
+      {
+        "value": 1,
+        "color": "#b40000"
+      }
+    ],
+    "min": 0.05,
+    "max": 1,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  }
+}

--- a/client/src/core/components/map/LayerLegend.tsx
+++ b/client/src/core/components/map/LayerLegend.tsx
@@ -1,0 +1,48 @@
+import type { LegendSpec } from '@shared/legend-types';
+
+// Compact inline legend for one map layer — a gradient bar with low/mid/high value
+// bounds (+ unit) for numeric layers, or labeled swatches for categorical.
+// Spec comes from client/public/sample-data/layer-legends.json (generate-legends.ts).
+
+const fmt = (v: number) => {
+  if (Number.isInteger(v)) return String(v);
+  const a = Math.abs(v);
+  if (a >= 100) return String(Math.round(v));
+  if (a >= 1) return v.toFixed(1);
+  return v.toFixed(2);
+};
+
+export function LayerLegend({ spec, name }: { spec?: LegendSpec; name?: string }) {
+  if (!spec) return null;
+
+  if (spec.kind === 'classes') {
+    return (
+      <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+        {spec.stops.map((s) => (
+          <span key={s.value} className="flex items-center gap-1 text-[9px] text-zinc-300">
+            <i className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: s.color }} />
+            {s.label ?? s.value}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  const min = spec.min ?? spec.stops[0].value;
+  const max = spec.max ?? spec.stops[spec.stops.length - 1].value;
+  const span = max - min || 1;
+  const gradient = `linear-gradient(to right, ${spec.stops
+    .map((s) => `${s.color} ${(((s.value - min) / span) * 100).toFixed(1)}%`)
+    .join(', ')})`;
+
+  return (
+    <div>
+      <div className="h-2 rounded-sm w-full border border-white/10" style={{ background: gradient }} />
+      <div className="flex justify-between text-[9px] text-zinc-400 mt-0.5 leading-none">
+        <span>{fmt(min)}</span>
+        <span>{fmt((min + max) / 2)}</span>
+        <span>{fmt(max)}{spec.unit ? ` ${spec.unit}` : ''}</span>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -38,6 +38,8 @@ import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
 import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS } from '@shared/geospatial-layers';
 import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, type HazardKey } from '@shared/risk-display';
+import { LayerLegend } from '@/core/components/map/LayerLegend';
+import type { LegendIndex } from '@shared/legend-types';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
 import ValueTooltip from '@/core/components/concept-note/ValueTooltip';
 
@@ -274,6 +276,14 @@ export default function SiteExplorerPage() {
   const layerRefs = useRef<Map<string, L.Layer>>(new Map());
   const layerDataCache = useRef<Map<string, any>>(new Map());
   const [loadingLayers, setLoadingLayers] = useState<Set<string>>(new Set());
+  // Per-layer legend specs (generate-legends.ts → layer-legends.json), loaded once.
+  const [legends, setLegends] = useState<LegendIndex>({});
+  useEffect(() => {
+    fetch('/sample-data/layer-legends.json')
+      .then(r => (r.ok ? r.json() : {}))
+      .then(setLegends)
+      .catch(() => {});
+  }, []);
 
   const isSampleModeActive = isSampleMode || isSampleRoute;
 
@@ -2090,6 +2100,17 @@ export default function SiteExplorerPage() {
                           );
                         })}
                       </div>
+                      {/* Inline legends for the enabled layers in this group (color scale + bounds) */}
+                      {groupLayers.some(l => l.enabled && legends[l.id]) && (
+                        <div className="mt-1.5 space-y-1.5 px-0.5">
+                          {groupLayers.filter(l => l.enabled && legends[l.id]).map(l => (
+                            <div key={l.id}>
+                              <div className="text-[9px] text-zinc-400 mb-0.5 truncate">{l.name}</div>
+                              <LayerLegend spec={legends[l.id]} />
+                            </div>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/docs/risk-catalog-migration-playbook.md
+++ b/docs/risk-catalog-migration-playbook.md
@@ -264,6 +264,23 @@ percentile, or band). We follow FEMA / the Climate Vulnerability Index:
 - **Honesty:** percentile hides absolute severity and is reference-population-dependent → the absolute
   anchor line is **required**, and every surface says "relative to PoA neighborhoods".
 
+## 5c. Layer legends (raster color scales)
+
+Each evidence layer shows an inline legend (color ramp + low/mid/high bounds + unit, or class
+swatches) under its group in the site-explorer drawer when toggled on. Colors are sourced hybrid
+by `scripts/generate-legends.ts` → `client/public/sample-data/layer-legends.json`:
+
+- **file** — 17 authoritative GDAL color-relief files in `geospatial-data` (`transformation/*/data/*_colors.txt`), exact breakpoints + unit. Map in `COLOR_FILES`.
+- **classes** — categorical layers (Dynamic World) from `valueEncoding.classes` + `CLASS_COLORS`.
+- **code** — local heat/landslide ramps mirrored from `generate-risk-tiles.ts` `colorFn`s.
+- **sampled** — OEF indices with no colormap (poa_flood_*, CHIRPS, HWM, FRI): colors recovered by
+  pairing value-tile decode × visual-tile RGB over central-POA z=13 tiles.
+
+When a new catalog layer lands: if it has a color file, add it to `COLOR_FILES`; if it's a baked
+OEF index with value tiles, sampling picks it up automatically; re-run the generator. Layers with
+no colormap/value-tile fall back to no legend (graceful). Legend bounds are the **raw tile value**
+(e.g. flood risk 0–0.33, HAND 0–100 m) — distinct from the zone percentile bands (§5b).
+
 ## 6. Reference — exact zone-priority formula
 
 **Current** (`scripts/generate-neighborhood-zones.ts`):

--- a/scripts/generate-legends.ts
+++ b/scripts/generate-legends.ts
@@ -1,0 +1,187 @@
+/**
+ * Generate per-layer legends → client/public/sample-data/layer-legends.json.
+ *
+ * Hybrid color sourcing (see docs/risk-catalog-migration-playbook.md):
+ *   - classes  : categorical layers from valueEncoding.classes (Dynamic World)
+ *   - file     : the 17 authoritative GDAL color-relief files in geospatial-data
+ *   - code     : the local heat/landslide ramps from generate-risk-tiles.ts
+ *   - sampled  : OEF index layers with no colormap (poa_flood_*, CHIRPS, HWM, FRI)
+ *                — recovered by pairing value-tile decode × visual-tile RGB.
+ *
+ * Usage: npx tsx scripts/generate-legends.ts
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+import { TILE_LAYERS, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS } from '../shared/geospatial-layers';
+import type { LegendSpec, LegendStop, LegendIndex } from '../shared/legend-types';
+
+const S3 = 'https://geo-test-api.s3.us-east-1.amazonaws.com';
+const GH_RAW = 'https://raw.githubusercontent.com/Open-Earth-Foundation/geospatial-data/main';
+const Z = 13;
+// Central-POA tiles at z=13 (cover the city core; enough for the ramp shape).
+const SAMPLE_TILES = [[2930, 4813], [2929, 4813], [2930, 4812], [2931, 4814], [2929, 4812]];
+
+const rgb = (r: number, g: number, b: number) => `#${[r, g, b].map(x => x.toString(16).padStart(2, '0')).join('')}`;
+
+// ── layerId → repo GDAL color file (authoritative breakpoints) ────────────────
+const COLOR_FILES: Record<string, { path: string; unit?: string }> = {
+  oef_copernicus_dem: { path: 'transformation/copernicus_dem/release/v1/data/dem_glo30_colors.txt', unit: 'm' },
+  oef_emsn194: { path: 'transformation/copernicus_emsn194/release/v1/2024/data/maxwaterdepth_visual_colors.txt', unit: 'm' },
+  oef_ghsl_built_up: { path: 'transformation/ghsl_built_up/release/v1/data/ghsl_built_up_colors.txt', unit: 'm²' },
+  oef_ghsl_urbanization: { path: 'transformation/ghsl_degree_urbanization/release/v2/data/ghsl_degree_urb_colors.txt' },
+  oef_ghsl_population: { path: 'transformation/ghsl_population/release/v1/data/ghsl_population_colors.txt', unit: 'people' },
+  oef_solar_tiles: { path: 'transformation/global_solar_atlas/release/v2/data/pvout_visual_colors.txt', unit: 'kWh/kWp' },
+  oef_hansen_forest: { path: 'transformation/hansen_forest_change/release/v1/data/hansen_loss_colors.txt' },
+  oef_hansen_treecover: { path: 'transformation/hansen_forest_change/release/v1/data/hansen_treecover2000_colors.txt', unit: '%' },
+  oef_jrc_occurrence: { path: 'transformation/jrc_global_surface_water/release/v1/data/gsw_occurrence_colors.txt', unit: '%' },
+  oef_jrc_seasonality: { path: 'transformation/jrc_global_surface_water/release/v1/data/gsw_seasonality_colors.txt', unit: 'months' },
+  oef_jrc_change: { path: 'transformation/jrc_global_surface_water/release/v1/data/gsw_transition_colors.txt' },
+  oef_merit_elv: { path: 'transformation/merit_hydro/release/v1/data/merit_elv_colors.txt', unit: 'm' },
+  oef_merit_hydro: { path: 'transformation/merit_hydro/release/v1/data/merit_hnd_colors.txt', unit: 'm' },
+  oef_merit_upa: { path: 'transformation/merit_hydro/release/v1/data/merit_upa_colors.txt', unit: 'cells' },
+  oef_modis_ndvi: { path: 'transformation/modis_ndvi/release/v1/2024/data/ndvi_visual_colors.txt', unit: 'NDVI' },
+  oef_viirs_nightlights: { path: 'transformation/noaa_viirs_nightlights/release/v1/data/nightlights_visual_colors.txt', unit: 'nW/cm²/sr' },
+};
+
+// Categorical class colors from the catalog datasets.yaml (valueEncoding.classes has names only).
+const CLASS_COLORS: Record<string, Record<number, string>> = {
+  oef_dynamic_world: { 0: '#62B0CC', 1: '#488C5F', 2: '#98B982', 3: '#A0AAC3', 4: '#D7A55F', 5: '#CDB982', 6: '#B45F55', 7: '#AFA89E', 8: '#B9CDE1' },
+};
+
+// Local risk ramps — mirror the colorFns in generate-risk-tiles.ts (value → color).
+const CODE_RAMPS: Record<string, LegendStop[]> = {
+  risk_heat_250m: [
+    { value: 0.15, color: '#fecdcd' }, { value: 0.3, color: '#fca5a5' },
+    { value: 0.5, color: '#dc2626' }, { value: 0.7, color: '#991b1b' },
+  ],
+  risk_landslide_250m: [
+    { value: 0.15, color: '#eab308' }, { value: 0.3, color: '#ca8a04' },
+    { value: 0.5, color: '#a16207' }, { value: 0.7, color: '#78350f' },
+  ],
+};
+
+async function fetchText(url: string): Promise<string | null> {
+  try { const r = await fetch(url, { signal: AbortSignal.timeout(15000) }); return r.ok ? await r.text() : null; }
+  catch { return null; }
+}
+async function fetchPNG(url: string): Promise<PNG | null> {
+  try { const r = await fetch(url, { signal: AbortSignal.timeout(15000) }); if (!r.ok) return null;
+    return PNG.sync.read(Buffer.from(await r.arrayBuffer())); } catch { return null; }
+}
+
+/** Parse a GDAL color-relief file: lines of `value R G B [A]`, skipping nv/comments. */
+function parseColorFile(text: string, unit?: string): LegendStop[] {
+  const stops: LegendStop[] = [];
+  for (const line of text.split('\n')) {
+    const s = line.trim();
+    if (!s || s.startsWith('#') || s.toLowerCase().startsWith('nv')) continue;
+    const p = s.split(/\s+/);
+    const v = Number(p[0]); const r = Number(p[1]), g = Number(p[2]), b = Number(p[3]);
+    if (!isFinite(v) || !isFinite(r)) continue;
+    stops.push({ value: v, color: rgb(r, g, b) });
+  }
+  return stops.sort((a, b) => a.value - b.value);
+}
+
+/** Recover a ramp from the baked tiles: decode value (24-bit / scale) × visual RGB. */
+async function sampleRamp(valueUrl: string, scale: number, offset: number): Promise<{ stops: LegendStop[]; min: number; max: number } | null> {
+  const visualUrl = valueUrl.replace('tiles_values', 'tiles_visual');
+  const pairs: { v: number; r: number; g: number; b: number }[] = [];
+  for (const [x, y] of SAMPLE_TILES) {
+    const sub = (u: string) => u.replace('{z}', String(Z)).replace('{x}', String(x)).replace('{y}', String(y));
+    const [val, vis] = await Promise.all([fetchPNG(sub(valueUrl)), fetchPNG(sub(visualUrl))]);
+    if (!val || !vis) continue;
+    for (let i = 0; i < val.data.length; i += 4) {
+      const aV = val.data[i + 3], aVis = vis.data[i + 3];
+      if (aV < 20 || aVis < 20) continue;
+      const raw = val.data[i] + 256 * val.data[i + 1] + 65536 * val.data[i + 2];
+      const v = (raw + offset) / scale;
+      if (!isFinite(v)) continue;
+      pairs.push({ v, r: vis.data[i], g: vis.data[i + 1], b: vis.data[i + 2] });
+    }
+  }
+  if (pairs.length < 50) return null;
+  pairs.sort((a, b) => a.v - b.v);
+  const q = (p: number) => pairs[Math.floor(p * (pairs.length - 1))].v;
+  const min = q(0.02), max = q(0.98);
+  if (max <= min) return null;
+  const N = 7;
+  const stops: LegendStop[] = [];
+  for (let k = 0; k < N; k++) {
+    const target = min + (k / (N - 1)) * (max - min);
+    const win = (max - min) / (N * 1.5);
+    const near = pairs.filter(p => Math.abs(p.v - target) <= win);
+    const pool = near.length >= 5 ? near : [pairs[Math.round((k / (N - 1)) * (pairs.length - 1))]];
+    pool.sort((a, b) => (a.r + a.g + a.b) - (b.r + b.g + b.b));
+    const m = pool[Math.floor(pool.length / 2)];
+    stops.push({ value: Math.round(target * 1000) / 1000, color: rgb(m.r, m.g, m.b) });
+  }
+  return { stops, min: Math.round(min * 1000) / 1000, max: Math.round(max * 1000) / 1000 };
+}
+
+async function main() {
+  const all = [...LOCAL_RISK_LAYERS, ...FLOOD_INDEX_LAYERS, ...TILE_LAYERS];
+  const legends: LegendIndex = {};
+  let nFile = 0, nClass = 0, nCode = 0, nSample = 0, nSkip = 0;
+
+  for (const l of all) {
+    const enc: any = (l as any).valueEncoding;
+    const id = l.id;
+
+    // 1) categorical
+    if (enc?.type === 'categorical' && enc.classes) {
+      const colors = CLASS_COLORS[id] || {};
+      const stops: LegendStop[] = Object.entries(enc.classes).map(([v, name]) => ({
+        value: Number(v), color: colors[Number(v)] || '#888', label: String(name),
+      }));
+      legends[id] = { layerId: id, kind: 'classes', stops, source: 'classes' };
+      nClass++; continue;
+    }
+
+    // 2) authoritative repo color file
+    if (COLOR_FILES[id]) {
+      const { path: p, unit } = COLOR_FILES[id];
+      const txt = await fetchText(`${GH_RAW}/${p}`);
+      if (txt) {
+        const stops = parseColorFile(txt, unit);
+        if (stops.length) {
+          legends[id] = { layerId: id, kind: 'gradient', unit: unit ?? enc?.unit, stops,
+            min: stops[0].value, max: stops[stops.length - 1].value, source: 'file' };
+          nFile++; continue;
+        }
+      }
+    }
+
+    // 3) local code ramp
+    if (CODE_RAMPS[id]) {
+      const stops = CODE_RAMPS[id];
+      legends[id] = { layerId: id, kind: 'gradient', unit: 'index 0–1', stops,
+        min: stops[0].value, max: stops[stops.length - 1].value, source: 'code',
+        note: 'screening index 0–1' };
+      nCode++; continue;
+    }
+
+    // 4) sample the baked tiles (OEF indices with value tiles, no colormap file)
+    if (enc?.urlTemplate && enc.urlTemplate.startsWith('http')) {
+      const res = await sampleRamp(enc.urlTemplate, enc.scale ?? 1, enc.offset ?? 0);
+      if (res) {
+        legends[id] = { layerId: id, kind: 'gradient', unit: enc.unit, stops: res.stops,
+          min: res.min, max: res.max, source: 'sampled', note: 'colors recovered from tiles' };
+        nSample++;
+        process.stdout.write(`  sampled ${id} (${res.min}–${res.max} ${enc.unit})\n`);
+        continue;
+      }
+    }
+
+    nSkip++;
+  }
+
+  const outPath = path.join(process.cwd(), 'client', 'public', 'sample-data', 'layer-legends.json');
+  fs.writeFileSync(outPath, JSON.stringify(legends, null, 2));
+  console.log(`\n✓ ${Object.keys(legends).length} legends → ${path.relative(process.cwd(), outPath)}`);
+  console.log(`  file ${nFile} · classes ${nClass} · code ${nCode} · sampled ${nSample} · skipped ${nSkip}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/shared/legend-types.ts
+++ b/shared/legend-types.ts
@@ -1,0 +1,31 @@
+// ============================================================================
+// LAYER LEGENDS — color-scale metadata for the evidence-layer legends
+// ============================================================================
+// Generated offline by scripts/generate-legends.ts into
+// client/public/sample-data/layer-legends.json (keyed by layer id), then shown
+// inline under each active layer in the site-explorer drawer.
+//
+// Sources (hybrid, see docs/risk-catalog-migration-playbook.md):
+//   - 'file'     parsed GDAL color-relief from geospatial-data (exact breakpoints + unit)
+//   - 'classes'  categorical {value→name,color} from the catalog
+//   - 'sampled'  recovered from the baked tiles (value-tile decode × visual-tile RGB)
+//   - 'code'     the local risk colorFns in generate-risk-tiles.ts
+
+export interface LegendStop {
+  value: number;   // data value at this stop (in `unit`)
+  color: string;   // hex
+  label?: string;  // for categorical: the class name
+}
+
+export interface LegendSpec {
+  layerId: string;
+  kind: 'gradient' | 'classes';
+  unit?: string;           // e.g. 'm', 'mm', 'index 0–1', '°C·days'
+  stops: LegendStop[];     // gradient: ascending by value; classes: one per class
+  min?: number;            // actual data min (gradient)
+  max?: number;            // actual data max (gradient)
+  source: 'file' | 'classes' | 'sampled' | 'code';
+  note?: string;           // e.g. "colors recovered from tiles" / relative caveat
+}
+
+export type LegendIndex = Record<string, LegendSpec>;


### PR DESCRIPTION
Toggling an evidence/index layer now shows its **color scale inline** under its group in the Camadas de Evidência drawer — a gradient bar with low/mid/high value bounds + unit, or labeled swatches for categorical. Only active layers show, so it stays readable with many on.

## How we know each layer's colors (the hard part)
Colormaps are sourced **hybrid** by `scripts/generate-legends.ts` → `client/public/sample-data/layer-legends.json` (offline, zero runtime cost):

| source | layers | how |
|---|---|---|
| **file** | 17 source layers (DEM, MERIT HAND, NDVI, flood depth, GHSL, JRC, Hansen, solar, VIIRS) | parse the authoritative GDAL `value R G B` color-relief files in `geospatial-data` — exact breakpoints + units |
| **classes** | Dynamic World | `valueEncoding.classes` + catalog class colors |
| **code** | heat / landslide | mirror the `colorFn`s in `generate-risk-tiles.ts` |
| **sampled** | **poa_flood_* (Flood Indices)**, CHIRPS, HWM, FRI | the OEF indices have **no colormap anywhere** — recover it by pairing value-tile decode × visual-tile RGB over central-POA z=13 tiles |

**35 legends** generated. The sampled poa_flood ramps come back as the real viridis-style gradients (risk 0.12–0.33, hazard 0.12–0.62); MERIT HAND 0–100 m; flood depth blue→red; Dynamic World class names + colors.

## Changes
- `shared/legend-types.ts` — `LegendSpec` / `LegendStop` / `LegendIndex`
- `scripts/generate-legends.ts` — the hybrid generator
- `client/src/core/components/map/LayerLegend.tsx` — gradient bar / class swatches
- `site-explorer.tsx` — load legends once, render under each group's grid for enabled layers
- playbook §5c

## Notes
- Legend bounds are the **raw tile value** (flood risk 0–0.33, HAND 0–100 m) — deliberately distinct from the zone *percentile* bands (PR #216); the legend explains the raster pixels, not the zone ranking.
- New layers: add to `COLOR_FILES`, or sampling auto-picks up any baked index with value tiles; no-colormap layers fall back to no legend (graceful).
- ConceptNoteMap legend reuse deferred (the site-explorer drawer is the primary surface).

`npm run check` clean on changed files; `npm run build` passes. Worth an eyeball after merge — toggle Flood Risk / Flood Hazard / Dynamic World and confirm the ramps read well on the dark panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)