### PR TITLE
fix(cougar): round-2 polish — visible lang toggle, minimized CTA, no emoji, contrast

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -12,14 +12,13 @@ import { Input } from '@/core/components/ui/input';
 // Greeting templates — shared between ShareLinkDialog and bulk summary so the
 // CBO-facing message is consistent everywhere.
 // ---------------------------------------------------------------------------
-// The wave is written as an explicit code-point escape (\u{1F44B}) rather than a
-// raw literal so it survives any non-UTF-8 re-save of this file in the toolchain
-// — a raw 👋 had been showing up as a replacement char (�) in the sent preview.
-const WAVE = '\u{1F44B}';
+// No emoji in the greeting: the wave (👋) kept rendering as a replacement char
+// (�) in the actual WhatsApp delivery despite the source code-point being
+// correct, so it's removed entirely rather than ship a broken glyph.
 export function cboGreetingMessage(orgName: string, url: string, isPt: boolean): string {
   return isPt
-    ? `Olá! ${WAVE}\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
-    : `Hi! ${WAVE}\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
+    ? `Olá!\n\nEste é o link da plataforma do COUGAR/Vila Flores para *${orgName}*. Aqui você vai construir o perfil da organização e o seu projeto NBS junto com os workshops:\n\n${url}\n\nQualquer dúvida, me chama!`
+    : `Hi!\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
 }
 
 export function whatsappDeepLink(message: string, phone?: string): string {

--- a/client/src/core/components/orchestrator/WorkshopCadence.tsx
+++ b/client/src/core/components/orchestrator/WorkshopCadence.tsx
@@ -230,7 +230,8 @@ function WorkshopRow({
       Icon: Lock,
       titleClass: 'text-foreground/55',
       pill: t('orchestrator.cohort.stateLocked', { defaultValue: 'Locked' }),
-      pillClass: 'bg-transparent text-muted-foreground border-foreground/10',
+      // Darker, readable gray (the old near-white pill had almost no contrast).
+      pillClass: 'bg-foreground/10 text-foreground/75 border-foreground/15 dark:bg-foreground/15 dark:text-foreground/80',
       contentOpacity: 'opacity-50',
     },
   }[state];
@@ -256,61 +257,106 @@ function WorkshopRow({
       className={`relative rounded-xl border ${stateMeta.ring} ${stateMeta.bg} transition-all ${collapsed ? 'p-2.5' : 'p-3.5'}`}
       data-testid={`workshop-row-${index}-${state}`}
     >
-      {/* Header row — topic icon, name, state pill. Click to expand/collapse. */}
-      <button
-        type="button"
-        onClick={() => setCollapsed(c => !c)}
-        aria-expanded={!collapsed}
-        className="w-full flex items-start gap-3 text-left"
-        data-testid={`workshop-toggle-${index}`}
-      >
-        {/* Topic icon tile — workshop-specific identity. State overlay
-            (✓ / lock) in the bottom-right corner for past + locked. */}
-        <div className="relative shrink-0">
-          <div
-            className={`w-10 h-10 rounded-xl flex items-center justify-center ${stateMeta.iconBg} ${
-              state === 'open' ? 'ring-1 ring-emerald-500/30' : ''
-            } ${state === 'past' ? 'ring-1 ring-emerald-200 dark:ring-emerald-900/60' : ''}`}
-          >
-            <TopicIcon className={`w-5 h-5 ${stateMeta.iconColor}`} strokeWidth={2} />
-          </div>
-          {(state === 'past' || state === 'locked') && (
+      {/* Header row. The toggle (icon + title) and the chevron expand/collapse;
+          when minimized, the schedule date + "Open for cohort" stay reachable so
+          the coordinator can act without expanding. */}
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          onClick={() => setCollapsed(c => !c)}
+          aria-expanded={!collapsed}
+          className="min-w-0 flex-1 flex items-start gap-3 text-left"
+          data-testid={`workshop-toggle-${index}`}
+        >
+          {/* Topic icon tile — workshop-specific identity. State overlay
+              (✓ / lock) in the bottom-right corner for past + locked. */}
+          <div className="relative shrink-0">
             <div
-              className={`absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full flex items-center justify-center ring-2 ring-background ${
-                state === 'past' ? 'bg-emerald-600' : 'bg-foreground/40'
-              }`}
+              className={`w-10 h-10 rounded-xl flex items-center justify-center ${stateMeta.iconBg} ${
+                state === 'open' ? 'ring-1 ring-emerald-500/30' : ''
+              } ${state === 'past' ? 'ring-1 ring-emerald-200 dark:ring-emerald-900/60' : ''}`}
             >
-              <StateIcon className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+              <TopicIcon className={`w-5 h-5 ${stateMeta.iconColor}`} strokeWidth={2} />
             </div>
-          )}
-        </div>
-
-        {/* Title + state pill */}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className={`text-sm tracking-tight ${stateMeta.titleClass}`}>
-              {workshop.name}
-            </span>
-            <span
-              className={`inline-flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full border ${stateMeta.pillClass}`}
-            >
-              {state === 'open' && (
-                <span className="relative flex h-1.5 w-1.5">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                </span>
-              )}
-              {stateMeta.pill}
-            </span>
+            {(state === 'past' || state === 'locked') && (
+              <div
+                className={`absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full flex items-center justify-center ring-2 ring-background ${
+                  state === 'past' ? 'bg-emerald-600' : 'bg-foreground/40'
+                }`}
+              >
+                <StateIcon className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+              </div>
+            )}
           </div>
-        </div>
 
-        {/* Expand/collapse affordance */}
-        <ChevronDown
-          className={`shrink-0 mt-1 w-4 h-4 text-muted-foreground transition-transform ${collapsed ? '-rotate-90' : ''}`}
-          strokeWidth={2}
-        />
-      </button>
+          {/* Title + state pill */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={`text-sm tracking-tight ${stateMeta.titleClass}`}>
+                {workshop.name}
+              </span>
+              <span
+                className={`inline-flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full border ${stateMeta.pillClass}`}
+              >
+                {state === 'open' && (
+                  <span className="relative flex h-1.5 w-1.5">
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                    <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                  </span>
+                )}
+                {stateMeta.pill}
+              </span>
+            </div>
+          </div>
+        </button>
+
+        {/* Minimized quick-actions — schedule date + the next-up CTA, without
+            expanding the row. (Expanded rows show these in the footer.) */}
+        {collapsed && (
+          <div className="flex items-center gap-1.5 shrink-0">
+            {workshop.openedAt ? (
+              <HeldOnPill openedAt={workshop.openedAt} />
+            ) : (
+              <DatePill
+                value={workshop.date}
+                placeholder={
+                  state === 'nextUp'
+                    ? t('orchestrator.cohort.scheduleDate', { defaultValue: 'Schedule date' })
+                    : t('orchestrator.cohort.addDate', { defaultValue: 'Add date' })
+                }
+                emphasis={state === 'nextUp' ? 'accent' : 'muted'}
+                disabled={disabled || state === 'locked'}
+                onSave={onUpdateDate}
+              />
+            )}
+            {state === 'nextUp' && (
+              <Button
+                size="sm"
+                disabled={disabled}
+                className="h-8 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold whitespace-nowrap shadow-sm"
+                onClick={onOpenForCohort}
+                data-testid={`button-open-workshop-${index}`}
+              >
+                <Unlock className="w-3.5 h-3.5 mr-1" />
+                {t('orchestrator.cohort.openForCohort', { defaultValue: 'Open for cohort' })}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Expand/collapse chevron */}
+        <button
+          type="button"
+          onClick={() => setCollapsed(c => !c)}
+          aria-label={collapsed ? 'Expand' : 'Collapse'}
+          className="shrink-0 mt-1 p-0.5"
+        >
+          <ChevronDown
+            className={`w-4 h-4 text-muted-foreground transition-transform ${collapsed ? '-rotate-90' : ''}`}
+            strokeWidth={2}
+          />
+        </button>
+      </div>
 
       {!collapsed && (<>
       {/* Body + footer — shown only when the row is expanded. State-driven

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
-  Mountain, Network, Plus, RotateCcw, Sparkles, Sprout, Trash2, Trees, Unlock, Users, Waves,
+  Mountain, Network, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Users, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -952,18 +952,28 @@ export default function OrchestratorLandingPage() {
                 </span>
                 {([['auto', null], ['pt', 'pt'], ['en', 'en']] as const).map(([label, val]) => {
                   const on = cohortLanguage === val;
+                  const labelText = label === 'auto' ? t('orchestrator.cohort.langAuto', { defaultValue: 'Auto' }) : label.toUpperCase();
                   return (
                     <button
                       key={label}
                       type="button"
-                      onClick={() => saveLanguage(val)}
+                      onClick={async () => {
+                        await saveLanguage(val);
+                        toast({
+                          title: val
+                            ? t('orchestrator.cohort.languageSet', { defaultValue: 'Cohort language: {{lang}}', lang: labelText })
+                            : t('orchestrator.cohort.languageAutoSet', { defaultValue: 'Cohort language: auto (phone language)' }),
+                        });
+                      }}
                       data-testid={`button-cohort-lang-${label}`}
                       aria-pressed={on}
-                      className={`px-2 py-1 text-[11px] font-medium transition-colors ${
-                        on ? 'bg-foreground/[0.08] text-foreground' : 'text-muted-foreground hover:bg-foreground/[0.04]'
+                      // Active = solid emerald + white so the selected language is
+                      // unmistakable (the faint highlight read as "nothing happened").
+                      className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                        on ? 'bg-emerald-600 text-white' : 'text-muted-foreground hover:bg-foreground/[0.06]'
                       }`}
                     >
-                      {label === 'auto' ? t('orchestrator.cohort.langAuto', { defaultValue: 'Auto' }) : label.toUpperCase()}
+                      {labelText}
                     </button>
                   );
                 })}
@@ -1006,23 +1016,6 @@ export default function OrchestratorLandingPage() {
           />
         </div>
 
-        {/* Co-design ribbon */}
-        <motion.div
-          initial={{ opacity: 0, y: -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="mb-6 flex items-start gap-3 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 px-4 py-3"
-        >
-          <Sparkles className="w-4 h-4 text-amber-600 dark:text-amber-300 mt-0.5 shrink-0" />
-          <div className="flex-1">
-            <BodySmall className="text-amber-900 dark:text-amber-200 font-medium">
-              {t('orchestrator.demo.codesignBannerTitle')}
-            </BodySmall>
-            <BodySmall className="text-amber-900/80 dark:text-amber-200/80 mt-0.5 text-xs">
-              {t('orchestrator.demo.codesignBannerBody')}
-            </BodySmall>
-          </div>
-        </motion.div>
 
         {/* Aggregate stats — diagnostic pipeline */}
         <motion.div

--- a/e2e/cougar-invite-emoji.spec.ts
+++ b/e2e/cougar-invite-emoji.spec.ts
@@ -2,35 +2,35 @@ import { test, expect } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
 import { TestApi } from './helpers/testApi';
 
-// Task #5 — the invite preview message must render the 👋 wave, not a
-// replacement char (�). The greeting is written with an explicit \u{1F44B}
-// escape so no toolchain re-save can mangle it. This drives the real share
-// dialog and asserts the rendered preview.
+// Task #5 (revised) — the 👋 wave kept rendering as a replacement char (�) in
+// real WhatsApp delivery despite the source code-point being correct, so it was
+// REMOVED. The invite greeting must now contain neither the emoji nor a
+// replacement char.
 
-test.describe('COUGAR #5 — invite preview renders the wave emoji', () => {
-  test('the share preview shows 👋, not a replacement char', async ({ page, request }) => {
+test.describe('COUGAR #5 — invite greeting has no emoji', () => {
+  test('the share preview has no wave emoji and no replacement char', async ({ page, request }) => {
     const ext = new TestApi(request);
     const { cohort } = await ext.createCohort('e2e emoji');
     const member = (await ext.inviteMember(cohort.id, { orgName: 'Org Wave', withSession: true })).member;
 
-    // Auth the page as a coordinator scoped to this cohort.
     const api = new TestApi(page.request);
     await api.createCoordinator({ email: `emoji-${randomUUID()}@e2e.test`, password: 'pw-123456', name: 'Emoji', cohortId: cohort.id });
 
     await page.goto('/orchestrator');
     const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
     await expect(card).toBeVisible({ timeout: 20_000 });
-    await page.waitForTimeout(800);
     await card.click(); // opens the share-link dialog
 
-    // Expand the message preview.
     await page.getByText('Preview message', { exact: false }).click();
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(800);
 
-    const dialog = page.getByRole('dialog');
-    const txt = await dialog.innerText();
-    expect(txt, 'preview should contain the wave emoji').toContain('\u{1F44B}');
-    expect(txt, 'preview should NOT contain the replacement char').not.toContain('�');
-    await page.waitForTimeout(1200); // hold for the video
+    const txt = await page.getByRole('dialog').innerText();
+    expect(txt, 'no wave emoji').not.toContain('\u{1F44B}');
+    expect(txt, 'no replacement char').not.toContain('�');
+
+    // And the real WhatsApp link carries a clean greeting (no emoji either).
+    const decoded = decodeURIComponent(((await page.locator('a[href*="wa.me"]').first().getAttribute('href')) || '').split('text=')[1] || '');
+    expect(decoded).toMatch(/^(Olá|Hi)!\n/);
+    expect(decoded).not.toContain('\u{1F44B}');
   });
 });

--- a/e2e/cougar-polish-round2.spec.ts
+++ b/e2e/cougar-polish-round2.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Round-2 polish, verified end-to-end (admin coordinator on the default cohort):
+//  • cohort language toggle — solid-emerald active state + a toast (was invisible)
+//  • workshop "Open for cohort" + date reachable in the MINIMIZED row
+//  • invite greeting has NO emoji (the 👋 broke in real WhatsApp)
+//  • delete-cohort actually removes the member (admin-only button)
+
+test.describe('COUGAR polish round 2', () => {
+  test('language toggle is obvious + works; minimized workshop CTA; no emoji; delete works', async ({ page, request }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `polish-${randomUUID()}@e2e.test`, password: 'polish-pass-1', name: 'Polish' }); // admin
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    const member = (await new TestApi(request).inviteMember(mine.cohort.id, { orgName: 'Org Polish', withSession: true })).member;
+
+    await page.goto('/orchestrator');
+
+    // ── Cohort language: click PT → obvious active + persisted ──
+    const pt = page.getByTestId('button-cohort-lang-pt');
+    await expect(pt).toBeVisible({ timeout: 20_000 });
+    await pt.click();
+    await expect(pt).toHaveAttribute('aria-pressed', 'true');
+    await expect(pt).toHaveClass(/bg-emerald-600/); // unmistakable active fill
+    const after = await (await page.request.get('/api/cohort/mine')).json();
+    expect(after?.cohort?.settings?.language).toBe('pt');
+    await page.waitForTimeout(900);
+    await page.screenshot({ path: 'test-results/polish-lang.png' });
+
+    // ── Minimized workshop row keeps the date + "Open for cohort" CTA ──
+    const toggle0 = page.getByTestId('workshop-toggle-0'); // Workshop 1 (next up) starts expanded
+    await toggle0.click(); // minimize it
+    await expect(toggle0).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByTestId('button-open-workshop-0')).toBeVisible(); // CTA still reachable
+    await page.waitForTimeout(900);
+    await page.screenshot({ path: 'test-results/polish-minimized.png' });
+
+    // ── Invite greeting has no emoji (and no replacement char) ──
+    const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
+    await card.click();
+    const waLink = page.locator('a[href*="wa.me"]').first();
+    await expect(waLink).toBeVisible();
+    const decoded = decodeURIComponent(((await waLink.getAttribute('href')) || '').split('text=')[1] || '');
+    expect(decoded).not.toContain('\u{1F44B}');
+    expect(decoded).not.toContain('�');
+    expect(decoded).toMatch(/^(Olá|Hi)!\n/); // greeting, straight into the newline — no emoji
+    await page.screenshot({ path: 'test-results/polish-share.png' });
+    await page.keyboard.press('Escape');
+
+    // ── Delete cohort actually removes the member (admin-only) ──
+    const del = page.getByTestId('button-delete-cohort');
+    await expect(del).toBeVisible();
+    await del.click();
+    await page.getByTestId('button-confirm-delete-cohort').click();
+    await expect(card).toHaveCount(0, { timeout: 15_000 });
+    await page.waitForTimeout(800);
+  });
+});


### PR DESCRIPTION
Five fixes from your live testing — each **reproduced and verified** (with screenshots), not assumed.

> First: confirmed all of #259–#268 **are** merged to main, and the language/delete/emoji code paths work in the harness. So these aren't "missing from main" — they're real UX bugs (mostly invisible feedback) + the emoji.

1. **Language toggle felt dead** — clicking Auto/PT/EN looked like nothing happened because the active state was a faint tint. The backend was fine (PATCH 200, persists `pt`). Now the selected language is a **solid emerald fill** + a **toast** ("Cohort language: PT").
2. **Workshop CTA in the minimized row** — "Open for cohort" + "Schedule date" are now reachable when a workshop row is **collapsed** (split the toggle from a chevron so the buttons can sit beside the title), not only expanded.
3. **Locked-pill contrast** — the near-white `LOCKED` pill → darker readable gray.
4. **Emoji removed** — the 👋 kept arriving as `�` in real WhatsApp even though the source code-point + `encodeURIComponent` are correct. Per your call, dropped it rather than ship a broken glyph.
5. **Removed the codesign banner** ("Early prototype — help us design this…").

## Note on cohort management (the rest of that card)
The **runbook already exists** (`docs/cougar-runbook.md`, from #266) covering how cohorts are created/defined/cleaned up. The language force + delete-cohort both work once this is republished.

## Testing
`e2e/cougar-polish-round2.spec.ts` (admin on the default cohort) verifies: emerald-active language toggle + persisted `pt`, the minimized "Open for cohort" CTA, an **emoji-free** wa.me link, and delete-cohort removing the member. `cougar-invite-emoji.spec` updated. **Chromium gate 22 passed**, WebKit/iPhone 2.

## Deploy note
Touches `CohortDialogs` greeting (emoji) — needs **republish** to clear the `�` live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)