### PR TITLE
ci(e2e): add GitHub Actions workflow for the e2e gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,74 @@
+name: e2e
+
+# Deterministic CBO e2e suite — the regression gate. Runs the fake-model suite
+# (no live API calls) against a Postgres service container on every PR and on
+# pushes to main. The live-model quality smoke is NOT run here (it self-skips
+# without RUN_LIVE_QUALITY); run that on-demand against a real preview.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nbs_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # db:push (drizzle) reads this; the Playwright webServer inherits it for
+      # the app process. The test flags + dummy API keys are set by the
+      # webServer.env in playwright.config.ts, so they don't belong here.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/nbs_e2e
+      CI: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Push schema to the test database
+        run: npx drizzle-kit push
+
+      - name: Install Playwright Chromium (+ OS deps)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run deterministic e2e suite
+        run: npm run test:e2e
+
+      - name: Upload HTML report (trace + video)
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload raw test results (screenshots/videos/traces)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 14


### PR DESCRIPTION
The e2e suite (#235–#241) is merged to `main`, but **its workflow file never landed there** — pushing anything under `.github/workflows/` needs the `workflow` OAuth scope, which wasn't available when #238 merged (the file got stranded on the old `feat/e2e-ci` branch). The scope is now granted, so this adds it directly off `main`.

## What it does
Runs the deterministic suite (`npm run test:e2e`) on every PR + push to main, against a Postgres 16 service container: `npm ci` → `drizzle-kit push` → `playwright install --with-deps chromium` → test. Uploads the **HTML report (trace + video)** as an artifact always, raw `test-results/` on failure. The live-model smoke self-skips (no API key needed in CI).

Once this merges, the gate is live — every future PR runs the e2e suite automatically. Repo Actions are already enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)