### PR TITLE
feat(e1): three-way project-readiness triage (selected project / idea / help)

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -10,7 +10,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
-import { AlertTriangle, Lightbulb, Compass } from 'lucide-react';
+import { AlertTriangle, Lightbulb, Compass, Target } from 'lucide-react';
 import type { CboSectionState, CboGapEntry } from '@shared/cbo-schema';
 
 type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
@@ -42,8 +42,8 @@ export function E1Cards({
 }: {
   section: CboSectionState;
   gaps: CboGapEntry[];
-  /** Two-path triage answer captured at E1 — drives the Caminho card chip. */
-  path: 'has-idea' | 'needs-help' | null;
+  /** Project-readiness triage answer captured at E1 — drives the Caminho chip. */
+  path: 'has-project' | 'has-idea' | 'needs-help' | null;
   onFieldEdit: (sectionId: string, field: string, value: string) => void;
   /** Injected from the parent — same EditableField used elsewhere on this page,
    *  so we don't duplicate the markdown + textarea behavior. */
@@ -110,11 +110,17 @@ export function E1Cards({
   // Caminho card has a special pre-table chip showing the triage answer
   const pathChip = path ? (
     <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40">
-      {path === 'has-idea' ? <Lightbulb className="w-4 h-4 text-emerald-700 dark:text-emerald-400" /> : <Compass className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />}
+      {path === 'has-project'
+        ? <Target className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />
+        : path === 'has-idea'
+          ? <Lightbulb className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />
+          : <Compass className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />}
       <span className="text-sm text-emerald-900 dark:text-emerald-200 font-medium">
-        {path === 'has-idea'
-          ? (isPt ? 'Já tem uma ideia de projeto NBS' : 'Has an NBS project idea')
-          : (isPt ? 'Quer descobrir uma ideia de projeto' : 'Wants to discover a project idea')}
+        {path === 'has-project'
+          ? (isPt ? 'Já tem um projeto NBS definido' : 'Has a selected NBS project')
+          : path === 'has-idea'
+            ? (isPt ? 'Já tem uma ideia de projeto NBS' : 'Has an NBS project idea')
+            : (isPt ? 'Quer descobrir uma ideia de projeto' : 'Wants to discover a project idea')}
       </span>
     </div>
   ) : (

--- a/client/src/core/components/cbo/encontroConfig.ts
+++ b/client/src/core/components/cbo/encontroConfig.ts
@@ -117,14 +117,15 @@ function isPathAware(cfg: SinglePathConfig | PathAwareConfig): cfg is PathAwareC
 export function getEncontroPreambleConfig(
   encontroNumber: number,
   lang: 'pt' | 'en',
-  path?: 'has-idea' | 'needs-help' | null,
+  path?: 'has-project' | 'has-idea' | 'needs-help' | null,
 ): EncontroPreambleConfig | null {
   const base = ENCONTRO_CONFIGS[encontroNumber];
   if (!base) return null;
   let langBase: EncontroBase;
   if (isPathAware(base)) {
-    // Default to has-idea when path is null (CBO hasn't been triaged yet).
-    // Most pre-triage cases are E1, which isn't path-aware anyway.
+    // Two preamble variants only: needs-help (discovery) vs project-forward.
+    // has-project + has-idea both collapse to the has-idea (project-forward)
+    // copy; null defaults there too (pre-triage cases are E1, not path-aware).
     const resolvedPath: Path = path === 'needs-help' ? 'needs-help' : 'has-idea';
     const variant = base[resolvedPath];
     langBase = variant[lang] ?? variant.pt;

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -221,10 +221,11 @@ export default function CboProfilePage() {
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
-  // Two-path triage from E1: 'has-idea' | 'needs-help' | null (until triaged).
+  // Project-readiness triage from E1: 'has-project' | 'has-idea' | 'needs-help'
+  // | null (until triaged). has-project + has-idea are project-forward.
   // Sourced from cohort_members.path via /api/cbo-member/:slug. Drives the
   // Caminho card chip in E1Cards.
-  const [memberPath, setMemberPath] = useState<'has-idea' | 'needs-help' | null>(null);
+  const [memberPath, setMemberPath] = useState<'has-project' | 'has-idea' | 'needs-help' | null>(null);
   // RequestSupport — async escalation. Available across all encontros via the
   // chat header. Pending count comes from /api/cbo-member/:slug; agent or
   // coordinator-side flows can also nudge the user to open this.
@@ -277,7 +278,7 @@ export default function CboProfilePage() {
       if (data.memberSlug) setMemberSlug(data.memberSlug);
       if (data.unlockedPhases) setUnlockedPhases(data.unlockedPhases);
       if (data.orgName) setMemberInfo({ orgName: data.orgName, neighborhood: data.neighborhood ?? null });
-      if (data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
+      if (data.path === 'has-project' || data.path === 'has-idea' || data.path === 'needs-help') setMemberPath(data.path);
       else if (data.path === null) setMemberPath(null);
       if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
       if (Array.isArray(data.inspirationPicks)) setInspirationPicks(data.inspirationPicks);

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,7 +19,7 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
   Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
@@ -77,10 +77,11 @@ type CboDemoProject = {
   updatedDaysAgo: number;
   /** i18n key for the 'next action' line on the card. */
   nextActionKey: string;
-  /** Two-path triage answer from E1 — drives a chip on the card so the
-   *  coordinator sees who needs more hand-holding (needs-help) vs who has
-   *  a concrete idea (has-idea). Null until E1's set_path tool fires. */
-  path: 'has-idea' | 'needs-help' | null;
+  /** Project-readiness triage from E1 — drives a chip on the card so the
+   *  coordinator sees who has a selected project (has-project) vs an idea
+   *  (has-idea) vs who needs more hand-holding (needs-help). Null until E1's
+   *  set_path tool fires. */
+  path: 'has-project' | 'has-idea' | 'needs-help' | null;
   /** Count of unresolved RequestSupport entries — surfaces an amber chip
    *  on the card so the coordinator can sweep pendencies daily. */
   supportPendingCount: number;
@@ -134,7 +135,7 @@ function memberToView(m: CohortMember): CboDemoProject {
     priorityFlagsMet: m.snapshotFlagsMet ?? 0,
     updatedDaysAgo: daysAgo,
     nextActionKey: NEXT_ACTION_KEY[phaseNum] ?? NEXT_ACTION_KEY[1],
-    path: (m.path as 'has-idea' | 'needs-help' | null | undefined) ?? null,
+    path: (m.path as 'has-project' | 'has-idea' | 'needs-help' | null | undefined) ?? null,
     supportPendingCount: Array.isArray((m as any).supportRequests)
       ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
       : 0,
@@ -511,16 +512,22 @@ function ProjectCard({
             {project.path && (
               <span
                 className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200/60 dark:border-emerald-900/40"
-                title={project.path === 'has-idea'
-                  ? t('orchestrator.demo.path.hasIdeaFull', { defaultValue: 'CBO arrived with a specific NBS project in mind' })
-                  : t('orchestrator.demo.path.needsHelpFull', { defaultValue: 'CBO wants help discovering a project — needs more hand-holding' })}
+                title={project.path === 'has-project'
+                  ? t('orchestrator.demo.path.hasProjectFull', { defaultValue: 'CBO arrived with a selected, scoped NBS project — more mature / implementer-ready' })
+                  : project.path === 'has-idea'
+                    ? t('orchestrator.demo.path.hasIdeaFull', { defaultValue: 'CBO arrived with a specific NBS project idea in mind' })
+                    : t('orchestrator.demo.path.needsHelpFull', { defaultValue: 'CBO wants help discovering a project — needs more hand-holding' })}
               >
-                {project.path === 'has-idea'
-                  ? <Lightbulb className="w-3 h-3" strokeWidth={2} />
-                  : <Compass className="w-3 h-3" strokeWidth={2} />}
-                {project.path === 'has-idea'
-                  ? t('orchestrator.demo.path.hasIdea', { defaultValue: 'Tem ideia' })
-                  : t('orchestrator.demo.path.needsHelp', { defaultValue: 'Quer descobrir' })}
+                {project.path === 'has-project'
+                  ? <Target className="w-3 h-3" strokeWidth={2} />
+                  : project.path === 'has-idea'
+                    ? <Lightbulb className="w-3 h-3" strokeWidth={2} />
+                    : <Compass className="w-3 h-3" strokeWidth={2} />}
+                {project.path === 'has-project'
+                  ? t('orchestrator.demo.path.hasProject', { defaultValue: 'Projeto definido' })
+                  : project.path === 'has-idea'
+                    ? t('orchestrator.demo.path.hasIdea', { defaultValue: 'Tem ideia' })
+                    : t('orchestrator.demo.path.needsHelp', { defaultValue: 'Quer descobrir' })}
               </span>
             )}
             {project.supportPendingCount > 0 && (

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -100,7 +100,7 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 11. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
 12. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
 13. `proud_moment` — optional free-text
-14. (cohort-level) `path` — enum on `cohort_members`: has-idea | needs-help
+14. (cohort-level) `path` — enum on `cohort_members`: has-project | has-idea | needs-help
 
 Plus on `state.maturityScores`:
 
@@ -242,18 +242,25 @@ You don't announce the tier or show it to the org. Use it to calibrate, and let 
 
 ## Path triage — the most important question
 
-Ask after the capacity questions, not before — the rest of the diagnostic builds trust that makes either answer feel acceptable.
+Ask after the capacity questions, not before — the rest of the diagnostic builds trust that makes any answer feel acceptable.
+
+Three buckets. They double as a maturity signal — a *selected, scoped* project reads as a more mature / implementer org; an idea or a request for help is the community-first norm. Don't say any of that to the user; just let them pick honestly.
 
 Frame:
-> "Última pergunta importante: você já tem uma ideia de projeto NBS (solução baseada na natureza) que quer levar adiante, ou quer ajuda da gente para encontrar uma?"
+> "Última pergunta importante: onde vocês estão com o projeto NBS (solução baseada na natureza)?"
 >
-> Chips: [💡 Já tenho uma ideia] [🤝 Quero ajuda]
+> Chips: [🎯 Já temos um projeto definido] [💡 Temos uma ideia] [🤝 Queremos ajuda pra encontrar]
 >
 > Note (small, after the chips): "Não há resposta certa — só muda como a gente segue no próximo encontro."
 
-Call `set_path(value)` to write the answer to `cohort_members.path`.
+Distinguish the first two if the user hesitates:
+- **Já temos um projeto definido** → they can name the project AND roughly where/what (site + scope) — a committed project, not just a wish. → `set_path('has-project')`
+- **Temos uma ideia** → a direction in mind, but the site or scope isn't locked. → `set_path('has-idea')`
+- **Queremos ajuda pra encontrar** → no project yet. → `set_path('needs-help')`
 
-**Advanced / NbS-first orgs:** a fast-track implementer is usually sourced *because* it already has a concrete project. If everything so far points to an existing project (an uploaded brief, a funded NbS project, "we're doing a rain garden at X"), don't ask the triage cold — confirm it warmly instead: *"Pelo que você contou, vocês já têm um projeto em mãos, certo?"* and set `path = 'has-idea'`. Only fall back to the open triage if it's genuinely unclear.
+Call `set_path(value)` to write the answer to `cohort_members.path`. (Downstream, `has-project` and `has-idea` follow the same project-forward flow in E2; `needs-help` goes to discovery — so don't agonize over the project/idea line, but do capture it: the coordinator sees it and it corroborates the maturity tier.)
+
+**Advanced / NbS-first orgs:** a fast-track implementer is usually sourced *because* it already has a concrete project. If everything so far points to a selected project (an uploaded brief, a funded NbS project, "we're doing a rain garden at X"), don't ask the triage cold — confirm it warmly instead: *"Pelo que você contou, vocês já têm um projeto definido, certo?"* and set `path = 'has-project'`. Only fall back to the open triage if it's genuinely unclear.
 
 ## File drops — invite at the open, accept anytime, never require
 
@@ -274,7 +281,9 @@ After both batches are answered (Step 2) and the path triage is done:
 
 > "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.
 >
-> [if path = 'has-idea']: No próximo encontro vamos olhar juntos o mapa de [bairro], ver os riscos climáticos, e começar pelo seu projeto.
+> [if path = 'has-project']: No próximo encontro vamos olhar o mapa de [bairro] e já posicionar o projeto de vocês no território — ver os riscos e onde ele se encaixa.
+>
+> [if path = 'has-idea']: No próximo encontro vamos olhar juntos o mapa de [bairro], ver os riscos climáticos, e começar pela sua ideia de projeto.
 >
 > [if path = 'needs-help']: No próximo encontro vamos descobrir juntos onde e como atuar — sem pressa.
 >
@@ -321,7 +330,7 @@ Common stuck patterns + responses:
 - `ask_user(questions[])` — pass an **array** of questions to batch them onto one screen (Step 2). Each entry has its own `question`, `options`, and optional `multiSelect`. One `ask_user` call = one batch = one turn.
 - `update_section('org_profile', { field: value })` — after each answer
 - `score_maturity(metric, score, justification)` — after capacity questions
-- `set_path('has-idea' | 'needs-help')` — after triage answer (NEW tool, needs to be added)
+- `set_path('has-project' | 'has-idea' | 'needs-help')` — after triage answer. has-project = a selected/scoped project; has-idea = a direction not yet locked; needs-help = no project yet
 - `score_maturity` — both metrics at end (no separate phase-complete tool exists; scoring + closing message is the signal that E1 is done)
 - `read_knowledge(path)` — silently, to inform scoring
 - `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -8,7 +8,9 @@ Loaded by `cboAgent.ts` (via `loadEncontroSkill(2)`) when state.phase == 2.
 
 ## Identity
 
-You are the COUGAR/Vila Flores agent in **Encontro 2 — Seu território**. The CBO already completed Encontro 1, so you know their name, neighborhood, mission, capacity, and most importantly their **path**: `has-idea` or `needs-help` (visible in the CURRENT STATE block of this prompt).
+You are the COUGAR/Vila Flores agent in **Encontro 2 — Seu território**. The CBO already completed Encontro 1, so you know their name, neighborhood, mission, capacity, and most importantly their **path**: `has-project`, `has-idea`, or `needs-help` (visible in the CURRENT STATE block of this prompt).
+
+> **`has-project` is project-forward — treat it exactly like `has-idea`** everywhere in this skill (same openings, same `browse` showcase mode, same composite-map site selection). The only difference is tone: a `has-project` org has a *selected, scoped* project, so you can be crisper and go straight to placing it on the map. Wherever this skill says "`has-idea`", that includes `has-project`. Only `needs-help` takes the discovery flow.
 
 Your job in this encontro is to:
 1. Anchor NBS in concrete Brazilian examples (via `show_examples`)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -297,12 +297,13 @@ function createCboMcpTools(cboId: string) {
     { annotations: { readOnlyHint: false } }
   );
 
-  // E1 two-path triage: stores 'has-idea' or 'needs-help' on the cohort member.
-  // Branches E2-E3 flows. No-op if the CBO isn't part of a cohort.
+  // E1 triage: stores the project-readiness path on the cohort member. Branches
+  // E2-E3 flows (has-project + has-idea are project-forward; needs-help is
+  // discovery). No-op if the CBO isn't part of a cohort.
   const setPath = sdkTool(
     "set_path",
-    "Record the user's path choice from the E1 triage. 'has-idea' = they have a specific NBS project in mind; 'needs-help' = they want to discover one.",
-    { path: z.enum(["has-idea", "needs-help"]) },
+    "Record the user's path choice from the E1 triage. 'has-project' = they already have a SELECTED, scoped NBS project (site + scope — typically a more mature / implementer org); 'has-idea' = they have a project direction in mind but it's not locked; 'needs-help' = they want help discovering one. Downstream, has-project is handled like has-idea (project-forward).",
+    { path: z.enum(["has-project", "has-idea", "needs-help"]) },
     async (args: any) => {
       try {
         const result = await db

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -72,10 +72,15 @@ export const cohortMembers = pgTable('cohort_members', {
   neighborhood: text('neighborhood'),
   role: text('role').$type<'priority' | 'alternate'>().default('priority'),
   origin: text('origin').$type<'cohort' | 'external'>().default('cohort'),
-  // Two-path triage captured at E1: 'has-idea' = CBO has a specific project in
-  // mind; 'needs-help' = CBO wants help discovering one. Null until E1 asks.
-  // See knowledge/runs/2026-05-15-encontros-curriculum/_paths/two-path-triage.md
-  path: text('path').$type<'has-idea' | 'needs-help'>(),
+  // Project-readiness triage captured at E1. Three self-reported buckets that
+  // double as a maturity signal:
+  //   'has-project' = a selected, scoped project (site + scope) — implementer /
+  //                   advanced-tier read; treated downstream like 'has-idea'.
+  //   'has-idea'    = a project direction in mind, not yet locked.
+  //   'needs-help'  = no project yet; wants help discovering one.
+  // Downstream (E2) collapses to two flows: has-project + has-idea are
+  // project-forward; needs-help goes to discovery. Null until E1 asks.
+  path: text('path').$type<'has-project' | 'has-idea' | 'needs-help'>(),
   // Cross-cutting RequestSupport queue. CBO submits via the chat-header button;
   // coordinator resolves from the orchestrator dashboard. JSONB so we don't need
   // a separate table for what is effectively a small per-member queue.
@@ -107,7 +112,7 @@ export const DEFAULT_WORKSHOPS: WorkshopConfig[] = [
     date: null,
     unlocksPhase: 1,
     description: 'The CBO introduces itself: mission, team, structure, prior projects, and the community groups it serves. The agent captures the core organizational identity and scores delivery capacity + technical experience.',
-    expectedOutput: 'A complete organizational profile (10 fields) with two maturity scores recorded. The CBO also declares their path — they either have a specific NBS project idea in mind, or they want help discovering one.',
+    expectedOutput: 'A complete organizational profile (10 fields) with two maturity scores recorded. The CBO also declares their path — they have a selected NBS project, an idea in mind, or want help discovering one.',
   },
   {
     name: 'Workshop 2 — Where We Work',


### PR DESCRIPTION
## What

The E1 path triage was binary — *have an idea* vs *need help*. This splits it into **three** self-reported buckets that double as a maturity signal:

| Chip | Meaning | Read |
|---|---|---|
| 🎯 **Já temos um projeto definido** | a **selected, scoped** project (site + scope) | mature / implementer |
| 💡 **Temos uma ideia** | a direction in mind, not yet locked | community-first |
| 🤝 **Queremos ajuda pra encontrar** | no project yet | community-first |

A *committed* project reads very differently from a loose idea, and capturing that at the moment they're already answering is a cheap, honest corroboration of the maturity tier the agent infers separately.

## Downstream behavior — collapses to the existing two flows

Per the decision: **has-project + has-idea are project-forward; needs-help is discovery.** E2/E3 are unchanged — `has-project` is handled *exactly* like `has-idea` (same openings, showcase mode, composite-map site selection; only the tone is crisper). The new value surfaces where it adds value:

- the **coordinator card** chip (Target icon, "Projeto definido") so they see who arrived implementer-ready
- the **E1 Caminho card** chip
- the **E1 closing copy** (3 branches)
- the inferred maturity tier (the agent uses it as a signal)

## No DB migration

`cohort_members.path` is a `text` column, so widening the `$type` enum is a **compile-time-only** change. Nothing to `db:push`.

## Files

- `shared/cohort-schema.ts` — path enum + docs
- `server/services/cboAgent.ts` — `set_path` tool enum + description
- `knowledge/_skills/encontro-1.md` — 3-chip triage, project/idea disambiguation, 3-branch closing, advanced-org confirm → `has-project`
- `knowledge/_skills/encontro-2.md` — explicit "treat `has-project` like `has-idea`"
- client — `cbo-profile` (memberPath type), `E1Cards` (chip + Target icon), `encontroConfig` (widened input; the existing `=== 'needs-help' ? … : 'has-idea'` already routes has-project to project-forward), `orchestrator-landing` (coordinator chip, 3-way)

## Testing

- `tsc` clean.
- Full deterministic e2e suite green (**12 passed**) — boots the real client, so the orchestrator / E1Cards 3-way render is exercised.
- `set_path` itself runs through the live agent (no fake-model op — consistent with how the prior two path values were covered). Worth a quick live walkthrough after merge.

## Deploy note

Skill change (`encontro-1.md` / `encontro-2.md`) → needs merge + republish to reach prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)