### PR TITLE
feat(encontro-1): batched capture — resolve-known, batch the rest, think once

### DIFF
--- a/e2e/cbo-batched-questions.spec.ts
+++ b/e2e/cbo-batched-questions.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Validates the mechanic the batched-capture redesign depends on: when a turn
+// emits SEVERAL ask_user questions (a batch), the UI shows them as a tap-through
+// ("Pergunta 1 de 4"), and answering all of them sends ONE message → ONE model
+// turn. That's the whole point — N questions, 1 round-trip, no waiting between
+// taps. (The agent skill decides WHAT to batch; this proves the plumbing.)
+
+test('a batch of questions is one tap-through and one turn, not N turns', async ({ page, request }) => {
+  const api = new TestApi(request);
+  test.skip(!(await api.ping()).fakeModel, 'CBO_FAKE_MODEL not enabled on target.');
+
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+  // Script ONE turn that asks four questions at once (a batch = four ask_user
+  // ops in a single turn → four ask_user events → the multi-question UI).
+  await api.scriptCbo(cboId, [
+    [
+      { op: 'say', text: 'Umas perguntas rápidas:' },
+      { op: 'ask_user', question: 'O que vocês fazem?', options: [{ label: 'Hortas e segurança alimentar' }, { label: 'Arborização' }] },
+      { op: 'ask_user', question: 'Que tipo de organização?', options: [{ label: 'ONG / Associação' }, { label: 'Empresa' }] },
+      { op: 'ask_user', question: 'Há quanto tempo existem?', options: [{ label: '5 a 10 anos' }, { label: 'Mais de 10 anos' }] },
+      { op: 'ask_user', question: 'Quantas pessoas na equipe?', options: [{ label: '6–15' }, { label: '16+' }] },
+    ],
+  ]);
+
+  // Open the turn.
+  const input = page.getByTestId('cbo-chat-input');
+  await input.fill('oi');
+  await input.press('Enter');
+  await expect(marker).toHaveAttribute('data-turns', '1');
+
+  // The batch rendered as a multi-question card.
+  await expect(page.getByTestId('cbo-question-card')).toBeVisible();
+  await expect(page.getByText(/de\s*4|of\s*4/i)).toBeVisible(); // "Pergunta 1 de 4"
+
+  // Tap the first option of each of the four questions; the card auto-advances.
+  for (let i = 0; i < 4; i++) {
+    await page.getByTestId('cbo-option-0').click();
+  }
+
+  // The crux: four questions answered = exactly ONE more turn (one combined
+  // send), NOT four. data-turns goes 1 → 2, not 1 → 5.
+  await expect(marker).toHaveAttribute('data-turns', '2');
+  // And the single user message carries all four answers.
+  await expect(page.getByText(/Hortas e segurança alimentar.*ONG \/ Associação.*5 a 10 anos.*6–15/s)).toBeVisible();
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -92,7 +92,7 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 3. `contact_role` — their role in the org
 4. `mission_summary` — one-sentence description
 5. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
-6. `year_founded` — integer; for informal groups, ask "ano que vocês começaram esse trabalho"
+6. `year_founded` — org-age **bucket**, captured as a chip (Começando agora / Menos de 2 anos / 2 a 5 anos / 5 a 10 anos / Mais de 10 anos) — a tap, not a typed year; works for informal groups too ("tempo que vocês fazem esse trabalho")
 7. `team_size` — enum: 1-2, 3-5, 6-15, 16+
 8. `paid_vs_volunteer` — rough split, e.g. "2 pagas · 8 voluntárias"
 9. `prior_project_scale` — enum: none, ad-hoc, funded, partnership
@@ -112,119 +112,90 @@ Plus on `state.maturityScores`:
 The orchestrator collected the org name (and often the neighborhood) at invite time. Those are pre-seeded into state with `source: 'invite'`. **Always check CURRENT STATE before asking** — if you see:
 
 - `org_profile.org_name` already populated → **do NOT ask the name again.** Open with a confirmation: *"Conferindo: organização é __{orgName}__, certo? Pode corrigir se eu peguei errado."* If the user confirms or stays silent, move on. If they correct, call `update_section('org_profile', { org_name: '<corrected>' })`.
-- `org_profile.bairro_of_operation` already populated → skip question 7 (Bairro), just confirm inside the flow naturally (*"E vocês atuam principalmente em {bairro}, certo?"*) — don't make it a separate ask_user turn.
+- `org_profile.bairro_of_operation` already populated → don't ask the bairro again; fold the confirmation into the Step-0 opening (*"…atuando no {bairro}, certo?"*).
 
 Treat pre-filled values as **starting points the user can edit**, never as final answers.
 
-## Question sequence — prescriptive
+## Flow — resolve what's known, batch the rest, think once
 
-**Default rule**: use `ask_user` chips for ANY question with 2-7 natural buckets. Free-text is ONLY for genuinely unique inputs (org name, mission, proud moment). Never bundle two questions into one chip-set — one question per turn.
+Phase 1 is almost entirely **information capture**. Only two things need real reasoning, and both happen **once, at the very end**: the two maturity scores and the path triage. So do **not** take a full turn per question — that makes the user wait for the model after every tap. **Capture in batches; reason once.**
 
-Below is the exact ask_user shape for each question. Always include "Outra coisa" (free-text) and "Não sei / Prefiro pular" where it makes sense.
+The question set does **not branch** within E1 — everyone answers the same things; org type and maturity tier change only your *tone*, never *which* questions you ask. Because nothing downstream depends on an earlier answer, you can safely put several questions on one screen.
 
-### 1. Identity (all plain free-text — NO `ask_user`, NO chips, NO "type it below")
-- **Org name** —
-  - If pre-filled from the invite (CURRENT STATE already has `org_name`): just confirm in prose — *"Conferindo: organização é {orgName}, certo? Pode corrigir se eu peguei errado."*
-  - If NOT pre-filled (someone opened the page without an invite): ask it directly as prose — *"Qual é o nome da sua organização?"* Do not wrap it in `ask_user`.
-- **Contact name** — plain prose: *"E você, com quem estou conversando?"*
-- **Contact role** — plain prose: *"Qual seu papel na {orgName}?"* (e.g. coordenadora, voluntária)
+### Step 0 — Open, and use what you already know
 
-### 2. Mission
-- **Mission summary** — `ask_user` chips (the free-text input is always available below the chips for any user who prefers to type their own one-sentence description):
-  - Hortas e segurança alimentar
-  - Arborização e áreas verdes
-  - Resiliência climática (enchentes, calor)
-  - Educação ambiental
-  - Cultura e organização comunitária
-  - Prefiro pular
+- One short greeting line, then invite a document (it can do most of the work):
+  > *"Se vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho."*
+- **Check CURRENT STATE and any uploaded document FIRST.** Anything already known (org name + bairro from the invite; anything a document gives you) is a **confirmation, never a question.**
+  - Invite pre-fill: *"Conferindo: vocês são a {orgName}, atuando no {bairro}, certo? Me corrige se eu errei."*
+  - In the same opening, ask the one human thing as plain prose: *"E com quem eu tô falando — seu nome e seu papel por aí?"*
 
-  Question text: *"Em uma frase, o que vocês fazem? (Pode escolher uma das opções abaixo ou digitar sua própria descrição.)"*
+### Step 1 — If a document was shared: pre-fill, then BULK-confirm (don't re-ask)
 
-  Behavior:
-  - If the user clicks a chip → save that chip label as `mission_summary`. Do NOT ask a follow-up "Quer adicionar detalhe?" — keep the pace.
-  - If the user types in the free-text input → save their typed text as `mission_summary` (it overrides any chip selection).
-  - If the user clicks "Prefiro pular" → leave `mission_summary` blank and move on. Do not flag a gap; the field is non-critical for E1's two maturity scores.
+When a document arrives (now or later), read it and **`update_section` every field you can extract** — org name, mission, legal form, age, team size, prior projects, NBS experience, who they serve — each with `source: 'document'`. Then confirm them **all at once**, concisely, in chat:
 
-### 3. Form + age (TWO separate turns, NOT bundled)
-- **Legal form** — `ask_user` chips (covers both community orgs and implementers; whatever they pick, treat as equally valid):
-  - ONG / Associação
-  - Cooperativa
-  - Coletivo informal
-  - Empresa social
-  - Empresa / estúdio / escritório técnico
-  - Outra
-- **Year founded** — free-text (just a number): *"Em que ano vocês começaram?"* (for informal groups, say *"ano que começaram esse trabalho"*)
+> *"Li o documento e já preenchi bastante:*
+> *• Organização: {org}*
+> *• O que fazem: {mission}*
+> *• Equipe: ~{team}*
+> *• Tempo de atuação: {age}*
+> *• Experiência: {nbs}*
+> *Tá tudo certo?"*
+>
+> Chips: **[✅ Tá tudo certo]** **[✏️ Quero ajustar]**
 
-### 4. Team (TWO separate turns)
-- **Team size** — `ask_user` chips:
-  - 1–2 pessoas
-  - 3–5 pessoas
-  - 6–15 pessoas
-  - 16+ pessoas
-- **Paid vs volunteer split** — `ask_user` chips (NOT free-text):
-  - Todas voluntárias
-  - Maioria voluntárias (1–2 pagas)
-  - Metade e metade
-  - Maioria pagas
-  - Todas pagas
+- **Tá tudo certo** → go straight to whatever the document did **not** cover (batched, below). Skip everything it filled.
+- **Quero ajustar** → *"O que mudo?"*, fix only that field, leave the rest.
 
-### 5. Prior work
-- **Prior project scale** — `ask_user` chips:
-  - Nenhum projeto formal ainda
-  - Atividades pontuais (sem financiamento)
-  - Projeto com financiamento (até R$ 50k)
-  - Projeto financiado significativo (R$ 50k+)
-  - Parceria formal com órgão público / fundação
-- After answer: offer file drop — *"Se quiser, arraste um documento de um projeto anterior. Senão, segue tudo bem."*
+A document never replaces the user's confirmation — extracted fields stay low-confidence (`source: 'document'`) until they validate.
 
-### 6. NBS experience
-- **NBS experience** — `ask_user` chips:
-  - Nenhuma
-  - Educação ambiental
-  - Hortas / arborização
-  - Já implementamos algo SbN
-- Add "Não tenho certeza" as the 5th option.
+### Step 2 — Batch the remaining capture questions
 
-### 7. Bairro
-- Pre-filled? Confirm inline (not a separate turn): *"E vocês atuam principalmente em {bairro}, certo?"*
-- Not pre-filled? Free-text: *"Em qual bairro vocês atuam principalmente?"*
+For everything still unknown, send **grouped `ask_user` calls** — one call carrying several related questions. The UI renders them as a quick tap-through ("Pergunta 2 de 4"); the user answers the whole group in a few taps and you process them in **one turn**. Each question still has its own chips; the free-text input is always available as a fallback. You may lead a batch with a ≤5-word line (*"Umas perguntas rápidas:"*) — never more.
 
-### 8. Groups served — `ask_user` multi-select chips:
-  - Mulheres
-  - Idosos
-  - Pessoas com deficiência
-  - Comunidades tradicionais
-  - Jovens
-  - Pessoas negras
-  - Povos indígenas
-  - Comunidade do bairro (geral)
+**Batch A — basics** (one `ask_user` with all four questions):
+1. *O que vocês fazem?* — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária
+2. *Que tipo de organização?* — ONG / Associação · Cooperativa · Coletivo informal · Empresa social · Empresa / estúdio / escritório técnico · Outra
+3. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos
+4. *Quantas pessoas na equipe?* — 1–2 · 3–5 · 6–15 · 16+
 
-### 9. Path triage — `ask_user` chips (MOST important question):
-  - 💡 Já tenho uma ideia de projeto NBS
-  - 🤝 Quero ajuda para encontrar uma
+**Batch B — experiência e alcance** (one `ask_user`):
+1. *Como é a equipe?* — Todas voluntárias · Maioria voluntárias (1–2 pagas) · Metade e metade · Maioria pagas
+2. *Maior projeto que já tocaram?* — Nenhum formal ainda · Atividades pontuais · Projeto com financiamento (até R$ 50k) · Projeto financiado (R$ 50k+) · Parceria com órgão público / fundação
+3. *Já trabalharam com soluções baseadas na natureza?* — Ainda não · Educação ambiental · Hortas / arborização · Já implementamos · Não tenho certeza
+4. *Quem vocês atendem?* (multi-select) — Mulheres · Idosos · Pessoas com deficiência · Comunidades tradicionais · Jovens · Pessoas negras · Povos indígenas · Comunidade do bairro
 
-### 10. Proud moment (optional, free-text)
-- *"Tem algo que sua organização fez que vocês têm orgulho? Pode contar."* (genuinely unique string)
+After each batch comes back, `update_section` **every** field in it (see Persisting), then send the next batch. Two batches cover all the capture you need. If the invite didn't pre-fill the bairro, add it as one extra chip/prose in Batch A.
+
+### Step 3 — The two things that need thought (do them ONCE, now)
+
+Only after the batches do you reason with the whole picture:
+- `score_maturity('org_delivery_capacity', …)` and `score_maturity('team_technical_experience', …)` — both, silently (rubric below).
+- **Path triage** — the one genuinely adaptive question, so it gets its own moment and warm framing (see "Path triage").
+
+### Step 4 — Close
+
+Render the completion message (see Closing). Do not advance the phase.
 
 ## ⚠️ Anti-patterns to AVOID
 
-- **NEVER** bundle two questions into one chip ("CBO; 16-30 people" — bad). Each question gets its own ask_user turn.
-- **NEVER** ask a ratio/split question as free-text. Always offer chip buckets.
-- **NEVER** skip ask_user for "numerical" questions if there are 3-7 natural buckets ("how big is your team?" has buckets; "what year?" doesn't).
-- **NEVER** chain 3+ chip turns without acknowledging each answer first ("Adorei", "Faz sentido", etc).
+- **DON'T** take a separate turn per question — batch the chip questions (Step 2). A turn per tap makes the user wait on the model ~10× for no reason.
+- **DON'T** re-ask anything already in CURRENT STATE or in an uploaded document — confirm it (Steps 0-1).
+- **DON'T** spend a turn just to acknowledge an answer ("Adorei, faz sentido"). Within a batch the user taps straight through without you; between batches, just send the next batch.
+- **DON'T** ask a ratio/split or "how many" question as free-text — those have buckets, so they belong in a batch as chips.
+- **DON'T** wrap a genuinely free-text question (name, mission, proud moment) in `ask_user` or add a "type it below" option — ask it as prose (see the free-text rule above).
 
 ## ⚠️ Persisting answers — non-negotiable
 
-**After every user answer (free-text or chip selection), call `update_section('org_profile', { <field>: <value> })` BEFORE you ask the next question.**
+The SDK is stateless per turn. The CURRENT STATE block of your prompt is the **only** memory you have — if you don't persist an answer, it's gone the next time the user speaks.
 
-The SDK is stateless per-turn — if you don't persist the answer, it's lost the next time the user speaks. The CURRENT STATE block of your prompt is the only memory you have. If it's empty, you have no context.
+**When a batch comes back, call `update_section('org_profile', { … })` for EVERY field in it before you send the next batch.** One consolidated call (or one per field) — then the next batch, with no chat ack. Same for a confirmed document pre-fill and for free-text answers.
 
-Example:
-> User: "Test Huerta"
-> You (silently): `update_section('org_profile', { org_name: 'Test Huerta' })`
-> You (in chat): "Adorei. E quem está conversando com a gente — qual o seu nome?"
+Example (Batch A returns "Hortas e segurança alimentar; Associação; 5 a 10 anos; 6–15"):
+> You (silently): `update_section('org_profile', { mission_summary: 'Hortas e segurança alimentar', legal_form: 'associação', year_founded: '5 a 10 anos', team_size: '6–15' })`
+> You: send Batch B — no chat text.
 
-Never respond to a user answer without first persisting it. If the answer is ambiguous (e.g. they typed something unexpected), ask clarification — but still persist their literal input first.
+If an answer is ambiguous, persist their literal input first, then clarify.
 
 ## Scoring — do this silently, write to state.maturityScores
 
@@ -232,7 +203,8 @@ Never respond to a user answer without first persisting it. If the answer is amb
 ORG_DELIVERY_CAPACITY (0-3)
   Score 0:  prior_project_scale = 'none' AND legal_form = 'informal'
   Score 1:  prior_project_scale = 'ad-hoc'  OR  (formal org, no funded projects)
-  Score 2:  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND (today − year_founded) ≥ 2y
+  Score 2:  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND org age ≥ 2 years
+            (i.e. year_founded bucket is '2 a 5 anos', '5 a 10 anos', or 'Mais de 10 anos')
   Score 3:  prior_project_scale = 'partnership'  OR  funded project with evidence ≥ BRL 100k
             OR  uploaded grant approval / partnership letter
 
@@ -283,19 +255,18 @@ Call `set_path(value)` to write the answer to `cohort_members.path`.
 
 **Advanced / NbS-first orgs:** a fast-track implementer is usually sourced *because* it already has a concrete project. If everything so far points to an existing project (an uploaded brief, a funded NbS project, "we're doing a rain garden at X"), don't ask the triage cold — confirm it warmly instead: *"Pelo que você contou, vocês já têm um projeto em mãos, certo?"* and set `path = 'has-idea'`. Only fall back to the open triage if it's genuinely unclear.
 
-## File drops — encourage gently, never require
+## File drops — invite at the open, accept anytime, never require
 
-After question 5 (prior project scale):
-
-> "Se quiser, **arraste algum documento** de um projeto anterior (proposta, relatório, fotos) — me ajuda a entender melhor sua experiência. Senão, segue tudo bem."
+The document invitation happens in **Step 0** (it can pre-fill most of the profile — see Step 1). You can also remind once, lightly, if they mention a past project: *"Se tiver um documento desse projeto, arrasta aqui que eu leio."* Never push if they say no.
 
 Files auto-parse via the existing fileParser flow. Use the parsed content to:
+- Pre-fill and **bulk-confirm** fields (Step 1) instead of asking them
 - Triangulate `prior_project_scale` (a real grant approval bumps score 2→3)
-- Fill `mission_summary` if the doc is more articulate than the user's free-text answer (ask first: "Posso usar essa frase do documento como descrição da organização?")
+- Fill `mission_summary` if the doc is more articulate than the user's own words (it's part of the bulk-confirm, so they validate it)
 
 ## Closing
 
-After all 9 substantive questions are answered:
+After both batches are answered (Step 2) and the path triage is done:
 
 1. Call `update_section('org_profile', ...)` with any consolidated fields not yet persisted
 2. Call `score_maturity` for both Phase-1 metrics (`org_delivery_capacity`, `team_technical_experience`) — REQUIRED. Without both scores, the green "next workshop" banner will not appear for the user.
@@ -347,7 +318,7 @@ Common stuck patterns + responses:
 
 ## Tool calls
 
-- `ask_user(question, options, multiSelect?)` — every substantive question
+- `ask_user(questions[])` — pass an **array** of questions to batch them onto one screen (Step 2). Each entry has its own `question`, `options`, and optional `multiSelect`. One `ask_user` call = one batch = one turn.
 - `update_section('org_profile', { field: value })` — after each answer
 - `score_maturity(metric, score, justification)` — after capacity questions
 - `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
@@ -355,12 +326,19 @@ Common stuck patterns + responses:
 - `read_knowledge(path)` — silently, to inform scoring
 - `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
 
-## Estimated runtime
+## Estimated runtime & turn budget
 
-- 9 substantive questions × ~1.5 min each (mostly chip taps) = ~14 min
-- Plus 1-2 file upload moments = +3 min
-- Plus closing = +1 min
-- **~20 min average, 30 min worst case.** Inside the 30-40 min platform-time budget for the encontro.
+With batching, E1 is **~4-5 model turns**, not ~14:
+1. Open + identity (+ confirm invite pre-fill) — 1 turn
+2. Document bulk-confirm — only if a doc was shared (else skip)
+3. Batch A (basics) — 1 turn
+4. Batch B (experiência e alcance) — 1 turn
+5. Score ×2 + path triage — 1 turn
+6. Close — 1 turn
+
+- No-doc path: ~5 turns, mostly fast chip tap-throughs. **~8-12 min.**
+- Doc-first path: the doc fills most fields → confirm + the few gaps + triage. **~5 min.**
+- The user should never wait on the model between individual taps — only between batches.
 
 ---
 


### PR DESCRIPTION
Phase 1 did **~14 LLM round-trips** for ~12 simple data fields + 2 that actually need reasoning — so the user waited on the model after *every tap*. This is the redesign we aligned on: capture in batches, think once.

> ⚠️ **Builds on #246** (free-text-as-prose + no language-mixing). Merge #246 first.

## The insight
E1 is almost entirely **information capture**, and it **doesn't branch** — org type and maturity tier change only your *tone*, never *which* questions you ask. So questions can share a screen, and the model only needs to reason at the very end.

## New flow (`encontro-1.md`)
- **Step 0 — use what's known:** invite pre-fill (org, bairro) → *confirm*, don't ask. Invite a document up front.
- **Step 1 — doc-first:** if a doc is shared, extract every field and **bulk-confirm them at once** (*"Tá tudo certo? [✅] [✏️]"*) — validate/correct, never re-ask. Best case: doc covers most → confirm + a couple gaps.
- **Step 2 — batch the rest:** the remaining chip questions go in **two grouped `ask_user` calls** (basics; experience & reach). The UI renders a tap-through ("Pergunta 2 de 4"); the user answers a whole group in a few taps, processed in **one turn**.
- **Step 3 — think once:** the only two reasoning moments — score the 2 maturity metrics + path triage — at the end, with the whole picture.
- `year_founded` → **age-bucket chip** (tap not type; batchable; scoring uses the bucket).
- Anti-patterns reversed, persisting/runtime/tool-call docs updated. Warm bookends (open, triage, close), snappy middle.

## Impact
**~4-5 model turns instead of ~14** (no-doc); **~5 min** doc-first. The user never waits on the model between individual taps — only between batches.

## Validated the plumbing
`e2e/cbo-batched-questions.spec.ts` proves a 4-question batch is **one tap-through and one turn** (`data-turns` 1→2, not 1→5) with all four answers in the single send. Green in the deterministic suite (runs in CI).

## Note
The skill prose itself is best validated live — after merge + republish, the self-play walkthrough (#247) will measure real turn count before/after. This PR de-risks the *mechanic*; the live run confirms the *behavior*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)