### PR TITLE
feat(cougar): coordinator-forced cohort language (#4)

### DIFF
--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -22,6 +22,7 @@ export interface UseCohortResult {
   invite: (params: { orgName: string; neighborhood?: string; role?: 'priority' | 'alternate' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
+  saveLanguage: (language: 'pt' | 'en' | null) => Promise<void>;
 }
 
 export function useCohort(): UseCohortResult {
@@ -95,5 +96,14 @@ export function useCohort(): UseCohortResult {
     await refresh();
   }, [refresh]);
 
-  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops };
+  const saveLanguage = useCallback(async (language: 'pt' | 'en' | null) => {
+    await fetch(`/api/cohort/${slugRef.current}/language`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language }),
+    });
+    await refresh();
+  }, [refresh]);
+
+  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage };
 }

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -288,6 +288,11 @@ export default function CboProfilePage() {
       if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
       if (Array.isArray(data.inspirationPicks)) setInspirationPicks(data.inspirationPicks);
       if (data.cohort?.name) setCohortName(data.cohort.name);
+      // Coordinator-forced cohort language overrides browser detection.
+      const cohortLang = data.cohort?.language;
+      if ((cohortLang === 'pt' || cohortLang === 'en') && i18n.resolvedLanguage !== cohortLang) {
+        i18n.changeLanguage(cohortLang);
+      }
       if (Array.isArray(data.workshops)) setWorkshops(data.workshops);
       setNextWorkshop(data.nextWorkshop ?? null);
       setFocusWorkshop(data.focusWorkshop ?? null);

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -666,8 +666,9 @@ export default function OrchestratorLandingPage() {
 
   const {
     cohort, members,
-    invite, unlockPhase, saveWorkshops, resetCohort,
+    invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage,
   } = useCohort();
+  const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
 
   const projects = useMemo(() => members.map(memberToView), [members]);
   const memberById = useMemo(() => new Map(members.map(m => [m.id, m])), [members]);
@@ -871,6 +872,33 @@ export default function OrchestratorLandingPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              {/* Forced cohort language — overrides each org's browser detection.
+                  Auto = fall back to detection. */}
+              <div
+                className="inline-flex items-center rounded-md border border-foreground/10 overflow-hidden"
+                title={t('orchestrator.cohort.languageTooltip', { defaultValue: 'Force the language for every org in this cohort (overrides their phone language)' })}
+              >
+                <span className="pl-2 pr-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t('orchestrator.cohort.language', { defaultValue: 'Lang' })}
+                </span>
+                {([['auto', null], ['pt', 'pt'], ['en', 'en']] as const).map(([label, val]) => {
+                  const on = cohortLanguage === val;
+                  return (
+                    <button
+                      key={label}
+                      type="button"
+                      onClick={() => saveLanguage(val)}
+                      data-testid={`button-cohort-lang-${label}`}
+                      aria-pressed={on}
+                      className={`px-2 py-1 text-[11px] font-medium transition-colors ${
+                        on ? 'bg-foreground/[0.08] text-foreground' : 'text-muted-foreground hover:bg-foreground/[0.04]'
+                      }`}
+                    >
+                      {label === 'auto' ? t('orchestrator.cohort.langAuto', { defaultValue: 'Auto' }) : label.toUpperCase()}
+                    </button>
+                  );
+                })}
+              </div>
               <Button
                 size="sm"
                 variant="ghost"

--- a/e2e/cougar-cohort-language.spec.ts
+++ b/e2e/cougar-cohort-language.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Task #4 — a coordinator can FORCE the UI language (PT/EN) for every org in a
+// cohort, overriding the org's browser detection. The browser here is pt-BR, so
+// detection would pick Portuguese; the cohort setting overrides it.
+
+test.use({ locale: 'pt-BR' });
+
+test.describe('COUGAR #4 — cohort-level forced language', () => {
+  test('coordinator sets EN/PT; the invited org gets it despite a pt-BR browser', async ({ page, request }) => {
+    const ext = new TestApi(request);
+    const { cohort } = await ext.createCohort('e2e language');
+    const invite = (await ext.inviteMember(cohort.id, { orgName: 'Org Idioma' })).inviteUrl as string;
+
+    // Auth the page as a coordinator that owns this cohort.
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `lang-${randomUUID()}@e2e.test`, password: 'lang-pass-12', name: 'Lang', cohortId: cohort.id });
+
+    // Force ENGLISH.
+    await page.goto('/orchestrator');
+    await expect(page.getByTestId('button-cohort-lang-en')).toBeVisible({ timeout: 20_000 });
+    await page.getByTestId('button-cohort-lang-en').click();
+    await expect(page.getByTestId('button-cohort-lang-en')).toHaveAttribute('aria-pressed', 'true');
+    await page.waitForTimeout(800);
+
+    // Open the org's invite (pt-BR browser) → forced to English.
+    await page.goto(invite);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en', { timeout: 20_000 });
+    await page.waitForTimeout(1500);
+
+    // Switch the cohort to PORTUGUESE.
+    await page.goto('/orchestrator');
+    await page.getByTestId('button-cohort-lang-pt').click();
+    await expect(page.getByTestId('button-cohort-lang-pt')).toHaveAttribute('aria-pressed', 'true');
+    await page.waitForTimeout(800);
+
+    // Re-open the invite → now forced to Portuguese.
+    await page.goto(invite);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'pt', { timeout: 20_000 });
+    await page.waitForTimeout(1500);
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -142,7 +142,7 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
     path: member.path ?? null,
     unlockedPhases: unlocked,
     cboStateId: member.cboStateId,
-    cohort: cohort ? { id: cohort.id, name: cohort.name } : null,
+    cohort: cohort ? { id: cohort.id, name: cohort.name, language: (cohort.settings as CohortSettings | null)?.language ?? null } : null,
     workshops,
     nextWorkshop,
     focusWorkshop,
@@ -240,12 +240,13 @@ export function registerCohortRoutes(app: Express): void {
   app.post('/api/cohort', wrap(async (req, res) => {
     // Only an admin (unscoped coordinator) may spin up new cohorts.
     if (reqCoordinator(req)?.cohortId) { res.status(403).json({ error: 'only an admin can create cohorts' }); return; }
-    const { name } = req.body ?? {};
+    const { name, language: rawLang } = req.body ?? {};
+    const language = rawLang === 'pt' || rawLang === 'en' ? rawLang : undefined;
     const coordinatorSlug = slug();
     const [created] = await db.insert(cohorts).values({
       coordinatorSlug,
       name: name || 'Untitled cohort',
-      settings: { workshops: DEFAULT_WORKSHOPS },
+      settings: { workshops: DEFAULT_WORKSHOPS, language },
     }).returning();
     res.json({ cohort: created });
   }));
@@ -329,6 +330,19 @@ export function registerCohortRoutes(app: Express): void {
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true });
+  }));
+
+  // Set the cohort's forced UI language ('pt' | 'en' | null to clear). Forces
+  // that language for every org in the cohort, overriding browser detection.
+  app.patch('/api/cohort/:coordinatorSlug/language', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const raw = req.body?.language;
+    const language = raw === 'pt' || raw === 'en' ? raw : undefined;
+    const settings: CohortSettings = { ...(cohort.settings as CohortSettings), language };
+    await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
+    res.json({ ok: true, language: language ?? null });
   }));
 
   // Unlock a phase — for one member, multiple members, or 'all'

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -23,6 +23,10 @@ export type WorkshopConfig = {
 
 export type CohortSettings = {
   workshops: WorkshopConfig[];
+  // Coordinator-forced UI language for every org in this cohort. When set, it
+  // OVERRIDES the org's browser language detection (so a PT phone in an EN
+  // cohort still gets EN, and vice-versa). Undefined = fall back to detection.
+  language?: 'pt' | 'en';
 };
 
 // RequestSupport — async escalation queue. CBO submits via chat-header button;


### PR DESCRIPTION
COUGAR backlog #4.

## What
A coordinator can **force the UI language** (PT/EN) for every org in a cohort, overriding each org's browser detection — a PT phone in an EN cohort gets EN, and vice-versa. **Auto** = fall back to detection.

## How
- `shared/cohort-schema.ts`: `CohortSettings.language?: 'pt' | 'en'`.
- `server/routes/cohortRoutes.ts`: `PATCH /api/cohort/:slug/language` (owner-guarded, mirrors the workshops PATCH); `buildMemberPayload` returns `cohort.language`; `POST /api/cohort` accepts it.
- `client/src/core/hooks/useCohort.ts`: `saveLanguage()`.
- `client/src/core/pages/orchestrator-landing.tsx`: an **Auto / PT / EN** segmented toggle in the cohort header.
- `client/src/core/pages/cbo-profile.tsx`: `applyMember` calls `i18n.changeLanguage(cohort.language)` — `lang` derives from i18n, so the whole CBO flow (chat + UI) follows.

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-cohort-language.spec.ts` (+ demo video): **pt-BR browser**, force EN → the org's app loads English; force PT → flips to Portuguese (asserted via `<html lang>`).

## Note
No DB migration — `language` lives in the existing `cohorts.settings` JSONB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)