### PR TITLE
feat(cbo): sticky session language — stop half-EN/PT documents (Session-1 hardening, fix 4b/6)

### DIFF
--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -98,16 +98,32 @@ export function registerCboRoutes(app: Express): void {
       }
     }
 
-    // Language: prefer explicit lang from UI picker, fall back to auto-detection
-    const isPt = lang === 'pt' || (!lang && (
-      /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
-      /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message)
-    ));
+    // Sticky session language — set ONCE, never auto-flipped mid-session. The
+    // old per-turn accent/keyword regex flipped EN↔PT on a short reply, which
+    // produced half-English/half-Portuguese documents. Now: an explicit UI pick
+    // (the language picker) always wins and updates the sticky value; otherwise
+    // use the stored language; otherwise detect once from this first message.
+    let sessionLang: 'pt' | 'en';
+    if (lang === 'pt' || lang === 'en') {
+      sessionLang = lang;
+    } else if (state.metadata.language) {
+      sessionLang = state.metadata.language;
+    } else {
+      sessionLang = (
+        /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
+        /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message)
+      ) ? 'pt' : 'en';
+    }
+    if (state.metadata.language !== sessionLang) {
+      state.metadata.language = sessionLang;
+      setCboState(req.params.id, state);
+    }
+    const isPt = sessionLang === 'pt';
     const langDirective = isPt
-      ? '\n[LANGUAGE: Respond in Portuguese. ask_user option labels in Portuguese. update_section content in Portuguese.]'
-      : '\n[LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian orgs.]';
+      ? '\n[LANGUAGE: Respond in Portuguese. ask_user option labels in Portuguese. update_section content in Portuguese. One language only.]'
+      : '\n[LANGUAGE: Respond in English. ask_user option labels in English. update_section content in English. One language only.]';
 
-    const resolvedLang = isPt ? 'pt' : 'en';
+    const resolvedLang = sessionLang;
     addCboMessage(req.params.id, { role: 'user', content: message, messageType: 'content', timestamp: new Date().toISOString() });
     await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang);
     debouncedPersist(req.params.id);

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -978,7 +978,7 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
     ? `Você é um consultor de preparação de projetos de SbN ajudando uma organização comunitária em ${state.city}. Você NÃO está apenas coletando dados — está ajudando-os a PENSAR como um consultor.
 IDIOMA: TUDO em português do Brasil. Todas as mensagens, opções de ask_user e valores de update_section. Sem exceções.`
     : `You are an NBS project preparation consultant helping a community organization in ${state.city}. You are NOT just collecting data — you are helping them THINK through their project like a consultant.
-LANGUAGE: Respond in English. update_section content in Portuguese for Brazilian orgs.`}
+LANGUAGE: Everything in English — all messages, ask_user options, AND update_section values. Keep one language per session; do not mix.`}
 
 Phase: ${state.phase}. Org: ${state.orgName || '(not set)'}.
 

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -89,6 +89,10 @@ export interface CboState {
     createdAt: string;
     updatedAt: string;
     sessionId?: string;
+    // Sticky session language, set once (first explicit pick / first-message
+    // detection) and never auto-flipped mid-session. Drives BOTH chat and
+    // update_section content so the document isn't half-EN/half-PT.
+    language?: 'pt' | 'en';
   };
 }
 


### PR DESCRIPTION
The language half of fix 4 — "root cause 5: language re-derived per turn → mixed EN/PT documents."

## Two bugs, one symptom (half-English/half-Portuguese profiles)

1. **Per-turn auto-detection flipped mid-session.** Language was re-derived every turn by an accent/keyword regex on the message, so a short accent-free reply ("ok", "3-5 pessoas") could flip the whole turn EN↔PT.
2. **Forced-Portuguese content even in English mode.** Both the appended turn directive and the system prompt literally said *"update_section content in Portuguese for Brazilian orgs"* — so the chat could be English while the document fields came out Portuguese.

## Fix — sticky session language

Language is now a persisted session property (`metadata.language`), **set once and never auto-flipped**:
- An explicit UI-picker pick (`lang: 'pt'|'en'`) always wins and updates the sticky value (a deliberate switch still works).
- Otherwise the stored value is used.
- Otherwise it's detected once from the first message.

Both the turn directive and the system prompt now keep **one language per session** across chat, `ask_user` labels, **and** `update_section` content. No schema migration — the field rides in the existing `metadata` JSONB.

## Safety
- Built on `main` (fixes 1–3, 4a merged).
- `npx tsc --noEmit`: 0 new errors (baseline 12).

## Remaining hardening
Deeper turn-contract (free-text Q as a tool) + single phase state machine + client reconnect/replay · fix 5 adaptive-tier `encontro-1` + org-type break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)