### PR TITLE
feat(platform): Phase 3 auth — coordinator login+gate, multi-cohort, token-only CBO access, logout

### DIFF
--- a/client/src/core/pages/coordinator-login.tsx
+++ b/client/src/core/pages/coordinator-login.tsx
@@ -1,9 +1,11 @@
-// Coordinator login — admin-provisioned email + password (Phase 3c). The
-// orchestrator dashboard will require this once the gate is flipped on (3c-ii);
-// for now it's a working login that sets the coordinator session cookie.
+// Coordinator login — admin-provisioned email + password (Phase 3c). Gates the
+// orchestrator dashboard. Premium-but-simple: animated card entrance, an inline
+// error alert with a subtle shake on failure, and a clear loading state.
 
 import { useState } from 'react';
 import { useLocation } from 'wouter';
+import { motion, AnimatePresence, useAnimationControls } from 'framer-motion';
+import { AlertCircle, Loader2, Network } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
 import { Input } from '@/core/components/ui/input';
@@ -14,6 +16,13 @@ export default function CoordinatorLoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const controls = useAnimationControls();
+
+  const fail = (msg: string) => {
+    setError(msg);
+    // A short, restrained shake — signals "try again" without being cartoonish.
+    controls.start({ x: [0, -8, 8, -6, 6, -3, 3, 0], transition: { duration: 0.4, ease: 'easeOut' } });
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,41 +35,91 @@ export default function CoordinatorLoginPage() {
         credentials: 'include',
         body: JSON.stringify({ email, password }),
       });
-      if (res.ok) {
-        navigate('/orchestrator');
-        return;
-      }
+      if (res.ok) { navigate('/orchestrator'); return; }
       const data = await res.json().catch(() => ({}));
-      setError(data?.error === 'invalid email or password' ? 'Incorrect email or password.' : 'Could not sign in. Try again.');
+      fail(data?.error === 'invalid email or password'
+        ? 'That email and password don’t match. Check them and try again.'
+        : 'Something went wrong signing in. Please try again.');
     } catch {
-      setError('Could not reach the server. Try again.');
+      fail('Couldn’t reach the server. Check your connection and try again.');
     } finally {
       setBusy(false);
     }
   };
 
+  // Clear the error the moment the user starts correcting their input.
+  const onEdit = (setter: (v: string) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (error) setError(null);
+    setter(e.target.value);
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-muted/30 p-4">
-      <Card className="w-full max-w-sm">
-        <CardContent className="pt-6">
-          <h1 className="text-lg font-semibold mb-1">Coordinator sign in</h1>
-          <p className="text-sm text-muted-foreground mb-5">Use the email and password the OEF team gave you.</p>
-          <form onSubmit={submit} className="space-y-3">
-            <Input
-              type="email" placeholder="Email" autoComplete="username" required
-              value={email} onChange={e => setEmail(e.target.value)} disabled={busy}
-            />
-            <Input
-              type="password" placeholder="Password" autoComplete="current-password" required
-              value={password} onChange={e => setPassword(e.target.value)} disabled={busy}
-            />
-            {error && <p className="text-sm text-red-600">{error}</p>}
-            <Button type="submit" className="w-full bg-emerald-600 hover:bg-emerald-700" disabled={busy}>
-              {busy ? 'Signing in…' : 'Sign in'}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-emerald-50/60 to-muted/40 dark:from-emerald-950/20 dark:to-background p-4">
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+      >
+        {/* Inner wrapper carries the shake so it composes with the entrance. */}
+        <motion.div animate={controls}>
+          <Card className="w-full max-w-sm shadow-xl border-border/60">
+            <CardContent className="pt-7 pb-6 px-6">
+              <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-emerald-100 dark:bg-emerald-900/40 mb-4">
+                <Network className="w-5 h-5 text-emerald-700 dark:text-emerald-300" />
+              </div>
+              <h1 className="text-xl font-semibold tracking-tight">Coordinator sign in</h1>
+              <p className="text-sm text-muted-foreground mt-1 mb-5">
+                Use the email and password the OEF team gave you.
+              </p>
+
+              <form onSubmit={submit} className="space-y-3" noValidate>
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground" htmlFor="coord-email">Email</label>
+                  <Input
+                    id="coord-email" type="email" autoComplete="username" required
+                    placeholder="you@organization.org"
+                    value={email} onChange={onEdit(setEmail)} disabled={busy}
+                    aria-invalid={!!error}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground" htmlFor="coord-password">Password</label>
+                  <Input
+                    id="coord-password" type="password" autoComplete="current-password" required
+                    placeholder="••••••••"
+                    value={password} onChange={onEdit(setPassword)} disabled={busy}
+                    aria-invalid={!!error}
+                  />
+                </div>
+
+                <AnimatePresence>
+                  {error && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0, marginTop: 0 }}
+                      animate={{ opacity: 1, height: 'auto', marginTop: 4 }}
+                      exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 dark:border-red-900/50 dark:bg-red-950/30 px-3 py-2 overflow-hidden"
+                      role="alert"
+                    >
+                      <AlertCircle className="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+                      <span className="text-sm text-red-700 dark:text-red-300 leading-snug">{error}</span>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                <Button
+                  type="submit"
+                  className="w-full bg-emerald-600 hover:bg-emerald-700 mt-1"
+                  disabled={busy || !email || !password}
+                >
+                  {busy ? (<><Loader2 className="w-4 h-4 mr-2 animate-spin" />Signing in…</>) : 'Sign in'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </motion.div>
     </div>
   );
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -28,6 +28,7 @@ import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
 import { useCohort } from '@/core/hooks/useCohort';
+import { useLocation } from 'wouter';
 import type { CohortMember, WorkshopConfig } from '@shared/cohort-schema';
 import {
   InviteCboDialog,
@@ -621,6 +622,18 @@ export default function OrchestratorLandingPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [riskLayers, setRiskLayers] = useState<RiskLayers>({ hotspots: false, recruitZones: false });
 
+  // Phase 3c-ii — require a coordinator session. On 401, bounce to login.
+  // `authed`: null = checking, false = redirecting, true = render the dashboard.
+  const [, navigate] = useLocation();
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/coordinator/me', { credentials: 'include' })
+      .then(r => { if (!cancelled) { if (r.ok) setAuthed(true); else { setAuthed(false); navigate('/coordinator-login'); } } })
+      .catch(() => { if (!cancelled) { setAuthed(false); navigate('/coordinator-login'); } });
+    return () => { cancelled = true; };
+  }, [navigate]);
+
   const handleBairroClick = (info: { name: string; primaryHazard: string; population: number; priorityScore: number }) => {
     // For this PR: surface a toast describing the bairro. The follow-up PR
     // (once #132's invite dialog is on main) wires this into a pre-filled
@@ -766,6 +779,16 @@ export default function OrchestratorLandingPage() {
   };
 
   const workshops: WorkshopConfig[] = cohort?.settings?.workshops ?? [];
+
+  // Hold the dashboard until the coordinator session is confirmed — avoids a
+  // flash of (now-empty, 401'd) cohort data before the redirect to login.
+  if (authed !== true) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-slate-50 to-white dark:from-slate-950 dark:to-background">
+        <Compass className="w-5 h-5 text-muted-foreground animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen relative bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -13,6 +13,7 @@ import {
   type WorkshopConfig,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { requireCoordinator } from '../services/coordinatorAuth';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -134,6 +135,13 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
 }
 
 export function registerCohortRoutes(app: Express): void {
+  // Phase 3c-ii — gate the entire coordinator surface behind a coordinator
+  // session. Every /api/cohort/* route is coordinator-facing (the CBO-facing
+  // routes live under /api/cbo-member and /api/cbo, which are NOT matched here),
+  // so one prefix mount closes the open roster + invite/unlock controls in a
+  // single place. Requires a provisioned coordinator (scripts/create-coordinator).
+  app.use('/api/cohort', requireCoordinator());
+
   // ──────────────────────────────────────────────────────────────────────
   // Singleton cohort — for the Vila Flores pilot, the orchestrator opens
   // straight to the one-and-only cohort. No coord slug to remember.


### PR DESCRIPTION
The complete Phase-3 auth surface, in one PR (all pieces share the same files — `cohortRoutes`, `cbo-profile`, `orchestrator-landing`, `CohortDialogs` — and are interdependent, so splitting would only create conflicts).

## Coordinators — login required
- `coordinator-login` page (premium: animated entrance, inline error alert + shake, spinner).
- `app.use('/api/cohort', requireCoordinator())` gates the whole coordinator surface; the orchestrator page redirects to login on 401.
- **Logout** button in the orchestrator header → `POST /api/coordinator/logout` (deletes the session) → back to login.

## Per-account multi-cohort
- `app.param('coordinatorSlug')` ownership guard on every `:slug` route (404 missing / 403 not-yours; admins pass) — no route can forget it.
- `GET /api/cohort/mine` resolves the cohort from the account (scoped → theirs; admin → default). `useCohort` loads `/mine` and targets the coordinator's own slug.
- Create-cohort is admin-only; `create-coordinator.ts` scopes by cohort slug.

## CBOs — token-only, NEVER a login
- The unguessable capability token (`?t=`) is the CBO's **sole** credential. The guessable org-name slug is fully retired (no real CBOs in use): removed the `?cbo=` entry + `GET /api/cbo-member/:slug`; snapshot/support/inspiration re-keyed to `/api/cbo-member/by-token/:token/*`.
- Every link builder that used `?cbo=` is fixed to `?t=` (SupportInbox deep-link, bulk + single invite shares) — token threaded through `BulkInviteResult` and the support-request items.

## Audit / known boundaries
- Cross-cohort access blocked (403 via param guard); CBO routes (`/api/cbo-member/*`) are correctly NOT coordinator-gated (token-addressed, no login).
- `/api/cbo/:id/*` chat/edit + `/api/documents/:id/original` remain open-by-UUID (unguessable) — capability-gating that surface is deliberately deferred (low practical risk; noted as the next hardening if the platform opens beyond the trusted pilot).
- Two unreachable `?cbo=` fallbacks remain in URL builders (all members have tokens). No admin cohort-switcher UI yet. `memberSlug` kept as an internal label.
- No schema change (all columns shipped earlier). `npx tsc --noEmit`: 0 new errors (baseline 12).

## ⚠️ Before publishing
Provision a coordinator or the orchestrator locks out:
```
npx tsx scripts/create-coordinator.ts you@oef.org 'password' 'Name' default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)