### PR TITLE
feat(cbo): voice-note input in the chat composer (tap-to-record)

### DIFF
--- a/client/src/core/hooks/useVoiceRecorder.ts
+++ b/client/src/core/hooks/useVoiceRecorder.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Voice-note recorder for the chat composer. Tap-to-start / tap-to-stop (NOT
+// hold-to-record): the audience is phone-first community orgs giving longer
+// spoken answers, and a toggle is easier to reach + more accessible than a
+// press-and-hold. On stop we POST the clip to /api/cbo/:id/transcribe (the
+// existing Replit AI transcription path) and hand the text back via onTranscript
+// — which the page drops into the input box for the user to REVIEW before
+// sending. The agent never receives audio, only the confirmed text.
+
+export type RecorderStatus = 'idle' | 'recording' | 'transcribing';
+export type RecorderError = 'permission' | 'unsupported' | 'transcribe' | 'empty' | 'mic';
+
+interface Options {
+  cboId: string | null;
+  lang?: string;
+  onTranscript: (text: string) => void;
+  onError?: (kind: RecorderError, message?: string) => void;
+}
+
+// `audio/mp4` is what iOS Safari emits; webm/opus is everyone else. Pick the
+// first the browser actually supports so the blob has a usable container.
+function pickMimeType(): string | undefined {
+  if (typeof MediaRecorder === 'undefined') return undefined;
+  const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus'];
+  for (const c of candidates) {
+    try { if (MediaRecorder.isTypeSupported(c)) return c; } catch { /* older Safari throws */ }
+  }
+  return undefined; // let the browser choose its default
+}
+
+function extFor(mime: string): string {
+  if (mime.includes('mp4')) return 'm4a';
+  if (mime.includes('ogg')) return 'ogg';
+  return 'webm';
+}
+
+export function useVoiceRecorder({ cboId, lang, onTranscript, onError }: Options) {
+  const [status, setStatus] = useState<RecorderStatus>('idle');
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const supported = typeof navigator !== 'undefined'
+    && !!navigator.mediaDevices?.getUserMedia
+    && typeof MediaRecorder !== 'undefined';
+
+  const cleanupStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach(tr => tr.stop());
+    streamRef.current = null;
+  }, []);
+
+  const transcribe = useCallback(async (blob: Blob, mime: string) => {
+    if (!cboId) { setStatus('idle'); return; }
+    if (blob.size < 1200) { setStatus('idle'); onError?.('empty'); return; }
+    setStatus('transcribing');
+    try {
+      const fd = new FormData();
+      fd.append('audio', blob, `voice.${extFor(mime)}`);
+      if (lang) fd.append('lang', lang);
+      const res = await fetch(`/api/cbo/${cboId}/transcribe`, { method: 'POST', body: fd });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        onError?.('transcribe', data?.fix || data?.error);
+        return;
+      }
+      const data = await res.json();
+      const text = (data?.text || '').trim();
+      if (text) onTranscript(text); else onError?.('empty');
+    } catch (e: any) {
+      onError?.('transcribe', e?.message);
+    } finally {
+      setStatus('idle');
+    }
+  }, [cboId, lang, onTranscript, onError]);
+
+  const start = useCallback(async () => {
+    if (!supported) { onError?.('unsupported'); return; }
+    if (status !== 'idle') return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = pickMimeType();
+      const rec = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      const usedMime = rec.mimeType || mimeType || 'audio/webm';
+      chunksRef.current = [];
+      rec.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
+      rec.onstop = () => {
+        cleanupStream();
+        const blob = new Blob(chunksRef.current, { type: usedMime });
+        chunksRef.current = [];
+        transcribe(blob, usedMime);
+      };
+      rec.onerror = () => { cleanupStream(); setStatus('idle'); onError?.('mic'); };
+      recorderRef.current = rec;
+      rec.start();
+      setStatus('recording');
+    } catch (e: any) {
+      cleanupStream();
+      setStatus('idle');
+      // getUserMedia rejects with NotAllowedError when the user denies the mic.
+      onError?.(e?.name === 'NotAllowedError' || e?.name === 'SecurityError' ? 'permission' : 'mic', e?.message);
+    }
+  }, [supported, status, transcribe, cleanupStream, onError]);
+
+  const stop = useCallback(() => {
+    const rec = recorderRef.current;
+    if (rec && rec.state !== 'inactive') rec.stop();
+    recorderRef.current = null;
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (status === 'recording') stop(); else if (status === 'idle') start();
+  }, [status, start, stop]);
+
+  // Stop the mic if the component unmounts mid-recording.
+  useEffect(() => () => {
+    try { recorderRef.current?.stop(); } catch { /* noop */ }
+    cleanupStream();
+  }, [cleanupStream]);
+
+  return { status, supported, start, stop, toggle };
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -27,8 +27,9 @@ import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/c
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
   FileText, Loader2, RotateCcw, Star, Leaf,
-  Check, Circle, AlertCircle, Pencil,
+  Check, Circle, AlertCircle, Pencil, Mic, Square,
 } from 'lucide-react';
+import { useVoiceRecorder, type RecorderError } from '@/core/hooks/useVoiceRecorder';
 import { CboWelcome } from '@/core/components/cbo/CboWelcome';
 import { CboProgress } from '@/core/components/cbo/CboProgress';
 import { EncontroPreamble, hasPreambleBeenSeen, markPreambleSeen } from '@/core/components/cbo/EncontroPreamble';
@@ -718,6 +719,44 @@ export default function CboProfilePage() {
     },
   });
 
+  // Voice input — tap the mic to record a spoken answer, tap again to stop. The
+  // transcript lands in the input box for the user to review/edit before
+  // sending (we never auto-send). Complements the chips + keyboard; doesn't
+  // replace them. Reuses the existing transcription endpoint — no new keys.
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const handleVoiceError = useCallback((kind: RecorderError, message?: string) => {
+    const msg = lang === 'pt'
+      ? {
+          permission: 'Não consegui acessar o microfone. Permita o acesso nas configurações do navegador.',
+          unsupported: 'Seu navegador não suporta gravação de áudio. Tente digitar ou anexar um arquivo.',
+          transcribe: message || 'Não consegui transcrever o áudio. Tente de novo ou digite.',
+          empty: 'Não captei nenhuma fala. Tente falar um pouco mais perto do microfone.',
+          mic: 'Houve um problema com o microfone. Tente de novo.',
+        }[kind]
+      : {
+          permission: "I couldn't access the microphone. Allow access in your browser settings.",
+          unsupported: "Your browser doesn't support audio recording. Try typing or attaching a file.",
+          transcribe: message || "I couldn't transcribe that. Try again or type it instead.",
+          empty: "I didn't catch any speech. Try speaking a little closer to the mic.",
+          mic: 'There was a problem with the microphone. Try again.',
+        }[kind];
+    setVoiceError(msg);
+  }, [lang]);
+  const voice = useVoiceRecorder({
+    cboId,
+    lang,
+    onTranscript: (text) => {
+      setVoiceError(null);
+      // Append to whatever's already typed so dictation builds on it, then
+      // focus the box so the user can edit before hitting send.
+      setInput(prev => (prev.trim() ? `${prev.trim()} ${text}` : text));
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
+    onError: handleVoiceError,
+  });
+  // Clear a stale voice error once the user starts a new recording or types.
+  useEffect(() => { if (voice.status === 'recording') setVoiceError(null); }, [voice.status]);
+
   const filledCount = useMemo(() => state ? Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length : 0, [state]);
 
   if (!state) return <div className="flex items-center justify-center h-[100dvh]"><Loader2 className="w-8 h-8 animate-spin text-muted-foreground" /></div>;
@@ -1206,6 +1245,24 @@ export default function CboProfilePage() {
 
           <div className={`p-3 border-t transition-colors ${isStreaming ? 'bg-muted/50' : currentQuestion ? 'bg-green-50 border-t-green-200' : ''}`}>
             {!isStreaming && currentQuestion && <p className="text-[10px] text-green-700 mb-1 font-medium">{t('cbo.yourTurn')}</p>}
+            {voice.status === 'recording' && (
+              <div className="flex items-center gap-2 mb-1.5 text-[11px] font-medium text-red-600">
+                <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                {t('cbo.voice.recording', { defaultValue: lang === 'pt' ? 'Gravando… toque para parar' : 'Recording… tap to stop' })}
+              </div>
+            )}
+            {voice.status === 'transcribing' && (
+              <div className="flex items-center gap-2 mb-1.5 text-[11px] font-medium text-muted-foreground">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                {t('cbo.voice.transcribing', { defaultValue: lang === 'pt' ? 'Transcrevendo…' : 'Transcribing…' })}
+              </div>
+            )}
+            {voiceError && (
+              <div className="flex items-start gap-1.5 mb-1.5 text-[11px] text-amber-700">
+                <AlertCircle className="w-3 h-3 mt-0.5 shrink-0" />
+                <span>{voiceError}</span>
+              </div>
+            )}
             <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input); }} className="flex gap-2">
               <input ref={fileInputRef} type="file" className="hidden" accept=".pdf,.docx,.xlsx,.txt,.md,.csv,.tsv,.json,.png,.jpg,.jpeg,.gif,.webp,.mp3,.wav,.m4a,.webm,.ogg,.opus,.aac,.flac,audio/*,image/*"
                 onChange={(e) => {
@@ -1224,7 +1281,33 @@ export default function CboProfilePage() {
               <Tooltip><TooltipTrigger asChild>
                 <Button type="button" variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isStreaming} className="shrink-0"><Paperclip className="w-4 h-4" /></Button>
               </TooltipTrigger><TooltipContent>{t('cbo.uploadDoc')}</TooltipContent></Tooltip>
-              <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
+              {voice.supported && (
+                <Tooltip><TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={voice.status === 'recording' ? 'default' : 'ghost'}
+                    size="sm"
+                    onClick={voice.toggle}
+                    disabled={isStreaming || voice.status === 'transcribing'}
+                    className={`shrink-0 ${voice.status === 'recording' ? 'bg-red-500 hover:bg-red-600 text-white animate-pulse' : ''}`}
+                    data-testid="button-cbo-voice"
+                    aria-label={voice.status === 'recording'
+                      ? (lang === 'pt' ? 'Parar gravação' : 'Stop recording')
+                      : (lang === 'pt' ? 'Gravar resposta por voz' : 'Record a voice answer')}
+                  >
+                    {voice.status === 'transcribing'
+                      ? <Loader2 className="w-4 h-4 animate-spin" />
+                      : voice.status === 'recording'
+                        ? <Square className="w-4 h-4" />
+                        : <Mic className="w-4 h-4" />}
+                  </Button>
+                </TooltipTrigger><TooltipContent>
+                  {voice.status === 'recording'
+                    ? t('cbo.voice.stop', { defaultValue: lang === 'pt' ? 'Parar gravação' : 'Stop recording' })
+                    : t('cbo.voice.record', { defaultValue: lang === 'pt' ? 'Falar a resposta' : 'Speak your answer' })}
+                </TooltipContent></Tooltip>
+              )}
+              <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : voice.status === 'recording' ? (lang === 'pt' ? 'Ouvindo…' : 'Listening…') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
           </div>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1724,6 +1724,12 @@
     "typePlaceholder": "Type your response...",
     "typeCustom": "Type a custom answer...",
     "uploadDoc": "Upload a document",
+    "voice": {
+      "record": "Speak your answer",
+      "stop": "Stop recording",
+      "recording": "Recording… tap to stop",
+      "transcribing": "Transcribing…"
+    },
     "interventionProfile": "Intervention Profile",
     "scorecard": {
       "investmentReady": "Investment Ready",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1711,6 +1711,12 @@
     "typePlaceholder": "Digite sua resposta...",
     "typeCustom": "Digite uma resposta personalizada...",
     "uploadDoc": "Enviar documento",
+    "voice": {
+      "record": "Falar a resposta",
+      "stop": "Parar gravação",
+      "recording": "Gravando… toque para parar",
+      "transcribing": "Transcrevendo…"
+    },
     "interventionProfile": "Perfil de Intervenção",
     "scorecard": {
       "investmentReady": "Pronto para Investimento",

--- a/e2e/cbo-voice-input.spec.ts
+++ b/e2e/cbo-voice-input.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+// Voice-note INPUT plumbing (deterministic). The real transcription runs on a
+// Replit AI key we don't have locally, so we DON'T test speech→text accuracy
+// here — that's a live/manual check. What we DO test is the whole browser-side
+// risk surface, which has no key dependency:
+//   • the mic button renders and toggles (tap-to-start / tap-to-stop),
+//   • MediaRecorder actually records and POSTs an audio blob to /transcribe,
+//   • the returned transcript lands in the input box for REVIEW,
+//   • it is NOT auto-sent (no turn fires, no user bubble appears).
+//
+// Chromium gets a synthetic mic via --use-fake-device-for-media-stream, and we
+// stub the /transcribe response in the browser (route interception) so no model
+// key is needed and the assertion is deterministic.
+
+const STUB_TRANSCRIPT = 'Somos a Horta Comunitária Cascata, do bairro Cascata.';
+
+// Synthetic audio device + auto-accepted mic prompt, plus an explicit grant.
+// launchOptions forces a dedicated worker, so it must be top-level (not in a
+// describe group) per Playwright.
+test.use({
+  launchOptions: { args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'] },
+  permissions: ['microphone'],
+});
+
+test.describe('CBO voice input (fake mic + stubbed transcription)', () => {
+  test('record → stop → transcript fills the input for review, not auto-sent', async ({ page }) => {
+    // Stub the transcription endpoint IN THE BROWSER so we never need a real key.
+    // Capture the request to prove the client actually uploaded recorded audio.
+    let postedAudioBytes = 0;
+    let transcribeHits = 0;
+    await page.route('**/api/cbo/*/transcribe', async (route) => {
+      transcribeHits++;
+      postedAudioBytes = route.request().postDataBuffer()?.length ?? 0;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ text: STUB_TRANSCRIPT }),
+      });
+    });
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+
+    const mic = page.getByTestId('button-cbo-voice');
+    const input = page.getByTestId('cbo-chat-input');
+    // The button only renders when the browser supports MediaRecorder — which
+    // Chromium does, so it must be here.
+    await expect(mic).toBeVisible();
+    await expect(input).toHaveValue('');
+    await expect(marker).toHaveAttribute('data-turns', '0');
+
+    // Tap to start. getUserMedia resolves against the fake device, MediaRecorder
+    // starts → the button flips to its "stop" affordance.
+    await mic.click();
+    await expect(mic).toHaveAttribute('aria-label', /stop|parar/i);
+
+    // Record long enough to clear the client's tiny-blob (silence) guard.
+    await page.waitForTimeout(2000);
+
+    // Tap to stop → onstop builds the blob and POSTs it to /transcribe (stubbed),
+    // then the transcript is appended to the input. Wait for that to land.
+    await mic.click();
+    await expect(input).toHaveValue(STUB_TRANSCRIPT, { timeout: 15_000 });
+
+    // It went into the box for REVIEW — it was NOT sent. No turn fired, and no
+    // user message bubble with the transcript exists.
+    await expect(marker).toHaveAttribute('data-turns', '0');
+    await expect(page.locator('.bg-green-600', { hasText: STUB_TRANSCRIPT })).toHaveCount(0);
+
+    // The client genuinely uploaded recorded audio (not an empty/sham blob).
+    expect(transcribeHits).toBe(1);
+    expect(postedAudioBytes, 'recorded audio should be a non-trivial multipart upload').toBeGreaterThan(1200);
+
+    // The mic returned to idle (ready to record again).
+    await expect(mic).toHaveAttribute('aria-label', /record|gravar/i);
+
+    // And the user can still edit + send normally from here: the transcript is
+    // just prefilled text. Append a word and confirm the composer accepts it.
+    await input.click();
+    await input.press('End');
+    await input.type(' Obrigada!');
+    await expect(input).toHaveValue(`${STUB_TRANSCRIPT} Obrigada!`);
+  });
+});

--- a/server/routes/uploadRoutes.ts
+++ b/server/routes/uploadRoutes.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from "express";
 import multer from "multer";
 import path from "path";
 import { saveAndParseUpload } from "../services/fileParser";
+import { transcribeAudio } from "../services/fileExtract";
 import { getCboState, setCboState, debouncedPersist } from "../services/cboAgent";
 import { createDocument, getOrgIdForCboState, updateDocumentStorageKey, getDocumentById } from "../services/documentPersistence";
 import { putObject, getObject, blobKey } from "../services/blobStorage";
@@ -39,6 +40,22 @@ const upload = multer({
       cb(null, true);
     } else {
       cb(new Error(`File type ${ext} not supported`));
+    }
+  },
+});
+
+// Voice-note recorder uploads — audio only, smaller ceiling. A spoken answer
+// is short; cap well under the transcription endpoint's ~25MB limit.
+const audioUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 20 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    const audioExts = ['.webm', '.mp4', '.m4a', '.ogg', '.oga', '.opus', '.mp3', '.wav', '.aac', '.flac'];
+    if ((file.mimetype || '').startsWith('audio/') || (file.mimetype || '').startsWith('video/webm') || audioExts.includes(ext)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Audio type ${file.mimetype || ext} not supported`));
     }
   },
 });
@@ -120,6 +137,30 @@ export function registerUploadRoutes(app: Express): void {
       });
     } catch (error: any) {
       console.error('[upload] Error:', error.message);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  // Voice-note transcription for the chat composer. Unlike /api/upload/cbo/:id
+  // (which stores a durable evidence document), this is a throwaway: the user
+  // taps the mic, speaks an answer, and gets the transcript back to REVIEW and
+  // edit in the input box before sending. Nothing is persisted — no doc row, no
+  // blob, no manifest entry. The mic feeds the same composer the keyboard does,
+  // so the agent never sees audio, only the (user-confirmed) text.
+  // Reuses the existing Replit AI transcription path — no new API keys.
+  app.post("/api/cbo/:id/transcribe", audioUpload.single('audio'), async (req: Request, res: Response) => {
+    try {
+      const file = (req as any).file;
+      if (!file) { res.status(400).json({ error: "No audio uploaded" }); return; }
+      // MediaRecorder names the blob by mime (webm/mp4/ogg); fall back to webm.
+      const ext = (path.extname(file.originalname).replace('.', '').toLowerCase())
+        || ((file.mimetype || '').split('/')[1] || 'webm').split(';')[0];
+      const lang = typeof req.body?.lang === 'string' ? req.body.lang.slice(0, 5) : undefined;
+      const r = await transcribeAudio(file.buffer, ext, lang);
+      if (!r.ok) { res.status(422).json({ error: r.reason, fix: r.fix }); return; }
+      res.json({ text: r.text });
+    } catch (error: any) {
+      console.error('[transcribe] Error:', error.message);
       res.status(500).json({ error: error.message });
     }
   });

--- a/server/services/fileExtract.ts
+++ b/server/services/fileExtract.ts
@@ -214,14 +214,36 @@ async function extractImage(buf: Buffer, ext: string, mime: string): Promise<Ext
 }
 
 async function extractAudio(buf: Buffer, filename: string, ext: string): Promise<ExtractResult> {
+  const r = await transcribeAudio(buf, ext);
+  if (!r.ok) return r;
+  // Document-grounding context wants the filename header; an empty transcript
+  // is annotated so the agent knows audio came through but had no speech.
+  return { ok: true, kind: "audio", text: r.text ? `[Transcription of ${filename}]\n${r.text}` : "[Audio uploaded — no speech detected.]" };
+}
+
+/**
+ * Transcribe an audio buffer to RAW text (no filename header, no placeholder).
+ * Shared by the document upload path (extractAudio) and the voice-note input
+ * route, which drops the raw transcript straight into the chat composer for the
+ * user to review before sending. `lang` is an optional ISO-639-1 hint
+ * (e.g. "pt") that nudges the model toward the right language.
+ */
+export async function transcribeAudio(
+  buf: Buffer,
+  ext: string,
+  lang?: string,
+): Promise<{ ok: true; text: string } | { ok: false; reason: string; fix?: string }> {
   if (buf.length > MAX_AUDIO_BYTES) {
     return { ok: false, reason: "That recording is too long to transcribe.", fix: "Send a clip under ~20MB, or split it into parts." };
   }
-  // Pass the real filename so the transcription endpoint detects the format.
+  // Pass the real extension so the transcription endpoint detects the format.
   const file = await toFile(buf, `audio.${ext || "mp3"}`);
-  const resp = await openai.audio.transcriptions.create({ file, model: TRANSCRIBE_MODEL });
-  const text = (resp as any).text?.trim() || "";
-  return { ok: true, kind: "audio", text: text ? `[Transcription of ${filename}]\n${text}` : "[Audio uploaded — no speech detected.]" };
+  const resp = await openai.audio.transcriptions.create({
+    file,
+    model: TRANSCRIBE_MODEL,
+    ...(lang ? { language: lang } : {}),
+  });
+  return { ok: true, text: (resp as any).text?.trim() || "" };
 }
 
 /**


### PR DESCRIPTION
## What

Phone-first Brazilian community orgs can now **answer by voice**. A mic button sits next to the paperclip in the chat composer:

- **Tap to start, tap to stop** — a toggle, not hold-to-record. Easier to reach one-handed and better for the longer spoken answers this audience gives.
- On stop, the clip is transcribed and the text lands **in the input box for the user to review and edit before sending**. We never auto-send.
- The agent only ever sees the **confirmed text**, never audio. Voice **complements** the chips + keyboard — it doesn't replace either.

Reuses the existing Replit AI transcription path (`gpt-4o-mini-transcribe`) — **no new API keys**.

## How

**Server**
- `transcribeAudio()` extracted from `fileExtract`'s audio path — returns the raw transcript (no filename header) and takes an optional ISO-639-1 `lang` hint. The existing document-upload `extractAudio()` now delegates to it, so the upload path is unchanged.
- `POST /api/cbo/:id/transcribe` — a **throwaway** transcription endpoint: no document row, no blob, no manifest entry (unlike `/api/upload/cbo/:id`, which is the durable evidence locker). Audio-only multer, 20MB cap.

**Client**
- `useVoiceRecorder` hook — `MediaRecorder`, mic-permission + browser-support guards, iOS Safari `mp4` / `webm-opus` container negotiation, cleanup on unmount.
- Mic button + recording / transcribing / error states in the composer. PT/EN strings; the `lang` hint is passed through so PT-BR transcribes correctly.

## States

`idle` → tap → (mic permission) → `recording` (red pulse, "tap to stop") → tap → `transcribing` (spinner) → transcript appended to input, focus returns. Errors (permission denied / unsupported browser / empty clip / transcribe failure) surface as an inline amber line in PT or EN.

## Testing

Needs a real mic + the live transcription key, so it's a **manual live check** (like the other `@live` quality tests), not a deterministic gate. To verify on the deployment: open a CBO chat, tap the mic, speak a sentence in Portuguese, confirm the transcript appears in the box (not auto-sent) and reads correctly.

## Note

The composer's `Input` also (re)gains `data-testid="cbo-chat-input"` here as part of the touched line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)