### PR TITLE
test(e2e): coordinator auth-gate specs + global teardown (PR 3/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ knowledge/runs/cbo-*/
 # OSM disk cache — runtime data fetched from Overpass mirrors. Re-fetched
 # automatically when missing. Don't commit (regenerable, can be large).
 knowledge/osm-cache/
+
+# Playwright e2e — generated artifacts (regenerable, can be large)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -170,6 +170,11 @@ export default function CboProfilePage() {
   const [messages, setMessages] = useState<CboChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
+  // Monotonic count of completed agent turns. Drives the e2e stream-complete
+  // contract (see the hidden #cbo-stream-status marker near the root) so tests
+  // can wait on "turn N finished" deterministically — networkidle never fires
+  // for SSE. Incremented once per send when the reader loop ends.
+  const [completedTurns, setCompletedTurns] = useState(0);
   // `stableStreamEnded` flips true only ~250ms after `isStreaming` becomes
   // false. The Continue-from-Phase-X button gate consults this instead of
   // `isStreaming` directly, to absorb the race where the SSE `done` event
@@ -628,6 +633,7 @@ export default function CboProfilePage() {
       }
     } catch (e: any) { setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${e.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); }
     setIsStreaming(false);
+    setCompletedTurns(n => n + 1);
   }, [cboId, isStreaming, processEvent]);
 
   // MC selection
@@ -787,6 +793,23 @@ export default function CboProfilePage() {
 
   return (
     <div className="h-[100dvh] flex flex-col bg-background">
+      {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
+          waits on this hidden marker's attributes instead: data-streaming flips
+          to 'false' when a turn ends, data-turns counts completed turns, and
+          data-cbo-id / data-phase let a spec read state without intercepting the
+          network. display:none is fine — attribute assertions don't need
+          visibility. Inert in production; just a few data attributes. */}
+      <div
+        data-testid="cbo-stream-status"
+        data-streaming={isStreaming ? 'true' : 'false'}
+        data-settled={stableStreamEnded ? 'true' : 'false'}
+        data-turns={completedTurns}
+        data-cbo-id={cboId ?? ''}
+        data-phase={state?.phase ?? ''}
+        data-org-name={state?.sections?.org_profile?.fields?.org_name?.value ?? ''}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
       {/* No global Header on /cbo-profile — CBOs are in a focused flow and the
           CityCatalyst-branded header eats vertical space that's critical on
           mobile. The per-CBO chat header below carries the identity (org name
@@ -1201,7 +1224,7 @@ export default function CboProfilePage() {
               <Tooltip><TooltipTrigger asChild>
                 <Button type="button" variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isStreaming} className="shrink-0"><Paperclip className="w-4 h-4" /></Button>
               </TooltipTrigger><TooltipContent>{t('cbo.uploadDoc')}</TooltipContent></Tooltip>
-              <Input ref={inputRef} value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
+              <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
           </div>
@@ -1532,7 +1555,7 @@ function CboQuestionCard({
   };
 
   return (
-    <div className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
+    <div data-testid="cbo-question-card" className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="text-sm font-medium prose prose-sm max-w-none flex-1">
           {questionNumber && <span className="text-muted-foreground mr-1">{questionNumber}.</span>}
@@ -1553,6 +1576,8 @@ function CboQuestionCard({
           const isHighlighted = isMulti ? isChecked : isFocused;
           return (
             <button key={i} onClick={() => handleClick(opt.label)}
+              data-testid={`cbo-option-${i}`}
+              data-option-label={opt.label}
               className={`w-full text-left px-3 py-2 rounded-md border text-sm transition-all flex items-start gap-2 ${
                 isHighlighted ? 'border-green-600 bg-green-50 ring-1 ring-green-600' : isFocused ? 'border-green-400 bg-green-50/50 ring-1 ring-green-400' : 'border-muted hover:border-green-400'
               } ${disabled ? 'opacity-50' : 'cursor-pointer'}`}>

--- a/e2e/cbo-golden-path.spec.ts
+++ b/e2e/cbo-golden-path.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Golden path: open the CBO flow as a user, drive ONE deterministic turn through
+// the fake model, and assert the turn rendered + persisted + advanced phase —
+// then prove it survives a reload. This is the end-to-end proof that the seam
+// (PR 1) + the stream-complete contract (this PR) work together. Branch/scenario
+// coverage comes in PR 3.
+
+test.describe('CBO golden path (fake model)', () => {
+  test('one scripted turn: chips render, field persists, phase advances, survives reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+
+    // Precondition: the target must have the fake model on, or the live SDK
+    // would run (non-deterministic). Skip loudly rather than flake.
+    const ping = await api.ping();
+    expect(ping.ok).toBeTruthy();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    // Open a fresh session. With no ?t= token the page creates its own CBO via
+    // POST /api/cbo and writes the id to the hidden status marker.
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    expect(cboId).toBeTruthy();
+
+    // Script the next agent turn deterministically: greet, persist the org name,
+    // advance to phase 1, and ask a chip question.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Boa! Vamos registrar sua organização.' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'org_name', value: 'Horta Comunitária Cascata' },
+        { op: 'set_phase', phase: 1 },
+        { op: 'ask_user', question: 'Quantas pessoas fazem parte?', options: [{ label: '1–5' }, { label: '6–20' }] },
+      ],
+    ]);
+
+    // Drive the turn — typing + Enter submits the composer form → sendMessage.
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Olá!');
+    await input.press('Enter');
+
+    // Wait for the turn to finish. SSE never goes network-idle, so we key off
+    // the marker's attributes instead.
+    await expect(marker).toHaveAttribute('data-turns', '1');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The agent's message rendered in chat.
+    await expect(page.getByText('Vamos registrar sua organização', { exact: false })).toBeVisible();
+
+    // The chip question rendered with the scripted options.
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible();
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', '1–5');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', '6–20');
+
+    // State propagated to the UI: org-name field filled, phase advanced.
+    await expect(marker).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+    await expect(marker).toHaveAttribute('data-phase', '1');
+
+    // Resume: a reload rehydrates the same session and keeps the persisted field.
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+  });
+});

--- a/e2e/coordinator-auth.spec.ts
+++ b/e2e/coordinator-auth.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Coverage for the merged Phase-3c auth gate (#234): coordinator routes require
+// a session, CBO routes stay open (CBOs never log in), the login page rejects a
+// bad password and redirects on success, and the orchestrator bounces anonymous
+// visitors to login.
+//
+// NOTE: per-account multi-cohort *isolation* (an owner guard so a scoped
+// coordinator can't read another cohort) is NOT on main yet, so it is not tested
+// here. See the PR description.
+//
+// Cleanup is global (e2e/global-teardown.ts), not per-test: a per-describe
+// afterAll that purges all e2e data races parallel tests and deletes their
+// coordinators mid-flight. Each test uses a unique email so runs never collide.
+
+test.describe('Coordinator auth gate', () => {
+  test('API boundary: /api/cohort is gated, /api/cbo is open', async ({ request }) => {
+    // The per-test `request` fixture starts with no cookies → unauthenticated.
+    const gated = await request.get('/api/cohort/default');
+    expect(gated.status()).toBe(401);
+
+    // The CBO-facing surface must stay reachable without any login.
+    const cbo = await request.post('/api/cbo', { data: { city: 'porto-alegre' } });
+    expect(cbo.ok()).toBeTruthy();
+    expect((await cbo.json()).cboId).toBeTruthy();
+  });
+
+  test('a coordinator session opens the gate', async ({ request }) => {
+    const api = new TestApi(request);
+    const email = `gate-${randomUUID()}@e2e.test`;
+    // /__test/coordinator creates + logs in, setting the coord cookie on this
+    // request context's jar.
+    await api.createCoordinator({ email, password: 'correct-horse-battery', name: 'Gate' });
+
+    const r = await request.get('/api/cohort/default');
+    expect(r.ok()).toBeTruthy();
+    expect((await r.json()).cohort).toBeTruthy();
+  });
+
+  test('login page: wrong password errors, correct password redirects', async ({ page, request }) => {
+    const email = `ui-${randomUUID()}@e2e.test`;
+    const password = 'right-pass-12345';
+    // Create the account (the cookie lands on `request`, not on `page`, so the
+    // page is genuinely anonymous until it logs in through the form).
+    await new TestApi(request).createCoordinator({ email, password, name: 'UI' });
+
+    await page.goto('/coordinator-login');
+    await page.locator('#coord-email').fill(email);
+    await page.locator('#coord-password').fill('totally-wrong');
+    await expect(page.locator('#coord-password')).toHaveValue('totally-wrong');
+    const [wrongResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/coordinator/login') && r.request().method() === 'POST'),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    expect(wrongResp.status()).toBe(401);
+
+    // Error surfaces; we stay on the login page.
+    await expect(page.getByRole('alert')).toBeVisible();
+    await expect(page).toHaveURL(/coordinator-login/);
+
+    // Correct password → bounce to the orchestrator. Two state-settled checks
+    // before submitting: the DOM value committed AND the error alert cleared (it
+    // clears on the corrective keystroke). Together they guarantee React
+    // re-rendered with the new password, so the handler can't capture the stale
+    // one (a controlled-input race).
+    await page.locator('#coord-password').fill(password);
+    await expect(page.locator('#coord-password')).toHaveValue(password);
+    await expect(page.getByRole('alert')).toBeHidden();
+    const [okResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/coordinator/login') && r.request().method() === 'POST'),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    expect(okResp.status()).toBe(200);
+    await expect(page).toHaveURL(/\/orchestrator/);
+  });
+
+  test('orchestrator requires auth: anonymous visit bounces to login', async ({ page }) => {
+    await page.goto('/orchestrator');
+    await expect(page).toHaveURL(/coordinator-login/);
+  });
+});

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,22 @@
+import { request } from '@playwright/test';
+
+// Runs once after the whole suite. Purges this harness's namespaced data
+// (e2e-* cohorts/members, *@e2e.test coordinators) in a single shot, so
+// per-test afterAll hooks can't race parallel tests by deleting their data
+// mid-flight. Best-effort: if the server is already gone, leftover throwaway
+// rows are harmless (every test uses unique ids, so they never collide).
+export default async function globalTeardown() {
+  const baseURL = process.env.E2E_BASE_URL || `http://localhost:${process.env.E2E_PORT || '5050'}`;
+  const ctx = await request.newContext({
+    baseURL,
+    extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
+  });
+  try {
+    const r = await ctx.post('/__test/cleanup');
+    if (r.ok()) console.log('[global-teardown] cleanup:', JSON.stringify(await r.json()));
+  } catch (e) {
+    console.warn('[global-teardown] cleanup skipped (server likely down):', (e as Error).message);
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/e2e/helpers/testApi.ts
+++ b/e2e/helpers/testApi.ts
@@ -1,0 +1,53 @@
+import type { APIRequestContext } from '@playwright/test';
+import type { FakeTurn } from '../../server/services/fakeCboModel';
+
+// Thin wrapper over the gated /__test API (PR 1). Uses Playwright's request
+// fixture, so it inherits baseURL + the x-test-secret header from the config.
+// Every method throws with the response body on a non-2xx so failures are loud.
+export class TestApi {
+  constructor(private request: APIRequestContext) {}
+
+  private async post(path: string, data?: unknown): Promise<any> {
+    const r = await this.request.post(`/__test${path}`, { data: data ?? {} });
+    if (!r.ok()) throw new Error(`POST /__test${path} → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  /** Probe the target before seeding: { ok, fakeModel, secret }. */
+  async ping(): Promise<{ ok: boolean; fakeModel: boolean; secret: boolean }> {
+    const r = await this.request.get('/__test/ping');
+    if (!r.ok()) throw new Error(`GET /__test/ping → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  newSession(city?: string) {
+    return this.post('/cbo/session', { city });
+  }
+
+  seedState(cboId: string, body: Record<string, unknown>) {
+    return this.post(`/cbo/${cboId}/seed-state`, body);
+  }
+
+  /** Queue deterministic fake-model turns. Each user message pops one. */
+  scriptCbo(cboId: string, turns: FakeTurn[]) {
+    return this.post(`/cbo/${cboId}/script`, { turns });
+  }
+
+  createCohort(name?: string) {
+    return this.post('/cohort', { name });
+  }
+
+  inviteMember(cohortId: string, body: Record<string, unknown> = {}) {
+    return this.post(`/cohort/${cohortId}/member`, body);
+  }
+
+  /** Create + log in a coordinator. Cookie is set on the request context. */
+  createCoordinator(body: Record<string, unknown> = {}) {
+    return this.post('/coordinator', body);
+  }
+
+  /** Purge this harness's namespaced data (e2e-* cohorts, *@e2e.test coords). */
+  cleanup() {
+    return this.post('/cleanup');
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "zod-validation-error": "^3.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@replit/vite-plugin-cartographer": "^0.3.0",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
@@ -2381,6 +2382,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -13618,6 +13635,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.77",
@@ -110,6 +113,7 @@
     "zod-validation-error": "^3.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@replit/vite-plugin-cartographer": "^0.3.0",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Target: a remote preview URL when E2E_BASE_URL is set (e.g. the Replit
+// preview), otherwise a locally-managed dev server. We never host the browser
+// on Replit — Playwright runs on your machine / CI and points at a URL.
+// Local hermetic server port. Defaults to 5050 to dodge macOS's AirPlay
+// Receiver, which squats on :5000 and answers 403 (override via E2E_PORT).
+const PORT = process.env.E2E_PORT || '5050';
+const baseURL = process.env.E2E_BASE_URL || `http://localhost:${PORT}`;
+const isRemote = !!process.env.E2E_BASE_URL;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  // HTML report (open with `npm run test:e2e:report`) + concise console list.
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL,
+    // trace = a scrubbable DOM/network timeline of the run; viewable in the
+    // HTML report. Kept on first retry to stay cheap on green runs.
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    // If the target enforces TEST_API_SECRET, send it on every request
+    // (harmless on app routes; required by /__test/*). The `request` fixture
+    // inherits these headers too, so the test-API helper needs no extra wiring.
+    extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  // Manage a local server ONLY when not pointed at a remote preview. The flags
+  // turn on the test API + deterministic fake model for this process; a
+  // DATABASE_URL must be present in the environment for DB-backed endpoints.
+  webServer: isRemote
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        // Dummy OAUTH_* just satisfy import-time checks in authService; the e2e
+        // suite never exercises the OAuth flow.
+        env: {
+          ENABLE_TEST_ROUTES: '1',
+          CBO_FAKE_MODEL: '1',
+          NODE_ENV: 'development',
+          PORT,
+          OAUTH_CLIENT_ID: 'e2e-dummy',
+          OAUTH_REDIRECT_URI: `${baseURL}/api/auth/oauth/callback`,
+          // Module-level OpenAI clients require a non-empty key at import. Dummy
+          // values — the deterministic suite never calls a model provider.
+          OPENAI_API_KEY: 'sk-e2e-dummy',
+          AI_INTEGRATIONS_OPENAI_API_KEY: 'e2e-dummy',
+        },
+      },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ const isRemote = !!process.env.E2E_BASE_URL;
 
 export default defineConfig({
   testDir: './e2e',
+  // One-shot purge of namespaced e2e data after the whole run (not per-describe,
+  // which would race parallel tests). Runs while the webServer is still up.
+  globalTeardown: './e2e/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,


### PR DESCRIPTION
**End-to-end coverage of the coordinator auth gate** (the merged #234 security work). PR 3 of 4.

> ⚠️ **Stacks on #235 → #236.** Merge those first; base is `main`.

## Specs (all green, stable at `--repeat-each=3`)
- **API boundary** — `/api/cohort/default` returns **401** unauthenticated; `/api/cbo` (create session) returns **200**. Proves the gate boundary is correct: coordinators gated, **CBOs never gated** (they have no login).
- **Session opens the gate** — create + log in a coordinator via `/__test/coordinator`, then `/api/cohort/default` → 200.
- **Login page UI** — wrong password → error alert + stays on `/coordinator-login`; correct password → redirect to `/orchestrator`.
- **Orchestrator requires auth** — anonymous visit to `/orchestrator` bounces to `/coordinator-login`.

## Two real issues found + fixed while writing these
1. **Controlled-input flush race** — refilling the password then clicking could submit the *stale* value (DOM updated, React state not yet committed). Hardened with value + alert-cleared settle checks and `waitForResponse` status assertions.
2. **Global cleanup raced parallel tests** — the per-describe `afterAll` called `/__test/cleanup`, which deletes *all* e2e data, so one test's teardown deleted another's coordinator mid-login. Moved to a **one-shot `globalTeardown`** (`e2e/global-teardown.ts`) and gave each test a unique `randomUUID` email. Now stable across repeats, fully parallel (15 passed).

## ⚠️ Finding — cross-cohort isolation is NOT enforced on main
While scoping this I found that the **per-account multi-cohort ownership guard** described in our architecture work — `/api/cohort/mine`, the `app.param('coordinatorSlug')` owner check, `isAdmin`/`ownsCohort` — **is not present on `main`.** `useCohort` still hits the singleton `/api/cohort/default`. So today **any logged-in coordinator can read any cohort by slug**. Low risk while there's a single pilot cohort (slugs are unguessable nanoid-24), but **the guard needs to land before a second cohort exists**. I deliberately did not write an isolation spec asserting a guard that isn't there. Happy to build that guard (+ its e2e) as a follow-up.

## Next
- **PR 4:** GitHub Actions gate (deterministic suite on every PR) + a separate non-gating live-model quality smoke; upload HTML report / trace / video as artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)