### PR TITLE
fix: OSM assets broken — Overpass 406 (missing User-Agent)

### DIFF
--- a/server/routes/overpassRoutes.ts
+++ b/server/routes/overpassRoutes.ts
@@ -177,7 +177,12 @@ export function registerOverpassRoutes(app: Express): void {
         const response = await fetch(mirror, {
           method: "POST",
           body: `data=${encodeURIComponent(queryDef.query)}`,
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          // Overpass mirrors (Apache) return 406 without a descriptive User-Agent.
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "NBSProjectBuilder/1.0 (nbs-project@openearth.org)",
+            "Accept": "application/json",
+          },
           signal: controller.signal,
         });
 

--- a/server/services/osmAssetService.ts
+++ b/server/services/osmAssetService.ts
@@ -144,6 +144,13 @@ export async function fetchOsmAssets(request: FetchOsmAssetsRequest): Promise<Fe
     const response = await fetch(OVERPASS_API_URL, {
       method: 'POST',
       body: query,
+      // Overpass (Apache) returns 406 Not Acceptable to requests without a descriptive
+      // User-Agent. A real UA + explicit Accept fixes the 406 that broke OSM asset loading.
+      headers: {
+        'User-Agent': 'NBSProjectBuilder/1.0 (nbs-project@openearth.org)',
+        'Content-Type': 'text/plain',
+        'Accept': 'application/json',
+      },
       signal: controller.signal,
     });
     


### PR DESCRIPTION
## Bug
All OSM asset loading stopped working — site-explorer flow, CBO and concept-note microapps all show **"Could not load map assets — Failed to fetch from OpenStreetMap (406)"**; `/api/osm/parks`, `/api/osm/schools`, `/api/geospatial/osm-assets` return 502.

## Cause (structural, external)
`overpass-api.de` (Apache) now returns **406 Not Acceptable** to requests **without a descriptive `User-Agent`**. Node's `undici` `fetch` doesn't send a default UA, and both Overpass callers set none:
- `server/services/osmAssetService.ts` — no headers at all
- `server/routes/overpassRoutes.ts` — `Content-Type` only

(Nominatim calls in `osmService.ts` already set a UA, which is why geocoding still worked — this was Overpass-specific.)

## Fix
Send `User-Agent: NBSProjectBuilder/1.0 (nbs-project@openearth.org)` + `Accept` on both Overpass callers. Kept each body's content-type correct (osmAssetService posts raw OQL → `text/plain`; overpassRoutes posts `data=` → `x-www-form-urlencoded`).

## Verified against live Overpass
```
no User-Agent        → 406
descriptive User-Agent → 200
```

`npm run build` passes. After merge + Replit redeploy, OSM assets (parks/schools/hospitals/wetlands), spatial queries, and the asset-selection flows should load again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)