### PR TITLE
fix(cbo): mobile chat shell fills the real viewport (iOS Safari gap)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -360,6 +360,34 @@ export default function CboProfilePage() {
     return () => { document.head.removeChild(style); };
   }, []);
 
+  // iOS Safari's `100dvh`/`100vh` can disagree with the actually-visible area as
+  // the address bar + bottom toolbar show/hide, leaving the chat shell SHORTER
+  // than the screen — a big empty gap below the composer + mobile tab bar (the
+  // chips/buttons get pushed up off the fold). Drive the shell height from the
+  // real visual viewport so it always fills exactly what's visible, and shrinks
+  // to sit above the keyboard when an input is focused. Falls back to 100dvh
+  // (the CSS var is unset) on browsers without visualViewport.
+  useEffect(() => {
+    const root = document.documentElement;
+    const setVH = () => {
+      const h = window.visualViewport?.height ?? window.innerHeight;
+      root.style.setProperty('--cbo-vh', `${Math.round(h)}px`);
+    };
+    setVH();
+    const vv = window.visualViewport;
+    vv?.addEventListener('resize', setVH);
+    vv?.addEventListener('scroll', setVH);
+    window.addEventListener('orientationchange', setVH);
+    window.addEventListener('resize', setVH);
+    return () => {
+      vv?.removeEventListener('resize', setVH);
+      vv?.removeEventListener('scroll', setVH);
+      window.removeEventListener('orientationchange', setVH);
+      window.removeEventListener('resize', setVH);
+      root.style.removeProperty('--cbo-vh');
+    };
+  }, []);
+
   // Auto-scroll to related sections when question changes
   useEffect(() => {
     // Check if current question has relatedSections (from ask_user event)
@@ -792,7 +820,7 @@ export default function CboProfilePage() {
   }
 
   return (
-    <div className="h-[100dvh] flex flex-col bg-background">
+    <div className="h-[100dvh] flex flex-col bg-background overflow-hidden" style={{ height: 'var(--cbo-vh, 100dvh)' }}>
       {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
           waits on this hidden marker's attributes instead: data-streaming flips
           to 'false' when a turn ends, data-turns counts completed turns, and
@@ -1443,7 +1471,7 @@ export default function CboProfilePage() {
       {/* MOBILE TAB BAR — visible only below md. Drives `mobileActiveTab` +
           (when on a non-Chat tab) `rightTab` so the right panel shows the
           right content. Hidden on desktop, where both panels render side-by-side. */}
-      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch">
+      <nav className="md:hidden shrink-0 border-t bg-background flex items-stretch safe-bottom">
         {(() => {
           // Compose the tabs available right now. Chat + Perfil are permanent.
           // Mapa / Intervenções appear only while the agent has those microapps active.


### PR DESCRIPTION
## Problem

On iPhone (Safari), the CBO chat rendered with a **large empty gap below the composer + the Chat/Perfil tab bar** — the question chips and buttons got pushed up off the fold (reported on iPhone 16 Pro).

Cause: `h-[100dvh]` disagrees with the actually-visible area as Safari's address bar + bottom toolbar show/hide, so the shell ends up **shorter than the screen**, exposing background below the bottom nav.

## Fix

Drive the shell height from the **real visual viewport** instead of `dvh`:

- a `--cbo-vh` CSS var set from `window.visualViewport.height` (updated on `resize` / `scroll` / `orientationchange`), so the shell fills exactly what's visible — and **shrinks to sit above the keyboard** when an input is focused (a bonus over `100dvh`, which stays full-height behind the keyboard).
- the root keeps `h-[100dvh]` as the **fallback** (`height: var(--cbo-vh, 100dvh)`) for browsers without `visualViewport`.
- `overflow-hidden` on the shell (its inner message list owns scrolling, so the shell itself shouldn't scroll/bounce).
- `safe-bottom` on the mobile tab bar so it clears the home indicator.

## Scope

Only `client/src/core/pages/cbo-profile.tsx` (the full-screen CBO chat shell). Desktop is unchanged (the shell already filled the window there).

## Testing

- `tsc` clean; full deterministic e2e suite green (**12 passed**) — boots the real client, so the shell still renders + the golden path works.
- The viewport behavior itself is device-specific (visualViewport + Safari chrome), so it wants a quick check on a real iPhone after deploy: open a CBO chat, confirm the composer + tab bar sit at the bottom with no empty gap, and that focusing the input keeps the composer above the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)