### PR TITLE
feat(platform): organizations entity — Phase 1 foundation

### DIFF
--- a/scripts/backfill-organizations.ts
+++ b/scripts/backfill-organizations.ts
@@ -1,0 +1,60 @@
+// One-time, idempotent backfill: create one organization per existing
+// cohort_member (and per orphan cbo_state), and link org_id everywhere.
+//
+// Run AFTER `npm run db:push` has created the organizations table + the
+// org_id columns:
+//
+//   npx tsx scripts/backfill-organizations.ts
+//
+// Safe to re-run — it only touches rows whose org_id is still NULL.
+
+import { isNull, eq } from 'drizzle-orm';
+import { db } from '../server/db';
+import { organizations } from '@shared/org-schema';
+import { cohortMembers } from '@shared/cohort-schema';
+import { cboStates } from '@shared/cbo-db-schema';
+
+async function main() {
+  let orgsCreated = 0;
+  let membersLinked = 0;
+  let statesLinked = 0;
+
+  // 1) One org per cohort_member missing an org_id. Cohort invites are
+  //    community-first by default; a coordinator can reclassify implementers.
+  const members = await db.select().from(cohortMembers).where(isNull(cohortMembers.orgId));
+  for (const m of members) {
+    const [org] = await db.insert(organizations).values({
+      name: m.orgName,
+      city: 'porto-alegre',
+      type: 'community',
+      cohortId: m.cohortId,
+    }).returning();
+    orgsCreated++;
+    await db.update(cohortMembers).set({ orgId: org.id }).where(eq(cohortMembers.id, m.id));
+    membersLinked++;
+    // Link the working profile too, if the member↔state join exists.
+    if (m.cboStateId) {
+      await db.update(cboStates).set({ orgId: org.id }).where(eq(cboStates.id, m.cboStateId));
+      statesLinked++;
+    }
+  }
+
+  // 2) Orphan cbo_states (no member, no org) — e.g. standalone/demo sessions.
+  const orphanStates = await db.select().from(cboStates).where(isNull(cboStates.orgId));
+  for (const s of orphanStates) {
+    const [org] = await db.insert(organizations).values({
+      name: s.orgName || '(unnamed)',
+      city: s.city || 'porto-alegre',
+      type: 'unknown',
+    }).returning();
+    orgsCreated++;
+    await db.update(cboStates).set({ orgId: org.id }).where(eq(cboStates.id, s.id));
+    statesLinked++;
+  }
+
+  console.log(`[backfill] done — orgs created: ${orgsCreated}, members linked: ${membersLinked}, cbo_states linked: ${statesLinked}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => { console.error('[backfill] failed:', e); process.exit(1); });

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -12,6 +12,7 @@ import {
   type SupportRequestType,
   type WorkshopConfig,
 } from '@shared/cohort-schema';
+import { createOrganization } from '../services/orgPersistence';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -156,8 +157,21 @@ export function registerCohortRoutes(app: Express): void {
       .filter(n => Number.isFinite(n) && n >= 1);
     const unlockedPhases = Array.from(new Set([1, ...openedPhases])).sort((a, b) => a - b);
 
+    // Every invited org now gets a real organization entity (the platform
+    // spine). Default type 'community' for cohort invites; the coordinator can
+    // reclassify an implementer later. Best-effort — a failure here must not
+    // block the invite, so org_id just stays null and the backfill picks it up.
+    let orgId: string | null = null;
+    try {
+      const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: 'community', cohortId: cohort.id });
+      orgId = org.id;
+    } catch (e: any) {
+      console.error('[cohort] org creation failed on invite (continuing, backfill will link):', e?.message || e);
+    }
+
     const [member] = await db.insert(cohortMembers).values({
       cohortId: cohort.id,
+      orgId,
       memberSlug,
       orgName,
       neighborhood: neighborhood || null,

--- a/server/services/orgPersistence.ts
+++ b/server/services/orgPersistence.ts
@@ -1,0 +1,34 @@
+// Organization persistence — thin CRUD over the organizations table.
+// See docs/cbo-platform-architecture.md (Layer 1 — org identity).
+
+import { db } from '../db';
+import { organizations, type Organization, type OrgType, type MaturityTier } from '@shared/org-schema';
+import { cboStates } from '@shared/cbo-db-schema';
+import { eq } from 'drizzle-orm';
+
+export async function createOrganization(input: {
+  name: string;
+  city?: string;
+  type?: OrgType;
+  cohortId?: string | null;
+  maturityTier?: MaturityTier | null;
+}): Promise<Organization> {
+  const [org] = await db.insert(organizations).values({
+    name: input.name,
+    city: input.city ?? 'porto-alegre',
+    type: input.type ?? 'unknown',
+    cohortId: input.cohortId ?? null,
+    maturityTier: input.maturityTier ?? null,
+  }).returning();
+  return org;
+}
+
+export async function getOrganization(id: string): Promise<Organization | null> {
+  const [org] = await db.select().from(organizations).where(eq(organizations.id, id)).limit(1);
+  return org ?? null;
+}
+
+/** Link a cbo_state to its owning org (set when the member↔state join is established). */
+export async function linkCboStateToOrg(cboStateId: string, orgId: string): Promise<void> {
+  await db.update(cboStates).set({ orgId }).where(eq(cboStates.id, cboStateId));
+}

--- a/shared/cbo-db-schema.ts
+++ b/shared/cbo-db-schema.ts
@@ -25,6 +25,9 @@ import type {
 
 export const cboStates = pgTable('cbo_states', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  // FK to organizations.id (see shared/org-schema.ts). Nullable during the
+  // Phase-1 migration; backfilled, then later phases scope access by it.
+  orgId: varchar('org_id'),
   orgName: text('org_name').default(''),
   city: text('city').default(''),
   phase: integer('phase').default(0),

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -56,6 +56,9 @@ export const cohorts = pgTable('cohorts', {
 export const cohortMembers = pgTable('cohort_members', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
   cohortId: varchar('cohort_id').notNull(),
+  // FK to organizations.id (see shared/org-schema.ts). Nullable during the
+  // Phase-1 migration; set at invite time for new members, backfilled for old.
+  orgId: varchar('org_id'),
   memberSlug: text('member_slug').notNull().unique(),
   // CBO state ID — links to the file-backed CBO profile (`knowledge/runs/cbo-<id>/`)
   cboStateId: text('cbo_state_id'),

--- a/shared/org-schema.ts
+++ b/shared/org-schema.ts
@@ -1,0 +1,38 @@
+// Organization — the platform spine (see docs/cbo-platform-architecture.md).
+//
+// Today an "org" is just a free-text `orgName` duplicated across cbo_states and
+// cohort_members, joined by a cboStateId the browser sets — there's no real
+// entity to own a profile, a cohort membership, uploaded documents, or (later)
+// the accounts that can access it. This table is that entity. Everything hangs
+// off `organizations.id`.
+//
+// Phase 1 (this file) introduces the table and nullable `org_id` FKs on the
+// existing tables, backfilled one org per existing cbo_state/cohort_member pair
+// (scripts/backfill-organizations.ts). Nothing reads org_id for gating yet —
+// it's pure spine. Later phases scope documents + access control by it.
+
+import { sql } from 'drizzle-orm';
+import { pgTable, text, varchar, timestamp } from 'drizzle-orm/pg-core';
+
+// community  = community-based org (Vila Flores Stream A).
+// implementer = NbS-capable org that may not be community-based (Stream B —
+//   e.g. a landscape studio); community-anchored through the project, not legal form.
+// unknown    = not yet classified (e.g. a backfilled row we couldn't infer).
+export type OrgType = 'community' | 'implementer' | 'unknown';
+export type MaturityTier = 'emerging' | 'developing' | 'advanced';
+
+export const organizations = pgTable('organizations', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  name: text('name').notNull(),
+  city: text('city').default('porto-alegre'),
+  type: text('type').$type<OrgType>().default('unknown'),
+  // Nullable: an NbS-first implementer may be sourced outside any cohort.
+  cohortId: varchar('cohort_id'),
+  // Coordinator-overridable maturity tier (the adaptive-intake signal). Written
+  // by the coordinator dashboard / a future agent tool; null until set.
+  maturityTier: text('maturity_tier').$type<MaturityTier>(),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export type Organization = typeof organizations.$inferSelect;
+export type NewOrganization = typeof organizations.$inferInsert;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -7,5 +7,6 @@ export * from './block-schemas';
 export * from './sample-constants';
 export * from './models/chat';
 export * from './knowledge-schema';
+export * from './org-schema';
 export * from './cohort-schema';
 export * from './cbo-db-schema';


### PR DESCRIPTION
First architecture phase from `docs/cbo-platform-architecture.md` (#225) — the **org identity spine** that the per-org knowledge base, data isolation, and accounts all hang off. Today an "org" is just a free-text `orgName` duplicated across two tables; this makes it a real entity.

## Changes
- **`shared/org-schema.ts`** — `organizations` table: `id, name, city, type (community|implementer|unknown), cohort_id (nullable), maturity_tier, created_at`.
- **Nullable `org_id` FK** on `cbo_states` and `cohort_members` — additive and **non-breaking**: nothing reads it for gating yet, it's pure spine.
- **`orgPersistence.ts`** — create/get/link helpers.
- **Invite wiring** — `POST /api/cohort/:slug/invite` now creates a real organization (default `community`; coordinator can reclassify a Stream-B implementer later) and links the new member. Best-effort in a try/catch so an invite still succeeds before the migration runs (org_id stays null and the backfill links it).
- **`scripts/backfill-organizations.ts`** — idempotent backfill: one org per existing `cohort_member` (+ orphan `cbo_state`), links `org_id` everywhere. Only touches `NULL` org_id rows, safe to re-run.

## Migration (run on Replit, in order)
```
npm run db:push                                  # creates the table + org_id columns
npx tsx scripts/backfill-organizations.ts        # backfills + links existing rows
```

## Safety
- No behavior change for existing flows; `org_id` is nullable and unread.
- `npx tsc --noEmit`: 0 new errors (baseline 12).

## Next (architecture phases)
2) durable per-org documents + KB (Replit Object Storage + `documents` table + `list/read_org_document` tools) · 3) capability tokens + isolation · 4) coordinator magic-link accounts. Per the doc, Phase 2 (KB) and Phase 3 (auth) are independent — KB can land next, or auth first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)