### PR TITLE
test(e2e): fake-model seam + gated /__test seeding API (PR 1/4)

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,129 @@
+# E2E testing harness — backend seam (PR 1)
+
+This is the foundation for driving the CBO workshop flow end-to-end in tests without
+manual setup or replaying full conversations. It ships two test-only seams, both
+**off by default** and safe to leave in the codebase:
+
+| Seam | Env flag | What it does |
+|---|---|---|
+| Gated test API (`/__test/*`) | `ENABLE_TEST_ROUTES=1` | Seed sessions, coordinators, cohorts, mid-conversation state; script the fake model; tear down. |
+| Fake CBO model | `CBO_FAKE_MODEL=1` | Replaces the live Claude Agent SDK in the CBO chat with a deterministic scripted driver. |
+
+> ⚠️ **Never set `ENABLE_TEST_ROUTES` or `CBO_FAKE_MODEL` on the production Deployment.**
+> When `ENABLE_TEST_ROUTES` is unset, the `/__test` routes are **not even registered**
+> (conditional registration in `server/routes.ts`) — they don't exist, they don't 403.
+> Set both flags (and a `TEST_API_SECRET`) only in the test/preview environment.
+
+## Why this shape
+
+The CBO chat is normally driven by the Claude Agent SDK — non-deterministic, slow, and
+billed. That can't gate every fix. So:
+
+- **Fake model** (`CBO_FAKE_MODEL=1`) makes a turn deterministic: it emits the *exact same*
+  SSE events the real path emits (`chat`, `field_update`, `ask_user`, `phase_change`,
+  `maturity_update`, `open_map`, `done`) from a script you provide. The real SDK path in
+  `cboAgent.ts` is byte-for-byte untouched — the fake is a separate, gated branch.
+- **State-seeding** (`/__test/cbo/:id/seed-state`) is the high-leverage primitive: jump a
+  session straight to any phase / tier / language / filled state and assert one transition,
+  instead of replaying 30 turns.
+
+Live-model behaviour (does the agent ask sensible questions?) is a *separate, non-gating*
+quality suite — out of scope for this PR.
+
+## Env flags
+
+```bash
+ENABLE_TEST_ROUTES=1     # mount /__test/*
+CBO_FAKE_MODEL=1         # deterministic chat turns
+TEST_API_SECRET=<secret> # optional; if set, every /__test call needs header x-test-secret
+NODE_ENV=development
+```
+
+## Test API
+
+All under `/__test`. If `TEST_API_SECRET` is set, send header `x-test-secret: <secret>`.
+
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| `GET`  | `/__test/ping` | — | `{ ok, fakeModel, secret }` — probe before seeding |
+| `POST` | `/__test/cbo/session` | `{ city? }` | `{ cboId, state }` |
+| `POST` | `/__test/cbo/:id/seed-state` | see below | `{ ok, state }` |
+| `POST` | `/__test/cbo/:id/script` | `{ turns: FakeTurn[] }` | `{ ok, queued, fakeModelEnabled }` |
+| `GET`  | `/__test/cbo/:id/script` | — | `{ remainingTurns }` |
+| `DELETE` | `/__test/cbo/:id/script` | — | `{ ok }` |
+| `POST` | `/__test/coordinator` | `{ email?, password?, name?, cohortId? }` | sets `coord_session` cookie; `{ coordinator, password, sessionToken }` |
+| `POST` | `/__test/cohort` | `{ name? }` | `{ cohort }` (slug namespaced `e2e-…`) |
+| `POST` | `/__test/cohort/:cohortId/member` | `{ orgName?, neighborhood?, role?, unlockedPhases?, withSession? }` | `{ member, inviteUrl }` |
+| `POST` | `/__test/cleanup` | — | `{ ok, deleted }` — purges only `e2e-*` cohorts/members and `*@e2e.test` coordinators |
+
+`cohortId` omitted on `/__test/coordinator` ⇒ an **admin** account (sees all cohorts).
+Pass a cohort id to scope it.
+
+### `seed-state` body (all fields optional)
+
+```json
+{
+  "phase": 3,
+  "language": "pt",
+  "orgName": "Horta Comunitária Cascata",
+  "sections": [
+    { "sectionId": "org_profile", "field": "org_name", "value": "Horta Cascata", "confidence": "high", "source": "user" }
+  ],
+  "maturity": [ { "metric": "org_delivery_capacity", "score": 2, "justification": "…" } ],
+  "priorityFlags": [ { "flag": "Land tenure secure or likely secure", "met": true } ]
+}
+```
+
+Valid section ids and maturity metrics are validated against `shared/cbo-schema.ts`
+(`isValidSectionId` / `isValidMaturityMetric`); unknown ones are silently skipped.
+
+## Fake-model script format
+
+A script is a **queue of turns**; each user message pops the next turn and runs its ops in
+order, then a `done` event is emitted. When the queue is empty, every turn falls back to a
+generic ack + two-option `ask_user` (PT/EN aware) so the chat stays driveable forever.
+
+```ts
+type FakeOp =
+  | { op: 'say'; text: string }
+  | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?; source? }
+  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean }[]; multiSelect?; showMap? }
+  | { op: 'score_maturity'; metric: string; score: number; justification? }
+  | { op: 'set_phase'; phase: number }
+  | { op: 'priority_flag'; flag: string; met: boolean; notes? }
+  | { op: 'open_map'; params? };
+type FakeTurn = FakeOp[];
+```
+
+Example — script one CBO turn, then drive it:
+
+```bash
+curl -s localhost:5000/__test/cbo/$ID/script -H 'content-type: application/json' -d '{
+  "turns": [[
+    { "op": "say", "text": "Qual é o nome da sua organização?" },
+    { "op": "ask_user", "question": "Tipo de organização?",
+      "options": [{ "label": "Associação comunitária" }, { "label": "Estúdio de paisagismo" }] }
+  ]]
+}'
+# Then the UI's next POST /api/cbo/$ID/chat plays that turn deterministically.
+```
+
+## Quick manual check (with a DB configured)
+
+```bash
+ENABLE_TEST_ROUTES=1 CBO_FAKE_MODEL=1 npm run dev
+curl -s localhost:5000/__test/ping
+ID=$(curl -s -XPOST localhost:5000/__test/cbo/session | jq -r .cboId)
+curl -s -XPOST localhost:5000/__test/cbo/$ID/seed-state -H 'content-type: application/json' \
+  -d '{"phase":1,"language":"pt","orgName":"Horta Cascata"}'
+```
+
+## Status / next
+
+- **PR 1 (this):** fake-model seam + gated `/__test` API + docs. No Playwright yet.
+- **PR 2:** `@playwright/test`, config (local `vite preview` + Replit preview URL projects),
+  a `data-testid="stream-complete"` SSE-close contract, and one golden-path spec.
+- **PR 3:** Phase-1 scenario coverage (two cohorts, PT/EN, uploads, coordinator login,
+  cross-cohort isolation).
+- **PR 4:** GitHub Actions gate + a separate non-gating live-model quality smoke. HTML
+  report + trace + video artifacts.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2001,6 +2001,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerTileProxyRoutes(app);
   registerOverpassRoutes(app);
 
+  // Test-only seeding API — CONDITIONALLY registered so the routes literally do
+  // not exist in production (the gate is registration, not a runtime check).
+  // Never set ENABLE_TEST_ROUTES on the production Deployment. See testRoutes.ts.
+  if (process.env.ENABLE_TEST_ROUTES === '1') {
+    const { registerTestRoutes } = await import('./routes/testRoutes');
+    registerTestRoutes(app);
+  }
+
   const httpServer = createServer(app);
   return httpServer;
 }

--- a/server/routes/testRoutes.ts
+++ b/server/routes/testRoutes.ts
@@ -1,0 +1,263 @@
+// ============================================================================
+// TEST-ONLY API — e2e seeding & state hooks
+// ============================================================================
+//
+// Mounted ONLY when ENABLE_TEST_ROUTES==='1' (see registerRoutes in routes.ts —
+// conditional *registration*, so in production these routes literally do not
+// exist, not merely "return 403"). Defence-in-depth: if TEST_API_SECRET is set,
+// every call must carry a matching `x-test-secret` header.
+//
+// Purpose: let Playwright seed the world without replaying full conversations —
+// create throwaway CBO sessions, coordinators, and cohorts; jump a session to
+// any phase / tier / language / fill state; script the fake model; tear down.
+//
+// NEVER set ENABLE_TEST_ROUTES or TEST_API_SECRET on the production Deployment.
+// All throwaway resources are namespaced ('e2e-*' slugs, '*@e2e.test' emails)
+// so /__test/cleanup can purge exactly this harness's data and nothing else.
+
+import type { Express, Request, Response, RequestHandler, NextFunction } from 'express';
+import { eq, like, inArray } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { db } from '../db';
+import {
+  createEmptyCboState,
+  isValidSectionId,
+  isValidMaturityMetric,
+  type CboState,
+  type Confidence,
+} from '@shared/cbo-schema';
+import {
+  getCboState,
+  setCboState,
+  flushNow,
+  loadCboFromDb,
+} from '../services/cboAgent';
+import { setFakeScript, clearFakeScript, peekFakeScript, type FakeTurn } from '../services/fakeCboModel';
+import { createCoordinator, login, COORD_COOKIE } from '../services/coordinatorAuth';
+import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { cohorts, cohortMembers, DEFAULT_WORKSHOPS } from '@shared/cohort-schema';
+import { coordinators, coordinatorSessions } from '@shared/coordinator-schema';
+
+// Namespacing prefixes — cleanup keys off these so we never touch real data.
+const E2E_COHORT_PREFIX = 'e2e-';
+const E2E_EMAIL_DOMAIN = '@e2e.test';
+
+const wrap = (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler =>
+  async (req, res, next) => {
+    try { await fn(req, res); }
+    catch (err: any) {
+      console.error('[__test] handler error', err);
+      if (res.headersSent) return next(err);
+      res.status(500).json({ error: err?.message || 'internal error' });
+    }
+  };
+
+// Shared-secret guard. Enforced only when TEST_API_SECRET is set (so a local
+// dev run with just ENABLE_TEST_ROUTES=1 stays frictionless, while a shared
+// preview env can require the header).
+function secretGuard(): RequestHandler {
+  const secret = process.env.TEST_API_SECRET;
+  if (!secret) {
+    console.warn('[__test] TEST_API_SECRET not set — test routes are open within this env. Fine locally; set a secret on any shared preview.');
+  }
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!secret) return next();
+    if (req.header('x-test-secret') === secret) return next();
+    res.status(401).json({ error: 'bad or missing x-test-secret' });
+  };
+}
+
+async function hydrate(id: string): Promise<CboState | undefined> {
+  let state = getCboState(id);
+  if (!state) {
+    const persisted = await loadCboFromDb(id);
+    if (persisted) { setCboState(id, persisted.state); state = persisted.state; }
+  }
+  return state;
+}
+
+export function registerTestRoutes(app: Express): void {
+  console.warn('⚠️  [__test] TEST ROUTES ENABLED (ENABLE_TEST_ROUTES=1). This must NEVER be set on the production Deployment.');
+  app.use('/__test', secretGuard());
+
+  // Liveness / config probe — lets Playwright global-setup confirm the target
+  // really has the test API mounted before it starts seeding.
+  app.get('/__test/ping', (_req, res) => {
+    res.json({ ok: true, fakeModel: process.env.CBO_FAKE_MODEL === '1', secret: !!process.env.TEST_API_SECRET });
+  });
+
+  // ── CBO sessions ──────────────────────────────────────────────────────────
+
+  // Fresh CBO session. Returns the id the chat UI drives (/cbo-profile?...).
+  app.post('/__test/cbo/session', wrap(async (req, res) => {
+    const city = typeof req.body?.city === 'string' ? req.body.city : 'porto-alegre';
+    const state = createEmptyCboState(city);
+    setCboState(state.id, state);
+    await flushNow(state.id);
+    res.json({ cboId: state.id, state });
+  }));
+
+  // Seed a session directly into any phase / language / filled state — the
+  // high-leverage primitive: jump to a branch without replaying turns.
+  // Body (all optional): { phase, language: 'pt'|'en', orgName,
+  //   sections: [{ sectionId, field, value, confidence?, source? }],
+  //   maturity: [{ metric, score, justification? }],
+  //   priorityFlags: [{ flag, met, notes? }] }
+  app.post('/__test/cbo/:id/seed-state', wrap(async (req, res) => {
+    const state = await hydrate(req.params.id);
+    if (!state) { res.status(404).json({ error: 'cbo not found' }); return; }
+    const b = req.body ?? {};
+
+    if (typeof b.phase === 'number') state.phase = Math.max(0, Math.min(6, b.phase));
+    if (b.language === 'pt' || b.language === 'en') state.metadata.language = b.language;
+    if (typeof b.orgName === 'string') state.orgName = b.orgName;
+
+    for (const f of Array.isArray(b.sections) ? b.sections : []) {
+      if (!isValidSectionId(f.sectionId)) continue;
+      const section = state.sections[f.sectionId as keyof typeof state.sections];
+      if (!section) continue;
+      section.fields[f.field] = {
+        value: String(f.value),
+        confidence: (f.confidence ?? 'high') as Confidence,
+        source: f.source ?? 'user',
+        userEdited: false,
+      };
+      section.lastUpdatedBy = 'agent';
+      if (f.sectionId === 'org_profile' && f.field === 'org_name' && !state.orgName) state.orgName = String(f.value);
+    }
+
+    for (const m of Array.isArray(b.maturity) ? b.maturity : []) {
+      if (!isValidMaturityMetric(m.metric)) continue;
+      state.maturityScores = state.maturityScores.filter(s => s.metric !== m.metric);
+      const score = Math.max(0, Math.min(3, Math.round(Number(m.score) || 0))) as 0 | 1 | 2 | 3;
+      state.maturityScores.push({ metric: m.metric, score, justification: m.justification ?? 'seed' });
+    }
+    state.totalMaturityScore = state.maturityScores.reduce((sum, s) => sum + s.score, 0);
+
+    for (const pf of Array.isArray(b.priorityFlags) ? b.priorityFlags : []) {
+      state.priorityFlags = state.priorityFlags.filter(f => f.flag !== pf.flag);
+      state.priorityFlags.push({ flag: pf.flag, met: !!pf.met, notes: pf.notes });
+    }
+
+    setCboState(req.params.id, state);
+    await flushNow(req.params.id);
+    res.json({ ok: true, state });
+  }));
+
+  // ── Fake-model scripting ────────────────────────────────────────────────
+  // Body: { turns: FakeTurn[] }. Each user message pops one turn. Requires
+  // CBO_FAKE_MODEL=1 to have any effect (otherwise the live SDK runs).
+  app.post('/__test/cbo/:id/script', wrap(async (req, res) => {
+    const turns = req.body?.turns;
+    if (!Array.isArray(turns)) { res.status(400).json({ error: 'turns array required' }); return; }
+    setFakeScript(req.params.id, turns as FakeTurn[]);
+    res.json({ ok: true, queued: turns.length, fakeModelEnabled: process.env.CBO_FAKE_MODEL === '1' });
+  }));
+
+  app.delete('/__test/cbo/:id/script', wrap(async (req, res) => {
+    clearFakeScript(req.params.id);
+    res.json({ ok: true });
+  }));
+
+  app.get('/__test/cbo/:id/script', wrap(async (req, res) => {
+    res.json(peekFakeScript(req.params.id));
+  }));
+
+  // ── Coordinators ──────────────────────────────────────────────────────────
+  // Create a throwaway coordinator and (default) mint a session so Playwright is
+  // logged in. Sets the httpOnly coord cookie AND returns the token for non-browser
+  // API clients. Email is forced into the e2e domain so cleanup can find it.
+  app.post('/__test/coordinator', wrap(async (req, res) => {
+    const raw = typeof req.body?.email === 'string' ? req.body.email : `coord-${nanoid(8)}`;
+    const email = raw.includes('@') ? raw : `${raw}${E2E_EMAIL_DOMAIN}`;
+    const password = typeof req.body?.password === 'string' ? req.body.password : nanoid(16);
+    const name = typeof req.body?.name === 'string' ? req.body.name : 'E2E Coordinator';
+    const cohortId = typeof req.body?.cohortId === 'string' ? req.body.cohortId : null; // null = admin
+
+    await createCoordinator({ email, password, name, cohortId });
+    const session = await login(email, password);
+    if (!session) { res.status(500).json({ error: 'login failed after create' }); return; }
+
+    res.cookie(COORD_COOKIE, session.token, { httpOnly: true, sameSite: 'lax', secure: process.env.NODE_ENV === 'production' });
+    res.json({ coordinator: { email, name, cohortId }, password, sessionToken: session.token, cookieName: COORD_COOKIE });
+  }));
+
+  // ── Cohorts & members ─────────────────────────────────────────────────────
+  // Create a throwaway cohort. coordinatorSlug is namespaced ('e2e-…') for cleanup.
+  app.post('/__test/cohort', wrap(async (req, res) => {
+    const coordinatorSlug = `${E2E_COHORT_PREFIX}${nanoid(10)}`;
+    const name = typeof req.body?.name === 'string' ? req.body.name : 'E2E Cohort';
+    const [cohort] = await db.insert(cohorts).values({
+      coordinatorSlug, name, settings: { workshops: DEFAULT_WORKSHOPS },
+    }).returning();
+    res.json({ cohort });
+  }));
+
+  // Invite a member directly (bypasses the coordinator gate — this is its own
+  // namespace). Mirrors the real invite: creates an org, an unguessable token,
+  // and optionally a linked CBO session so the spec can drive immediately.
+  // Body: { cohortId, orgName, neighborhood?, role?, unlockedPhases?, withSession? }
+  app.post('/__test/cohort/:cohortId/member', wrap(async (req, res) => {
+    const cohortId = req.params.cohortId;
+    const [cohort] = await db.select().from(cohorts).where(eq(cohorts.id, cohortId)).limit(1);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const orgName = typeof req.body?.orgName === 'string' && req.body.orgName.trim() ? req.body.orgName.trim() : `E2E Org ${nanoid(5)}`;
+    const neighborhood = typeof req.body?.neighborhood === 'string' ? req.body.neighborhood : null;
+    const role = req.body?.role === 'alternate' ? 'alternate' : 'priority';
+    const unlockedPhases = Array.isArray(req.body?.unlockedPhases) ? req.body.unlockedPhases : [1];
+
+    let orgId: string | null = null;
+    try {
+      const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: 'community', cohortId });
+      orgId = org.id;
+    } catch (e: any) {
+      console.error('[__test] org creation failed (continuing):', e?.message || e);
+    }
+
+    let cboStateId: string | null = null;
+    if (req.body?.withSession) {
+      const state = createEmptyCboState('porto-alegre');
+      if (orgName) state.orgName = orgName;
+      setCboState(state.id, state);
+      await flushNow(state.id);
+      cboStateId = state.id;
+      if (orgId) { try { await linkCboStateToOrg(cboStateId, orgId); } catch { /* best-effort */ } }
+    }
+
+    const [member] = await db.insert(cohortMembers).values({
+      cohortId,
+      orgId,
+      memberSlug: `${E2E_COHORT_PREFIX}${nanoid(10)}`,
+      capabilityToken: nanoid(24),
+      orgName,
+      neighborhood,
+      role,
+      origin: 'cohort',
+      unlockedPhases,
+      cboStateId,
+    }).returning();
+
+    res.json({ member, inviteUrl: `/cbo-profile?t=${member.capabilityToken}` });
+  }));
+
+  // ── Teardown ────────────────────────────────────────────────────────────
+  // Purge only this harness's namespaced data. Idempotent. Returns counts.
+  app.post('/__test/cleanup', wrap(async (_req, res) => {
+    const e2eCohorts = await db.select().from(cohorts).where(like(cohorts.coordinatorSlug, `${E2E_COHORT_PREFIX}%`));
+    const cohortIds = e2eCohorts.map(c => c.id);
+    let members = 0;
+    if (cohortIds.length) {
+      const m = await db.delete(cohortMembers).where(inArray(cohortMembers.cohortId, cohortIds)).returning();
+      members = m.length;
+      await db.delete(cohorts).where(inArray(cohorts.id, cohortIds));
+    }
+    const e2eCoords = await db.select().from(coordinators).where(like(coordinators.email, `%${E2E_EMAIL_DOMAIN}`));
+    const coordIds = e2eCoords.map(c => c.id);
+    if (coordIds.length) {
+      await db.delete(coordinatorSessions).where(inArray(coordinatorSessions.coordinatorId, coordIds));
+      await db.delete(coordinators).where(inArray(coordinators.id, coordIds));
+    }
+    res.json({ ok: true, deleted: { cohorts: cohortIds.length, members, coordinators: coordIds.length } });
+  }));
+}

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -26,6 +26,7 @@ import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
 import { eq } from "drizzle-orm";
 import { getOrgIdForCboState, listDocumentsByOrg, getDocumentForOrg } from "./documentPersistence";
+import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -805,6 +806,17 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   }
 
   setActivePushEvent(cboId, pushEvent);
+
+  // Test-only deterministic seam. When CBO_FAKE_MODEL=1 (set ONLY in the
+  // test/preview env, never the prod Deployment), drive the turn from a scripted
+  // fake instead of the live SDK — fast, free, and reproducible. The real path
+  // below is byte-for-byte untouched. See server/services/fakeCboModel.ts.
+  if (isFakeModelEnabled()) {
+    await streamWithFakeModel(cboId, userMessage, state, pushEvent, lang, { setCboState });
+    res.end();
+    return;
+  }
+
   const isSdkReady = await loadSdk();
 
   if (isSdkReady) {

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -1,0 +1,173 @@
+// ============================================================================
+// FAKE CBO MODEL — deterministic turn driver for e2e tests
+// ============================================================================
+//
+// The CBO chat is normally driven by the Claude Agent SDK (`streamWithSdk` in
+// cboAgent.ts), which is non-deterministic, slow, and costs tokens — unusable
+// as a per-fix regression gate. This module is the test-only seam: when
+// CBO_FAKE_MODEL=1, `streamCboChat` routes here instead of the SDK and we emit
+// a *scripted* sequence of the exact same SSE events the real path emits
+// (`chat`, `field_update`, `ask_user`, `phase_change`, `open_map`, `done`).
+//
+// Two modes:
+//   1. Scripted — a test POSTs a per-CBO script via /__test/cbo/:id/script.
+//      Each user message pops the next turn and runs its ops. This lets a
+//      Playwright spec drive an exact, reproducible conversation.
+//   2. Default — when no script (or the script is exhausted), every turn emits
+//      a short ack + a generic two-option ask_user + done. This keeps the chat
+//      UI permanently driveable so specs can click through phases that were
+//      seeded directly via the test API.
+//
+// SAFETY: this module does nothing unless CBO_FAKE_MODEL === '1'. Production
+// never sets that flag (it is wired only into the test/preview env alongside
+// ENABLE_TEST_ROUTES), so the real SDK path is the only one that ever runs in
+// the live deployment. The real turn machinery in cboAgent.ts is untouched.
+
+import {
+  type CboState,
+  type CboEvent,
+  type Confidence,
+  MATURITY_METRICS,
+  isValidMaturityMetric,
+  isValidSectionId,
+} from '@shared/cbo-schema';
+
+export function isFakeModelEnabled(): boolean {
+  return process.env.CBO_FAKE_MODEL === '1';
+}
+
+// ── Script shape ────────────────────────────────────────────────────────────
+// A script is a queue of turns; a turn is a list of ops executed in order. The
+// op names mirror the real MCP tools so a script reads like the agent's intent.
+export type FakeOp =
+  | { op: 'say'; text: string }
+  | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
+  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean }[]; multiSelect?: boolean; showMap?: boolean }
+  | { op: 'score_maturity'; metric: string; score: number; justification?: string }
+  | { op: 'set_phase'; phase: number }
+  | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
+  | { op: 'open_map'; params?: Record<string, unknown> };
+
+export type FakeTurn = FakeOp[];
+
+// Per-CBO script queues. Plain in-memory Map — scripts are ephemeral test
+// fixtures, never persisted. Keyed by cboId.
+const scripts = new Map<string, FakeTurn[]>();
+
+export function setFakeScript(cboId: string, turns: FakeTurn[]): void {
+  scripts.set(cboId, [...turns]);
+}
+
+export function clearFakeScript(cboId: string): void {
+  scripts.delete(cboId);
+}
+
+export function peekFakeScript(cboId: string): { remainingTurns: number } {
+  return { remainingTurns: scripts.get(cboId)?.length ?? 0 };
+}
+
+type PushEvent = (event: CboEvent) => void;
+interface FakeDeps {
+  // Passed in from streamCboChat (same module that owns the real path) so this
+  // module never has to import from cboAgent — avoids a circular import.
+  setCboState: (id: string, state: CboState) => void;
+}
+
+// ── Driver ──────────────────────────────────────────────────────────────────
+// Mirrors the signature of streamWithSdk so streamCboChat can swap them cleanly.
+export async function streamWithFakeModel(
+  cboId: string,
+  userMessage: string,
+  state: CboState,
+  pushEvent: PushEvent,
+  lang: string,
+  deps: FakeDeps,
+): Promise<void> {
+  const queue = scripts.get(cboId);
+  const turn = queue && queue.length > 0 ? queue.shift()! : defaultTurn(lang, userMessage);
+
+  for (const op of turn) {
+    runOp(cboId, op, state, pushEvent, deps);
+  }
+
+  pushEvent({ type: 'done', summary: 'Response complete (fake model)' });
+}
+
+function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent, deps: FakeDeps): void {
+  switch (op.op) {
+    case 'say': {
+      pushEvent({ type: 'chat', content: op.text, role: 'assistant' });
+      break;
+    }
+    case 'update_section': {
+      if (!isValidSectionId(op.sectionId)) break;
+      const section = state.sections[op.sectionId as keyof typeof state.sections];
+      if (!section) break;
+      section.fields[op.field] = {
+        value: op.value,
+        confidence: (op.confidence ?? 'high') as Confidence,
+        source: op.source ?? 'user',
+        userEdited: false,
+      };
+      section.lastUpdatedBy = 'agent';
+      if (op.sectionId === 'org_profile' && op.field === 'org_name' && !state.orgName) {
+        state.orgName = op.value;
+      }
+      deps.setCboState(cboId, state);
+      pushEvent({ type: 'field_update', sectionId: op.sectionId, field: op.field, value: String(op.value), confidence: (op.confidence ?? 'high') as Confidence, source: op.source ?? 'user' });
+      break;
+    }
+    case 'ask_user': {
+      const options = (op.options ?? []).map(o => ({ label: o.label, description: o.description ?? '', recommended: o.recommended }));
+      pushEvent({ type: 'ask_user', question: op.question, options, showMap: op.showMap, multiSelect: op.multiSelect });
+      break;
+    }
+    case 'score_maturity': {
+      if (!isValidMaturityMetric(op.metric)) break;
+      const score = Math.max(0, Math.min(3, Math.round(Number(op.score) || 0))) as 0 | 1 | 2 | 3;
+      // Replace any existing score for this metric (mirror real upsert intent).
+      state.maturityScores = state.maturityScores.filter(s => s.metric !== op.metric);
+      state.maturityScores.push({ metric: op.metric, score, justification: op.justification ?? 'fake' });
+      state.totalMaturityScore = state.maturityScores.reduce((sum, s) => sum + s.score, 0);
+      deps.setCboState(cboId, state);
+      pushEvent({ type: 'maturity_update', scores: state.maturityScores, total: state.totalMaturityScore, flags: state.priorityFlags });
+      break;
+    }
+    case 'set_phase': {
+      const phase = Math.max(0, Math.min(6, Number(op.phase) || 0));
+      state.phase = phase;
+      deps.setCboState(cboId, state);
+      pushEvent({ type: 'phase_change', phase });
+      break;
+    }
+    case 'priority_flag': {
+      state.priorityFlags = state.priorityFlags.filter(f => f.flag !== op.flag);
+      state.priorityFlags.push({ flag: op.flag, met: !!op.met, notes: op.notes });
+      deps.setCboState(cboId, state);
+      pushEvent({ type: 'maturity_update', scores: state.maturityScores, total: state.totalMaturityScore, flags: state.priorityFlags });
+      break;
+    }
+    case 'open_map': {
+      pushEvent({ type: 'open_map', params: (op.params ?? {}) as any });
+      break;
+    }
+  }
+}
+
+// A safe, generic turn used whenever no script is queued: keeps the chat UI
+// driveable without asserting any particular content. PT/EN aware so the
+// sticky-language fix can be exercised against it.
+function defaultTurn(lang: string, _userMessage: string): FakeTurn {
+  const pt = lang === 'pt';
+  return [
+    { op: 'say', text: pt ? 'Entendi. Vamos continuar.' : "Got it. Let's continue." },
+    {
+      op: 'ask_user',
+      question: pt ? 'Como deseja prosseguir?' : 'How would you like to proceed?',
+      options: [
+        { label: pt ? 'Continuar' : 'Continue', description: pt ? 'Seguir para a próxima etapa' : 'Move to the next step' },
+        { label: pt ? 'Outra coisa' : 'Something else', description: pt ? 'Responder com texto livre' : 'Reply in free text' },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
**Foundation for end-to-end testing the CBO workshop flow** — drive any cohort/phase/branch in tests without manual setup or replaying conversations. This is PR 1 of 4 (backend seam; no Playwright yet).

## What's in here
Two test-only seams, **both off by default and inert in production**:

### 1. Fake CBO model — `CBO_FAKE_MODEL=1`
`server/services/fakeCboModel.ts`. Replaces the live Claude Agent SDK in the CBO chat with a deterministic scripted driver that emits the **exact same SSE events** the real path emits (`chat`, `field_update`, `ask_user`, `phase_change`, `maturity_update`, `open_map`, `done`).
- `streamCboChat` branches to it **only** when the flag is set — the real `streamWithSdk` path is byte-for-byte untouched.
- A script is a queue of turns; each user message pops one. Empty/exhausted ⇒ a generic PT/EN ack + `ask_user` so the chat stays driveable forever.

### 2. Gated test API — `ENABLE_TEST_ROUTES=1`
`server/routes/testRoutes.ts`, mounted via **conditional registration** in `routes.ts` — when the flag is unset the routes are *not registered at all* (they don't exist, they don't 403). Optional `x-test-secret` header (`TEST_API_SECRET`) for shared previews.

| Endpoint | Purpose |
|---|---|
| `GET /__test/ping` | probe before seeding |
| `POST /__test/cbo/session` | fresh CBO session |
| `POST /__test/cbo/:id/seed-state` | **jump to any phase / tier / language / filled state** |
| `POST·GET·DELETE /__test/cbo/:id/script` | script the fake model |
| `POST /__test/coordinator` | throwaway coordinator + login cookie (admin or scoped) |
| `POST /__test/cohort` | throwaway cohort (`e2e-…` slug) |
| `POST /__test/cohort/:id/member` | invite member + token (+ optional linked session) |
| `POST /__test/cleanup` | purge only `e2e-*` / `*@e2e.test` data |

## Safety
- ⚠️ **Never set `ENABLE_TEST_ROUTES` / `CBO_FAKE_MODEL` on the production Deployment.** Set them (and `TEST_API_SECRET`) only in the test/preview env.
- All throwaway resources are namespaced so `cleanup` touches exactly this harness's data.

## Verification
- Fake driver smoke-tested offline: scripted turns mutate state + emit correct events; default turn keeps UI driveable; invalid metric/section ignored gracefully; seam off without the flag.
- Changed files typecheck clean (`tsc --noEmit`); the two remaining errors are pre-existing in untouched files.

## Next
- **PR 2:** `@playwright/test` + config (local `vite preview` + Replit preview URL) + `data-testid="stream-complete"` SSE-close contract + one golden-path spec.
- **PR 3:** Phase-1 scenarios (two cohorts, PT/EN, uploads, coordinator login, cross-cohort isolation).
- **PR 4:** GitHub Actions gate + non-gating live-model quality smoke; HTML report + trace + video artifacts.

Docs: `docs/e2e-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)