### PR TITLE
feat(coordinator): secret-gated bootstrap endpoint (provision dev + prod)

### DIFF
--- a/scripts/bootstrap-coordinator.sh
+++ b/scripts/bootstrap-coordinator.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Provision a coordinator on a running deployment via the bootstrap endpoint —
+# the env-agnostic way to mirror dev and prod: run it once against the dev URL and
+# once against the prod URL (each hits its own database). The endpoint is disabled
+# unless BOOTSTRAP_COORDINATOR_SECRET is set in that deployment's env.
+#
+# Usage:
+#   BOOTSTRAP_COORDINATOR_SECRET=<secret> \
+#     bash scripts/bootstrap-coordinator.sh <base-url> <email> <password> ["Full Name"]
+#
+# Examples:
+#   # dev (workspace)
+#   BOOTSTRAP_COORDINATOR_SECRET=xyz bash scripts/bootstrap-coordinator.sh \
+#     http://localhost:5000 joaquin@openearth.org Test_1234 "Joaquin"
+#   # prod (published)
+#   BOOTSTRAP_COORDINATOR_SECRET=xyz bash scripts/bootstrap-coordinator.sh \
+#     https://nbs-project-preparation.replit.app joaquin@openearth.org Test_1234 "Joaquin"
+
+set -euo pipefail
+BASE="${1:?usage: bootstrap-coordinator.sh <base-url> <email> <password> [name]}"
+EMAIL="${2:?email required}"
+PASS="${3:?password required}"
+NAME="${4:-}"
+SECRET="${BOOTSTRAP_COORDINATOR_SECRET:?set BOOTSTRAP_COORDINATOR_SECRET in your env}"
+
+curl -sS -X POST "$BASE/api/coordinator/bootstrap" \
+  -H "x-bootstrap-secret: $SECRET" \
+  -H 'content-type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\",\"name\":\"$NAME\"}"
+echo

--- a/server/routes/coordinatorRoutes.ts
+++ b/server/routes/coordinatorRoutes.ts
@@ -3,7 +3,7 @@
 // (that gate flips on in 3c-ii after an account is provisioned).
 
 import type { Express, Request, Response } from 'express';
-import { login, logout, getCoordinatorBySession, publicCoordinator, COORD_COOKIE } from '../services/coordinatorAuth';
+import { login, logout, getCoordinatorBySession, getCoordinatorByEmail, createCoordinator, publicCoordinator, COORD_COOKIE } from '../services/coordinatorAuth';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -46,6 +46,38 @@ export function registerCoordinatorRoutes(app: Express): void {
       res.json({ coordinator: publicCoordinator(coordinator) });
     } catch (e: any) {
       console.error('[coordinator] me error', e);
+      res.status(500).json({ error: 'internal error' });
+    }
+  });
+
+  // Bootstrap a coordinator over HTTP — the simple, env-agnostic way to provision
+  // accounts in BOTH dev and prod: same call, hit the dev URL → dev DB, hit the
+  // prod URL → prod DB (each deployment talks to its own database). DISABLED
+  // unless BOOTSTRAP_COORDINATOR_SECRET is set, and every call must carry it in
+  // the x-bootstrap-secret header. Idempotent: if the email already exists it's
+  // returned unchanged (never silently resets a password). Set the secret, create
+  // your coordinators, then optionally unset it to close the endpoint entirely.
+  app.post('/api/coordinator/bootstrap', async (req: Request, res: Response) => {
+    try {
+      const secret = process.env.BOOTSTRAP_COORDINATOR_SECRET;
+      if (!secret) { res.status(404).json({ error: 'not found' }); return; } // disabled when unset
+      if (req.header('x-bootstrap-secret') !== secret) { res.status(401).json({ error: 'bad bootstrap secret' }); return; }
+
+      const { email, password, name, cohortId } = req.body ?? {};
+      if (!email || !password) { res.status(400).json({ error: 'email and password required' }); return; }
+
+      const existing = await getCoordinatorByEmail(String(email));
+      if (existing) { res.json({ created: false, coordinator: publicCoordinator(existing) }); return; }
+
+      const c = await createCoordinator({
+        email: String(email),
+        password: String(password),
+        name: name ? String(name) : undefined,
+        cohortId: typeof cohortId === 'string' ? cohortId : null, // null = admin
+      });
+      res.status(201).json({ created: true, coordinator: publicCoordinator(c) });
+    } catch (e: any) {
+      console.error('[coordinator] bootstrap error', e);
       res.status(500).json({ error: 'internal error' });
     }
   });

--- a/server/services/coordinatorAuth.ts
+++ b/server/services/coordinatorAuth.ts
@@ -42,6 +42,11 @@ export async function createCoordinator(input: {
   return c;
 }
 
+export async function getCoordinatorByEmail(email: string): Promise<Coordinator | null> {
+  const [c] = await db.select().from(coordinators).where(eq(coordinators.email, email.trim().toLowerCase())).limit(1);
+  return c ?? null;
+}
+
 /** Verify credentials and mint a session. Returns null on bad email/password. */
 export async function login(email: string, password: string): Promise<{ token: string; coordinator: Coordinator } | null> {
   const [c] = await db.select().from(coordinators).where(eq(coordinators.email, email.trim().toLowerCase())).limit(1);


### PR DESCRIPTION
**The simple, env-agnostic way to create coordinator accounts in both dev and prod** — solving the Replit dev/prod DB split (the workspace shell writes to the *dev* DB, so `create-coordinator` there never shows up on the published app).

## How it works
`POST /api/coordinator/bootstrap` creates a coordinator in **whichever database that deployment talks to**. So:
- hit the **dev URL** → coordinator in dev
- hit the **prod URL** → coordinator in prod
- run it twice with the same body → **mirrored** in both.

```bash
BOOTSTRAP_COORDINATOR_SECRET=<secret> bash scripts/bootstrap-coordinator.sh \
  https://nbs-project-preparation.replit.app joaquin@openearth.org Test_1234 "Joaquin"
```

## Safety
- **Disabled unless `BOOTSTRAP_COORDINATOR_SECRET` is set** (returns 404) — so it's inert on any env that doesn't configure it.
- Every call must carry the secret in `x-bootstrap-secret`.
- **Idempotent** — an existing email is returned unchanged (never silently resets a password). `cohortId` omitted = admin.
- Recommended flow: set the secret → create your accounts → **unset the secret** to close the endpoint entirely.

## Verified
Local: no secret → 401, correct secret + new email → 201 `created:true`, re-run → `created:false`, then login with the new creds → 200.

## To use (after merge + republish)
1. Set `BOOTSTRAP_COORDINATOR_SECRET` in **both** the dev workspace secrets and the **deployment** secrets (same value).
2. Run the script against the dev URL and the prod URL.
3. Optionally unset the secret afterward.

This unblocks the real-invite-link test path (a coordinator can then create the E2E Test cohort + invites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)