### PR TITLE
fix(cougar): harden invite-preview wave emoji against mojibake (#5)

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -12,10 +12,14 @@ import { Input } from '@/core/components/ui/input';
 // Greeting templates — shared between ShareLinkDialog and bulk summary so the
 // CBO-facing message is consistent everywhere.
 // ---------------------------------------------------------------------------
+// The wave is written as an explicit code-point escape (\u{1F44B}) rather than a
+// raw literal so it survives any non-UTF-8 re-save of this file in the toolchain
+// — a raw 👋 had been showing up as a replacement char (�) in the sent preview.
+const WAVE = '\u{1F44B}';
 export function cboGreetingMessage(orgName: string, url: string, isPt: boolean): string {
   return isPt
-    ? `Olá! 👋\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
-    : `Hi! 👋\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
+    ? `Olá! ${WAVE}\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
+    : `Hi! ${WAVE}\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
 }
 
 export function whatsappDeepLink(message: string, phone?: string): string {

--- a/e2e/cougar-invite-emoji.spec.ts
+++ b/e2e/cougar-invite-emoji.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Task #5 — the invite preview message must render the 👋 wave, not a
+// replacement char (�). The greeting is written with an explicit \u{1F44B}
+// escape so no toolchain re-save can mangle it. This drives the real share
+// dialog and asserts the rendered preview.
+
+test.describe('COUGAR #5 — invite preview renders the wave emoji', () => {
+  test('the share preview shows 👋, not a replacement char', async ({ page, request }) => {
+    const ext = new TestApi(request);
+    const { cohort } = await ext.createCohort('e2e emoji');
+    const member = (await ext.inviteMember(cohort.id, { orgName: 'Org Wave', withSession: true })).member;
+
+    // Auth the page as a coordinator scoped to this cohort.
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `emoji-${randomUUID()}@e2e.test`, password: 'pw-123456', name: 'Emoji', cohortId: cohort.id });
+
+    await page.goto('/orchestrator');
+    const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(800);
+    await card.click(); // opens the share-link dialog
+
+    // Expand the message preview.
+    await page.getByText('Preview message', { exact: false }).click();
+    await page.waitForTimeout(1000);
+
+    const dialog = page.getByRole('dialog');
+    const txt = await dialog.innerText();
+    expect(txt, 'preview should contain the wave emoji').toContain('\u{1F44B}');
+    expect(txt, 'preview should NOT contain the replacement char').not.toContain('�');
+    await page.waitForTimeout(1200); // hold for the video
+  });
+});


### PR DESCRIPTION
COUGAR backlog #5.

## Finding
The sent invite preview showed the 👋 as a replacement char (`�`). On investigation the **source literal is a valid U+1F44B**, and the rendered preview is actually correct (verified in the harness) — so the live `�` was a **stale deploy**, not a source bug.

## Fix (hardening)
To make it permanently safe regardless of the toolchain, the wave is now an explicit code-point escape `\u{1F44B}` (immune to any non-UTF-8 re-save of the file).

- `client/src/core/components/orchestrator/CohortDialogs.tsx`: `cboGreetingMessage` uses `const WAVE = '\u{1F44B}'`.

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-invite-emoji.spec.ts` (+ demo video): drives the real share dialog → expands "Preview message" → asserts the text contains **U+1F44B** and **no** replacement char.

## Deploy note
Needs **republish** to clear the stale `�` on the live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)