### PR TITLE
feat(cougar): hide city view from landing, reachable at /city (#8)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,6 +39,9 @@ function Router() {
       <Route path='/coordinator-login' component={CoordinatorLoginPage} />
       <Route path='/orchestrator' component={OrchestratorLandingPage} />
       <Route path='/auth/callback' component={OAuthCallback} />
+      {/* City view is hidden from the landing (no role card) but stays reachable
+          by direct URL. /city is the memorable entry; /cities kept for existing links. */}
+      <Route path='/city' component={CitySelection} />
       <Route path='/cities' component={CitySelection} />
       <Route path='/project/:projectId' component={ProjectPage} />
       

--- a/client/src/core/pages/role-selection.tsx
+++ b/client/src/core/pages/role-selection.tsx
@@ -105,19 +105,10 @@ const TONE_STYLES: Record<NbsTypology['tone'], { bubble: string; fg: string; chi
   biodiversity: { bubble: 'bg-emerald-50 dark:bg-emerald-950/40', fg: 'text-emerald-600 dark:text-emerald-300', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800' },
 };
 
+// NOTE: the 'city' role is intentionally NOT presented here — the city view is
+// hidden from the landing and reachable only by direct URL (/city). See App.tsx.
+// ROLE_CONFIGS.city still exists so the route/flow works if visited directly.
 const PRESENTATIONS: RolePresentation[] = [
-  {
-    id: 'city',
-    Icon: Building2,
-    accent: {
-      bubble: 'bg-blue-50 dark:bg-blue-950/40',
-      iconFg: 'text-blue-600 dark:text-blue-300',
-      ringHover: 'group-hover:ring-blue-300/60 dark:group-hover:ring-blue-700/60',
-      glowFrom: 'from-blue-400/20',
-      glowVia: 'via-sky-300/15',
-      corner: 'from-blue-400/15',
-    },
-  },
   {
     id: 'cbo',
     Icon: Users,

--- a/e2e/cougar-hide-city.spec.ts
+++ b/e2e/cougar-hide-city.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+// Task #8 — the city view is hidden from the landing (no role card) but stays
+// reachable by direct URL at /city. Recorded as a short demo video.
+
+test.describe('COUGAR #8 — hide city view behind /city', () => {
+  test('landing has no city card; /city still renders the city view', async ({ page }) => {
+    // Landing: role selection, with the city card removed.
+    await page.goto('/');
+    await expect(page.getByTestId('text-landing-title')).toBeVisible();
+    await page.waitForTimeout(1200); // let the card animations settle (for the video)
+
+    await expect(page.getByTestId('card-role-city')).toHaveCount(0);
+    await expect(page.getByTestId('card-role-cbo')).toBeVisible();
+    await expect(page.getByTestId('card-role-orchestrator')).toBeVisible();
+    await page.waitForTimeout(800);
+
+    // The city view is still reachable by direct URL — it lands on the
+    // CityCatalyst gate (auth or sample), exactly as the city role always did;
+    // only the entry point moved (off the landing → /city).
+    await page.goto('/city');
+    await expect(page.getByTestId('text-login-title')).toBeVisible();
+    await page.waitForTimeout(1000);
+
+    // Through the sample-data path, the actual city view renders.
+    await page.getByTestId('button-sample-login').click();
+    await expect(page.getByTestId('text-page-title')).toBeVisible();
+    await expect(page.getByTestId('grid-cities')).toBeVisible();
+    await page.waitForTimeout(1500); // hold on the city view for the video
+  });
+});


### PR DESCRIPTION
COUGAR backlog #8.

## What
- The **city** role card is removed from the role-selection landing — only **CBO** + **Coordinator** remain.
- The city view is no longer surfaced but stays reachable by **direct URL `/city`**. The CityCatalyst auth/sample gate is unchanged (the city view always required it) — only the entry point moved off the landing.
- `/cities` kept working for any existing links.

## Files
- `client/src/core/pages/role-selection.tsx` — drop the `city` card (`ROLE_CONFIGS.city` kept so the direct-URL flow still works)
- `client/src/App.tsx` — add `/city` → `CitySelection`

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-hide-city.spec.ts` (with demo video): landing has no city card → `/city` → CityCatalyst gate → Use Sample Data → Porto Alegre city view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)