### PR TITLE
fix(encontro-1): free-text as prose (no 'type it below') + no language mixing

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -62,6 +62,19 @@ Forbidden patterns:
 - Acknowledging an answer in plain text and ending the turn without firing the next `ask_user`.
 - Generating a paragraph saying *"once we're done with a few more questions, I'll ask about X"* instead of just asking X.
 
+### Free-text questions are PLAIN PROSE — never wrapped in `ask_user`
+
+A handful of questions have no natural buckets: **org name** (when not pre-filled), **contact name**, **contact role**, **year founded**, **proud moment**. Ask these as a **plain-text question** and stop. The chat always shows a text input below the conversation, so the user just types their answer.
+
+This is an **explicit exception** to "every turn ends with a tool call." A plain-text *question* is NOT a stranded turn — the turn carries text (the question), the input box is right there, and the user answers. The stranded-turn failure is only when you call `update_section` and end with **nothing at all** (no question, no tool).
+
+**NEVER do this for a free-text question:**
+- ❌ Calling `ask_user` with a single option like *"I'll type it below"* / *"Type my name"* / *"Outra coisa"*. That forces the user to click a button **and then** type — two steps for one answer. It is the most common pace-killer in this flow. Just ask the question in prose.
+- ❌ Adding chips to a name/year question. There are no buckets; chips only add friction.
+
+Right: *"E você, com quem estou conversando?"* → (user types "Marina") → next question.
+Wrong: `ask_user("Qual seu nome?", ["✍️ Vou digitar abaixo"])` → user clicks → then types.
+
 ## ⚠️ Org type — capture it through `legal_form`, don't interrogate it
 
 Do **not** open with a blunt *"What type of organization are you?"* / *"are you a CBO?"* — it's friction, especially for a community group (like asking *"Are you a person?"*). The org type falls out naturally from the `legal_form` question (#3 below), which now includes an **implementer / company / studio** option — so an NbS-first implementer (e.g. a landscape studio) self-identifies without being made to feel out of place, and a community group isn't quizzed.
@@ -109,10 +122,12 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 
 Below is the exact ask_user shape for each question. Always include "Outra coisa" (free-text) and "Não sei / Prefiro pular" where it makes sense.
 
-### 1. Identity
-- **Org name** — pre-filled, just confirm: *"Conferindo: organização é {orgName}, certo? Pode corrigir se eu peguei errado."* (free-text reply OK)
-- **Contact name** — free-text: *"E você, com quem estou conversando?"*
-- **Contact role** — free-text: *"Qual seu papel na {orgName}?"* (e.g. coordenadora, voluntária)
+### 1. Identity (all plain free-text — NO `ask_user`, NO chips, NO "type it below")
+- **Org name** —
+  - If pre-filled from the invite (CURRENT STATE already has `org_name`): just confirm in prose — *"Conferindo: organização é {orgName}, certo? Pode corrigir se eu peguei errado."*
+  - If NOT pre-filled (someone opened the page without an invite): ask it directly as prose — *"Qual é o nome da sua organização?"* Do not wrap it in `ask_user`.
+- **Contact name** — plain prose: *"E você, com quem estou conversando?"*
+- **Contact role** — plain prose: *"Qual seu papel na {orgName}?"* (e.g. coordenadora, voluntária)
 
 ### 2. Mission
 - **Mission summary** — `ask_user` chips (the free-text input is always available below the chips for any user who prefers to type their own one-sentence description):

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -120,8 +120,8 @@ export function registerCboRoutes(app: Express): void {
     }
     const isPt = sessionLang === 'pt';
     const langDirective = isPt
-      ? '\n[LANGUAGE: Respond in Portuguese. ask_user option labels in Portuguese. update_section content in Portuguese. One language only.]'
-      : '\n[LANGUAGE: Respond in English. ask_user option labels in English. update_section content in English. One language only.]';
+      ? '\n[LANGUAGE: Respond ONLY in Portuguese — every single word, including ask_user option labels and update_section content. Do NOT mix in any English words or phrases, even if the user writes some English back. One language, Portuguese, with no exceptions.]'
+      : '\n[LANGUAGE: Respond ONLY in English — every single word, including ask_user option labels and update_section content. Do NOT mix in any Portuguese words or phrases, even if the user writes some Portuguese back. One language, English, with no exceptions.]';
 
     const resolvedLang = sessionLang;
     addCboMessage(req.params.id, { role: 'user', content: message, messageType: 'content', timestamp: new Date().toISOString() });


### PR DESCRIPTION
Both fixes come straight from the **real live-agent run** we did against the deployment.

## #1 — Kill the "type it below" chip on free-text questions
The agent asked org name / contact name via an `ask_user` with a single chip like *"I'll type it below"* → the user clicks it **and then** types: two steps for one answer, ×every free-text field. **Root cause:** the skill's "every turn must end with a tool call" rule conflicts with free-text questions (which have no turn-ender tool), so the agent wrapped them in `ask_user` to comply.

**Fix (`encontro-1.md`):**
- New rule: free-text questions (org name when not pre-filled, contact name, contact role, year, proud moment) are **plain prose** — an explicit exception to the tool-call rule (a prose *question* carries text and the input box is always shown, so it's not a stranded turn). Explicitly forbids the "type it below" / single-option `ask_user` pattern.
- Identity section now handles the **no-invite** case (ask the org name fresh as prose instead of assuming it's pre-filled).

## #2 — No language mixing
The live run showed the agent leaking both languages in one message (*"Que ótimo, Marina! That sounds like a wonderful combination…"*). **Fix (`cboRoutes.ts`):** strengthened the per-turn LANGUAGE directive to forbid mixing PT and EN in the same message, even when the user writes some of the other language. (The skill already defaults to Brazilian Portuguese and switches only if the user writes English first — the English-only run was a *test* artifact: Playwright's en-US browser made the page send `lang=en`. I'm fixing the test to run in pt-BR separately.)

## Note
These edit the live `encontro-1.md` skill + the language directive, so they affect the production flow on next republish. Verified `tsc` clean. Best validated by re-running the live walkthrough after merge (which I'll do once the prod coordinator + pt-BR locale are in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)