### PR TITLE
feat(cougar): coordinator runbook + delete-cohort cleanup (#6)

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -762,3 +762,48 @@ export function ResetConfirmDialog({
     </Dialog>
   );
 }
+
+// ---------------------------------------------------------------------------
+// DeleteCohortConfirmDialog — admin cleanup. Unlike Reset (keeps the cohort),
+// this removes the cohort and its members entirely.
+// ---------------------------------------------------------------------------
+export function DeleteCohortConfirmDialog({
+  open, onOpenChange, onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}) {
+  const { t } = useTranslation();
+  const [busy, setBusy] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-red-600" />
+            {t('orchestrator.cohort.deleteTitle', { defaultValue: 'Delete cohort?' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.deleteDesc', {
+              defaultValue: 'Permanently removes this cohort and every invited CBO. The default cohort is re-created empty. This can\'t be undone.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => { setBusy(true); try { await onConfirm(); } finally { setBusy(false); } }}
+            disabled={busy}
+            data-testid="button-confirm-delete-cohort"
+          >
+            {busy ? t('common.working', { defaultValue: 'Working…' }) : t('orchestrator.cohort.confirmDelete', { defaultValue: 'Yes, delete' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -23,6 +23,7 @@ export interface UseCohortResult {
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
   saveLanguage: (language: 'pt' | 'en' | null) => Promise<void>;
+  deleteCohort: () => Promise<void>;
 }
 
 export function useCohort(): UseCohortResult {
@@ -105,5 +106,17 @@ export function useCohort(): UseCohortResult {
     await refresh();
   }, [refresh]);
 
-  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage };
+  const deleteCohort = useCallback(async () => {
+    setLoading(true);
+    try {
+      await fetch(`/api/cohort/${slugRef.current}`, { method: 'DELETE' });
+      // Re-resolve: the default cohort is re-created empty; a deleted scoped
+      // cohort falls back to whatever /mine now returns.
+      await fetchCohort();
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchCohort]);
+
+  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
-  Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trees, Unlock, Users, Waves,
+  Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trash2, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -35,6 +35,7 @@ import {
   ShareLinkDialog,
   BulkInviteSummaryDialog,
   ResetConfirmDialog,
+  DeleteCohortConfirmDialog,
   type BulkInviteResult,
 } from '@/core/components/orchestrator/CohortDialogs';
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
@@ -709,8 +710,8 @@ export default function OrchestratorLandingPage() {
   };
 
   const {
-    cohort, members,
-    invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage,
+    cohort, members, isAdmin,
+    invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage, deleteCohort,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
 
@@ -743,6 +744,7 @@ export default function OrchestratorLandingPage() {
   const [bulkSummaryOpen, setBulkSummaryOpen] = useState(false);
   const [bulkInvitations, setBulkInvitations] = useState<BulkInviteResult[]>([]);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [supportInboxOpen, setSupportInboxOpen] = useState(false);
   // Mirrored from /support-requests?status=pending — drives the badge on
   // the inbox trigger. Initialized from member.supportRequests when the
@@ -807,6 +809,12 @@ export default function OrchestratorLandingPage() {
     setResetConfirmOpen(false);
     await resetCohort();
     toast({ title: t('orchestrator.cohort.resetDone', { defaultValue: 'Cohort reset' }) });
+  };
+
+  const handleDeleteConfirm = async () => {
+    setDeleteConfirmOpen(false);
+    await deleteCohort();
+    toast({ title: t('orchestrator.cohort.deleteDone', { defaultValue: 'Cohort deleted' }) });
   };
 
   const handleInviteOpen = () => setInviteOpen(true);
@@ -954,6 +962,19 @@ export default function OrchestratorLandingPage() {
                 <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
                 {t('orchestrator.cohort.reset', { defaultValue: 'Reset' })}
               </Button>
+              {isAdmin && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setDeleteConfirmOpen(true)}
+                  className="text-muted-foreground hover:text-red-600"
+                  data-testid="button-delete-cohort"
+                  title={t('orchestrator.cohort.deleteTooltip', { defaultValue: 'Delete this cohort entirely' })}
+                >
+                  <Trash2 className="w-3.5 h-3.5 mr-1.5" />
+                  {t('orchestrator.cohort.delete', { defaultValue: 'Delete cohort' })}
+                </Button>
+              )}
               <Button size="sm" onClick={handleInviteOpen} data-testid="button-invite-cbo">
                 <Plus className="w-3.5 h-3.5 mr-1.5" />
                 {t('orchestrator.cohort.invite', { defaultValue: 'Invite CBO' })}
@@ -1113,6 +1134,11 @@ export default function OrchestratorLandingPage() {
         open={resetConfirmOpen}
         onOpenChange={setResetConfirmOpen}
         onConfirm={handleResetConfirm}
+      />
+      <DeleteCohortConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        onConfirm={handleDeleteConfirm}
       />
       <InviteCboDialog
         open={inviteOpen}

--- a/docs/cougar-runbook.md
+++ b/docs/cougar-runbook.md
@@ -1,0 +1,88 @@
+# COUGAR / Vila Flores — Coordinator Runbook
+
+How to provision a coordinator, set up a cohort, invite community orgs (CBOs),
+re-issue links, and clean up. For the platform at `https://nbs-project-preparation.replit.app`.
+
+> **Roles in one line.** *Coordinators* log in and manage a cohort. *CBOs never
+> log in* — their invite link (`?t=<token>`) is their sole credential.
+
+---
+
+## 1. Provision a coordinator
+
+Coordinators are **admin-provisioned** (no self-signup). Two ways:
+
+### a) Bootstrap endpoint (works against prod without shell access)
+A secret-gated endpoint creates + (optionally) scopes a coordinator. Set
+`BOOTSTRAP_COORDINATOR_SECRET` in **both** the Replit Workspace and Deployment
+secrets, republish, then:
+
+```bash
+# scripts/bootstrap-coordinator.sh wraps this:
+curl -sS -X POST "$BASE/api/coordinator/bootstrap" \
+  -H "x-bootstrap-secret: $BOOTSTRAP_COORDINATOR_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"coord@org.org","password":"<strong>","name":"Coord","cohortId":null}'
+```
+
+- `cohortId: null` → an **admin** (can create/delete cohorts, sees the default).
+- `cohortId: "<id>"` → a **scoped** coordinator (only their cohort).
+- Idempotent. Unset the secret again after provisioning if you like.
+
+> **DEV vs PROD.** Replit's shell `DATABASE_URL` points at the **dev** DB; the
+> deployment has its own. The bootstrap call hits whichever URL you point at —
+> use the **prod** URL to create a prod coordinator.
+
+### b) Shell script (local / dev)
+```bash
+npx tsx scripts/create-coordinator.ts <email> <password> "<Name>" [cohortSlug]
+```
+
+Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
+
+---
+
+## 2. Create / configure a cohort
+
+- The pilot uses **one default cohort** ("Vila Flores"); an admin coordinator
+  sees it automatically on `/orchestrator` (created on first load).
+- **Language:** set the cohort's forced UI language with the **Auto / PT / EN**
+  toggle in the cohort header. PT/EN *overrides* each org's phone language
+  (Auto = let the phone decide).
+- **Workshops:** the cadence rail shows the 6 workshops as collapsible rows.
+  Schedule a date, and click **Open for cohort** on the next-up workshop to
+  unlock that phase for every org.
+
+---
+
+## 3. Invite CBOs
+
+- **Invite** (single or bulk) from the orchestrator → each org gets an
+  unguessable link **`/cbo-profile?t=<token>`** and a ready-to-send WhatsApp
+  message (the preview shows it).
+- Each invite carries its **own token**. Opening a new invite on a phone that
+  already used another invite starts a **fresh** session (sessions are scoped
+  per token) — it won't resume the previous org's conversation.
+- **Re-issue a link:** re-open the share dialog for that org and copy the link
+  again (same token), or reset/re-invite for a brand-new token.
+
+---
+
+## 4. Clean up
+
+| Action | What it does | Where |
+|---|---|---|
+| **Reset cohort** | Removes every invited CBO + clears workshop progress. The cohort row **stays** (same singleton, fresh state). | Header → **Reset** |
+| **Delete cohort** *(admin)* | Removes the cohort **and** its members entirely. The default cohort is re-created empty on next load. | Header → **Delete cohort** |
+| **Namespaced test data** | The e2e harness namespaces its data (`e2e-*` cohorts, `*@e2e.test` coordinators) and purges it via `POST /__test/cleanup` (gated by `ENABLE_TEST_ROUTES`). | test only |
+
+> **Never** set `ENABLE_TEST_ROUTES` / `CBO_FAKE_MODEL` / `TEST_API_SECRET` on
+> the prod Deployment.
+
+---
+
+## 5. After a deploy
+
+The Repl serves the compiled `build/` — **rebuild + republish** after merging
+anything that changes app behavior (skills, server, client). Skill changes
+(`knowledge/_skills/encontro-*.md`) only reach prod after a republish.

--- a/e2e/cougar-cohort-delete.spec.ts
+++ b/e2e/cougar-cohort-delete.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Task #6 — cleanup. An admin coordinator can DELETE a cohort entirely (members
+// + the cohort row), beyond the existing Reset (which only wipes members). The
+// default cohort is re-created empty afterward. (Runbook in docs/cougar-runbook.md.)
+
+test.describe('COUGAR #6 — delete-cohort cleanup', () => {
+  test('an admin deletes a cohort with a member; the member disappears', async ({ page, request }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `del-${randomUUID()}@e2e.test`, password: 'del-pass-123', name: 'Del' }); // admin
+
+    // Resolve the admin's (default) cohort, then drop a member into it.
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    const ext = new TestApi(request);
+    const member = (await ext.inviteMember(mine.cohort.id, { orgName: 'Org ToDelete', withSession: true })).member;
+
+    await page.goto('/orchestrator');
+    const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(1000);
+
+    // Delete cohort (admin-only) → confirm.
+    await page.getByTestId('button-delete-cohort').click();
+    await expect(page.getByTestId('button-confirm-delete-cohort')).toBeVisible();
+    await page.waitForTimeout(700);
+    await page.getByTestId('button-confirm-delete-cohort').click();
+
+    // The cohort (and its member) are gone — the default is re-created empty.
+    await expect(card).toHaveCount(0, { timeout: 15_000 });
+    await page.waitForTimeout(1200); // hold for the video
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -233,6 +233,18 @@ export function registerCohortRoutes(app: Express): void {
     res.json({ cohort: refreshed, members: [] });
   }));
 
+  // Delete a cohort ENTIRELY — its members + the cohort row (unlike reset, which
+  // keeps the cohort). The :coordinatorSlug app.param guard enforces ownership;
+  // the default cohort is re-created empty on the next /mine. Cleanup for
+  // throwaway/test cohorts.
+  app.delete('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
+    const cohort = (req as any).cohort ?? await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+    await db.delete(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    await db.delete(cohorts).where(eq(cohorts.id, cohort.id));
+    res.json({ ok: true, deleted: cohort.id });
+  }));
+
   // ──────────────────────────────────────────────────────────────────────
   // Create cohort — kept for backward-compat with anything that still calls
   // it. The pilot's UI no longer surfaces this.


### PR DESCRIPTION
COUGAR backlog #6 — "how do we set up cohorts / invite coordinators / clean up."

## What
- **Runbook** — `docs/cougar-runbook.md`: provision a coordinator (bootstrap endpoint / create-coordinator script, with the DEV/PROD DB note), create + configure a cohort (forced language + workshops), invite CBOs (`?t=` tokens, per-token sessions), re-issue links, and **cleanup** (Reset vs Delete vs namespaced test data) + the republish reminder.
- **Delete cohort** — the existing **Reset** only wipes members and keeps the cohort. Added a true **delete** (cohort + members), admin-only:
  - `DELETE /api/cohort/:slug` (owner/admin-guarded via the `app.param` tenancy check); the default cohort is re-created empty on next `/mine`.
  - `useCohort.deleteCohort()`, a `DeleteCohortConfirmDialog`, and an admin-only **"Delete cohort"** button next to Reset.

## Testing
`tsc` clean. Full chromium e2e gate green (14 passed). New `e2e/cougar-cohort-delete.spec.ts` (+ demo video): an admin deletes a cohort that has a member → the member disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)