### PR TITLE
fix(cougar): scope CBO session cache by invite token (#7)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -153,9 +153,23 @@ function migrateCboState(state: CboState): CboState {
   return state;
 }
 
-function getSavedId(): string | null { try { return localStorage.getItem(STORAGE_KEY); } catch { return null; } }
-function saveId(id: string) { try { localStorage.setItem(STORAGE_KEY, id); } catch {} }
-function clearId() { try { localStorage.removeItem(STORAGE_KEY); } catch {} }
+// Cached-session key is SCOPED to the invite token. Otherwise a single global
+// 'cbo-session-id' key collides across invites on the same device: open a new
+// invite (?t=tokenB) on a phone that already has org A's session cached and the
+// chat resumes A's conversation instead of starting B's. Per-token keys keep
+// each invited org's session separate; the standalone /cbo-profile flow (no
+// token) keeps the plain key. (The member's server-side cboStateId remains the
+// cross-device source of truth via the snapshot binding.)
+function sessionStorageKey(): string {
+  try {
+    const p = new URLSearchParams(window.location.search);
+    const ref = p.get('t') || p.get('cbo');
+    return ref ? `${STORAGE_KEY}:${ref}` : STORAGE_KEY;
+  } catch { return STORAGE_KEY; }
+}
+function getSavedId(): string | null { try { return localStorage.getItem(sessionStorageKey()); } catch { return null; } }
+function saveId(id: string) { try { localStorage.setItem(sessionStorageKey(), id); } catch {} }
+function clearId() { try { localStorage.removeItem(sessionStorageKey()); } catch {} }
 function getSavedMapParams(): OpenMapParams | null { try { const s = sessionStorage.getItem(MAP_PARAMS_KEY); return s ? JSON.parse(s) : null; } catch { return null; } }
 function saveMapParams(p: OpenMapParams | null) { try { if (p) sessionStorage.setItem(MAP_PARAMS_KEY, JSON.stringify(p)); else sessionStorage.removeItem(MAP_PARAMS_KEY); } catch {} }
 

--- a/e2e/cougar-invite-session.spec.ts
+++ b/e2e/cougar-invite-session.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Task #7 — a NEW invite opened on a device that already has another org's
+// session cached must NOT resume that prior conversation. The fix scopes the
+// cached-session localStorage key by invite token, so each invited org keeps a
+// separate session; re-opening the same invite still resumes its own.
+
+test.describe('COUGAR #7 — new invite never resumes a prior org session', () => {
+  test('two invites on the same browser get separate sessions; re-opening resumes', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const { cohort } = await api.createCohort('e2e invite-isolation');
+    const a = await api.inviteMember(cohort.id, { orgName: 'Org Alpha' });
+    const b = await api.inviteMember(cohort.id, { orgName: 'Org Beta' });
+
+    // Open an invite, click through welcome (+ preamble), return its chat session id.
+    const openInvite = async (inviteUrl: string): Promise<string> => {
+      await page.goto(inviteUrl);
+      await page.getByTestId('button-cbo-welcome-cta').click({ timeout: 30_000 });
+      const pre = page.getByTestId('button-encontro-1-start');
+      if (await pre.isVisible({ timeout: 8_000 }).catch(() => false)) await pre.click();
+      const marker = page.getByTestId('cbo-stream-status');
+      await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+      await page.waitForTimeout(900); // hold for the video
+      return (await marker.getAttribute('data-cbo-id'))!;
+    };
+
+    const idA = await openInvite(a.inviteUrl);
+    const idB = await openInvite(b.inviteUrl);
+    // The core fix: invite B starts its OWN session, not org A's.
+    expect(idB, 'a new invite must NOT resume the previous org session').not.toBe(idA);
+
+    // And re-opening invite A still resumes A's own session.
+    const idA2 = await openInvite(a.inviteUrl);
+    expect(idA2, 're-opening the same invite resumes its own session').toBe(idA);
+
+    // Sessions are cached under per-token keys, not the single global key.
+    const keys = await page.evaluate(() => Object.keys(localStorage).filter(k => k.startsWith('cbo-session-id')));
+    expect(keys.filter(k => k.includes(':')).length, 'per-token session keys exist').toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
COUGAR backlog #7.

## Bug
A **new invite** opened on a device that already had another org's session cached **resumed that prior conversation**. The cached-session key was a single global `cbo-session-id`, so opening `?t=tokenB` on a phone with org A's session loaded **A's chat** — the banner showed B, but the conversation was A's. (Confirmed: the invite-resolution effect set the banner but never touched the session; the init effect adopted the global cached id regardless of the token.)

## Fix
Scope the cached-session key by invite token: `cbo-session-id:<token>`. Each invited org keeps a separate session, so a new invite always starts fresh; re-opening the same invite still resumes its own. The standalone `/cbo-profile` flow (no token) keeps the plain key. The member's server-side `cboStateId` stays the cross-device source of truth via the snapshot binding.

- `client/src/core/pages/cbo-profile.tsx`: `sessionStorageKey()` derives the key from `?t=` / `?cbo=`; `getSavedId/saveId/clearId` use it.

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-invite-session.spec.ts` (+ demo video): two invites (Org Alpha, Org Beta) on one browser get **separate** sessions, re-opening Alpha resumes Alpha, and per-token keys exist. Without the fix, Beta resumes Alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)