### PR TITLE
feat(platform): coordinator accounts — Phase 3c-i (auth machinery)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import Login from '@/core/pages/login';
 import RoleSelectionPage from '@/core/pages/role-selection';
 import OrchestratorLandingPage from '@/core/pages/orchestrator-landing';
+import CoordinatorLoginPage from '@/core/pages/coordinator-login';
 import CitySelection from '@/core/pages/city-selection';
 import ProjectPage from '@/core/pages/project';
 import SiteExplorerPage from '@/core/pages/site-explorer';
@@ -35,6 +36,7 @@ function Router() {
     <Switch>
       <Route path='/' component={RoleSelectionPage} />
       <Route path='/login' component={Login} />
+      <Route path='/coordinator-login' component={CoordinatorLoginPage} />
       <Route path='/orchestrator' component={OrchestratorLandingPage} />
       <Route path='/auth/callback' component={OAuthCallback} />
       <Route path='/cities' component={CitySelection} />

--- a/client/src/core/pages/coordinator-login.tsx
+++ b/client/src/core/pages/coordinator-login.tsx
@@ -1,0 +1,66 @@
+// Coordinator login — admin-provisioned email + password (Phase 3c). The
+// orchestrator dashboard will require this once the gate is flipped on (3c-ii);
+// for now it's a working login that sets the coordinator session cookie.
+
+import { useState } from 'react';
+import { useLocation } from 'wouter';
+import { Card, CardContent } from '@/core/components/ui/card';
+import { Button } from '@/core/components/ui/button';
+import { Input } from '@/core/components/ui/input';
+
+export default function CoordinatorLoginPage() {
+  const [, navigate] = useLocation();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/coordinator/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        navigate('/orchestrator');
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      setError(data?.error === 'invalid email or password' ? 'Incorrect email or password.' : 'Could not sign in. Try again.');
+    } catch {
+      setError('Could not reach the server. Try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/30 p-4">
+      <Card className="w-full max-w-sm">
+        <CardContent className="pt-6">
+          <h1 className="text-lg font-semibold mb-1">Coordinator sign in</h1>
+          <p className="text-sm text-muted-foreground mb-5">Use the email and password the OEF team gave you.</p>
+          <form onSubmit={submit} className="space-y-3">
+            <Input
+              type="email" placeholder="Email" autoComplete="username" required
+              value={email} onChange={e => setEmail(e.target.value)} disabled={busy}
+            />
+            <Input
+              type="password" placeholder="Password" autoComplete="current-password" required
+              value={password} onChange={e => setPassword(e.target.value)} disabled={busy}
+            />
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <Button type="submit" className="w-full bg-emerald-600 hover:bg-emerald-700" disabled={busy}>
+              {busy ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/scripts/create-coordinator.ts
+++ b/scripts/create-coordinator.ts
@@ -1,0 +1,24 @@
+// Provision a coordinator account (admin-run; we hand the password to the
+// coordinator out-of-band). Run AFTER `npm run db:push` creates the
+// coordinators table:
+//
+//   npx tsx scripts/create-coordinator.ts <email> <password> ["Full Name"] [cohortId]
+//
+// Example:
+//   npx tsx scripts/create-coordinator.ts julia@vilaflores.org 'S0meStrongPass' 'Julia Caon'
+
+import { createCoordinator } from '../server/services/coordinatorAuth';
+
+async function main() {
+  const [email, password, name, cohortId] = process.argv.slice(2);
+  if (!email || !password) {
+    console.error('Usage: npx tsx scripts/create-coordinator.ts <email> <password> ["Name"] [cohortId]');
+    process.exit(1);
+  }
+  const c = await createCoordinator({ email, password, name: name || undefined, cohortId: cohortId || null });
+  console.log(`[create-coordinator] created ${c.email} (id ${c.id})${c.cohortId ? `, cohort ${c.cohortId}` : ', all cohorts'}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => { console.error('[create-coordinator] failed:', e?.message || e); process.exit(1); });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -64,6 +64,7 @@ import { registerAgentRoutes } from './routes/agentRoutes';
 import { registerConceptNoteRoutes } from './routes/conceptNoteRoutes';
 import { registerCboRoutes } from './routes/cboRoutes';
 import { registerCohortRoutes } from './routes/cohortRoutes';
+import { registerCoordinatorRoutes } from './routes/coordinatorRoutes';
 import { registerUploadRoutes } from './routes/uploadRoutes';
 import { registerTileProxyRoutes } from './routes/tileProxyRoutes';
 import { registerKnowledgeRoutes } from './routes/knowledgeRoutes';
@@ -1995,6 +1996,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerConceptNoteRoutes(app);
   registerCboRoutes(app);
   registerCohortRoutes(app);
+  registerCoordinatorRoutes(app);
   registerUploadRoutes(app);
   registerTileProxyRoutes(app);
   registerOverpassRoutes(app);

--- a/server/routes/coordinatorRoutes.ts
+++ b/server/routes/coordinatorRoutes.ts
@@ -1,0 +1,52 @@
+// Coordinator auth routes — login / logout / me. Phase 3c-i: the auth flow is
+// fully functional but not yet REQUIRED by the orchestrator/cohort routes
+// (that gate flips on in 3c-ii after an account is provisioned).
+
+import type { Express, Request, Response } from 'express';
+import { login, logout, getCoordinatorBySession, publicCoordinator, COORD_COOKIE } from '../services/coordinatorAuth';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function registerCoordinatorRoutes(app: Express): void {
+  app.post('/api/coordinator/login', async (req: Request, res: Response) => {
+    try {
+      const { email, password } = req.body ?? {};
+      if (!email || !password) { res.status(400).json({ error: 'email and password required' }); return; }
+      const result = await login(String(email), String(password));
+      if (!result) { res.status(401).json({ error: 'invalid email or password' }); return; }
+      res.cookie(COORD_COOKIE, result.token, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: THIRTY_DAYS_MS,
+        path: '/',
+      });
+      res.json({ coordinator: publicCoordinator(result.coordinator) });
+    } catch (e: any) {
+      console.error('[coordinator] login error', e);
+      res.status(500).json({ error: 'internal error' });
+    }
+  });
+
+  app.post('/api/coordinator/logout', async (req: Request, res: Response) => {
+    try {
+      await logout((req as any).cookies?.[COORD_COOKIE]);
+      res.clearCookie(COORD_COOKIE, { path: '/' });
+      res.json({ ok: true });
+    } catch (e: any) {
+      console.error('[coordinator] logout error', e);
+      res.status(500).json({ error: 'internal error' });
+    }
+  });
+
+  app.get('/api/coordinator/me', async (req: Request, res: Response) => {
+    try {
+      const coordinator = await getCoordinatorBySession((req as any).cookies?.[COORD_COOKIE]);
+      if (!coordinator) { res.status(401).json({ error: 'not authenticated' }); return; }
+      res.json({ coordinator: publicCoordinator(coordinator) });
+    } catch (e: any) {
+      console.error('[coordinator] me error', e);
+      res.status(500).json({ error: 'internal error' });
+    }
+  });
+}

--- a/server/services/coordinatorAuth.ts
+++ b/server/services/coordinatorAuth.ts
@@ -1,0 +1,88 @@
+// Coordinator auth — admin-provisioned email+password + opaque session cookie.
+// scrypt for hashing (Node built-in, no native dep). See Phase 3c in
+// docs/cbo-platform-architecture.md.
+
+import crypto from 'crypto';
+import { promisify } from 'util';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { eq, and, gt } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { db } from '../db';
+import { coordinators, coordinatorSessions, type Coordinator } from '@shared/coordinator-schema';
+
+const scryptAsync = promisify(crypto.scrypt) as (pw: string, salt: string, keylen: number) => Promise<Buffer>;
+const KEYLEN = 64;
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const COORD_COOKIE = 'coord_session';
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const hash = (await scryptAsync(password, salt, KEYLEN)).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+export async function verifyPassword(password: string, stored: string): Promise<boolean> {
+  const [salt, hash] = (stored || '').split(':');
+  if (!salt || !hash) return false;
+  const hashBuf = Buffer.from(hash, 'hex');
+  const testBuf = await scryptAsync(password, salt, KEYLEN);
+  return hashBuf.length === testBuf.length && crypto.timingSafeEqual(hashBuf, testBuf);
+}
+
+export async function createCoordinator(input: {
+  email: string; password: string; name?: string; cohortId?: string | null;
+}): Promise<Coordinator> {
+  const passwordHash = await hashPassword(input.password);
+  const [c] = await db.insert(coordinators).values({
+    email: input.email.trim().toLowerCase(),
+    passwordHash,
+    name: input.name ?? null,
+    cohortId: input.cohortId ?? null,
+  }).returning();
+  return c;
+}
+
+/** Verify credentials and mint a session. Returns null on bad email/password. */
+export async function login(email: string, password: string): Promise<{ token: string; coordinator: Coordinator } | null> {
+  const [c] = await db.select().from(coordinators).where(eq(coordinators.email, email.trim().toLowerCase())).limit(1);
+  if (!c) return null;
+  if (!(await verifyPassword(password, c.passwordHash))) return null;
+  const token = nanoid(40);
+  await db.insert(coordinatorSessions).values({ token, coordinatorId: c.id, expiresAt: new Date(Date.now() + SESSION_TTL_MS) });
+  return { token, coordinator: c };
+}
+
+export async function getCoordinatorBySession(token: string | undefined): Promise<Coordinator | null> {
+  if (!token) return null;
+  const [s] = await db.select().from(coordinatorSessions)
+    .where(and(eq(coordinatorSessions.token, token), gt(coordinatorSessions.expiresAt, new Date())))
+    .limit(1);
+  if (!s) return null;
+  const [c] = await db.select().from(coordinators).where(eq(coordinators.id, s.coordinatorId)).limit(1);
+  return c ?? null;
+}
+
+export async function logout(token: string | undefined): Promise<void> {
+  if (token) await db.delete(coordinatorSessions).where(eq(coordinatorSessions.token, token));
+}
+
+/** Public coordinator shape (never expose the password hash). */
+export function publicCoordinator(c: Coordinator) {
+  return { id: c.id, email: c.email, name: c.name, cohortId: c.cohortId };
+}
+
+// Auth middleware — NOT applied to any route yet (Phase 3c-i ships the machinery;
+// Phase 3c-ii flips this on over the orchestrator/cohort routes once a
+// coordinator account is provisioned, so the live dashboard isn't locked out).
+export interface CoordinatorRequest extends Request {
+  coordinator?: Coordinator;
+}
+export function requireCoordinator(): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const token = (req as any).cookies?.[COORD_COOKIE];
+    const coordinator = await getCoordinatorBySession(token);
+    if (!coordinator) { res.status(401).json({ error: 'coordinator auth required' }); return; }
+    (req as CoordinatorRequest).coordinator = coordinator;
+    next();
+  };
+}

--- a/shared/coordinator-schema.ts
+++ b/shared/coordinator-schema.ts
@@ -1,0 +1,32 @@
+// Coordinator accounts — admin-provisioned email + password (see
+// docs/cbo-platform-architecture.md Phase 3c). Coordinators are the people who
+// manage cohorts (OEF / Pyxera / Vila Flores staff): a small, known set, so we
+// create the accounts and hand out the password — no self-signup, no email
+// sending. Distinct principal from the CityCatalyst OAuth `users` table.
+
+import { sql } from 'drizzle-orm';
+import { pgTable, text, varchar, timestamp } from 'drizzle-orm/pg-core';
+
+export const coordinators = pgTable('coordinators', {
+  id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
+  email: text('email').notNull().unique(),
+  // scrypt, stored as `salt:hash` hex. Never a plaintext password.
+  passwordHash: text('password_hash').notNull(),
+  name: text('name'),
+  // Which cohort this coordinator manages. Null = all cohorts (e.g. an OEF
+  // admin). For the single-cohort pilot this is the Vila Flores cohort id.
+  cohortId: varchar('cohort_id'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+// Opaque session tokens (httpOnly cookie). Separate from the OAuth `sessions`
+// table so the two principal types don't entangle.
+export const coordinatorSessions = pgTable('coordinator_sessions', {
+  token: varchar('token').primaryKey(),
+  coordinatorId: varchar('coordinator_id').notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export type Coordinator = typeof coordinators.$inferSelect;
+export type CoordinatorSession = typeof coordinatorSessions.$inferSelect;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -8,5 +8,6 @@ export * from './sample-constants';
 export * from './models/chat';
 export * from './knowledge-schema';
 export * from './org-schema';
+export * from './coordinator-schema';
 export * from './cohort-schema';
 export * from './cbo-db-schema';


### PR DESCRIPTION
Admin-provisioned **email + password** login for coordinators (the people who manage cohorts — OEF / Pyxera / Vila Flores staff). A small, known set, so we create accounts and hand out the password — no self-signup, no email-sending infra. Phase 3c from `docs/cbo-platform-architecture.md`, split into two so the **live orchestrator isn't locked out**: this PR ships the working auth flow; **the gate over the orchestrator/cohort routes flips on in 3c-ii** once an account is provisioned.

## Changes
- **`shared/coordinator-schema.ts`** — `coordinators` (email unique, scrypt `password_hash`, name, cohortId) + `coordinator_sessions` (opaque token, expiry). Distinct from the CityCatalyst OAuth `users`/`sessions`.
- **`coordinatorAuth.ts`** — scrypt hash/verify (Node built-in, **no native dep**), `createCoordinator`, `login` (mint session), `getCoordinatorBySession`, `logout`, and a `requireCoordinator()` middleware — **exported but not yet applied to any route**.
- **`coordinatorRoutes.ts`** — `POST /api/coordinator/login` (sets an httpOnly cookie), `POST /logout`, `GET /me`. Registered.
- **`scripts/create-coordinator.ts`** — provisioning: `npx tsx scripts/create-coordinator.ts <email> <password> "Name"`.
- **Client** — a `/coordinator-login` page (sets the session cookie, redirects to `/orchestrator`).

## Safety
- **Nothing is gated yet** — the live orchestrator keeps working exactly as before. This is purely additive auth machinery, testable end-to-end (provision → login → `/me`).
- scrypt + `timingSafeEqual`; password hash never leaves the server (`publicCoordinator` strips it).
- `npx tsc --noEmit`: 0 new errors (baseline 12).

## Migration (Replit)
```
npm run db:push                                                  # coordinators + sessions tables
npx tsx scripts/create-coordinator.ts you@oef.org 'pass' 'Name'  # provision an account
```

## Next — 3c-ii (separate PR)
Apply `requireCoordinator()` to `/api/cohort/*` and the orchestrator routes, and guard the orchestrator page client-side (redirect to `/coordinator-login` on 401). Done after you've provisioned an account and confirmed login works, so the gate can't lock you out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)