### PR TITLE
test(e2e): Playwright + stream-complete contract + golden-path spec (PR 2/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ knowledge/runs/cbo-*/
 # OSM disk cache — runtime data fetched from Overpass mirrors. Re-fetched
 # automatically when missing. Don't commit (regenerable, can be large).
 knowledge/osm-cache/
+
+# Playwright e2e — generated artifacts (regenerable, can be large)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -170,6 +170,11 @@ export default function CboProfilePage() {
   const [messages, setMessages] = useState<CboChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
+  // Monotonic count of completed agent turns. Drives the e2e stream-complete
+  // contract (see the hidden #cbo-stream-status marker near the root) so tests
+  // can wait on "turn N finished" deterministically — networkidle never fires
+  // for SSE. Incremented once per send when the reader loop ends.
+  const [completedTurns, setCompletedTurns] = useState(0);
   // `stableStreamEnded` flips true only ~250ms after `isStreaming` becomes
   // false. The Continue-from-Phase-X button gate consults this instead of
   // `isStreaming` directly, to absorb the race where the SSE `done` event
@@ -628,6 +633,7 @@ export default function CboProfilePage() {
       }
     } catch (e: any) { setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${e.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); }
     setIsStreaming(false);
+    setCompletedTurns(n => n + 1);
   }, [cboId, isStreaming, processEvent]);
 
   // MC selection
@@ -787,6 +793,23 @@ export default function CboProfilePage() {
 
   return (
     <div className="h-[100dvh] flex flex-col bg-background">
+      {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
+          waits on this hidden marker's attributes instead: data-streaming flips
+          to 'false' when a turn ends, data-turns counts completed turns, and
+          data-cbo-id / data-phase let a spec read state without intercepting the
+          network. display:none is fine — attribute assertions don't need
+          visibility. Inert in production; just a few data attributes. */}
+      <div
+        data-testid="cbo-stream-status"
+        data-streaming={isStreaming ? 'true' : 'false'}
+        data-settled={stableStreamEnded ? 'true' : 'false'}
+        data-turns={completedTurns}
+        data-cbo-id={cboId ?? ''}
+        data-phase={state?.phase ?? ''}
+        data-org-name={state?.sections?.org_profile?.fields?.org_name?.value ?? ''}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
       {/* No global Header on /cbo-profile — CBOs are in a focused flow and the
           CityCatalyst-branded header eats vertical space that's critical on
           mobile. The per-CBO chat header below carries the identity (org name
@@ -1201,7 +1224,7 @@ export default function CboProfilePage() {
               <Tooltip><TooltipTrigger asChild>
                 <Button type="button" variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isStreaming} className="shrink-0"><Paperclip className="w-4 h-4" /></Button>
               </TooltipTrigger><TooltipContent>{t('cbo.uploadDoc')}</TooltipContent></Tooltip>
-              <Input ref={inputRef} value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
+              <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
           </div>
@@ -1532,7 +1555,7 @@ function CboQuestionCard({
   };
 
   return (
-    <div className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
+    <div data-testid="cbo-question-card" className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="text-sm font-medium prose prose-sm max-w-none flex-1">
           {questionNumber && <span className="text-muted-foreground mr-1">{questionNumber}.</span>}
@@ -1553,6 +1576,8 @@ function CboQuestionCard({
           const isHighlighted = isMulti ? isChecked : isFocused;
           return (
             <button key={i} onClick={() => handleClick(opt.label)}
+              data-testid={`cbo-option-${i}`}
+              data-option-label={opt.label}
               className={`w-full text-left px-3 py-2 rounded-md border text-sm transition-all flex items-start gap-2 ${
                 isHighlighted ? 'border-green-600 bg-green-50 ring-1 ring-green-600' : isFocused ? 'border-green-400 bg-green-50/50 ring-1 ring-green-400' : 'border-muted hover:border-green-400'
               } ${disabled ? 'opacity-50' : 'cursor-pointer'}`}>

--- a/e2e/cbo-golden-path.spec.ts
+++ b/e2e/cbo-golden-path.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Golden path: open the CBO flow as a user, drive ONE deterministic turn through
+// the fake model, and assert the turn rendered + persisted + advanced phase —
+// then prove it survives a reload. This is the end-to-end proof that the seam
+// (PR 1) + the stream-complete contract (this PR) work together. Branch/scenario
+// coverage comes in PR 3.
+
+test.describe('CBO golden path (fake model)', () => {
+  test('one scripted turn: chips render, field persists, phase advances, survives reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+
+    // Precondition: the target must have the fake model on, or the live SDK
+    // would run (non-deterministic). Skip loudly rather than flake.
+    const ping = await api.ping();
+    expect(ping.ok).toBeTruthy();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    // Open a fresh session. With no ?t= token the page creates its own CBO via
+    // POST /api/cbo and writes the id to the hidden status marker.
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    expect(cboId).toBeTruthy();
+
+    // Script the next agent turn deterministically: greet, persist the org name,
+    // advance to phase 1, and ask a chip question.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Boa! Vamos registrar sua organização.' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'org_name', value: 'Horta Comunitária Cascata' },
+        { op: 'set_phase', phase: 1 },
+        { op: 'ask_user', question: 'Quantas pessoas fazem parte?', options: [{ label: '1–5' }, { label: '6–20' }] },
+      ],
+    ]);
+
+    // Drive the turn — typing + Enter submits the composer form → sendMessage.
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Olá!');
+    await input.press('Enter');
+
+    // Wait for the turn to finish. SSE never goes network-idle, so we key off
+    // the marker's attributes instead.
+    await expect(marker).toHaveAttribute('data-turns', '1');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The agent's message rendered in chat.
+    await expect(page.getByText('Vamos registrar sua organização', { exact: false })).toBeVisible();
+
+    // The chip question rendered with the scripted options.
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible();
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', '1–5');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', '6–20');
+
+    // State propagated to the UI: org-name field filled, phase advanced.
+    await expect(marker).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+    await expect(marker).toHaveAttribute('data-phase', '1');
+
+    // Resume: a reload rehydrates the same session and keeps the persisted field.
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+  });
+});

--- a/e2e/helpers/testApi.ts
+++ b/e2e/helpers/testApi.ts
@@ -1,0 +1,53 @@
+import type { APIRequestContext } from '@playwright/test';
+import type { FakeTurn } from '../../server/services/fakeCboModel';
+
+// Thin wrapper over the gated /__test API (PR 1). Uses Playwright's request
+// fixture, so it inherits baseURL + the x-test-secret header from the config.
+// Every method throws with the response body on a non-2xx so failures are loud.
+export class TestApi {
+  constructor(private request: APIRequestContext) {}
+
+  private async post(path: string, data?: unknown): Promise<any> {
+    const r = await this.request.post(`/__test${path}`, { data: data ?? {} });
+    if (!r.ok()) throw new Error(`POST /__test${path} → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  /** Probe the target before seeding: { ok, fakeModel, secret }. */
+  async ping(): Promise<{ ok: boolean; fakeModel: boolean; secret: boolean }> {
+    const r = await this.request.get('/__test/ping');
+    if (!r.ok()) throw new Error(`GET /__test/ping → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  newSession(city?: string) {
+    return this.post('/cbo/session', { city });
+  }
+
+  seedState(cboId: string, body: Record<string, unknown>) {
+    return this.post(`/cbo/${cboId}/seed-state`, body);
+  }
+
+  /** Queue deterministic fake-model turns. Each user message pops one. */
+  scriptCbo(cboId: string, turns: FakeTurn[]) {
+    return this.post(`/cbo/${cboId}/script`, { turns });
+  }
+
+  createCohort(name?: string) {
+    return this.post('/cohort', { name });
+  }
+
+  inviteMember(cohortId: string, body: Record<string, unknown> = {}) {
+    return this.post(`/cohort/${cohortId}/member`, body);
+  }
+
+  /** Create + log in a coordinator. Cookie is set on the request context. */
+  createCoordinator(body: Record<string, unknown> = {}) {
+    return this.post('/coordinator', body);
+  }
+
+  /** Purge this harness's namespaced data (e2e-* cohorts, *@e2e.test coords). */
+  cleanup() {
+    return this.post('/cleanup');
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "zod-validation-error": "^3.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@replit/vite-plugin-cartographer": "^0.3.0",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
@@ -2381,6 +2382,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -13618,6 +13635,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.77",
@@ -110,6 +113,7 @@
     "zod-validation-error": "^3.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@replit/vite-plugin-cartographer": "^0.3.0",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Target: a remote preview URL when E2E_BASE_URL is set (e.g. the Replit
+// preview), otherwise a locally-managed dev server. We never host the browser
+// on Replit — Playwright runs on your machine / CI and points at a URL.
+// Local hermetic server port. Defaults to 5050 to dodge macOS's AirPlay
+// Receiver, which squats on :5000 and answers 403 (override via E2E_PORT).
+const PORT = process.env.E2E_PORT || '5050';
+const baseURL = process.env.E2E_BASE_URL || `http://localhost:${PORT}`;
+const isRemote = !!process.env.E2E_BASE_URL;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  // HTML report (open with `npm run test:e2e:report`) + concise console list.
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL,
+    // trace = a scrubbable DOM/network timeline of the run; viewable in the
+    // HTML report. Kept on first retry to stay cheap on green runs.
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    // If the target enforces TEST_API_SECRET, send it on every request
+    // (harmless on app routes; required by /__test/*). The `request` fixture
+    // inherits these headers too, so the test-API helper needs no extra wiring.
+    extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  // Manage a local server ONLY when not pointed at a remote preview. The flags
+  // turn on the test API + deterministic fake model for this process; a
+  // DATABASE_URL must be present in the environment for DB-backed endpoints.
+  webServer: isRemote
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        // Dummy OAUTH_* just satisfy import-time checks in authService; the e2e
+        // suite never exercises the OAuth flow.
+        env: {
+          ENABLE_TEST_ROUTES: '1',
+          CBO_FAKE_MODEL: '1',
+          NODE_ENV: 'development',
+          PORT,
+          OAUTH_CLIENT_ID: 'e2e-dummy',
+          OAUTH_REDIRECT_URI: `${baseURL}/api/auth/oauth/callback`,
+          // Module-level OpenAI clients require a non-empty key at import. Dummy
+          // values — the deterministic suite never calls a model provider.
+          OPENAI_API_KEY: 'sk-e2e-dummy',
+          AI_INTEGRATIONS_OPENAI_API_KEY: 'e2e-dummy',
+        },
+      },
+});


### PR DESCRIPTION
**Makes the CBO flow driveable end-to-end — and visible** (HTML report, scrubbable trace, video). PR 2 of 4.

> ⚠️ **Stacks on #235 (PR 1).** This branch is based on `feat/e2e-test-api`, so its diff includes #235's commits until that merges. **Merge #235 first**, then this. Base is `main` (not the feature branch).

## What's in here

### stream-complete contract (the SSE-safe wait signal)
SSE never goes network-idle, so a hidden `#cbo-stream-status` marker in `cbo-profile.tsx` exposes the turn state as data attributes — `data-streaming`, `data-turns`, `data-cbo-id`, `data-phase`, `data-org-name`. Specs wait on these instead of guessing. Adds a `completedTurns` counter (bumped when the SSE reader loop ends) and stable testids on the chat input (`cbo-chat-input`) and option chips (`cbo-option-N` + `cbo-question-card`). All inert in production — just a few data attributes on a `display:none` node.

### Playwright config — two targeting modes
- **Local (default):** manages a dev server on **port 5050** (dodges macOS AirPlay squatting on :5000 with a 403). webServer env flips on the test API + fake model and injects dummy `OAUTH_*` / `OPENAI_*` keys to satisfy import-time checks — no model provider is ever called.
- **Remote:** set `E2E_BASE_URL` to the Replit preview URL → no webServer (we never host the browser on Replit).
- Reporter: **HTML** + **trace** on first retry + **video/screenshot** retain-on-failure → `npm run test:e2e:report`.

### Golden-path spec
`e2e/cbo-golden-path.spec.ts`: open a fresh session → script one fake turn → drive it → assert **chips render + agent text shown + org-name field persisted + phase advanced + survives reload**. Plus `e2e/helpers/testApi.ts` (typed `/__test` wrapper) and `test:e2e` / `test:e2e:ui` / `test:e2e:report` scripts.

## Verification (ran for real)
- ✅ **1 passed** against a Postgres-backed server (created a throwaway DB, `db:push`, `playwright install chromium`, ran the suite).
- ✅ Prod-safety: with `ENABLE_TEST_ROUTES` unset, the boot warning is absent and the `/__test` handler is not registered (conditional registration confirmed).

## How to run it yourself
```bash
ENABLE_TEST_ROUTES=1 CBO_FAKE_MODEL=1 DATABASE_URL=... npm run test:e2e
npm run test:e2e:report   # open the HTML report (trace + video)
# against the Replit preview instead:
E2E_BASE_URL=https://<preview> TEST_API_SECRET=<secret> npm run test:e2e
```

## Next
- **PR 3:** Phase-1 scenarios — Stream A vs Stream B implementer, PT/EN, photo/voice/scanned-PDF upload, coordinator login + wrong-pw shake, cross-cohort isolation.
- **PR 4:** GitHub Actions gate + non-gating live-model quality smoke; upload report/trace/video artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)