### PR TITLE
feat(cougar): coordinator map v2 — interpolated flood, zone-priority colors, full-width

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -30,6 +30,7 @@ import { useResetRole } from '@/core/contexts/role-context';
 import { useCohort } from '@/core/hooks/useCohort';
 import { useLocation } from 'wouter';
 import type { CohortMember, WorkshopConfig } from '@shared/cohort-schema';
+import { TYPOLOGY_COLORS, zoneRiskOpacity } from '@shared/risk-display';
 import {
   InviteCboDialog,
   ShareLinkDialog,
@@ -187,32 +188,39 @@ const BAND_CHIP: Record<ReturnType<typeof maturityBand>, string> = {
 // clicking the active one turns it off (just the outlines + CBO markers remain).
 type RiskView = 'flood' | 'heat' | 'landslide' | 'risk';
 
-// Hazard raster overlays, fed LIVE from the data catalog: flood = catalog
-// poa_flood_risk (H×E×V) via the tile proxy; heat / landslide = the local 250m
-// risk tiles. So a catalog update flows straight through to this map.
+// Hazard raster overlays, fed LIVE from the data catalog via the tile proxy.
+// Flood = the catalog poa_flood_HAZARD (the IDW-interpolated, gap-free build —
+// the hazard layer covers the whole territory, unlike the sparse H×E×V risk
+// composite). Heat / landslide = the local 250m risk tiles.
 const HAZARD_RASTER: Record<'flood' | 'heat' | 'landslide', { url: string; attribution: string }> = {
-  flood:     { url: '/api/geospatial/tiles/poa_flood_risk/{z}/{x}/{y}.png', attribution: 'OEF catalog · flood risk (H×E×V)' },
-  heat:      { url: '/tiles/heat_risk/{z}/{x}/{y}.png',                     attribution: 'OEF risk grid (250m)' },
-  landslide: { url: '/tiles/landslide_risk/{z}/{x}/{y}.png',               attribution: 'OEF risk grid (250m)' },
+  flood:     { url: '/api/geospatial/tiles/poa_flood_hazard/{z}/{x}/{y}.png', attribution: 'OEF catalog · flood hazard (interpolated)' },
+  heat:      { url: '/tiles/heat_risk/{z}/{x}/{y}.png',                       attribution: 'OEF risk grid (250m)' },
+  landslide: { url: '/tiles/landslide_risk/{z}/{x}/{y}.png',                 attribution: 'OEF risk grid (250m)' },
 };
 
-const PRIORITY_BANDS: Array<{ max: number; fill: string; label: string }> = [
-  { max: 0.5, fill: '#86efac', label: 'low' },        // emerald-300
-  { max: 1.0, fill: '#fde68a', label: 'medium' },     // amber-200
-  { max: 1.5, fill: '#fb923c', label: 'high' },       // orange-400
-  { max: Infinity, fill: '#ef4444', label: 'very high' }, // red-500
-];
-
-function priorityFill(score: number): string {
-  for (const band of PRIORITY_BANDS) if (score <= band.max) return band.fill;
-  return PRIORITY_BANDS[PRIORITY_BANDS.length - 1].fill;
+// City-wide min/max of the per-zone max-hazard mean, for normalizing the 'risk'
+// choropleth opacity (same approach as the site-explorer). Filled when the
+// bairro layer is built.
+type RiskRange = { min: number; max: number };
+function zoneMaxRisk(p: any): number {
+  return Math.max(p?.meanFlood || 0, p?.meanHeat || 0, p?.meanLandslide || 0);
 }
 
-// Bairro polygon style: always outlined; filled by composite priority only in
-// the 'risk' view, otherwise transparent so the hazard raster reads underneath.
-function bairroStyle(feat: any, view: RiskView | null): L.PathOptions {
+// Bairro polygon style. Always outlined. In the 'risk' view it fills with the
+// site-explorer encoding — HUE = typology (which risk), OPACITY = how risky
+// (normalized to the city's range) — so the most at-risk bairros read strongest.
+// In a hazard view it's outline-only so the raster reads underneath.
+function bairroStyle(feat: any, view: RiskView | null, range: RiskRange): L.PathOptions {
   if (view === 'risk') {
-    return { color: '#ffffff', weight: 1, opacity: 0.9, fillColor: priorityFill(feat?.properties?.priorityScore ?? 0), fillOpacity: 0.55 };
+    const p = feat?.properties || {};
+    const norm = (zoneMaxRisk(p) - range.min) / ((range.max - range.min) || 0.01);
+    return {
+      color: '#ffffff',
+      weight: 1 + Math.max(0, Math.min(1, norm)) * 1.5,
+      opacity: 0.85,
+      fillColor: TYPOLOGY_COLORS[p.typologyLabel] || TYPOLOGY_COLORS.LOW,
+      fillOpacity: zoneRiskOpacity(norm),
+    };
   }
   return { color: '#475569', weight: 1, opacity: 0.85, fillOpacity: 0 };
 }
@@ -241,6 +249,8 @@ function MapPanel({
   const rasterLayerRef = useRef<L.TileLayer | null>(null);
   const recruitLayerRef = useRef<L.GeoJSON | null>(null);
   const neighborhoodCacheRef = useRef<any>(null);
+  // City-wide risk range for the 'risk' choropleth opacity normalization.
+  const riskRangeRef = useRef<RiskRange>({ min: 0, max: 1 });
   // Latest activeRisk for the async layer-build closure (the bairro GeoJSON
   // loads once; this lets the first build style itself for the current view).
   const activeRiskRef = useRef(activeRisk);
@@ -328,8 +338,11 @@ function MapPanel({
 
     const buildLayer = (fc: any) => {
       if (!mapInstanceRef.current || cancelled || recruitLayerRef.current) return;
+      // City-wide risk range, for the 'risk' choropleth opacity (site-explorer parity).
+      const risks = (fc.features ?? []).map((f: any) => zoneMaxRisk(f?.properties));
+      riskRangeRef.current = { min: Math.min(...risks, 0), max: Math.max(...risks, 0.01) };
       const layer = L.geoJSON(fc, {
-        style: (feat: any) => bairroStyle(feat, activeRiskRef.current),
+        style: (feat: any) => bairroStyle(feat, activeRiskRef.current, riskRangeRef.current),
         onEachFeature: (feat: any, lyr: L.Layer) => {
           const p = feat.properties || {};
           const name: string = p.neighbourhoodName || 'Unknown';
@@ -340,7 +353,7 @@ function MapPanel({
           (lyr as L.Path).bindTooltip(tipHtml, { direction: 'top', className: 'orch-marker-tip', sticky: true });
           lyr.on('click', () => onBairroClickRef.current({ name, primaryHazard: hazard, population: pop, priorityScore: score }));
           lyr.on('mouseover', () => (lyr as L.Path).setStyle({ weight: 2.5, color: '#0f172a' }));
-          lyr.on('mouseout', () => (lyr as L.Path).setStyle(bairroStyle(feat, activeRiskRef.current)));
+          lyr.on('mouseout', () => (lyr as L.Path).setStyle(bairroStyle(feat, activeRiskRef.current, riskRangeRef.current)));
         },
       });
       layer.addTo(mapInstanceRef.current);
@@ -369,7 +382,7 @@ function MapPanel({
   useEffect(() => {
     const layer = recruitLayerRef.current;
     if (!layer) return;
-    layer.setStyle((feat: any) => bairroStyle(feat, activeRisk));
+    layer.setStyle((feat: any) => bairroStyle(feat, activeRisk, riskRangeRef.current));
     layer.bringToBack();
   }, [activeRisk]);
 
@@ -393,7 +406,7 @@ function MapPanel({
   }, [activeRisk]);
 
   return (
-    <div className="relative h-[420px] md:h-full w-full overflow-hidden rounded-xl border border-foreground/10 bg-muted">
+    <div className="relative h-full w-full overflow-hidden rounded-xl border border-foreground/10 bg-muted">
       <div ref={mapRef} className="absolute inset-0" />
     </div>
   );
@@ -450,18 +463,22 @@ function MapLayerControls({
       {active === 'risk' && (
         <div className="pt-1.5 mt-1.5 border-t border-foreground/5 space-y-0.5">
           <div className="text-[9px] uppercase tracking-wide text-muted-foreground">
-            {t('orchestrator.map.priorityScore', { defaultValue: 'Priority score' })}
+            {t('orchestrator.map.zonePriority', { defaultValue: 'Zone priority' })}
           </div>
-          {PRIORITY_BANDS.map((b, i) => (
-            <div key={i} className="flex items-center gap-1.5">
-              <span className="inline-block w-3 h-3 rounded-sm" style={{ background: b.fill }} />
-              <span className="text-[10px] text-muted-foreground">
-                {i === 0 ? `≤ ${b.max.toFixed(1)}` :
-                 i === PRIORITY_BANDS.length - 1 ? `> ${PRIORITY_BANDS[i - 1].max.toFixed(1)}` :
-                 `${PRIORITY_BANDS[i - 1].max.toFixed(1)} – ${b.max.toFixed(1)}`}
-              </span>
+          {([
+            ['FLOOD', t('orchestrator.map.flood', { defaultValue: 'Flood' })],
+            ['HEAT', t('orchestrator.map.heat', { defaultValue: 'Heat' })],
+            ['LANDSLIDE', t('orchestrator.map.landslide', { defaultValue: 'Landslide' })],
+            ['FLOOD_HEAT', t('orchestrator.map.multiHazard', { defaultValue: 'Multi-hazard' })],
+          ] as const).map(([key, label]) => (
+            <div key={key} className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded-sm" style={{ background: TYPOLOGY_COLORS[key] }} />
+              <span className="text-[10px] text-muted-foreground">{label}</span>
             </div>
           ))}
+          <div className="text-[9px] text-muted-foreground/80 pt-0.5">
+            {t('orchestrator.map.intensityNote', { defaultValue: 'Stronger fill = higher risk' })}
+          </div>
         </div>
       )}
       {active && active !== 'risk' && (
@@ -1045,11 +1062,12 @@ export default function OrchestratorLandingPage() {
           </BodySmall>
         </div>
 
-        {/* Map + cards */}
-        <div className="flex flex-col md:flex-row gap-4 md:gap-6 md:items-stretch">
-          {/* Map column — ~60% on desktop */}
-          <div className="md:flex-[3] md:min-h-[640px]">
-            <div className="relative h-[420px] md:h-full w-full">
+        {/* Map (full width) on top, participants list below. Presenting the map
+            this way keeps the orgs' states off-screen (below the fold). */}
+        <div className="flex flex-col gap-5">
+          {/* Map — full width */}
+          <div className="w-full">
+            <div className="relative h-[56vh] md:h-[64vh] w-full">
               <MapPanel
                 projects={projects}
                 selectedId={selectedId}
@@ -1061,8 +1079,8 @@ export default function OrchestratorLandingPage() {
             </div>
           </div>
 
-          {/* Card list column — ~40%, independently scrollable */}
-          <div className="md:flex-[2] md:max-h-[640px] md:overflow-y-auto pr-1 space-y-3">
+          {/* Participants — full-width list/grid below the map */}
+          <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {projects.map((p, i) => {
               const member = memberById.get(p.id);
               const maxUnlocked = Math.max(0, ...(member?.unlockedPhases ?? [1]));

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -37,7 +37,7 @@ import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
 import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS } from '@shared/geospatial-layers';
-import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, type HazardKey } from '@shared/risk-display';
+import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, TYPOLOGY_COLORS, type HazardKey } from '@shared/risk-display';
 import { LayerLegend } from '@/core/components/map/LayerLegend';
 import type { LegendIndex } from '@shared/legend-types';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
@@ -191,15 +191,8 @@ const INTERVENTION_COLORS: Record<string, string> = {
   multi_benefit: '#10b981',
 };
 
-const TYPOLOGY_COLORS: Record<string, string> = {
-  FLOOD: '#3b82f6',
-  HEAT: '#ef4444',
-  LANDSLIDE: '#a16207',
-  FLOOD_HEAT: '#8b5cf6',
-  FLOOD_LANDSLIDE: '#0891b2',
-  HEAT_LANDSLIDE: '#db2777',
-  LOW: '#10b981',
-};
+// TYPOLOGY_COLORS now lives in shared/risk-display.ts (imported above) so the
+// coordinator risk map renders zones identically. Values unchanged.
 
 interface InterventionCategory {
   id: string;

--- a/e2e/cougar-coordinator-risk-map.spec.ts
+++ b/e2e/cougar-coordinator-risk-map.spec.ts
@@ -2,50 +2,62 @@ import { test, expect } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
 import { TestApi } from './helpers/testApi';
 
-// Task #1 — the coordinator map shows the neighborhoods always, with FOUR
-// exclusive risk views: Flood / Heat / Landslide hazard rasters + the composite
-// Risk-by-neighborhood choropleth. One at a time. Recorded as a demo video.
+// Coordinator risk map (v2). Full-width map on top with the participant list
+// below; always-on neighborhoods; four exclusive views — Flood/Heat/Landslide
+// (raster, flood = interpolated gap-free hazard) + Risk-by-neighborhood, now
+// colored like the site explorer (typology hue + risk-scaled intensity).
 
-test.describe('COUGAR #1 — coordinator risk map (exclusive views)', () => {
-  test('four exclusive risk-view buttons drive the map; neighborhoods always shown', async ({ page }) => {
+test.describe('COUGAR #1 — coordinator risk map (v2)', () => {
+  test('full-width map + participants below; four exclusive views; zone-priority coloring', async ({ page, request }) => {
     const api = new TestApi(page.request);
-    await api.createCoordinator({ email: `map-${randomUUID()}@e2e.test`, password: 'map-pass-123', name: 'Map' });
+    await api.createCoordinator({ email: `map-${randomUUID()}@e2e.test`, password: 'map-pass-123', name: 'Map' }); // admin
+
+    // A participant so the list-below-the-map renders (#3).
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    const member = (await new TestApi(request).inviteMember(mine.cohort.id, { orgName: 'Org Mapa', withSession: true })).member;
 
     await page.goto('/orchestrator');
-
-    // The map renders with the always-on neighborhood outlines.
-    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 20_000 });
+    const mapBox = page.locator('.leaflet-container').first();
+    await expect(mapBox).toBeVisible({ timeout: 20_000 });
 
     const flood = page.getByTestId('risk-view-flood');
     const heat = page.getByTestId('risk-view-heat');
     const landslide = page.getByTestId('risk-view-landslide');
     const risk = page.getByTestId('risk-view-risk');
-    await expect(flood).toBeVisible();
+    const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
 
-    // Defaults to flood.
+    // #3 — map is full-width on top; the participant card sits BELOW it.
+    await expect(card).toBeVisible();
+    const mb = (await mapBox.boundingBox())!;
+    const cb = (await card.boundingBox())!;
+    expect(cb.y, 'participant card is below the map').toBeGreaterThan(mb.y + mb.height - 4);
+    expect(mb.width, 'map spans most of the page width').toBeGreaterThan(900);
+    await page.waitForTimeout(1200);
+
+    // Defaults to flood (now the interpolated hazard raster).
     await expect(flood).toHaveAttribute('aria-pressed', 'true');
-    await page.waitForTimeout(1500); // hold on flood raster
+    await page.waitForTimeout(1200);
 
-    // Exclusive switching: each view turns the others off.
+    // Exclusive switching.
     await heat.click();
     await expect(heat).toHaveAttribute('aria-pressed', 'true');
     await expect(flood).toHaveAttribute('aria-pressed', 'false');
-    await page.waitForTimeout(1300);
+    await page.waitForTimeout(1000);
 
     await landslide.click();
     await expect(landslide).toHaveAttribute('aria-pressed', 'true');
-    await expect(heat).toHaveAttribute('aria-pressed', 'false');
-    await page.waitForTimeout(1300);
+    await page.waitForTimeout(1000);
 
-    // Risk-by-neighborhood → choropleth + priority legend.
+    // #4 — Risk by neighborhood: zone-priority coloring (typology hue + intensity).
     await risk.click();
     await expect(risk).toHaveAttribute('aria-pressed', 'true');
-    await expect(page.getByText('Priority score', { exact: false })).toBeVisible();
-    await page.waitForTimeout(1500);
+    await expect(page.getByText('Zone priority', { exact: false })).toBeVisible();
+    await expect(page.getByText('Stronger fill = higher risk', { exact: false })).toBeVisible();
+    await page.waitForTimeout(1600);
 
-    // Clicking the active view turns it off (just outlines + markers remain).
+    // Click the active view off → just outlines + markers.
     await risk.click();
     await expect(risk).toHaveAttribute('aria-pressed', 'false');
-    await page.waitForTimeout(1200);
+    await page.waitForTimeout(1000);
   });
 });

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -108,7 +108,7 @@ open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
   layers: ['osm_parks', 'osm_schools', 'osm_wetlands'],
-  tileLayers: ['poa_flood_risk', 'oef_hwm_2024'],
+  tileLayers: ['poa_flood_hazard', 'oef_hwm_2024'],
   prompt: 'Marca onde vocês querem atuar — primeiro o bairro, depois o lugar específico.'
 })
 ```
@@ -120,7 +120,7 @@ First, exploration mode with a narration banner. The user can scroll the map, to
 ```
 open_map({
   selectionMode: 'browse-only',
-  tileLayers: ['poa_flood_risk', 'oef_hwm_2024'],
+  tileLayers: ['poa_flood_hazard', 'oef_hwm_2024'],
   prompt: 'Olha o seu bairro. As cores mostram os riscos.',
   narrationOverlay: 'Azul = áreas de enchente. Laranja = ilhas de calor. Toque "Voltar ao chat" quando quiser.'
 })
@@ -138,7 +138,7 @@ Listen for cues. If they name a spot, transition to Beat 2b. If they're still un
 open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
-  tileLayers: ['poa_flood_risk', 'oef_hwm_2024'],
+  tileLayers: ['poa_flood_hazard', 'oef_hwm_2024'],
   prompt: 'Agora marca o lugar específico onde vocês querem atuar.'
 })
 ```

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -426,19 +426,19 @@ Include showMap: true on a question only when the user genuinely needs the map t
 
 ## Available layers
 OSM (vector): osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles (raster): poa_flood_risk (Flood Risk), oef_hwm_2024 (Heatwave), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
+Tiles (raster): poa_flood_hazard (Flood Risk), oef_hwm_2024 (Heatwave), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_parks_heatwave, sq_schools_heatwave
 
 ## Recipes
-- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_risk, oef_hwm_2024]
-- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_risk]
-- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_risk, oef_hwm_2024]
-- Environmental analysis: sample + [] + [poa_flood_risk, oef_hwm_2024, oef_copernicus_dem]
+- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, oef_hwm_2024]
+- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard]
+- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, oef_hwm_2024]
+- Environmental analysis: sample + [] + [poa_flood_hazard, oef_hwm_2024, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
     {
       layers: z.array(z.string()).optional().describe("OSM layer IDs to show: osm_parks, osm_schools, osm_hospitals, osm_wetlands"),
-      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs as toggleable overlays (not auto-shown): poa_flood_risk, oef_hwm_2024, etc."),
+      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs as toggleable overlays (not auto-shown): poa_flood_hazard, oef_hwm_2024, etc."),
       spatialQueries: z.array(z.string()).optional().describe("Pre-filter features: sq_parks_flood, sq_schools_heatwave, etc."),
       selectionMode: z.enum(["zones", "assets", "sample", "composite", "browse-only"]).describe("composite = zone first, then sites. assets = sites only. zones = zones only. sample = click-to-read-values. browse-only = exploration; no commitment (E2 needs-help)."),
       prompt: z.string().describe("Clear instruction for the user, e.g. 'Select the zone where you work, then pick the parks and schools you are targeting'"),
@@ -1159,12 +1159,12 @@ Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
     case 2:
       return isPt
         ? `**Fase 2: Onde Atuamos** (intervention_site)
-Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_risk","oef_hwm_2024"], prompt: "Selecione seu bairro, depois escolha os locais" }).
+Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","oef_hwm_2024"], prompt: "Selecione seu bairro, depois escolha os locais" }).
 Após seleção: perguntar condições atuais, população, posse do terreno, engajamento comunitário.
 Se desenharem ponto/área customizada: perguntar "Esse local tem um nome?"
 Pedir fotos do local. Avaliar: Controle do Local (0-3), Ancoragem Comunitária (0-3).`
         : `**Phase 2: Where We Work** (intervention_site)
-Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_risk","oef_hwm_2024"], prompt: "Select your neighborhood, then pick sites" }).
+Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","oef_hwm_2024"], prompt: "Select your neighborhood, then pick sites" }).
 After selection: ask current conditions, population, land tenure, community engagement.
 If they draw custom point/area: ask "Does this site have a name?"
 Ask for site photos. Score: Site Control (0-3), Community Anchoring (0-3).`;

--- a/server/services/conceptNoteAgent.ts
+++ b/server/services/conceptNoteAgent.ts
@@ -224,18 +224,18 @@ function createConceptNoteToolsForSdk(noteId: string) {
 
 ## Available layers
 OSM: osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles: poa_flood_risk, oef_hwm_2024, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
+Tiles: poa_flood_hazard, oef_hwm_2024, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_parks_heatwave, sq_schools_heatwave
 
 ## Recipes
-- Territorial scope (Phase 2): zones + [] + [poa_flood_risk, oef_hwm_2024]
-- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_risk]
-- Environmental evidence: sample + [] + [poa_flood_risk, oef_hwm_2024, oef_copernicus_dem]
+- Territorial scope (Phase 2): zones + [] + [poa_flood_hazard, oef_hwm_2024]
+- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_hazard]
+- Environmental evidence: sample + [] + [poa_flood_hazard, oef_hwm_2024, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
     {
       layers: z.array(z.string()).optional().describe("OSM layer IDs: osm_parks, osm_schools, osm_hospitals, osm_wetlands"),
-      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs as toggleable overlays: poa_flood_risk, oef_hwm_2024, etc."),
+      tileLayers: z.array(z.string()).optional().describe("Tile layer IDs as toggleable overlays: poa_flood_hazard, oef_hwm_2024, etc."),
       spatialQueries: z.array(z.string()).optional().describe("Pre-filter features: sq_parks_flood, sq_schools_heatwave, etc."),
       selectionMode: z.enum(["zones", "assets", "sample", "composite"]).describe("composite = zone→sites. assets = sites only. zones = zones only. sample = click-to-read."),
       prompt: z.string().describe("Clear instruction for the user"),
@@ -809,7 +809,7 @@ The user may be:
 3. **open_map({selectionMode, layers, tileLayers, prompt, ...})** — open an interactive map microapp. The user can select OSM features (parks, schools, hospitals), draw custom sites, or sample raster values. Use for spatial questions instead of ask_user with showMap.
    - selectionMode: "zones" (zone boundaries), "assets" (individual features), "sample" (click-to-sample), "composite" (zones + assets)
    - layers: OSM layer IDs like ["osm_parks", "osm_schools", "osm_hospitals", "osm_wetlands"]
-   - tileLayers: tile layer IDs like ["poa_flood_risk", "oef_hwm_2024"] for evidence overlays
+   - tileLayers: tile layer IDs like ["poa_flood_hazard", "oef_hwm_2024"] for evidence overlays
    - spatialQueries: spatial query IDs like ["sq_parks_flood"] to pre-filter features
    - prompt: instruction for the user, e.g. "Select the parks you want to target for NBS interventions"
 4. **set_phase(phase)** — advance to next phase (0-10).

--- a/shared/risk-display.ts
+++ b/shared/risk-display.ts
@@ -16,6 +16,25 @@
 
 export type HazardKey = 'flood' | 'heat' | 'landslide';
 
+// Zone-typology hue, keyed by a zone's `typologyLabel` (the dominant hazard or
+// hazard-combo). Shared by the site-explorer map + the coordinator risk map so
+// the "zone priority" coloring can't drift between them. Pair the hue (which
+// risk) with `zoneRiskOpacity` (how intense) for the full encoding.
+export const TYPOLOGY_COLORS: Record<string, string> = {
+  FLOOD: '#3b82f6',
+  HEAT: '#ef4444',
+  LANDSLIDE: '#a16207',
+  FLOOD_HEAT: '#8b5cf6',
+  FLOOD_LANDSLIDE: '#0891b2',
+  HEAT_LANDSLIDE: '#db2777',
+  LOW: '#10b981',
+};
+
+/** Zone fill opacity from a 0..1 normalized risk: faint (low) → solid (high). */
+export function zoneRiskOpacity(normalizedRisk: number): number {
+  return 0.08 + Math.max(0, Math.min(1, normalizedRisk)) * 0.57;
+}
+
 export interface RiskBand {
   key: 'very_low' | 'low' | 'moderate' | 'high' | 'very_high';
   label: string;   // English fallback; UI should translate via `riskBands.${key}`


### PR DESCRIPTION
Four improvements to the coordinator risk map (refined with the data catalog + the site-explorer encoding).

## 1 · Flood = interpolated, gap-free hazard
The flood overlay used the sparse `poa_flood_risk` (H×E×V composite, ~14% coverage). Swapped **everywhere** to the catalog's IDW-interpolated **`poa_flood_hazard`** — gap-free, **same path** (republished 2026-06-08, already live via the proxy; confirmed by a coverage sample: the hazard tiles carry ~50% more data per tile across POA, and were re-uploaded ~50 min after the risk = the IDW build). Coordinator map + CBO/concept-note `open_map` overlays + the E2 skill. (The site-explorer already exposes `poa_flood_hazard` in its "Flood Indices" group.)

## 2 · Hazard views unchanged
Flood/Heat/Landslide keep the **raster overlay + the always-on bairro boundary** — as requested.

## 3 · Full-width map, participants below
The map was a ~60/40 split beside the participant cards. Now the **map is full-width on top** and the **participant list is below it** — so presenting the map doesn't put orgs' states on screen.

## 4 · "Risk by neighborhood" = site-explorer zone priority
Replaced the old priority-score green→red ramp with the **site-explorer map encoding**: **HUE = typology** (which risk: flood/heat/landslide/multi), **OPACITY = how risky** (the zone's risk normalized to the city range) — the most at-risk bairros read strongest. Extracted `TYPOLOGY_COLORS` + `zoneRiskOpacity` to `shared/risk-display.ts` so the orchestrator + site-explorer **can't drift**.

## Testing
`tsc` clean. Chromium gate **21 passed**, WebKit/iPhone **2 passed**. `e2e/cougar-coordinator-risk-map.spec.ts` updated (full-width + participant-below + zone-priority legend) with a demo video.

## Deploy note
Skill change (`encontro-2.md`) → needs republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)