### PR TITLE
test(e2e): video/trace toggles + one-command local runner (PR 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ knowledge/runs/cbo-*/
 # OSM disk cache — runtime data fetched from Overpass mirrors. Re-fetched
 # automatically when missing. Don't commit (regenerable, can be large).
 knowledge/osm-cache/
+
+# Playwright e2e — generated artifacts (regenerable, can be large)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -1,22 +1,22 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import type { Cohort, CohortMember, WorkshopConfig } from '@shared/cohort-schema';
 
 // ---------------------------------------------------------------------------
-// useCohort — singleton-cohort model for the Vila Flores pilot.
+// useCohort — loads the coordinator's OWN cohort from GET /api/cohort/mine.
 //
-// There is exactly one cohort for the entire deployment, served from
-// GET /api/cohort/default. The orchestrator opens straight to it — no slug
-// to remember, no auth, no "Create" / "Load existing" dance. A Reset action
-// wipes members and restores the default workshop cadence for demo dry runs.
-//
-// When auth lands in a later phase, this hook becomes the place that swaps
-// `default` for a real coordinator session.
+// The account resolves the cohort: a scoped coordinator gets their cohort, an
+// admin gets the default singleton. All mutations target that cohort's real
+// coordinatorSlug (held in slugRef so callbacks never capture a stale slug),
+// which the server's app.param ownership guard then validates — so a scoped
+// coordinator physically cannot act on another cohort. `isAdmin` is surfaced
+// for a future cohort switcher (deferred until a 2nd cohort exists).
 // ---------------------------------------------------------------------------
 
 export interface UseCohortResult {
   loading: boolean;
   cohort: Cohort | null;
   members: CohortMember[];
+  isAdmin: boolean;
   refresh: () => Promise<void>;
   resetCohort: () => Promise<void>;
   invite: (params: { orgName: string; neighborhood?: string; role?: 'priority' | 'alternate' }) => Promise<CohortMember | null>;
@@ -24,21 +24,25 @@ export interface UseCohortResult {
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
 }
 
-const COORDINATOR_SLUG = 'default';
-
 export function useCohort(): UseCohortResult {
   const [cohort, setCohort] = useState<Cohort | null>(null);
   const [members, setMembers] = useState<CohortMember[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
+  // The resolved cohort's slug, kept in a ref so mutation callbacks always use
+  // the current one without re-creating on every cohort change.
+  const slugRef = useRef<string>('default');
 
   const fetchCohort = useCallback(async () => {
     setLoading(true);
     try {
-      const r = await fetch('/api/cohort/default');
+      const r = await fetch('/api/cohort/mine');
       if (!r.ok) return;
       const data = await r.json();
       setCohort(data.cohort);
       setMembers(data.members ?? []);
+      setIsAdmin(!!data.isAdmin);
+      if (data.cohort?.coordinatorSlug) slugRef.current = data.cohort.coordinatorSlug;
     } finally {
       setLoading(false);
     }
@@ -51,7 +55,7 @@ export function useCohort(): UseCohortResult {
   const resetCohort = useCallback(async () => {
     setLoading(true);
     try {
-      const r = await fetch('/api/cohort/default/reset', { method: 'POST' });
+      const r = await fetch(`/api/cohort/${slugRef.current}/reset`, { method: 'POST' });
       if (!r.ok) return;
       const data = await r.json();
       setCohort(data.cohort);
@@ -62,7 +66,7 @@ export function useCohort(): UseCohortResult {
   }, []);
 
   const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, role }) => {
-    const r = await fetch(`/api/cohort/${COORDINATOR_SLUG}/invite`, {
+    const r = await fetch(`/api/cohort/${slugRef.current}/invite`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orgName, neighborhood, role }),
@@ -74,7 +78,7 @@ export function useCohort(): UseCohortResult {
   }, [refresh]);
 
   const unlockPhase = useCallback(async (memberIds: string[] | 'all', phase: number) => {
-    await fetch(`/api/cohort/${COORDINATOR_SLUG}/unlock`, {
+    await fetch(`/api/cohort/${slugRef.current}/unlock`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ memberIds, phase }),
@@ -83,7 +87,7 @@ export function useCohort(): UseCohortResult {
   }, [refresh]);
 
   const saveWorkshops = useCallback(async (workshops: WorkshopConfig[]) => {
-    await fetch(`/api/cohort/${COORDINATOR_SLUG}/workshops`, {
+    await fetch(`/api/cohort/${slugRef.current}/workshops`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ workshops }),
@@ -91,5 +95,5 @@ export function useCohort(): UseCohortResult {
     await refresh();
   }, [refresh]);
 
-  return { loading, cohort, members, refresh, resetCohort, invite, unlockPhase, saveWorkshops };
+  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops };
 }

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -170,6 +170,11 @@ export default function CboProfilePage() {
   const [messages, setMessages] = useState<CboChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
+  // Monotonic count of completed agent turns. Drives the e2e stream-complete
+  // contract (see the hidden #cbo-stream-status marker near the root) so tests
+  // can wait on "turn N finished" deterministically — networkidle never fires
+  // for SSE. Incremented once per send when the reader loop ends.
+  const [completedTurns, setCompletedTurns] = useState(0);
   // `stableStreamEnded` flips true only ~250ms after `isStreaming` becomes
   // false. The Continue-from-Phase-X button gate consults this instead of
   // `isStreaming` directly, to absorb the race where the SSE `done` event
@@ -628,6 +633,7 @@ export default function CboProfilePage() {
       }
     } catch (e: any) { setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${e.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); }
     setIsStreaming(false);
+    setCompletedTurns(n => n + 1);
   }, [cboId, isStreaming, processEvent]);
 
   // MC selection
@@ -787,6 +793,23 @@ export default function CboProfilePage() {
 
   return (
     <div className="h-[100dvh] flex flex-col bg-background">
+      {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
+          waits on this hidden marker's attributes instead: data-streaming flips
+          to 'false' when a turn ends, data-turns counts completed turns, and
+          data-cbo-id / data-phase let a spec read state without intercepting the
+          network. display:none is fine — attribute assertions don't need
+          visibility. Inert in production; just a few data attributes. */}
+      <div
+        data-testid="cbo-stream-status"
+        data-streaming={isStreaming ? 'true' : 'false'}
+        data-settled={stableStreamEnded ? 'true' : 'false'}
+        data-turns={completedTurns}
+        data-cbo-id={cboId ?? ''}
+        data-phase={state?.phase ?? ''}
+        data-org-name={state?.sections?.org_profile?.fields?.org_name?.value ?? ''}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
       {/* No global Header on /cbo-profile — CBOs are in a focused flow and the
           CityCatalyst-branded header eats vertical space that's critical on
           mobile. The per-CBO chat header below carries the identity (org name
@@ -1201,7 +1224,7 @@ export default function CboProfilePage() {
               <Tooltip><TooltipTrigger asChild>
                 <Button type="button" variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isStreaming} className="shrink-0"><Paperclip className="w-4 h-4" /></Button>
               </TooltipTrigger><TooltipContent>{t('cbo.uploadDoc')}</TooltipContent></Tooltip>
-              <Input ref={inputRef} value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
+              <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
           </div>
@@ -1532,7 +1555,7 @@ function CboQuestionCard({
   };
 
   return (
-    <div className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
+    <div data-testid="cbo-question-card" className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="text-sm font-medium prose prose-sm max-w-none flex-1">
           {questionNumber && <span className="text-muted-foreground mr-1">{questionNumber}.</span>}
@@ -1553,6 +1576,8 @@ function CboQuestionCard({
           const isHighlighted = isMulti ? isChecked : isFocused;
           return (
             <button key={i} onClick={() => handleClick(opt.label)}
+              data-testid={`cbo-option-${i}`}
+              data-option-label={opt.label}
               className={`w-full text-left px-3 py-2 rounded-md border text-sm transition-all flex items-start gap-2 ${
                 isHighlighted ? 'border-green-600 bg-green-50 ring-1 ring-green-600' : isFocused ? 'border-green-400 bg-green-50/50 ring-1 ring-green-400' : 'border-muted hover:border-green-400'
               } ${disabled ? 'opacity-50' : 'cursor-pointer'}`}>

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -118,12 +118,36 @@ curl -s -XPOST localhost:5000/__test/cbo/$ID/seed-state -H 'content-type: applic
   -d '{"phase":1,"language":"pt","orgName":"Horta Cascata"}'
 ```
 
-## Status / next
+## Running the suites
 
-- **PR 1 (this):** fake-model seam + gated `/__test` API + docs. No Playwright yet.
-- **PR 2:** `@playwright/test`, config (local `vite preview` + Replit preview URL projects),
-  a `data-testid="stream-complete"` SSE-close contract, and one golden-path spec.
-- **PR 3:** Phase-1 scenario coverage (two cohorts, PT/EN, uploads, coordinator login,
-  cross-cohort isolation).
-- **PR 4:** GitHub Actions gate + a separate non-gating live-model quality smoke. HTML
-  report + trace + video artifacts.
+```bash
+# Deterministic gate (fake model). Needs a DATABASE_URL; the config boots a local
+# dev server on :5050 with the test flags, or set E2E_BASE_URL for a remote target.
+npm run test:e2e
+npm run test:e2e:ui        # interactive runner
+npm run test:e2e:report    # open the HTML report (trace + video)
+
+# Non-gating live-model quality smoke — real agent, loose assertions. Point at a
+# real (non-fake) deployment; self-skips otherwise.
+E2E_BASE_URL=https://<preview> TEST_API_SECRET=<secret> npm run test:quality
+```
+
+CI: `.github/workflows/e2e.yml` runs the deterministic suite on every PR + push to
+main against a Postgres service container, and uploads the HTML report (trace +
+video) as an artifact. The live smoke self-skips in CI (no API key needed).
+
+## Status
+
+- ✅ **PR 1 (#235):** fake-model seam + gated `/__test` API + docs.
+- ✅ **PR 2 (#236):** `@playwright/test`, config (local server / remote `E2E_BASE_URL`),
+  the `cbo-stream-status` SSE-complete contract, golden-path spec.
+- ✅ **PR 3 (#237):** coordinator auth-gate specs + one-shot global teardown.
+- ✅ **PR 4 (this):** GitHub Actions gate + non-gating live-model quality smoke.
+
+### Known follow-up
+Cross-cohort **isolation** is not yet enforced on `main` — the per-account ownership
+guard (`/api/cohort/mine` + `app.param` owner check) described in the architecture
+work isn't present; `useCohort` hits the singleton `/api/cohort/default`. Any
+logged-in coordinator can read any cohort by slug. Low risk with one pilot cohort
+(unguessable slugs), but the guard + its isolation spec should land before a second
+cohort exists.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -124,9 +124,24 @@ curl -s -XPOST localhost:5000/__test/cbo/$ID/seed-state -H 'content-type: applic
 # Deterministic gate (fake model). Needs a DATABASE_URL; the config boots a local
 # dev server on :5050 with the test flags, or set E2E_BASE_URL for a remote target.
 npm run test:e2e
-npm run test:e2e:ui        # interactive runner
-npm run test:e2e:report    # open the HTML report (trace + video)
+npm run test:e2e:ui        # interactive runner (watch it run live, time-travel)
+npm run test:e2e:video     # record a video + full trace for EVERY test
+npm run test:e2e:report    # open the HTML report (videos + traces)
 
+# One-command "test it and share the video": sets up a throwaway Postgres DB,
+# pushes the schema, runs the whole suite with video + trace, leaves the report
+# ready. Then `npm run test:e2e:report` to watch.
+bash scripts/e2e-local.sh                  # whole suite
+bash scripts/e2e-local.sh cbo-golden-path  # one spec
+```
+
+> Video is captured only for tests that drive a **browser page** (golden path,
+> login UI, orchestrator redirect, live smoke). The HTTP-layer tests (auth-API
+> boundary, cross-cohort isolation, sticky language) have nothing visual to
+> film, but they still record a **trace** you can scrub in the report. Toggles:
+> `E2E_VIDEO=on` / `E2E_TRACE=on` (default: failures only).
+
+```bash
 # Non-gating live-model quality smoke — real agent, loose assertions. Point at a
 # real (non-fake) deployment; self-skips otherwise.
 E2E_BASE_URL=https://<preview> TEST_API_SECRET=<secret> npm run test:quality
@@ -142,12 +157,16 @@ video) as an artifact. The live smoke self-skips in CI (no API key needed).
 - ✅ **PR 2 (#236):** `@playwright/test`, config (local server / remote `E2E_BASE_URL`),
   the `cbo-stream-status` SSE-complete contract, golden-path spec.
 - ✅ **PR 3 (#237):** coordinator auth-gate specs + one-shot global teardown.
-- ✅ **PR 4 (this):** GitHub Actions gate + non-gating live-model quality smoke.
+- ✅ **PR 4 (#238):** GitHub Actions gate + non-gating live-model quality smoke.
+- ✅ **PR 5 (#239):** cross-cohort ownership guard (`/api/cohort/mine` + `app.param`
+  owner check) + isolation spec. **Closes the isolation gap below.**
+- ✅ **PR 6 (#240):** sticky-language (#226) + upload/per-org-KB (#230) specs.
+- ✅ **PR 7 (this):** video/trace toggles + `scripts/e2e-local.sh` one-command runner.
 
-### Known follow-up
-Cross-cohort **isolation** is not yet enforced on `main` — the per-account ownership
-guard (`/api/cohort/mine` + `app.param` owner check) described in the architecture
-work isn't present; `useCohort` hits the singleton `/api/cohort/default`. Any
-logged-in coordinator can read any cohort by slug. Low risk with one pilot cohort
-(unguessable slugs), but the guard + its isolation spec should land before a second
-cohort exists.
+Coverage of the deterministic gate: golden path · stream-complete contract · auth
+gate boundary · cross-cohort isolation · sticky language · upload + per-org KB.
+
+### Deferred (by decision / live-only)
+- Admin cohort-switcher UI — `isAdmin` is surfaced; build when a 2nd cohort exists.
+- Stream A vs B *behavioural* differences + photo/voice/scanned-PDF vision — live
+  quality smoke, not the deterministic gate.

--- a/e2e/cbo-golden-path.spec.ts
+++ b/e2e/cbo-golden-path.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Golden path: open the CBO flow as a user, drive ONE deterministic turn through
+// the fake model, and assert the turn rendered + persisted + advanced phase —
+// then prove it survives a reload. This is the end-to-end proof that the seam
+// (PR 1) + the stream-complete contract (this PR) work together. Branch/scenario
+// coverage comes in PR 3.
+
+test.describe('CBO golden path (fake model)', () => {
+  test('one scripted turn: chips render, field persists, phase advances, survives reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+
+    // Precondition: the target must have the fake model on, or the live SDK
+    // would run (non-deterministic). Skip loudly rather than flake.
+    const ping = await api.ping();
+    expect(ping.ok).toBeTruthy();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    // Open a fresh session. With no ?t= token the page creates its own CBO via
+    // POST /api/cbo and writes the id to the hidden status marker.
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    expect(cboId).toBeTruthy();
+
+    // Script the next agent turn deterministically: greet, persist the org name,
+    // advance to phase 1, and ask a chip question.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Boa! Vamos registrar sua organização.' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'org_name', value: 'Horta Comunitária Cascata' },
+        { op: 'set_phase', phase: 1 },
+        { op: 'ask_user', question: 'Quantas pessoas fazem parte?', options: [{ label: '1–5' }, { label: '6–20' }] },
+      ],
+    ]);
+
+    // Drive the turn — typing + Enter submits the composer form → sendMessage.
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Olá!');
+    await input.press('Enter');
+
+    // Wait for the turn to finish. SSE never goes network-idle, so we key off
+    // the marker's attributes instead.
+    await expect(marker).toHaveAttribute('data-turns', '1');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The agent's message rendered in chat.
+    await expect(page.getByText('Vamos registrar sua organização', { exact: false })).toBeVisible();
+
+    // The chip question rendered with the scripted options.
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible();
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', '1–5');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', '6–20');
+
+    // State propagated to the UI: org-name field filled, phase advanced.
+    await expect(marker).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+    await expect(marker).toHaveAttribute('data-phase', '1');
+
+    // Resume: a reload rehydrates the same session and keeps the persisted field.
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
+  });
+});

--- a/e2e/cbo-language.spec.ts
+++ b/e2e/cbo-language.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Sticky session language (#226). Once a session's language is set, the server
+// must keep using it — it must NOT re-detect per message (the bug that produced
+// half-EN/half-PT documents). We verify the server's language resolution
+// directly: seed the sticky language, send a chat with NO `lang` override and a
+// message in the OTHER language, and confirm the fake model's (language-aware)
+// default turn comes back in the sticky language, not the message's.
+//
+// Driven at the API layer because the chat composer always sends the UI `lang`;
+// omitting it is what exercises the sticky fallback (cboRoutes resolves
+// lang ?? state.metadata.language ?? detect(message)).
+
+test.describe('Sticky session language', () => {
+  test('PT stays PT even when the message is English', async ({ request }) => {
+    const api = new TestApi(request);
+    const { cboId } = await api.newSession();
+    await api.seedState(cboId, { language: 'pt' });
+
+    const resp = await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'hello there' } });
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.text();
+    expect(body).toContain('Vamos continuar'); // PT default turn
+    expect(body).not.toContain('Got it');       // not the EN one
+  });
+
+  test('EN stays EN even when the message has Portuguese accents', async ({ request }) => {
+    const api = new TestApi(request);
+    const { cboId } = await api.newSession();
+    await api.seedState(cboId, { language: 'en' });
+
+    // Accented, clearly-Portuguese message — the OLD per-message detector would
+    // have flipped to PT. Sticky EN must win.
+    const resp = await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'olá, somos uma organização da comunidade' } });
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.text();
+    expect(body).toContain('Got it');            // EN default turn
+    expect(body).not.toContain('Vamos continuar'); // not the PT one
+  });
+});

--- a/e2e/cbo-upload.spec.ts
+++ b/e2e/cbo-upload.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Multi-format upload + per-org knowledge base (#223 intake, #230 doc store). A
+// text upload needs no AI, so it's fully deterministic: it should extract the
+// content AND file a durable, org-scoped document row referenceable across
+// sessions. (Photo/voice/scanned-PDF go through vision/transcription — covered
+// by the live quality suite, not here.)
+
+test.describe('Upload intake + per-org KB', () => {
+  test('a text upload is extracted and filed in the org document store', async ({ request }) => {
+    const api = new TestApi(request);
+    const cohort = (await api.createCohort('Upload cohort')).cohort;
+    // withSession links a fresh CBO state to the org, so the doc store has an
+    // org to file under.
+    const { member } = await api.inviteMember(cohort.id, { orgName: 'Horta da Cascata', withSession: true });
+    const cboId = member.cboStateId as string;
+    expect(cboId).toBeTruthy();
+
+    const text = 'Our community garden on Rua Cascata reduced flooding after the 2024 storms.';
+    const resp = await request.post(`/api/upload/cbo/${cboId}`, {
+      multipart: {
+        file: { name: 'evidence.txt', mimeType: 'text/plain', buffer: Buffer.from(text) },
+      },
+    });
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.json();
+    expect(body.content).toContain('reduced flooding'); // extracted, not stored blindly
+
+    // The durable per-org KB now holds the document with its full text.
+    const docs = await api.listDocs(cboId);
+    expect(docs.orgId).toBeTruthy();
+    expect(docs.documents.length).toBeGreaterThanOrEqual(1);
+    const doc = docs.documents.find((d: any) => d.filename === 'evidence.txt');
+    expect(doc).toBeTruthy();
+    expect(doc.fullText).toContain('community garden');
+  });
+});

--- a/e2e/cohort-isolation.spec.ts
+++ b/e2e/cohort-isolation.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Cross-cohort isolation — the multi-tenant ownership guard. A scoped
+// coordinator may act only on their own cohort; an admin (no cohortId) may act
+// on any and may create cohorts. Each test creates its own throwaway cohorts
+// (e2e-* slugs) and a uniquely-named coordinator; cleanup is the global
+// teardown. The per-test `request` fixture starts cookie-less, so creating the
+// coordinator (which logs in) sets exactly that role for the assertions.
+
+test.describe('Cross-cohort isolation', () => {
+  test('a scoped coordinator can read only their own cohort', async ({ request }) => {
+    const api = new TestApi(request);
+    const a = (await api.createCohort('Iso A')).cohort;
+    const b = (await api.createCohort('Iso B')).cohort;
+    // Scope a coordinator to cohort A — sets the coord session cookie on `request`.
+    await api.createCoordinator({ email: `scoped-${randomUUID()}@e2e.test`, password: 'pw-123456', cohortId: a.id });
+
+    // /mine resolves to their OWN cohort, flagged non-admin.
+    const mine = await request.get('/api/cohort/mine');
+    expect(mine.ok()).toBeTruthy();
+    const mineBody = await mine.json();
+    expect(mineBody.cohort.id).toBe(a.id);
+    expect(mineBody.isAdmin).toBe(false);
+
+    // Own cohort → 200, someone else's → 403, unknown slug → 404.
+    expect((await request.get(`/api/cohort/${a.coordinatorSlug}`)).status()).toBe(200);
+    expect((await request.get(`/api/cohort/${b.coordinatorSlug}`)).status()).toBe(403);
+    expect((await request.get('/api/cohort/no-such-slug-xyz')).status()).toBe(404);
+
+    // Mutations on another cohort are blocked too (not just reads).
+    expect((await request.post(`/api/cohort/${b.coordinatorSlug}/invite`, { data: { orgName: 'X' } })).status()).toBe(403);
+
+    // Scoped coordinators can't create cohorts.
+    expect((await request.post('/api/cohort', { data: { name: 'nope' } })).status()).toBe(403);
+  });
+
+  test('an admin can read any cohort and create cohorts', async ({ request }) => {
+    const api = new TestApi(request);
+    const a = (await api.createCohort('Admin A')).cohort;
+    const b = (await api.createCohort('Admin B')).cohort;
+    // Admin = no cohortId.
+    await api.createCoordinator({ email: `admin-${randomUUID()}@e2e.test`, password: 'pw-123456' });
+
+    const mine = await request.get('/api/cohort/mine');
+    expect(mine.ok()).toBeTruthy();
+    expect((await mine.json()).isAdmin).toBe(true);
+
+    // Reaches both cohorts.
+    expect((await request.get(`/api/cohort/${a.coordinatorSlug}`)).status()).toBe(200);
+    expect((await request.get(`/api/cohort/${b.coordinatorSlug}`)).status()).toBe(200);
+
+    // And can create a new one.
+    expect((await request.post('/api/cohort', { data: { name: 'Admin can create' } })).ok()).toBeTruthy();
+  });
+});

--- a/e2e/coordinator-auth.spec.ts
+++ b/e2e/coordinator-auth.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Coverage for the merged Phase-3c auth gate (#234): coordinator routes require
+// a session, CBO routes stay open (CBOs never log in), the login page rejects a
+// bad password and redirects on success, and the orchestrator bounces anonymous
+// visitors to login.
+//
+// NOTE: per-account multi-cohort *isolation* (an owner guard so a scoped
+// coordinator can't read another cohort) is NOT on main yet, so it is not tested
+// here. See the PR description.
+//
+// Cleanup is global (e2e/global-teardown.ts), not per-test: a per-describe
+// afterAll that purges all e2e data races parallel tests and deletes their
+// coordinators mid-flight. Each test uses a unique email so runs never collide.
+
+test.describe('Coordinator auth gate', () => {
+  test('API boundary: /api/cohort is gated, /api/cbo is open', async ({ request }) => {
+    // The per-test `request` fixture starts with no cookies → unauthenticated.
+    const gated = await request.get('/api/cohort/default');
+    expect(gated.status()).toBe(401);
+
+    // The CBO-facing surface must stay reachable without any login.
+    const cbo = await request.post('/api/cbo', { data: { city: 'porto-alegre' } });
+    expect(cbo.ok()).toBeTruthy();
+    expect((await cbo.json()).cboId).toBeTruthy();
+  });
+
+  test('a coordinator session opens the gate', async ({ request }) => {
+    const api = new TestApi(request);
+    const email = `gate-${randomUUID()}@e2e.test`;
+    // /__test/coordinator creates + logs in, setting the coord cookie on this
+    // request context's jar.
+    await api.createCoordinator({ email, password: 'correct-horse-battery', name: 'Gate' });
+
+    const r = await request.get('/api/cohort/default');
+    expect(r.ok()).toBeTruthy();
+    expect((await r.json()).cohort).toBeTruthy();
+  });
+
+  test('login page: wrong password errors, correct password redirects', async ({ page, request }) => {
+    const email = `ui-${randomUUID()}@e2e.test`;
+    const password = 'right-pass-12345';
+    // Create the account (the cookie lands on `request`, not on `page`, so the
+    // page is genuinely anonymous until it logs in through the form).
+    await new TestApi(request).createCoordinator({ email, password, name: 'UI' });
+
+    await page.goto('/coordinator-login');
+    await page.locator('#coord-email').fill(email);
+    await page.locator('#coord-password').fill('totally-wrong');
+    await expect(page.locator('#coord-password')).toHaveValue('totally-wrong');
+    const [wrongResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/coordinator/login') && r.request().method() === 'POST'),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    expect(wrongResp.status()).toBe(401);
+
+    // Error surfaces; we stay on the login page.
+    await expect(page.getByRole('alert')).toBeVisible();
+    await expect(page).toHaveURL(/coordinator-login/);
+
+    // Correct password → bounce to the orchestrator. Two state-settled checks
+    // before submitting: the DOM value committed AND the error alert cleared (it
+    // clears on the corrective keystroke). Together they guarantee React
+    // re-rendered with the new password, so the handler can't capture the stale
+    // one (a controlled-input race).
+    await page.locator('#coord-password').fill(password);
+    await expect(page.locator('#coord-password')).toHaveValue(password);
+    await expect(page.getByRole('alert')).toBeHidden();
+    const [okResp] = await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/coordinator/login') && r.request().method() === 'POST'),
+      page.locator('button[type="submit"]').click(),
+    ]);
+    expect(okResp.status()).toBe(200);
+    await expect(page).toHaveURL(/\/orchestrator/);
+  });
+
+  test('orchestrator requires auth: anonymous visit bounces to login', async ({ page }) => {
+    await page.goto('/orchestrator');
+    await expect(page).toHaveURL(/coordinator-login/);
+  });
+});

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,22 @@
+import { request } from '@playwright/test';
+
+// Runs once after the whole suite. Purges this harness's namespaced data
+// (e2e-* cohorts/members, *@e2e.test coordinators) in a single shot, so
+// per-test afterAll hooks can't race parallel tests by deleting their data
+// mid-flight. Best-effort: if the server is already gone, leftover throwaway
+// rows are harmless (every test uses unique ids, so they never collide).
+export default async function globalTeardown() {
+  const baseURL = process.env.E2E_BASE_URL || `http://localhost:${process.env.E2E_PORT || '5050'}`;
+  const ctx = await request.newContext({
+    baseURL,
+    extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
+  });
+  try {
+    const r = await ctx.post('/__test/cleanup');
+    if (r.ok()) console.log('[global-teardown] cleanup:', JSON.stringify(await r.json()));
+  } catch (e) {
+    console.warn('[global-teardown] cleanup skipped (server likely down):', (e as Error).message);
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/e2e/helpers/testApi.ts
+++ b/e2e/helpers/testApi.ts
@@ -1,0 +1,53 @@
+import type { APIRequestContext } from '@playwright/test';
+import type { FakeTurn } from '../../server/services/fakeCboModel';
+
+// Thin wrapper over the gated /__test API (PR 1). Uses Playwright's request
+// fixture, so it inherits baseURL + the x-test-secret header from the config.
+// Every method throws with the response body on a non-2xx so failures are loud.
+export class TestApi {
+  constructor(private request: APIRequestContext) {}
+
+  private async post(path: string, data?: unknown): Promise<any> {
+    const r = await this.request.post(`/__test${path}`, { data: data ?? {} });
+    if (!r.ok()) throw new Error(`POST /__test${path} → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  /** Probe the target before seeding: { ok, fakeModel, secret }. */
+  async ping(): Promise<{ ok: boolean; fakeModel: boolean; secret: boolean }> {
+    const r = await this.request.get('/__test/ping');
+    if (!r.ok()) throw new Error(`GET /__test/ping → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
+  newSession(city?: string) {
+    return this.post('/cbo/session', { city });
+  }
+
+  seedState(cboId: string, body: Record<string, unknown>) {
+    return this.post(`/cbo/${cboId}/seed-state`, body);
+  }
+
+  /** Queue deterministic fake-model turns. Each user message pops one. */
+  scriptCbo(cboId: string, turns: FakeTurn[]) {
+    return this.post(`/cbo/${cboId}/script`, { turns });
+  }
+
+  createCohort(name?: string) {
+    return this.post('/cohort', { name });
+  }
+
+  inviteMember(cohortId: string, body: Record<string, unknown> = {}) {
+    return this.post(`/cohort/${cohortId}/member`, body);
+  }
+
+  /** Create + log in a coordinator. Cookie is set on the request context. */
+  createCoordinator(body: Record<string, unknown> = {}) {
+    return this.post('/coordinator', body);
+  }
+
+  /** Purge this harness's namespaced data (e2e-* cohorts, *@e2e.test coords). */
+  cleanup() {
+    return this.post('/cleanup');
+  }
+}

--- a/e2e/helpers/testApi.ts
+++ b/e2e/helpers/testApi.ts
@@ -33,6 +33,13 @@ export class TestApi {
     return this.post(`/cbo/${cboId}/script`, { turns });
   }
 
+  /** The per-org KB documents for the org this session is linked to. */
+  async listDocs(cboId: string): Promise<{ orgId: string | null; documents: any[] }> {
+    const r = await this.request.get(`/__test/cbo/${cboId}/documents`);
+    if (!r.ok()) throw new Error(`GET /__test/cbo/${cboId}/documents → ${r.status()} ${await r.text()}`);
+    return r.json();
+  }
+
   createCohort(name?: string) {
     return this.post('/cohort', { name });
   }

--- a/e2e/quality/cbo-live-smoke.spec.ts
+++ b/e2e/quality/cbo-live-smoke.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+// LIVE quality smoke — NON-GATING. Drives the REAL Claude Agent SDK (not the
+// fake model) to confirm the live turn path still works and the agent produces
+// a coherent first turn. Wording is non-deterministic, so assertions are loose
+// and structural; this is a trend/health check, never a per-PR gate.
+//
+// Run on-demand against a real (non-fake) deployment:
+//   E2E_BASE_URL=https://<preview> TEST_API_SECRET=<secret> npm run test:quality
+// It self-skips otherwise (and is skipped in CI), so it never needs an API key
+// in the gating pipeline.
+
+const RUN = process.env.RUN_LIVE_QUALITY === '1';
+
+test.describe('CBO live quality smoke (real model)', () => {
+  test.skip(!RUN, 'Set RUN_LIVE_QUALITY=1 and point E2E_BASE_URL at a real (non-fake-model) deployment to run.');
+
+  test('the agent completes a coherent first turn', async ({ page }) => {
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Olá, somos uma horta comunitária no bairro Cascata em Porto Alegre.');
+    await input.press('Enter');
+
+    // The real model is slow; give it room. Wait for the turn to finish.
+    await expect(marker).toHaveAttribute('data-turns', '1', { timeout: 90_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // Loose, structural assertions only. The agent should not strand the user:
+    // it should have either asked a chip question OR written a non-empty reply.
+    const askedAQuestion = await page.getByTestId('cbo-question-card').isVisible().catch(() => false);
+    const wroteSomething = await page.locator('.prose, [data-testid="cbo-chat-input"]').first().isVisible().catch(() => false);
+    expect(askedAQuestion || wroteSomething).toBeTruthy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "zod-validation-error": "^3.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@replit/vite-plugin-cartographer": "^0.3.0",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
@@ -2381,6 +2382,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -13618,6 +13635,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.77",
@@ -110,6 +113,7 @@
     "zod-validation-error": "^3.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@replit/vite-plugin-cartographer": "^0.3.0",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check .",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:video": "E2E_VIDEO=on E2E_TRACE=on playwright test",
     "test:e2e:report": "playwright show-report",
     "test:quality": "RUN_LIVE_QUALITY=1 playwright test e2e/quality"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier --check .",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "test:quality": "RUN_LIVE_QUALITY=1 playwright test e2e/quality"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.77",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Target: a remote preview URL when E2E_BASE_URL is set (e.g. the Replit
+// preview), otherwise a locally-managed dev server. We never host the browser
+// on Replit — Playwright runs on your machine / CI and points at a URL.
+// Local hermetic server port. Defaults to 5050 to dodge macOS's AirPlay
+// Receiver, which squats on :5000 and answers 403 (override via E2E_PORT).
+const PORT = process.env.E2E_PORT || '5050';
+const baseURL = process.env.E2E_BASE_URL || `http://localhost:${PORT}`;
+const isRemote = !!process.env.E2E_BASE_URL;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  // HTML report (open with `npm run test:e2e:report`) + concise console list.
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL,
+    // trace = a scrubbable DOM/network timeline of the run; viewable in the
+    // HTML report. Kept on first retry to stay cheap on green runs.
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    // If the target enforces TEST_API_SECRET, send it on every request
+    // (harmless on app routes; required by /__test/*). The `request` fixture
+    // inherits these headers too, so the test-API helper needs no extra wiring.
+    extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  // Manage a local server ONLY when not pointed at a remote preview. The flags
+  // turn on the test API + deterministic fake model for this process; a
+  // DATABASE_URL must be present in the environment for DB-backed endpoints.
+  webServer: isRemote
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        // Dummy OAUTH_* just satisfy import-time checks in authService; the e2e
+        // suite never exercises the OAuth flow.
+        env: {
+          ENABLE_TEST_ROUTES: '1',
+          CBO_FAKE_MODEL: '1',
+          NODE_ENV: 'development',
+          PORT,
+          OAUTH_CLIENT_ID: 'e2e-dummy',
+          OAUTH_REDIRECT_URI: `${baseURL}/api/auth/oauth/callback`,
+          // Module-level OpenAI clients require a non-empty key at import. Dummy
+          // values — the deterministic suite never calls a model provider.
+          OPENAI_API_KEY: 'sk-e2e-dummy',
+          AI_INTEGRATIONS_OPENAI_API_KEY: 'e2e-dummy',
+        },
+      },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ const isRemote = !!process.env.E2E_BASE_URL;
 
 export default defineConfig({
   testDir: './e2e',
+  // One-shot purge of namespaced e2e data after the whole run (not per-describe,
+  // which would race parallel tests). Runs while the webServer is still up.
+  globalTeardown: './e2e/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,10 +25,13 @@ export default defineConfig({
   use: {
     baseURL,
     // trace = a scrubbable DOM/network timeline of the run; viewable in the
-    // HTML report. Kept on first retry to stay cheap on green runs.
-    trace: 'on-first-retry',
+    // HTML report. Cheap default (first retry only); E2E_TRACE=on records every
+    // test. Video likewise: failures only by default, every test with
+    // E2E_VIDEO=on (the `test:e2e:video` script / scripts/e2e-local.sh). There
+    // is no Playwright CLI flag for these, so we toggle via env.
+    trace: process.env.E2E_TRACE === 'on' ? 'on' : 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.E2E_VIDEO === 'on' ? 'on' : 'retain-on-failure',
     // If the target enforces TEST_API_SECRET, send it on every request
     // (harmless on app routes; required by /__test/*). The `request` fixture
     // inherits these headers too, so the test-API helper needs no extra wiring.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# One-command local e2e run WITH video + trace, for the "test it and share the
+# video" flow. Sets up a throwaway Postgres DB, pushes the schema, runs the
+# deterministic suite recording a video + scrubbable trace for every test, then
+# leaves the HTML report ready to open with `npm run test:e2e:report`.
+#
+# Usage:
+#   bash scripts/e2e-local.sh                 # whole suite
+#   bash scripts/e2e-local.sh cbo-golden-path # one spec (any playwright args)
+#
+# Env overrides:
+#   E2E_DB_NAME        (default: nbs_e2e)
+#   E2E_DATABASE_URL   (default: postgresql://localhost:5432/<E2E_DB_NAME>)
+
+set -uo pipefail
+
+DB_NAME="${E2E_DB_NAME:-nbs_e2e}"
+export DATABASE_URL="${E2E_DATABASE_URL:-postgresql://localhost:5432/${DB_NAME}}"
+
+echo "▶ e2e DB: ${DATABASE_URL}"
+createdb "${DB_NAME}" 2>/dev/null && echo "  created ${DB_NAME}" || echo "  reusing ${DB_NAME}"
+
+echo "▶ pushing schema…"
+echo "y" | npx drizzle-kit push >/dev/null 2>&1 || npx drizzle-kit push
+
+echo "▶ running e2e with video + trace…"
+E2E_VIDEO=on E2E_TRACE=on npx playwright test "$@"
+status=$?
+
+echo ""
+echo "▶ videos:   $(find test-results -name '*.webm' 2>/dev/null | wc -l | tr -d ' ') recorded under test-results/"
+echo "▶ open the report (videos + traces): npm run test:e2e:report"
+exit $status

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -13,7 +13,7 @@ import {
   type WorkshopConfig,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
-import { requireCoordinator } from '../services/coordinatorAuth';
+import { requireCoordinator, type CoordinatorRequest } from '../services/coordinatorAuth';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -54,12 +54,17 @@ async function uniqueMemberSlug(base: string): Promise<string> {
 async function getOrCreateDefaultCohort() {
   const existing = await findCohortByCoordinatorSlug(DEFAULT_COORDINATOR_SLUG);
   if (existing) return existing;
-  const [created] = await db.insert(cohorts).values({
+  // Race-safe create: concurrent first-callers (cold start, or parallel
+  // requests) would otherwise both INSERT and one would hit the unique
+  // coordinator_slug constraint → 500. onConflictDoNothing + read-back makes it
+  // idempotent.
+  const inserted = await db.insert(cohorts).values({
     coordinatorSlug: DEFAULT_COORDINATOR_SLUG,
     name: DEFAULT_COHORT_NAME,
     settings: { workshops: DEFAULT_WORKSHOPS },
-  }).returning();
-  return created;
+  }).onConflictDoNothing().returning();
+  if (inserted.length) return inserted[0];
+  return (await findCohortByCoordinatorSlug(DEFAULT_COORDINATOR_SLUG))!;
 }
 
 // Wrap async handlers so a thrown DB error becomes a 500 response instead of
@@ -79,6 +84,20 @@ const wrap = (fn: (req: Request, res: Response) => Promise<unknown>): RequestHan
 async function findCohortByCoordinatorSlug(coordinatorSlug: string) {
   const [c] = await db.select().from(cohorts).where(eq(cohorts.coordinatorSlug, coordinatorSlug)).limit(1);
   return c;
+}
+
+// The coordinator attached by requireCoordinator(). Carries `cohortId`:
+// null/undefined ⇒ admin (all cohorts), a value ⇒ scoped to that one cohort.
+function reqCoordinator(req: Request) {
+  return (req as CoordinatorRequest).coordinator;
+}
+
+// Tenancy check: admins may act on any cohort; a scoped coordinator only on
+// their own. Used by the literal /default routes (the :coordinatorSlug routes
+// are covered by the app.param guard instead).
+function mayAccessCohort(req: Request, cohortId: string): boolean {
+  const c = reqCoordinator(req);
+  return !c?.cohortId || c.cohortId === cohortId;
 }
 
 async function findMemberBySlug(memberSlug: string) {
@@ -143,17 +162,54 @@ export function registerCohortRoutes(app: Express): void {
   app.use('/api/cohort', requireCoordinator());
 
   // ──────────────────────────────────────────────────────────────────────
-  // Singleton cohort — for the Vila Flores pilot, the orchestrator opens
-  // straight to the one-and-only cohort. No coord slug to remember.
+  // Per-account ownership guard — the multi-tenant isolation boundary. Runs
+  // for every cohort route keyed by :coordinatorSlug. A scoped coordinator
+  // (cohortId set) may only touch their own cohort; an admin (cohortId null)
+  // may touch any. 404 for an unknown slug, 403 for someone else's cohort.
+  // Without this the auth gate proves only "a coordinator", not "this
+  // coordinator's cohort", so any logged-in coordinator could read any cohort
+  // by slug.
   // ──────────────────────────────────────────────────────────────────────
-  app.get('/api/cohort/default', wrap(async (_req, res) => {
+  app.param('coordinatorSlug', async (req, res, next, slugValue) => {
+    try {
+      const cohort = await findCohortByCoordinatorSlug(String(slugValue));
+      if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+      if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
+      (req as any).cohort = cohort;
+      next();
+    } catch (err) { next(err as any); }
+  });
+
+  // Account-resolved cohort — what the orchestrator loads on boot (replacing
+  // the hardcoded /default). A scoped coordinator gets their own cohort; an
+  // admin opens the default singleton. `isAdmin` lets the UI decide whether to
+  // ever show a cohort switcher (deferred until a 2nd cohort exists).
+  app.get('/api/cohort/mine', wrap(async (req, res) => {
+    const coordinator = reqCoordinator(req);
+    let cohort: Awaited<ReturnType<typeof getOrCreateDefaultCohort>> | undefined;
+    if (coordinator?.cohortId) {
+      const [c] = await db.select().from(cohorts).where(eq(cohorts.id, coordinator.cohortId)).limit(1);
+      cohort = c;
+    }
+    if (!cohort) cohort = await getOrCreateDefaultCohort();
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    res.json({ cohort, members, isAdmin: !coordinator?.cohortId });
+  }));
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Singleton cohort — legacy entry point. Still serves the default cohort,
+  // but now ownership-checked so a scoped coordinator can't read/wipe it.
+  // ──────────────────────────────────────────────────────────────────────
+  app.get('/api/cohort/default', wrap(async (req, res) => {
     const cohort = await getOrCreateDefaultCohort();
+    if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     res.json({ cohort, members });
   }));
 
-  app.post('/api/cohort/default/reset', wrap(async (_req, res) => {
+  app.post('/api/cohort/default/reset', wrap(async (req, res) => {
     const cohort = await getOrCreateDefaultCohort();
+    if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
     // Wipe members, restore default workshop cadence. The cohort row itself
     // stays — same singleton, fresh state.
     await db.delete(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
@@ -164,11 +220,26 @@ export function registerCohortRoutes(app: Express): void {
     res.json({ cohort: refreshed, members: [] });
   }));
 
+  // Generic reset for a scoped cohort (the :coordinatorSlug app.param guard
+  // already enforced ownership). Mirrors /default/reset.
+  app.post('/api/cohort/:coordinatorSlug/reset', wrap(async (req, res) => {
+    const cohort = (req as any).cohort ?? await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    await db.delete(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    await db.update(cohorts)
+      .set({ settings: { workshops: DEFAULT_WORKSHOPS } })
+      .where(eq(cohorts.id, cohort.id));
+    const [refreshed] = await db.select().from(cohorts).where(eq(cohorts.id, cohort.id)).limit(1);
+    res.json({ cohort: refreshed, members: [] });
+  }));
+
   // ──────────────────────────────────────────────────────────────────────
   // Create cohort — kept for backward-compat with anything that still calls
   // it. The pilot's UI no longer surfaces this.
   // ──────────────────────────────────────────────────────────────────────
   app.post('/api/cohort', wrap(async (req, res) => {
+    // Only an admin (unscoped coordinator) may spin up new cohorts.
+    if (reqCoordinator(req)?.cohortId) { res.status(403).json({ error: 'only an admin can create cohorts' }); return; }
     const { name } = req.body ?? {};
     const coordinatorSlug = slug();
     const [created] = await db.insert(cohorts).values({

--- a/server/routes/testRoutes.ts
+++ b/server/routes/testRoutes.ts
@@ -35,6 +35,7 @@ import {
 import { setFakeScript, clearFakeScript, peekFakeScript, type FakeTurn } from '../services/fakeCboModel';
 import { createCoordinator, login, COORD_COOKIE } from '../services/coordinatorAuth';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { getOrgIdForCboState, listDocumentsByOrg } from '../services/documentPersistence';
 import { cohorts, cohortMembers, DEFAULT_WORKSHOPS } from '@shared/cohort-schema';
 import { coordinators, coordinatorSessions } from '@shared/coordinator-schema';
 
@@ -161,6 +162,15 @@ export function registerTestRoutes(app: Express): void {
 
   app.get('/__test/cbo/:id/script', wrap(async (req, res) => {
     res.json(peekFakeScript(req.params.id));
+  }));
+
+  // Per-org KB inspection — the documents filed for the org this session is
+  // linked to. Lets a spec assert that an upload landed in the durable store.
+  app.get('/__test/cbo/:id/documents', wrap(async (req, res) => {
+    const orgId = await getOrgIdForCboState(req.params.id);
+    if (!orgId) { res.json({ orgId: null, documents: [] }); return; }
+    const documents = await listDocumentsByOrg(orgId);
+    res.json({ orgId, documents });
   }));
 
   // ── Coordinators ──────────────────────────────────────────────────────────


### PR DESCRIPTION
**Makes "test it and share the video" a single command.** PR 7.

> ⚠️ **Stacks on #235→…→#240.** Base is `main`.

## What
- **`scripts/e2e-local.sh`** — sets up a throwaway Postgres DB, pushes the schema, runs the suite recording a **video + scrubbable trace for every test**, and tells you where to watch. Takes any Playwright args:
  ```bash
  bash scripts/e2e-local.sh                  # whole suite
  bash scripts/e2e-local.sh cbo-golden-path  # one spec
  npm run test:e2e:report                    # open the report → watch
  ```
- **`test:e2e:video`** script + **`E2E_VIDEO=on` / `E2E_TRACE=on`** config toggles (Playwright has no CLI flag for these). Default stays failures-only so green runs don't pile up footage.
- Docs updated, incl. the note below.

## How "show me the video" works
You say *"test it and share the video"* → I run `scripts/e2e-local.sh` → open the HTML report (`playwright show-report`, served at :9323) which embeds the **video per test + the trace** (DOM snapshot at every step). Demonstrated this run: the golden-path test's `video.webm` plays the CBO chat being driven end to end.

> Video is captured only for tests that drive a **browser page** (golden path, login UI, orchestrator redirect, live smoke). The HTTP-layer specs (auth-API boundary, isolation, sticky language) have nothing visual to film — but they still record a **trace** you can scrub.

## Verified
`bash scripts/e2e-local.sh cbo-golden-path cohort-isolation` → 3 passed; golden-path `video.webm` produced; report served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)