### PR TITLE
feat(platform): per-org knowledge base — Phase 2 (Postgres full-text)

### DIFF
--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -12,7 +12,7 @@ import {
   type SupportRequestType,
   type WorkshopConfig,
 } from '@shared/cohort-schema';
-import { createOrganization } from '../services/orgPersistence';
+import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -431,8 +431,10 @@ export function registerCohortRoutes(app: Express): void {
       }
     }
 
+    const linkedStateId = cboStateId ?? member.cboStateId ?? null;
+
     await db.update(cohortMembers).set({
-      cboStateId: cboStateId ?? member.cboStateId ?? null,
+      cboStateId: linkedStateId,
       startedAt: member.startedAt ?? new Date(),
       snapshotPhase: nextPhase,
       snapshotSectionsComplete: typeof sectionsComplete === 'number' ? sectionsComplete : member.snapshotSectionsComplete,
@@ -441,6 +443,15 @@ export function registerCohortRoutes(app: Express): void {
       snapshotIntervention: typeof intervention === 'string' ? intervention : member.snapshotIntervention,
       snapshotUpdatedAt: new Date(),
     }).where(eq(cohortMembers.id, member.id));
+
+    // Propagate the org link onto the working profile so the per-org document
+    // store (and anything else scoped by org) works for this CBO. The member
+    // got its org_id at invite time; the cbo_state↔org link is established here,
+    // when the browser first reports which cboStateId it created.
+    if (linkedStateId && member.orgId) {
+      await linkCboStateToOrg(linkedStateId, member.orgId).catch(
+        (e: any) => console.error('[cohort] link cbo_state→org failed:', e?.message || e));
+    }
     res.json({ ok: true });
   }));
 }

--- a/server/routes/uploadRoutes.ts
+++ b/server/routes/uploadRoutes.ts
@@ -3,6 +3,21 @@ import multer from "multer";
 import path from "path";
 import { saveAndParseUpload } from "../services/fileParser";
 import { getCboState, setCboState, debouncedPersist } from "../services/cboAgent";
+import { createDocument, getOrgIdForCboState } from "../services/documentPersistence";
+import type { DocumentKind } from "@shared/document-schema";
+
+// Map an upload to the document kind (mirrors fileExtract's routing).
+function kindFromUpload(filename: string, mime?: string): DocumentKind {
+  const ext = (filename.split('.').pop() || '').toLowerCase();
+  const m = (mime || '').toLowerCase();
+  if (m.startsWith('audio/') || ['mp3','wav','m4a','webm','ogg','oga','opus','aac','flac'].includes(ext)) return 'audio';
+  if (m.startsWith('image/') || ['png','jpg','jpeg','gif','webp'].includes(ext)) return 'image';
+  if (ext === 'pdf' || m === 'application/pdf') return 'pdf';
+  if (ext === 'docx' || m.includes('wordprocessingml')) return 'docx';
+  if (ext === 'xlsx' || m.includes('spreadsheetml')) return 'xlsx';
+  if (['txt','md','csv','tsv','json','xml','yaml','yml'].includes(ext) || m.startsWith('text/')) return 'text';
+  return 'other';
+}
 
 const RUNS_DIR = path.join(process.cwd(), 'knowledge', 'runs');
 
@@ -50,10 +65,12 @@ export function registerUploadRoutes(app: Express): void {
         file.mimetype,
       );
 
-      // Record the upload on the CBO state so it survives a cold reload (the
-      // parsed content the agent acted on is otherwise untraceable, and a
-      // re-hydrated session loses all upload history). uploadedFiles was in the
-      // schema but never written until now.
+      // Record the upload two ways:
+      //  - cbo_states.uploadedFiles: lightweight manifest for the live session
+      //    UI (kept for backward-compat; will be deprecated once the doc store
+      //    fully replaces it).
+      //  - documents table: the durable, org-scoped evidence locker holding the
+      //    FULL extracted text, referenceable across every future session.
       if (type === 'cbo') {
         const state = getCboState(sessionId);
         if (state) {
@@ -65,6 +82,24 @@ export function registerUploadRoutes(app: Express): void {
           });
           setCboState(sessionId, state);
           debouncedPersist(sessionId);
+        }
+        // Best-effort: a doc-store failure must not fail the upload.
+        try {
+          const orgId = await getOrgIdForCboState(sessionId);
+          await createDocument({
+            orgId,
+            cboStateId: sessionId,
+            filename: file.originalname,
+            mimeType: file.mimetype,
+            kind: kindFromUpload(file.originalname, file.mimetype),
+            sizeBytes: file.size,
+            fullText: content,
+            summary: content.slice(0, 280),
+            droppedInPhase: state?.phase ?? null,
+            source: 'upload',
+          });
+        } catch (e: any) {
+          console.error('[upload] doc-store write failed (continuing):', e?.message || e);
         }
       }
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -25,6 +25,7 @@ import {
 import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
 import { eq } from "drizzle-orm";
+import { getOrgIdForCboState, listDocumentsByOrg, getDocumentForOrg } from "./documentPersistence";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -554,6 +555,40 @@ USE THIS TOOL PROACTIVELY when guiding the user. Don't just ask questions — re
     { annotations: { readOnlyHint: true } }
   );
 
+  // ── Per-org knowledge base (the evidence locker) ──
+  // These read the org's accumulated documents across ALL sessions, scoped to
+  // the org that owns this CBO profile, so Encontro 4 can reference the budget
+  // dropped in Encontro 1. See docs/cbo-platform-architecture.md.
+  const listOrgDocuments = sdkTool(
+    "list_org_documents",
+    "List the documents this organization has shared so far (across all sessions) — proposals, budgets, photos, voice memos, prior-project docs. Use this to recall what evidence already exists before asking the user to re-explain something. Returns an id, filename, kind, and short summary for each.",
+    {},
+    async () => {
+      const orgId = await getOrgIdForCboState(cboId);
+      if (!orgId) return { content: [{ type: "text" as const, text: "No documents on file yet." }] };
+      const docs = await listDocumentsByOrg(orgId);
+      if (docs.length === 0) return { content: [{ type: "text" as const, text: "No documents on file yet." }] };
+      const lines = docs.map(d => `- [${d.id}] ${d.filename} (${d.kind ?? 'file'}${d.droppedInPhase ? `, Encontro ${d.droppedInPhase}` : ''}) — ${(d.summary || '').slice(0, 160)}`);
+      return { content: [{ type: "text" as const, text: `Documents on file (${docs.length}):\n${lines.join('\n')}\n\nUse read_org_document with an [id] to read the full text.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
+  const readOrgDocument = sdkTool(
+    "read_org_document",
+    "Read the full extracted text of one of this organization's documents (by id from list_org_documents). Use to pull details from a budget, proposal, or prior-project doc the org shared earlier — including in a previous session.",
+    { id: z.string().describe("Document id from list_org_documents") },
+    async (args: any) => {
+      const orgId = await getOrgIdForCboState(cboId);
+      if (!orgId) return { content: [{ type: "text" as const, text: "No documents available." }], isError: true };
+      const doc = await getDocumentForOrg(args.id, orgId);
+      if (!doc) return { content: [{ type: "text" as const, text: `Document ${args.id} not found for this organization.` }], isError: true };
+      const text = doc.fullText || doc.summary || '(no extracted text)';
+      return { content: [{ type: "text" as const, text: `# ${doc.filename}\n\n${text.length > 6000 ? text.slice(0, 6000) + '\n...(truncated)' : text}` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
   const openInterventionSelector = sdkTool(
     "open_intervention_selector",
     `Open the NBS Intervention Type Selector micro-app. Shows 6 NBS types as visual cards with REAL PHOTOS from Brazilian case studies, cost data, outcomes, and timelines. The user browses and selects one or more intervention types.
@@ -599,7 +634,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, listOrgDocuments, readOrgDocument, openInterventionSelector],
   });
 }
 
@@ -790,6 +825,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const mcpServer = getMcpServer(cboId);
   const sysCtx = await buildSystemContext(state, lang);
   const stateSummary = buildStateSummary(state);
+  const documentsBlock = await buildDocumentsBlock(cboId);
   const decisionLog = buildDecisionLog(cboId);
   const policy = await getPhasePolicyForCbo(cboId);
   const accessPolicy = buildAccessPolicyPrompt(policy);
@@ -809,7 +845,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // turn. This mirrors conceptNoteAgent and is the SDK's expected shape;
   // tool-use rules placed in the system prompt are followed more reliably
   // than rules concatenated into the user message string.
-  const systemPrompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}`;
+  const systemPrompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}${documentsBlock}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}`;
 
   console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, model ${model}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 
@@ -841,6 +877,8 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__score_maturity",
           "mcp__cbo__set_priority_flag",
           "mcp__cbo__read_knowledge",
+          "mcp__cbo__list_org_documents",
+          "mcp__cbo__read_org_document",
         ],
         mcpServers: mcpServer ? { cbo: mcpServer } : {},
         permissionMode: "bypassPermissions",
@@ -929,6 +967,25 @@ function buildStateSummary(state: CboState): string {
     lines.push(`Flags: ${state.priorityFlags.map(f => `${f.met ? '✅' : '⬜'} ${f.flag}`).join(', ')}`);
   }
   return lines.join('\n');
+}
+
+// A compact "documents on file" list for the org that owns this profile —
+// injected into the system prompt so the agent always knows what evidence the
+// org has shared (across every session) and can read_org_document([id]) instead
+// of re-asking. Best-effort; never blocks a turn.
+async function buildDocumentsBlock(cboId: string): Promise<string> {
+  try {
+    const orgId = await getOrgIdForCboState(cboId);
+    if (!orgId) return '';
+    const docs = await listDocumentsByOrg(orgId);
+    if (docs.length === 0) return '';
+    const lines = docs.slice(0, 20).map(d =>
+      `- [${d.id}] ${d.filename} (${d.kind ?? 'file'}${d.droppedInPhase ? `, Encontro ${d.droppedInPhase}` : ''}) — ${(d.summary || '').slice(0, 120)}`);
+    return `\n\n## DOCUMENTS ON FILE (${docs.length})\nThis org has already shared these. Read the full text with read_org_document([id]) before re-asking for information that's likely in them:\n${lines.join('\n')}`;
+  } catch (e: any) {
+    console.error('[cbo] buildDocumentsBlock failed:', e?.message || e);
+    return '';
+  }
 }
 
 function buildDecisionLog(cboId: string): string {

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -1,0 +1,52 @@
+// Per-org document store persistence (see docs/cbo-platform-architecture.md).
+
+import { db } from '../db';
+import { documents, type DocumentRow, type DocumentKind } from '@shared/document-schema';
+import { cboStates } from '@shared/cbo-db-schema';
+import { eq, desc, and } from 'drizzle-orm';
+
+/** The owning org of a CBO working profile (org_id was linked in Phase 1). */
+export async function getOrgIdForCboState(cboStateId: string): Promise<string | null> {
+  const [row] = await db.select({ orgId: cboStates.orgId }).from(cboStates).where(eq(cboStates.id, cboStateId)).limit(1);
+  return row?.orgId ?? null;
+}
+
+export async function createDocument(input: {
+  orgId: string | null;
+  cboStateId: string | null;
+  filename: string;
+  mimeType?: string | null;
+  kind?: DocumentKind | null;
+  sizeBytes?: number | null;
+  fullText?: string | null;
+  summary?: string | null;
+  droppedInPhase?: number | null;
+  source?: 'upload' | 'agent';
+}): Promise<DocumentRow> {
+  const [doc] = await db.insert(documents).values({
+    orgId: input.orgId ?? null,
+    cboStateId: input.cboStateId ?? null,
+    filename: input.filename,
+    mimeType: input.mimeType ?? null,
+    kind: input.kind ?? null,
+    sizeBytes: input.sizeBytes ?? null,
+    fullText: input.fullText ?? null,
+    summary: input.summary ?? null,
+    droppedInPhase: input.droppedInPhase ?? null,
+    source: input.source ?? 'upload',
+  }).returning();
+  return doc;
+}
+
+/** All of an org's documents, newest first. The evidence locker for the agent. */
+export async function listDocumentsByOrg(orgId: string): Promise<DocumentRow[]> {
+  return db.select().from(documents).where(eq(documents.orgId, orgId)).orderBy(desc(documents.createdAt));
+}
+
+/** A single document, scoped to its org so one org can't read another's files. */
+export async function getDocumentForOrg(id: string, orgId: string): Promise<DocumentRow | null> {
+  const [doc] = await db.select().from(documents)
+    .where(and(eq(documents.id, id), eq(documents.orgId, orgId)))
+    .limit(1);
+  return doc ?? null;
+}

--- a/shared/document-schema.ts
+++ b/shared/document-schema.ts
@@ -1,0 +1,44 @@
+// Per-org document store — the evidence locker (see docs/cbo-platform-architecture.md
+// Layer 3). Promotes uploads from a side effect of a chat turn (truncated text
+// buried in the chat log + a 280-char summary on cbo_states.uploadedFiles, with
+// the original on ephemeral disk) into a durable, org-scoped record holding the
+// FULL extracted text.
+//
+// Phase 2a (this table): Postgres full-text only — fullText is the whole
+// extraction the #223 extractor already produces (doc parse / image vision /
+// audio transcription). Durable blob originals (Replit Object Storage) are a
+// later add-on; storageKey is reserved for it.
+
+import { sql } from 'drizzle-orm';
+import { pgTable, text, varchar, integer, timestamp, index } from 'drizzle-orm/pg-core';
+
+// Mirrors fileExtract's ExtractKind.
+export type DocumentKind = 'pdf' | 'docx' | 'xlsx' | 'text' | 'image' | 'audio' | 'other';
+
+export const documents = pgTable('documents', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  // The owning org — the locker is org-scoped so it accumulates across every
+  // session/encontro. Nullable only to survive a row whose org isn't linked yet.
+  orgId: varchar('org_id'),
+  // Which working profile this upload informed (provenance).
+  cboStateId: varchar('cbo_state_id'),
+  filename: text('filename').notNull(),
+  mimeType: text('mime_type'),
+  kind: text('kind').$type<DocumentKind>(),
+  sizeBytes: integer('size_bytes'),
+  // The WHOLE extracted text — not the 8K chat-truncated copy. This is what
+  // later sessions read back via read_org_document.
+  fullText: text('full_text'),
+  summary: text('summary'),
+  // Provenance: which phase the upload arrived in, and who added it.
+  droppedInPhase: integer('dropped_in_phase'),
+  source: text('source').$type<'upload' | 'agent'>().default('upload'),
+  // Reserved for Phase 2b (durable blob originals in object storage).
+  storageKey: text('storage_key'),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  byOrg: index('documents_by_org').on(table.orgId),
+}));
+
+export type DocumentRow = typeof documents.$inferSelect;
+export type NewDocument = typeof documents.$inferInsert;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -10,3 +10,4 @@ export * from './knowledge-schema';
 export * from './org-schema';
 export * from './cohort-schema';
 export * from './cbo-db-schema';
+export * from './document-schema';


### PR DESCRIPTION
The per-org **evidence locker** from `docs/cbo-platform-architecture.md` (Layer 3) — the thing that lets a later session reference what an org shared earlier. Postgres-full-text flavor, per the decision (durable blob originals = a later Phase 2b).

## The gap it closes
Today an upload's content survives only **truncated (8K) inside the chat log**, plus a 280-char summary on `cbo_states.uploadedFiles`, with the original on **ephemeral disk**. So there's nothing durable to reference in Encontro 4 from what was dropped in Encontro 1. Now every upload becomes a durable, **org-scoped** document holding the **FULL extracted text** (the #223 extractor already produces it for docs / image vision / audio transcription).

## Changes
- **`shared/document-schema.ts`** — `documents` table: `org_id` (scope), `cbo_state_id` (provenance), `kind`, `full_text`, `summary`, `dropped_in_phase`, `source`; `storage_key` reserved for Phase 2b blobs. Indexed by `org_id`.
- **`documentPersistence.ts`** — `createDocument`, `listDocumentsByOrg`, `getDocumentForOrg` (**org-scoped read — one org can't read another's files**), `getOrgIdForCboState`.
- **Upload route** writes a document row (full text) alongside the existing `uploadedFiles` manifest. Best-effort — a doc-store failure never fails the upload.
- **Two agent tools** — `list_org_documents` + `read_org_document`, scoped to the session's org, so the agent can pull the budget from a prior session on demand.
- **System prompt injection** — a "DOCUMENTS ON FILE" list every turn, so the agent proactively knows what's been shared instead of re-asking.
- **Snapshot endpoint** now links `cbo_state.org_id` from the member's org when the browser first reports its `cboStateId` (Phase-1 backfill only covered existing rows; this makes the KB work for *new* members).

## Migration (Replit)
```
npm run db:push          # creates the documents table
```
No backfill needed — new uploads populate; old `uploadedFiles` rows stay as-is (they predate full-text capture).

## Safety
- `org_id`-scoped reads enforce isolation at the document layer already.
- `npx tsc --noEmit`: 0 new errors (baseline 12).

## Next
Phase 2b (durable blob originals in Replit Object Storage) · Phase 3 (capability tokens + the `requireOrgCapability` gate + coordinator magic-link accounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)