### PR TITLE
feat(cbo): durable persistence — transactional flush, phase-boundary flush, audit fields (Session-1 hardening, fix 3/6)

### DIFF
--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -7,6 +7,7 @@ import {
   getCboMessages,
   addCboMessage,
   debouncedPersist,
+  flushNow,
   loadCboFromDb,
   getFlushedMessageCount,
   hasPendingFlush,
@@ -200,7 +201,9 @@ export function registerCboRoutes(app: Express): void {
 
     state.phase = target;
     setCboState(req.params.id, state);
-    debouncedPersist(req.params.id);
+    // Phase boundary — flush synchronously so the unlock is durable before we
+    // ack the client (this is the path the "Start Encontro" green card hits).
+    await flushNow(req.params.id);
     res.json({ ok: true, phase: target, state });
   });
 

--- a/server/routes/uploadRoutes.ts
+++ b/server/routes/uploadRoutes.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from "express";
 import multer from "multer";
 import path from "path";
 import { saveAndParseUpload } from "../services/fileParser";
+import { getCboState, setCboState, debouncedPersist } from "../services/cboAgent";
 
 const RUNS_DIR = path.join(process.cwd(), 'knowledge', 'runs');
 
@@ -41,6 +42,24 @@ export function registerUploadRoutes(app: Express): void {
         file.originalname,
         runDir,
       );
+
+      // Record the upload on the CBO state so it survives a cold reload (the
+      // parsed content the agent acted on is otherwise untraceable, and a
+      // re-hydrated session loses all upload history). uploadedFiles was in the
+      // schema but never written until now.
+      if (type === 'cbo') {
+        const state = getCboState(sessionId);
+        if (state) {
+          state.uploadedFiles.push({
+            name: file.originalname,
+            path: savedPath,
+            parsedAt: new Date().toISOString(),
+            summary: content.slice(0, 280),
+          });
+          setCboState(sessionId, state);
+          debouncedPersist(sessionId);
+        }
+      }
 
       res.json({
         filename: file.originalname,

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -20,8 +20,7 @@ import { loadEncontroSkill } from "./encontroSkills";
 import {
   loadCboState as dbLoadCboState,
   loadCboMessages as dbLoadCboMessages,
-  upsertCboState,
-  appendCboMessages,
+  flushCbo,
 } from "./cboPersistence";
 import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
@@ -124,24 +123,21 @@ export async function loadCboFromDb(id: string): Promise<{ state: CboState; mess
   return { state, messages };
 }
 
-// Debounced flush — UPSERT cbo_states + INSERT any new cbo_messages since
-// last flush. Single transaction would be nicer but Drizzle's transaction
-// API is awkward across two tables; the worst case is a half-flush (state
-// upserted but messages not appended) which is recoverable on next chat turn.
+// Flush = UPSERT cbo_states + INSERT any new cbo_messages since last flush, in
+// a single transaction (see cboPersistence.flushCbo). The flush pointer only
+// advances when the whole transaction commits, so a failure can't strand state
+// without its messages.
 const saveTimers = new Map<string, NodeJS.Timeout>();
 const SAVE_DEBOUNCE_MS = 2000;
 
 async function persistCbo(id: string) {
   const state = cboStates.get(id);
   if (!state) return;
-  await upsertCboState(state);
   const allMessages = cboMessages.get(id) ?? [];
   const flushed = flushedMessageCount.get(id) ?? 0;
-  if (allMessages.length > flushed) {
-    const newMessages = allMessages.slice(flushed);
-    await appendCboMessages(id, flushed, newMessages);
-    flushedMessageCount.set(id, allMessages.length);
-  }
+  const newMessages = allMessages.length > flushed ? allMessages.slice(flushed) : [];
+  const { flushedCount } = await flushCbo(state, newMessages, flushed);
+  flushedMessageCount.set(id, flushedCount);
 }
 
 export function debouncedPersist(id: string) {
@@ -151,6 +147,16 @@ export function debouncedPersist(id: string) {
     persistCbo(id).catch(e => console.error(`[cbo] persist(${id}) failed`, e));
     saveTimers.delete(id);
   }, SAVE_DEBOUNCE_MS));
+}
+
+// Immediate, durable flush — cancels any pending debounce and persists now.
+// Use on phase boundaries (set_phase, /advance-phase) so a completed session
+// (e.g. a finished Session-1 org profile) is never lost to the 2s debounce
+// window if the process restarts right after the user finishes.
+export async function flushNow(id: string) {
+  const existing = saveTimers.get(id);
+  if (existing) { clearTimeout(existing); saveTimers.delete(id); }
+  await persistCbo(id).catch(e => console.error(`[cbo] flushNow(${id}) failed`, e));
 }
 
 // Reset the flush pointer when a CBO is deleted so a fresh re-creation
@@ -204,8 +210,10 @@ function createCboMcpTools(cboId: string) {
       }
       const section = state.sections[args.sectionId as keyof typeof state.sections];
       if (!section) return { content: [{ type: "text" as const, text: `Unknown section: ${args.sectionId}` }], isError: true };
+      const oldValue = section.fields[args.field]?.value ?? null;
       section.fields[args.field] = { value: args.value, confidence: args.confidence as Confidence, source: args.source, userEdited: false };
       section.lastUpdatedBy = 'agent';
+      state.editLog.push({ timestamp: new Date().toISOString(), sectionId: args.sectionId, field: args.field, oldValue, newValue: args.value, source: 'agent' });
       section.confidence = args.confidence as Confidence;
       if (args.source && !section.sources.includes(args.source)) section.sources.push(args.source);
       state.gaps = state.gaps.filter(g => !(g.sectionId === args.sectionId && g.field === args.field));
@@ -253,6 +261,9 @@ function createCboMcpTools(cboId: string) {
       state.phase = args.phase;
       setCboState(cboId, state);
       pushEvent({ type: 'phase_change', phase: args.phase });
+      // Phase boundary — persist immediately so the transition (and everything
+      // that led to it) survives a restart, instead of riding the 2s debounce.
+      await flushNow(cboId);
       return { content: [{ type: "text" as const, text: `Phase ${args.phase}` }] };
     },
     { annotations: { readOnlyHint: false } }
@@ -1195,8 +1206,10 @@ export async function handleCboEdit(cboId: string, sectionId: string, field: str
   if (!state) { res.status(404).json({ error: "Not found" }); return; }
   const section = state.sections[sectionId as keyof typeof state.sections];
   if (!section) { res.status(400).json({ error: `Unknown section: ${sectionId}` }); return; }
+  const oldValue = section.fields[field]?.value ?? null;
   section.fields[field] = { ...section.fields[field], value: newValue, userEdited: true };
   section.lastUpdatedBy = 'user';
+  state.editLog.push({ timestamp: new Date().toISOString(), sectionId, field, oldValue, newValue, source: 'user' });
   setCboState(cboId, state);
   await streamCboChat(cboId, `User edited ${sectionId}.${field} to: "${newValue}". Update related fields if needed.`, res, state);
 }

--- a/server/services/cboPersistence.ts
+++ b/server/services/cboPersistence.ts
@@ -138,6 +138,58 @@ export async function appendCboMessages(
 }
 
 /**
+ * Transactional flush — UPSERT the state row AND append any new messages in a
+ * single DB transaction. Replaces the prior two separate awaits whose worst
+ * case was a "half-flush" (state saved, messages lost), which left a cold load
+ * with a short decision log and an agent that lost conversational context.
+ * The node-postgres Pool supports interactive transactions, so this is safe.
+ * Returns the new flushed-message count so the caller can advance its pointer
+ * only when the whole transaction committed.
+ */
+export async function flushCbo(
+  state: CboState,
+  newMessages: CboChatMessage[],
+  startPosition: number,
+): Promise<{ committed: boolean; flushedCount: number }> {
+  const values = {
+    id: state.id,
+    orgName: state.orgName ?? '',
+    city: state.city ?? '',
+    phase: state.phase ?? 0,
+    totalMaturityScore: state.totalMaturityScore ?? 0,
+    sections: state.sections ?? {},
+    gaps: state.gaps ?? [],
+    maturityScores: state.maturityScores ?? [],
+    priorityFlags: state.priorityFlags ?? [],
+    editLog: state.editLog ?? [],
+    uploadedFiles: state.uploadedFiles ?? [],
+    metadata: state.metadata ?? { createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    updatedAt: new Date(),
+  };
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(cboStates).values(values).onConflictDoUpdate({ target: cboStates.id, set: values });
+      if (newMessages.length > 0) {
+        await tx.insert(cboMessages).values(newMessages.map((m, i) => ({
+          cboStateId: state.id,
+          position: startPosition + i,
+          role: m.role,
+          content: m.content,
+          messageType: m.messageType,
+          timestamp: m.timestamp ? new Date(m.timestamp) : new Date(),
+        })));
+      }
+    });
+    return { committed: true, flushedCount: startPosition + newMessages.length };
+  } catch (e) {
+    logDbError('flushCbo', state.id, e);
+    // Pointer is NOT advanced on failure — the same messages retry next flush,
+    // and the state row will be re-upserted (idempotent), so nothing is lost.
+    return { committed: false, flushedCount: startPosition };
+  }
+}
+
+/**
  * Self-check at boot — probes for the cbo_states table. If it doesn't exist,
  * log a single LOUD line so the dev sees the fix immediately instead of
  * chasing the symptom (re-introducing agent, 404s on cold load, etc).


### PR DESCRIPTION
Third engine fix from the Session-1 hardening plan (`docs/cbo-session1-hardening.md`) — "root cause 4: best-effort persistence that loses data silently."

## What this fixes

**1. Transactional flush.** `cboPersistence.flushCbo()` now UPSERTs the state row **and** appends new messages in a single `db.transaction()` (the driver is node-postgres `Pool`, which supports interactive transactions). The per-CBO flush pointer advances **only when the whole transaction commits** — so a write failure can no longer strand a state row without the messages that produced it (the prior two-separate-awaits design admitted a "half-flush" that degraded the agent's decision log on the next cold load).

**2. Flush on phase boundaries.** New `flushNow()` cancels the pending 2s debounce and persists synchronously. Wired into `set_phase` (agent tool) and `/advance-phase` (the green "Start Encontro" card). A completed Session-1 org profile is no longer lost to the debounce window if the process restarts right after the user finishes — the exact "does my profile even save?" anxiety Vila Flores raised in the demo.

**3. Populate the audit fields that were in the schema but never written:**
- `editLog` — agent (`update_section`) and user (`handleCboEdit`) edits now log `{oldValue, newValue, source}`. The concept-note agent already did this; the CBO agent didn't.
- `uploadedFiles` — the upload route now records `{name, path, parsedAt, summary}` on the CBO state, so a re-hydrated session keeps its upload history instead of losing all trace of the docs the agent acted on.

## Safety / scope

- Built on `main` (includes merged #220 + #221).
- `npx tsc --noEmit`: 0 new errors across the 4 changed files (13 pre-existing baseline, untouched).
- The boot-time table check already exists and runs (`server/index.ts` → `checkCboTablesExist`), emitting a loud banner; deliberately left as a warning rather than hard-gating session creation (a fresh dev env without `db:push` should still boot).

## Remaining (per the doc)

4) session-level language + unified file intake (images/CSV dead-end today) · 5) adaptive-tier `encontro-1` refinement + org-type break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)