### PR TITLE
feat(platform): capability tokens for CBO access — Phase 3a (auth)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -253,11 +253,23 @@ export default function CboProfilePage() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const slug = params.get('cbo');
-    if (!slug) return;
-    setMemberSlug(slug);
+    // Preferred: unguessable capability token (?t=). Legacy: org-name slug
+    // (?cbo=) for already-issued links. The token path resolves once via
+    // /by-token; both then drive the same slug-based snapshot/support calls
+    // (the resolved payload carries memberSlug), so the rest of the flow is
+    // unchanged during the Phase-3a transition.
+    const token = params.get('t');
+    const slugParam = params.get('cbo');
+    if (!token && !slugParam) return;
+    const memberUrl = token
+      ? `/api/cbo-member/by-token/${token}`
+      : `/api/cbo-member/${slugParam}`;
+    if (slugParam) setMemberSlug(slugParam);
+
     const applyMember = (data: any) => {
       if (!data) return;
+      // Token path: adopt the resolved slug so subsequent calls work.
+      if (data.memberSlug) setMemberSlug(data.memberSlug);
       if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
       if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
@@ -270,9 +282,9 @@ export default function CboProfilePage() {
       setFocusWorkshop(data.focusWorkshop ?? null);
       setFocusWorkshopIsCurrent(!!data.focusWorkshopIsCurrent);
     };
-    const refetch = () => fetch(`/api/cbo-member/${slug}`).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
+    const refetch = () => fetch(memberUrl).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
 
-    fetch(`/api/cbo-member/${slug}`)
+    fetch(memberUrl)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         applyMember(data);

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -89,6 +89,16 @@ const TOTAL_SECTIONS = 7;
 const TOTAL_FLAGS = 6;
 const TOTAL_MATURITY = 27;
 
+// Build a member's invite/profile URL, preferring the unguessable capability
+// token over the legacy org-name slug (Phase 3a). Falls back to the slug for
+// any member that predates the token backfill.
+function memberInviteUrl(m: { capabilityToken?: string | null; memberSlug?: string | null }): string {
+  const base = window.location.origin;
+  return m.capabilityToken
+    ? `${base}/cbo-profile?t=${m.capabilityToken}`
+    : `${base}/cbo-profile?cbo=${m.memberSlug}`;
+}
+
 // Adapter: convert a CohortMember (server or sample) into the view-model the
 // existing card + map render from. Keeps the rendering code path single while
 // data source changes.
@@ -682,9 +692,9 @@ export default function OrchestratorLandingPage() {
 
   const openProject = (p: CboDemoProject) => {
     const member = memberById.get(p.id);
-    if (member?.memberSlug) {
+    if (member?.capabilityToken || member?.memberSlug) {
       openShare(
-        `${window.location.origin}/cbo-profile?cbo=${member.memberSlug}`,
+        memberInviteUrl(member),
         { kind: 'cbo', orgName: member.orgName }
       );
     }
@@ -745,12 +755,12 @@ export default function OrchestratorLandingPage() {
       toast({ title: t('orchestrator.cohort.inviteFailed', { defaultValue: 'Could not create invitation' }) });
       return null;
     }
-    return { memberSlug: created.memberSlug, orgName: created.orgName };
+    return { memberSlug: created.memberSlug, capabilityToken: created.capabilityToken, orgName: created.orgName };
   };
 
-  const handleSingleInviteSuccess = (result: { memberSlug: string; orgName: string }) => {
+  const handleSingleInviteSuccess = (result: { memberSlug: string; capabilityToken?: string | null; orgName: string }) => {
     openShare(
-      `${window.location.origin}/cbo-profile?cbo=${result.memberSlug}`,
+      memberInviteUrl(result),
       { kind: 'cbo', orgName: result.orgName },
     );
   };

--- a/scripts/backfill-capability-tokens.ts
+++ b/scripts/backfill-capability-tokens.ts
@@ -1,0 +1,28 @@
+// One-time, idempotent backfill: give every existing cohort_member an
+// unguessable capability token (the new invite-link credential). Run AFTER
+// `npm run db:push` has added the capability_token column:
+//
+//   npx tsx scripts/backfill-capability-tokens.ts
+//
+// Safe to re-run — only touches rows whose capability_token is still NULL.
+// After running, RE-ISSUE invite links to existing members (orchestrator UI
+// builds /cbo-profile?t=<token>) before retiring slug access in Phase 3b.
+
+import { isNull, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { db } from '../server/db';
+import { cohortMembers } from '@shared/cohort-schema';
+
+async function main() {
+  const members = await db.select().from(cohortMembers).where(isNull(cohortMembers.capabilityToken));
+  let filled = 0;
+  for (const m of members) {
+    await db.update(cohortMembers).set({ capabilityToken: nanoid(24) }).where(eq(cohortMembers.id, m.id));
+    filled++;
+  }
+  console.log(`[backfill] capability tokens set for ${filled} member(s).`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => { console.error('[backfill] failed:', e); process.exit(1); });

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -85,6 +85,54 @@ async function findMemberBySlug(memberSlug: string) {
   return m;
 }
 
+async function findMemberByToken(token: string) {
+  if (!token) return undefined;
+  const [m] = await db.select().from(cohortMembers).where(eq(cohortMembers.capabilityToken, token)).limit(1);
+  return m;
+}
+
+// Shared member-facing payload builder — used by both the legacy by-slug read
+// and the new by-token read so they can't drift. Includes memberSlug + (for the
+// token path) the token, so the client can keep making slug-based snapshot /
+// support calls after resolving via an unguessable token URL.
+async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
+  const [cohort] = await db.select().from(cohorts).where(eq(cohorts.id, member.cohortId)).limit(1);
+  const workshops = (cohort?.settings as CohortSettings | null)?.workshops ?? [];
+
+  const unlocked = (member.unlockedPhases as number[] | null) ?? [1];
+  const maxUnlocked = Math.max(0, ...unlocked);
+  const nextPhase = maxUnlocked + 1;
+  const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
+
+  const memberPhase = typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0
+    ? member.snapshotPhase
+    : 1;
+  const focusWorkshop = workshops.find(w => w.unlocksPhase === memberPhase) ?? workshops[0] ?? null;
+  const focusWorkshopIsCurrent =
+    !!focusWorkshop?.openedAt && typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0;
+
+  const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
+  const supportPending = supportRequests.filter(r => !r.resolvedAt);
+
+  return {
+    id: member.id,
+    memberSlug: member.memberSlug,
+    orgName: member.orgName,
+    neighborhood: member.neighborhood,
+    path: member.path ?? null,
+    unlockedPhases: unlocked,
+    cboStateId: member.cboStateId,
+    cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
+    workshops,
+    nextWorkshop,
+    focusWorkshop,
+    focusWorkshopIsCurrent,
+    supportRequests,
+    supportPendingCount: supportPending.length,
+    inspirationPicks: Array.isArray(member.inspirationPicks) ? member.inspirationPicks : [],
+  };
+}
+
 export function registerCohortRoutes(app: Express): void {
   // ──────────────────────────────────────────────────────────────────────
   // Singleton cohort — for the Vila Flores pilot, the orchestrator opens
@@ -173,6 +221,9 @@ export function registerCohortRoutes(app: Express): void {
       cohortId: cohort.id,
       orgId,
       memberSlug,
+      // Unguessable invite-link credential (nanoid 24). The link shared via
+      // WhatsApp carries this, not the org-name-derived slug.
+      capabilityToken: slug(),
       orgName,
       neighborhood: neighborhood || null,
       role: role === 'alternate' ? 'alternate' : 'priority',
@@ -224,62 +275,23 @@ export function registerCohortRoutes(app: Express): void {
     res.json({ ok: true, updated: targets.length });
   }));
 
-  // Member-facing read (no auth beyond knowing the slug). Also returns the
-  // cohort's workshop cadence so the CBO welcome page can show *which*
-  // workshop will unlock their next phase, and when.
+  // Member-facing read by unguessable capability token (the new invite-link
+  // credential). Preferred over the legacy by-slug path. Returns memberSlug so
+  // the client can keep making slug-based snapshot/support calls during the
+  // backward-compatible transition (Phase 3a).
+  app.get('/api/cbo-member/by-token/:token', wrap(async (req, res) => {
+    const member = await findMemberByToken(req.params.token);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    res.json(await buildMemberPayload(member));
+  }));
+
+  // Member-facing read (legacy: no auth beyond knowing the slug). Kept for
+  // backward compat with already-issued links; retired in Phase 3b once links
+  // are re-issued as capability-token URLs.
   app.get('/api/cbo-member/:memberSlug', wrap(async (req, res) => {
     const member = await findMemberBySlug(req.params.memberSlug);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
-
-    const [cohort] = await db.select().from(cohorts).where(eq(cohorts.id, member.cohortId)).limit(1);
-    const workshops = (cohort?.settings as CohortSettings | null)?.workshops ?? [];
-
-    const unlocked = (member.unlockedPhases as number[] | null) ?? [1];
-    const maxUnlocked = Math.max(0, ...unlocked);
-    const nextPhase = maxUnlocked + 1;
-    const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
-
-    // The "focus workshop" is what the CBO welcome card should highlight —
-    // it must reflect THIS member's progress, not the cohort's global state.
-    // Workshops are cohort-wide (one `openedAt` per workshop shared by all
-    // members), so a late-joining member inherited the most-recently-opened
-    // workshop as their "current" — pushing Test Farm to W2 before they'd
-    // done W1. Fix: pick the earliest workshop the member hasn't completed
-    // (= the workshop whose `unlocksPhase` equals their current snapshot
-    // phase). Fall back to the first workshop in the sequence for brand-new
-    // members with no snapshot yet.
-    const memberPhase = typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0
-      ? member.snapshotPhase
-      : 1; // brand-new member → start at W1 (unlocks phase 1)
-    const focusWorkshop =
-      workshops.find(w => w.unlocksPhase === memberPhase) ??
-      workshops[0] ??
-      null;
-    // "Current" if the member has actually started (any opened workshop AND
-    // the member has at least passed the welcome screen, i.e. snapshotPhase
-    // moved past null). For brand-new invitees, the workshop is "upcoming."
-    const focusWorkshopIsCurrent =
-      !!focusWorkshop?.openedAt && typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0;
-
-    const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
-    const supportPending = supportRequests.filter(r => !r.resolvedAt);
-
-    res.json({
-      id: member.id,
-      orgName: member.orgName,
-      neighborhood: member.neighborhood,
-      path: member.path ?? null,
-      unlockedPhases: unlocked,
-      cboStateId: member.cboStateId,
-      cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
-      workshops,
-      nextWorkshop,
-      focusWorkshop,
-      focusWorkshopIsCurrent,
-      supportRequests,
-      supportPendingCount: supportPending.length,
-      inspirationPicks: Array.isArray(member.inspirationPicks) ? member.inspirationPicks : [],
-    });
+    res.json(await buildMemberPayload(member));
   }));
 
   // CBO submits a support request. Returns the created entry (with id).

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -60,6 +60,12 @@ export const cohortMembers = pgTable('cohort_members', {
   // Phase-1 migration; set at invite time for new members, backfilled for old.
   orgId: varchar('org_id'),
   memberSlug: text('member_slug').notNull().unique(),
+  // Opaque, unguessable capability token (the invite link credential — see
+  // docs/cbo-platform-architecture.md Phase 3). Replaces the org-name-derived,
+  // guessable memberSlug as the shared-URL secret. Nullable during the Phase-3a
+  // migration (backfilled), then becomes the only resolution path once slug
+  // access is retired (Phase 3b).
+  capabilityToken: text('capability_token').unique(),
   // CBO state ID — links to the file-backed CBO profile (`knowledge/runs/cbo-<id>/`)
   cboStateId: text('cbo_state_id'),
   orgName: text('org_name').notNull(),


### PR DESCRIPTION
First slice of the hybrid auth (`docs/cbo-platform-architecture.md`, Phase 3). Today a CBO is reached by a URL **slug derived from the org name** (guessable: `horta-da-cascata`), and that slug is the *only* credential. This introduces an **unguessable capability token** as the invite-link credential — **backward-compatible**, so the live pilot's existing slug links keep working during the transition.

## Changes
- **`cohort_members.capability_token`** (unique, nanoid 24) — the shared-URL secret. Generated at invite; backfilled for existing members.
- **`GET /api/cbo-member/by-token/:token`** resolves token → member (returns `memberSlug` so the client keeps using slug-based snapshot/support calls during the transition). Shares one `buildMemberPayload()` with the legacy by-slug read so they can't drift.
- **Client** reads `?t=<token>` (preferred) or `?cbo=<slug>` (legacy) — same downstream flow.
- **Orchestrator** share links now build `?t=<token>` (`memberInviteUrl` helper), falling back to the slug for un-backfilled members.

## Migration (Replit, in order)
```
npm run db:push                                  # adds capability_token column
npx tsx scripts/backfill-capability-tokens.ts    # tokens for existing members
```
Then **re-issue links** to members (the orchestrator now builds `?t=` URLs) before Phase 3b retires slug access.

## Scope — what this does and doesn't close
3a is the **foundation**: new/re-issued invite links are unguessable. The hole isn't *fully* closed until:
- **3b** — retire slug resolution (`/api/cbo-member/:slug`) once links are re-issued, so a guessed slug stops working.
- **3c** — gate the orchestrator/roster (`/api/cohort/default`) behind **coordinator accounts** — it's unauthenticated today and exposes member data (and would expose tokens). This needs an email provider for magic-link, which is an open decision.

`npx tsc --noEmit`: 0 new errors (baseline 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)