### PR TITLE
fix(i18n): pt-BR browsers get Portuguese, not English

### DIFF
--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -12,6 +12,12 @@ i18n
   .init({
     fallbackLng: 'en',
     supportedLngs: ['en', 'pt'],
+    // Map region locales to the base language — without this, a `pt-BR` browser
+    // (every Brazilian user + Playwright's pt-BR locale) doesn't match the
+    // supported `pt` and silently falls back to English. This is why the CBO
+    // agent kept answering in English to Portuguese-speaking users.
+    load: 'languageOnly',
+    nonExplicitSupportedLngs: true,
     debug: false,
 
     interpolation: {


### PR DESCRIPTION
**The root cause of the CBO agent answering in English to Portuguese-speaking users.**

`supportedLngs` is `['en','pt']`, but there was no `load: 'languageOnly'` — so a **`pt-BR` browser locale (every Brazilian user)** doesn't match `pt`, silently falls back to `fallbackLng: 'en'`, the page sends `lang='en'` to the agent, and the kickoff greets in English.

**Fix:** `load: 'languageOnly'` + `nonExplicitSupportedLngs: true` so `pt-BR` → `pt`.

**Verified locally** (Playwright): a `pt-BR` browser now sends `lang='pt'` and the flow runs in Portuguese ("Entendi. Vamos continuar."); `en-US` still sends `'en'`. This affects **all real Brazilian users**, not just the e2e test — it's why the live walkthrough kept running in English.

One file. After merge + republish, I'll confirm the real agent greets + runs in Portuguese on the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)