### PR TITLE
feat(cougar): workshop cadence as collapsible rows (#2)

### DIFF
--- a/client/src/core/components/orchestrator/WorkshopCadence.tsx
+++ b/client/src/core/components/orchestrator/WorkshopCadence.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Calendar, Check, ChevronRight, Lock, Pencil, Unlock,
+  Calendar, Check, ChevronDown, ChevronRight, Lock, Pencil, Unlock,
   Users, MapPin, Sprout, HandCoins, ClipboardCheck, Send,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -246,13 +246,24 @@ function WorkshopRow({
         .filter(s => s.length > 0)
     : [];
 
+  // Collapsible: minimized by default to keep the cadence compact, with the
+  // active (open) + next-up workshops expanded so their detail + CTA are
+  // immediately visible. The whole header toggles; a chevron signals state.
+  const [collapsed, setCollapsed] = useState(state !== 'open' && state !== 'nextUp');
+
   return (
     <div
-      className={`relative rounded-xl border ${stateMeta.ring} ${stateMeta.bg} transition-all p-3.5`}
+      className={`relative rounded-xl border ${stateMeta.ring} ${stateMeta.bg} transition-all ${collapsed ? 'p-2.5' : 'p-3.5'}`}
       data-testid={`workshop-row-${index}-${state}`}
     >
-      {/* Header row — topic icon, name, state pill */}
-      <div className="flex items-start gap-3">
+      {/* Header row — topic icon, name, state pill. Click to expand/collapse. */}
+      <button
+        type="button"
+        onClick={() => setCollapsed(c => !c)}
+        aria-expanded={!collapsed}
+        className="w-full flex items-start gap-3 text-left"
+        data-testid={`workshop-toggle-${index}`}
+      >
         {/* Topic icon tile — workshop-specific identity. State overlay
             (✓ / lock) in the bottom-right corner for past + locked. */}
         <div className="relative shrink-0">
@@ -293,11 +304,17 @@ function WorkshopRow({
             </span>
           </div>
         </div>
-      </div>
 
-      {/* Body — description + expected output. Always rendered, but
-          state-driven opacity dims past + locked so the eye still flows
-          to the active workshops. */}
+        {/* Expand/collapse affordance */}
+        <ChevronDown
+          className={`shrink-0 mt-1 w-4 h-4 text-muted-foreground transition-transform ${collapsed ? '-rotate-90' : ''}`}
+          strokeWidth={2}
+        />
+      </button>
+
+      {!collapsed && (<>
+      {/* Body + footer — shown only when the row is expanded. State-driven
+          opacity dims past + locked so the eye still flows to active ones. */}
       <div className={stateMeta.contentOpacity}>
         {description && (
           <p className="mt-3 text-[12px] leading-relaxed text-foreground/80">
@@ -367,6 +384,7 @@ function WorkshopRow({
           </Button>
         )}
       </div>
+      </>)}
     </div>
   );
 }
@@ -414,7 +432,7 @@ export function WorkshopCadence({
         </span>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
+      <div className="flex flex-col gap-2">
         {workshops.map((w, i) => (
           <WorkshopRow
             key={i}

--- a/e2e/cougar-workshop-rows.spec.ts
+++ b/e2e/cougar-workshop-rows.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Task #2 — the workshop cadence is now single-column collapsible rows (was a
+// 2-column grid of always-expanded cards). Rows minimize to a compact header
+// to take less space; the active/next-up one stays expanded; any row toggles.
+// Recorded as a demo video.
+
+test.describe('COUGAR #2 — workshops as collapsible rows', () => {
+  test('compact rows; active expanded, others minimized; any row toggles', async ({ page }) => {
+    // Auth the PAGE's own context (cookie shared with page.request), then the
+    // orchestrator loads the default cohort with its 6 seeded workshops.
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `ws-${randomUUID()}@e2e.test`, password: 'ws-pass-12345', name: 'WS' });
+
+    await page.goto('/orchestrator');
+
+    // All six workshops render as rows (single column).
+    const toggle0 = page.getByTestId('workshop-toggle-0');
+    const toggle1 = page.getByTestId('workshop-toggle-1');
+    await expect(toggle0).toBeVisible();
+    await expect(page.getByTestId('workshop-toggle-5')).toBeVisible();
+    await page.waitForTimeout(1200);
+
+    // The next-up (first) workshop is expanded by default; a later one is
+    // collapsed (compact).
+    await expect(toggle0).toHaveAttribute('aria-expanded', 'true');
+    await expect(toggle1).toHaveAttribute('aria-expanded', 'false');
+    await page.waitForTimeout(600);
+
+    // Expand a collapsed row → its body (Expected output) appears.
+    await toggle1.click();
+    await expect(toggle1).toHaveAttribute('aria-expanded', 'true');
+    await page.waitForTimeout(1200);
+
+    // Collapse it again → back to compact.
+    await toggle1.click();
+    await expect(toggle1).toHaveAttribute('aria-expanded', 'false');
+    await page.waitForTimeout(1000);
+  });
+});


### PR DESCRIPTION
COUGAR backlog #2.

## What
The workshop cadence was a **2-column grid of always-expanded cards** — it ate a lot of vertical space. Now it's a **single column of collapsible rows**:

- Each row minimizes to a **compact header** (topic icon + name + state pill + chevron).
- The body (description + Expected output + date/CTA footer) shows **only when expanded**.
- The **active (open) + next-up** workshops start expanded (their CTA is immediately visible); the rest start **minimized**.
- Clicking a header toggles any row.

## Files
- `client/src/core/components/orchestrator/WorkshopCadence.tsx` — `grid lg:grid-cols-2` → `flex-col`; `WorkshopRow` gains a `collapsed` state (default = not open/next-up), a clickable header `<button>` with `aria-expanded`, a rotating chevron, and wraps body+footer behind `!collapsed`.

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-workshop-rows.spec.ts` (with demo video): 6 rows render single-column, next-up expanded, others collapsed, any row toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)