### PR TITLE
feat(cbo): auto-send voice notes after a 3s undo window

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -168,7 +168,11 @@ export default function CboProfilePage() {
   const lang = i18n.resolvedLanguage || 'en';
   const [cboId, setCboId] = useState<string | null>(null);
   const [state, setState] = useState<CboState | null>(null);
-  const [messages, setMessages] = useState<CboChatMessage[]>([]);
+  // `viaVoice` is a client-only marker: when a message was dictated (sent from
+  // the voice recorder), the bubble shows a 🎤 so a slightly-off transcription
+  // reads as "came from voice." It's not persisted — reloaded history shows the
+  // plain text, which is fine.
+  const [messages, setMessages] = useState<Array<CboChatMessage & { viaVoice?: boolean }>>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   // Monotonic count of completed agent turns. Drives the e2e stream-complete
@@ -639,12 +643,12 @@ export default function CboProfilePage() {
     return () => clearTimeout(t);
   }, [isStreaming]);
 
-  // Send message
-  const sendMessage = useCallback(async (text: string, hidden = false) => {
+  // Send message. `viaVoice` marks the optimistic user bubble as dictated (🎤).
+  const sendMessage = useCallback(async (text: string, hidden = false, viaVoice = false) => {
     if (!cboId || !text.trim() || isStreaming) return;
     setInput('');
     setActiveQuestions([]);
-    if (!hidden) setMessages(prev => [...prev, { role: 'user', content: text, messageType: 'content', timestamp: new Date().toISOString() }]);
+    if (!hidden) setMessages(prev => [...prev, { role: 'user', content: text, messageType: 'content', timestamp: new Date().toISOString(), viaVoice }]);
     setIsStreaming(true);
     try {
       const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang }) });
@@ -748,11 +752,22 @@ export default function CboProfilePage() {
     },
   });
 
-  // Voice input — tap the mic to record a spoken answer, tap again to stop. The
-  // transcript lands in the input box for the user to review/edit before
-  // sending (we never auto-send). Complements the chips + keyboard; doesn't
-  // replace them. Reuses the existing transcription endpoint — no new keys.
+  // Voice input — tap the mic to record a spoken answer, tap again to stop. On
+  // stop the clip is transcribed and then AUTO-SENDS after a short countdown
+  // (WhatsApp-style) — but with a 3s "enviando… [cancelar]" undo window so a
+  // misrecognized PT-BR transcript is recoverable: cancel drops the text into
+  // the input box to edit instead of sending. Complements chips + keyboard.
+  // Reuses the existing transcription endpoint — no new keys.
+  const VOICE_SEND_COUNTDOWN = 3;
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  // Pending auto-send: the transcript is held for `secondsLeft` before it fires.
+  const [pendingVoice, setPendingVoice] = useState<{ text: string; secondsLeft: number } | null>(null);
+  const pendingTickRef = useRef<number | null>(null);
+  const pendingSendRef = useRef<number | null>(null);
+  const clearPendingVoice = useCallback(() => {
+    if (pendingTickRef.current) { clearInterval(pendingTickRef.current); pendingTickRef.current = null; }
+    if (pendingSendRef.current) { clearTimeout(pendingSendRef.current); pendingSendRef.current = null; }
+  }, []);
   const handleVoiceError = useCallback((kind: RecorderError, message?: string) => {
     const msg = lang === 'pt'
       ? {
@@ -771,20 +786,43 @@ export default function CboProfilePage() {
         }[kind];
     setVoiceError(msg);
   }, [lang]);
+  // Start the auto-send countdown for a fresh transcript: a ticking display +
+  // a timeout that actually sends. Untouched → sends (marked viaVoice).
+  const startPendingVoiceSend = useCallback((text: string) => {
+    clearPendingVoice();
+    setVoiceError(null);
+    setPendingVoice({ text, secondsLeft: VOICE_SEND_COUNTDOWN });
+    pendingTickRef.current = window.setInterval(() => {
+      setPendingVoice(prev => prev ? { ...prev, secondsLeft: Math.max(0, prev.secondsLeft - 1) } : prev);
+    }, 1000);
+    pendingSendRef.current = window.setTimeout(() => {
+      clearPendingVoice();
+      setPendingVoice(null);
+      sendMessage(text, false, true);
+    }, VOICE_SEND_COUNTDOWN * 1000);
+  }, [clearPendingVoice, sendMessage]);
+  // Cancel the auto-send: keep the transcript by dropping it into the input box
+  // for the user to edit, then focus it.
+  const cancelPendingVoice = useCallback(() => {
+    const text = pendingVoice?.text;
+    clearPendingVoice();
+    setPendingVoice(null);
+    if (text) {
+      setInput(prev => (prev.trim() ? `${prev.trim()} ${text}` : text));
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [pendingVoice, clearPendingVoice]);
+
   const voice = useVoiceRecorder({
     cboId,
     lang,
-    onTranscript: (text) => {
-      setVoiceError(null);
-      // Append to whatever's already typed so dictation builds on it, then
-      // focus the box so the user can edit before hitting send.
-      setInput(prev => (prev.trim() ? `${prev.trim()} ${text}` : text));
-      setTimeout(() => inputRef.current?.focus(), 0);
-    },
+    onTranscript: (text) => startPendingVoiceSend(text),
     onError: handleVoiceError,
   });
-  // Clear a stale voice error once the user starts a new recording or types.
+  // Clear a stale voice error once the user starts a new recording.
   useEffect(() => { if (voice.status === 'recording') setVoiceError(null); }, [voice.status]);
+  // Clean up any pending-send timers on unmount.
+  useEffect(() => () => clearPendingVoice(), [clearPendingVoice]);
 
   const filledCount = useMemo(() => state ? Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length : 0, [state]);
 
@@ -1016,7 +1054,12 @@ export default function CboProfilePage() {
               <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div className={`max-w-[90%] rounded-lg px-4 py-2.5 ${msg.role === 'user' ? 'bg-green-600 text-white' : msg.messageType === 'thinking' ? 'bg-muted/50 border border-dashed border-muted-foreground/20' : 'bg-muted'}`}>
                   {msg.messageType === 'thinking' && <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('cbo.working')}</p>}
-                  {msg.role === 'user' ? <p className="text-sm">{msg.content}</p> : (
+                  {msg.role === 'user' ? (
+                    <p className="text-sm">
+                      {msg.viaVoice && <Mic className="w-3 h-3 inline-block mr-1 -mt-0.5 opacity-80" aria-label={lang === 'pt' ? 'mensagem de voz' : 'voice message'} />}
+                      {msg.content}
+                    </p>
+                  ) : (
                     <div className={`text-sm prose prose-sm max-w-none ${msg.messageType === 'thinking' ? 'text-muted-foreground italic text-xs' : ''}`}>
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{fixMarkdownTables(msg.content)}</ReactMarkdown>
                     </div>
@@ -1292,6 +1335,23 @@ export default function CboProfilePage() {
                 <span>{voiceError}</span>
               </div>
             )}
+            {/* Auto-send undo window: the transcript shows here and fires after a
+                short countdown unless the user cancels (→ drops into the box to
+                edit). Replaces the composer for the ~3s window. */}
+            {pendingVoice ? (
+              <div className="flex items-center gap-2" data-testid="cbo-voice-pending">
+                <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-md bg-green-50 border border-green-200 min-w-0">
+                  <Mic className="w-4 h-4 text-green-700 shrink-0" />
+                  <span className="text-sm text-green-900 truncate flex-1">{pendingVoice.text}</span>
+                  <span className="text-[11px] font-medium text-green-700 tabular-nums shrink-0">
+                    {lang === 'pt' ? 'enviando…' : 'sending…'} {pendingVoice.secondsLeft}
+                  </span>
+                </div>
+                <Button type="button" variant="outline" size="sm" onClick={cancelPendingVoice} data-testid="button-cbo-voice-cancel" className="shrink-0">
+                  {t('cbo.voice.cancel', { defaultValue: lang === 'pt' ? 'Cancelar' : 'Cancel' })}
+                </Button>
+              </div>
+            ) : (
             <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input); }} className="flex gap-2">
               <input ref={fileInputRef} type="file" className="hidden" accept=".pdf,.docx,.xlsx,.txt,.md,.csv,.tsv,.json,.png,.jpg,.jpeg,.gif,.webp,.mp3,.wav,.m4a,.webm,.ogg,.opus,.aac,.flac,audio/*,image/*"
                 onChange={(e) => {
@@ -1339,6 +1399,7 @@ export default function CboProfilePage() {
               <Input ref={inputRef} data-testid="cbo-chat-input" value={input} onChange={e => setInput(e.target.value)} placeholder={isStreaming ? t('cbo.working') : voice.status === 'recording' ? (lang === 'pt' ? 'Ouvindo…' : 'Listening…') : currentQuestion ? t('cbo.typeCustom') : t('cbo.typePlaceholder')} disabled={isStreaming} className="flex-1" />
               <Button type="submit" disabled={isStreaming || !input.trim()} size="sm" className="bg-green-600 hover:bg-green-700"><Send className="w-4 h-4" /></Button>
             </form>
+            )}
           </div>
         </div>
 

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1728,7 +1728,9 @@
       "record": "Speak your answer",
       "stop": "Stop recording",
       "recording": "Recording… tap to stop",
-      "transcribing": "Transcribing…"
+      "transcribing": "Transcribing…",
+      "sending": "sending…",
+      "cancel": "Cancel"
     },
     "interventionProfile": "Intervention Profile",
     "scorecard": {

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1715,7 +1715,9 @@
       "record": "Falar a resposta",
       "stop": "Parar gravação",
       "recording": "Gravando… toque para parar",
-      "transcribing": "Transcrevendo…"
+      "transcribing": "Transcrevendo…",
+      "sending": "enviando…",
+      "cancel": "Cancelar"
     },
     "interventionProfile": "Perfil de Intervenção",
     "scorecard": {

--- a/e2e/cbo-voice-input.spec.ts
+++ b/e2e/cbo-voice-input.spec.ts
@@ -6,12 +6,13 @@ import { test, expect } from '@playwright/test';
 // risk surface, which has no key dependency:
 //   • the mic button renders and toggles (tap-to-start / tap-to-stop),
 //   • MediaRecorder actually records and POSTs an audio blob to /transcribe,
-//   • the returned transcript lands in the input box for REVIEW,
-//   • it is NOT auto-sent (no turn fires, no user bubble appears).
+//   • on stop the transcript AUTO-SENDS after a short undo window,
+//   • cancelling the undo window keeps the text in the box instead (recovery).
 //
 // Chromium gets a synthetic mic via --use-fake-device-for-media-stream, and we
 // stub the /transcribe response in the browser (route interception) so no model
-// key is needed and the assertion is deterministic.
+// key is needed and the assertion is deterministic. The chat turn itself runs
+// against the deterministic fake model (CBO_FAKE_MODEL=1).
 
 const STUB_TRANSCRIPT = 'Somos a Horta Comunitária Cascata, do bairro Cascata.';
 
@@ -23,64 +24,68 @@ test.use({
   permissions: ['microphone'],
 });
 
-test.describe('CBO voice input (fake mic + stubbed transcription)', () => {
-  test('record → stop → transcript fills the input for review, not auto-sent', async ({ page }) => {
-    // Stub the transcription endpoint IN THE BROWSER so we never need a real key.
-    // Capture the request to prove the client actually uploaded recorded audio.
-    let postedAudioBytes = 0;
-    let transcribeHits = 0;
-    await page.route('**/api/cbo/*/transcribe', async (route) => {
-      transcribeHits++;
-      postedAudioBytes = route.request().postDataBuffer()?.length ?? 0;
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ text: STUB_TRANSCRIPT }),
-      });
-    });
+async function stubTranscribe(page: import('@playwright/test').Page) {
+  const probe = { hits: 0, bytes: 0 };
+  await page.route('**/api/cbo/*/transcribe', async (route) => {
+    probe.hits++;
+    probe.bytes = route.request().postDataBuffer()?.length ?? 0;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ text: STUB_TRANSCRIPT }) });
+  });
+  return probe;
+}
 
+async function recordOnce(page: import('@playwright/test').Page) {
+  const mic = page.getByTestId('button-cbo-voice');
+  await expect(mic).toBeVisible();
+  await mic.click();                                   // tap to start
+  await expect(mic).toHaveAttribute('aria-label', /stop|parar/i);
+  await page.waitForTimeout(2000);                     // record enough to clear the silence guard
+  await mic.click();                                   // tap to stop → transcribe → undo window
+}
+
+test.describe('CBO voice input (fake mic + stubbed transcription)', () => {
+  test('record → stop → auto-sends after the undo window (marked as voice)', async ({ page }) => {
+    const probe = await stubTranscribe(page);
     await page.goto('/cbo-profile');
     const marker = page.getByTestId('cbo-stream-status');
     await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
-
-    const mic = page.getByTestId('button-cbo-voice');
-    const input = page.getByTestId('cbo-chat-input');
-    // The button only renders when the browser supports MediaRecorder — which
-    // Chromium does, so it must be here.
-    await expect(mic).toBeVisible();
-    await expect(input).toHaveValue('');
     await expect(marker).toHaveAttribute('data-turns', '0');
 
-    // Tap to start. getUserMedia resolves against the fake device, MediaRecorder
-    // starts → the button flips to its "stop" affordance.
-    await mic.click();
-    await expect(mic).toHaveAttribute('aria-label', /stop|parar/i);
+    await recordOnce(page);
 
-    // Record long enough to clear the client's tiny-blob (silence) guard.
-    await page.waitForTimeout(2000);
+    // The undo window appears with the transcript + a cancel button.
+    await expect(page.getByTestId('cbo-voice-pending')).toBeVisible();
+    await expect(page.getByTestId('cbo-voice-pending')).toContainText(STUB_TRANSCRIPT);
 
-    // Tap to stop → onstop builds the blob and POSTs it to /transcribe (stubbed),
-    // then the transcript is appended to the input. Wait for that to land.
-    await mic.click();
-    await expect(input).toHaveValue(STUB_TRANSCRIPT, { timeout: 15_000 });
-
-    // It went into the box for REVIEW — it was NOT sent. No turn fired, and no
-    // user message bubble with the transcript exists.
-    await expect(marker).toHaveAttribute('data-turns', '0');
-    await expect(page.locator('.bg-green-600', { hasText: STUB_TRANSCRIPT })).toHaveCount(0);
+    // Left untouched, it auto-sends: the transcript shows as a sent user bubble
+    // and a turn fires (the fake model answers). The undo bar goes away.
+    await expect(page.locator('.bg-green-600', { hasText: STUB_TRANSCRIPT })).toBeVisible({ timeout: 15_000 });
+    await expect(marker).toHaveAttribute('data-turns', '1', { timeout: 30_000 });
+    await expect(page.getByTestId('cbo-voice-pending')).toHaveCount(0);
 
     // The client genuinely uploaded recorded audio (not an empty/sham blob).
-    expect(transcribeHits).toBe(1);
-    expect(postedAudioBytes, 'recorded audio should be a non-trivial multipart upload').toBeGreaterThan(1200);
+    expect(probe.hits).toBe(1);
+    expect(probe.bytes, 'recorded audio should be a non-trivial multipart upload').toBeGreaterThan(1200);
+  });
 
-    // The mic returned to idle (ready to record again).
-    await expect(mic).toHaveAttribute('aria-label', /record|gravar/i);
+  test('cancel during the undo window keeps the text in the box, does not send', async ({ page }) => {
+    await stubTranscribe(page);
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    await expect(marker).toHaveAttribute('data-turns', '0');
 
-    // And the user can still edit + send normally from here: the transcript is
-    // just prefilled text. Append a word and confirm the composer accepts it.
-    await input.click();
-    await input.press('End');
-    await input.type(' Obrigada!');
-    await expect(input).toHaveValue(`${STUB_TRANSCRIPT} Obrigada!`);
+    await recordOnce(page);
+
+    // Cancel before the countdown elapses → transcript drops into the input,
+    // nothing is sent.
+    await expect(page.getByTestId('cbo-voice-pending')).toBeVisible();
+    await page.getByTestId('button-cbo-voice-cancel').click();
+
+    await expect(page.getByTestId('cbo-chat-input')).toHaveValue(STUB_TRANSCRIPT);
+    await expect(page.getByTestId('cbo-voice-pending')).toHaveCount(0);
+    await expect(marker).toHaveAttribute('data-turns', '0');
+    // Not sent as a bubble either.
+    await expect(page.locator('.bg-green-600', { hasText: STUB_TRANSCRIPT })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Follow-up to the merged voice-input PR (#253). Re-homed onto current `main` after the original commit was accidentally pushed to the already-merged branch.

## What

Voice notes now **auto-send** (WhatsApp-style) instead of landing in the input for a manual send — but with a **3s "enviando… [cancelar]" undo window** so a misrecognized PT-BR transcript is recoverable:

- stop recording → transcript shows in an undo bar → auto-fires after the countdown
- **cancel** within 3s → text drops into the box to edit instead of sending
- sent voice messages carry a small 🎤 in the bubble, so a slightly-off word reads as "came from voice" (and the user still sees what was understood)

Decided via /refine: undo-window over instant-send (safer for this audience) + voice-marked bubbles.

## How

- `sendMessage` gains a `viaVoice` flag → 🎤 on the optimistic user bubble; messages state widened to `CboChatMessage & { viaVoice?: boolean }` (client-only marker, not persisted)
- pending-send = a display tick interval + a send timeout, with clean cancel + unmount cleanup
- the composer is replaced by the undo bar during the window

## Testing

`tsc` clean. `e2e/cbo-voice-input.spec.ts` updated + green (fake mic + stubbed transcribe + fake model): asserts auto-send fires (turn + bubble) and that cancel keeps the text in the box without sending. Real speech→text stays a live/manual check (Replit AI key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)