### PR TITLE
fix(cougar): invite message follows the forced cohort language

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -22,6 +22,15 @@ export function cboGreetingMessage(orgName: string, url: string, isPt: boolean):
     : `Hi! ${WAVE}\n\nHere's the COUGAR / Vila Flores platform link for *${orgName}*. You'll build your organization profile and your NBS project here alongside the workshops:\n\n${url}\n\nReach out anytime.`;
 }
 
+// Language of the CBO-facing invite message: a FORCED cohort language wins, so
+// the message matches the page the org will see. Falls back to the coordinator's
+// own browser language when the cohort is on Auto.
+export function inviteIsPt(cohortLanguage: 'pt' | 'en' | null | undefined, browserLang?: string): boolean {
+  if (cohortLanguage === 'pt') return true;
+  if (cohortLanguage === 'en') return false;
+  return !!browserLang?.startsWith('pt');
+}
+
 export function whatsappDeepLink(message: string, phone?: string): string {
   const text = encodeURIComponent(message);
   return phone ? `https://wa.me/${phone}?text=${text}` : `https://wa.me/?text=${text}`;
@@ -462,16 +471,18 @@ export function InviteCboDialog({
 // action at the top stuffs every link into a single clipboard block.
 // ---------------------------------------------------------------------------
 export function BulkInviteSummaryDialog({
-  open, onOpenChange, invitations, origin,
+  open, onOpenChange, invitations, origin, cohortLanguage,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   invitations: BulkInviteResult[];
   /** window.location.origin from the caller — kept as a prop so this component is testable. */
   origin: string;
+  /** Forced cohort language — the message matches the page the org will see. */
+  cohortLanguage?: 'pt' | 'en' | null;
 }) {
   const { t, i18n } = useTranslation();
-  const isPt = i18n.language?.startsWith('pt');
+  const isPt = inviteIsPt(cohortLanguage, i18n.language);
   const [copiedAll, setCopiedAll] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
 
@@ -584,14 +595,19 @@ type ShareLinkContext =
   | { kind: 'coordinator'; cohortName: string };
 
 export function ShareLinkDialog({
-  open, onOpenChange, url, context,
+  open, onOpenChange, url, context, cohortLanguage,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   url: string;
   context: ShareLinkContext | null;
+  /** Forced cohort language — the CBO invite message matches the org's page. */
+  cohortLanguage?: 'pt' | 'en' | null;
 }) {
   const { t, i18n } = useTranslation();
+  // The CBO greeting follows the cohort language; the coordinator's own link
+  // message stays in the coordinator's browser language (it's for them).
+  const cboIsPt = inviteIsPt(cohortLanguage, i18n.language);
   const isPt = i18n.language?.startsWith('pt');
   const [copiedLink, setCopiedLink] = useState(false);
   const [copiedMessage, setCopiedMessage] = useState(false);
@@ -604,7 +620,7 @@ export function ShareLinkDialog({
   const whatsappMessage = (() => {
     if (!context) return url;
     if (context.kind === 'cbo') {
-      return cboGreetingMessage(context.orgName, url, isPt);
+      return cboGreetingMessage(context.orgName, url, cboIsPt);
     }
     // Coordinator-facing — short, just for their own notes
     return isPt

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -1176,12 +1176,13 @@ export default function OrchestratorLandingPage() {
           setBulkSummaryOpen(true);
         }}
       />
-      <ShareLinkDialog open={shareOpen} onOpenChange={setShareOpen} url={shareUrl} context={shareContext} />
+      <ShareLinkDialog open={shareOpen} onOpenChange={setShareOpen} url={shareUrl} context={shareContext} cohortLanguage={cohortLanguage} />
       <BulkInviteSummaryDialog
         open={bulkSummaryOpen}
         onOpenChange={setBulkSummaryOpen}
         invitations={bulkInvitations}
         origin={typeof window !== 'undefined' ? window.location.origin : ''}
+        cohortLanguage={cohortLanguage}
       />
     </div>
   );

--- a/e2e/cougar-invite-message-lang.spec.ts
+++ b/e2e/cougar-invite-message-lang.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// The invite message should follow the FORCED cohort language, not the
+// coordinator's browser — so "set PT" gives the org a PT message AND a PT page.
+// Here the coordinator's browser is English; the cohort is forced to PT.
+test.use({ locale: 'en-US' });
+
+test.describe('COUGAR — invite message follows cohort language', () => {
+  test('EN-browser coordinator + PT cohort → the invite message is Portuguese', async ({ page, request }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `iml-${randomUUID()}@e2e.test`, password: 'iml-pass-1', name: 'IML' }); // admin
+
+    // Force the cohort to PT.
+    await page.request.patch('/api/cohort/default/language', { data: { language: 'pt' } });
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    const member = (await new TestApi(request).inviteMember(mine.cohort.id, { orgName: 'Org Msg', withSession: true })).member;
+
+    await page.goto('/orchestrator');
+    const card = page.getByTestId(`card-orchestrator-project-${member.id}`);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await card.click(); // share dialog
+
+    const decoded = decodeURIComponent(((await page.locator('a[href*="wa.me"]').first().getAttribute('href')) || '').split('text=')[1] || '');
+    // Portuguese greeting despite the en-US browser, because the cohort is PT.
+    expect(decoded.startsWith('Olá'), `expected PT message, got: ${decoded.slice(0, 20)}`).toBeTruthy();
+    expect(decoded).toContain('Este é o link da plataforma');
+  });
+});


### PR DESCRIPTION
Closes the message↔page language mismatch you hit.

## The gap
The WhatsApp **invite message** was built from the **coordinator's browser language**, but the **CBO page** follows the **cohort's forced language**. So a coordinator on an English browser running a PT cohort would send an *English message* while the org's page loaded in *Portuguese* (your PT message was a coincidence of your browser being PT, not the cohort). "Set PT" now means PT **everywhere**.

## Fix
- `inviteIsPt(cohortLanguage, browserLang)` — the forced cohort language wins; falls back to the coordinator's browser when the cohort is on **Auto**.
- `ShareLinkDialog` + `BulkInviteSummaryDialog` take `cohortLanguage`; the CBO greeting uses it. (The coordinator's *own* link message stays in their browser language — it's for them.)
- The orchestrator passes `cohortLanguage` to both.

## Testing
`e2e/cougar-invite-message-lang.spec.ts`: an **en-US** coordinator with a **PT** cohort produces a **Portuguese** invite message. `tsc` clean, full gate **22 passed**.

> Independent of the emoji-removal PR (#269) — different lines, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)