### PR TITLE
feat(cougar): in-app admin cohort panel — provision + switch cohorts

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -158,6 +158,175 @@ export function LoadCohortDialog({
 }
 
 // ---------------------------------------------------------------------------
+// ProvisionCohortDialog — admin-only. Creates a coordinator account AND their
+// cohort in one form (replaces the create-coordinator shell script + UUID
+// dance). The admin stays logged in as themselves; the new coordinator gets the
+// email + password entered here to log in, scoped to the new cohort.
+// ---------------------------------------------------------------------------
+export function ProvisionCohortDialog({
+  open, onOpenChange, onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: {
+    coordinatorName?: string;
+    email: string;
+    password: string;
+    cohortName: string;
+    language?: 'pt' | 'en' | null;
+  }) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
+}) {
+  const { t } = useTranslation();
+  const [coordinatorName, setCoordinatorName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [cohortName, setCohortName] = useState('');
+  const [language, setLanguage] = useState<'pt' | 'en' | null>('pt');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the form whenever the dialog re-opens, so a previous error/values
+  // don't bleed into the next provisioning.
+  useEffect(() => {
+    if (open) {
+      setCoordinatorName(''); setEmail(''); setPassword('');
+      setCohortName(''); setLanguage('pt'); setError(null); setBusy(false);
+    }
+  }, [open]);
+
+  const canSubmit = !!email.trim() && password.length >= 6 && !!cohortName.trim();
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setBusy(true); setError(null);
+    try {
+      const res = await onSubmit({
+        coordinatorName: coordinatorName.trim() || undefined,
+        email: email.trim(),
+        password,
+        cohortName: cohortName.trim(),
+        language,
+      });
+      if (res.ok) onOpenChange(false);
+      else setError(res.error ?? 'Could not create cohort');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[460px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Plus className="w-4 h-4" />
+            {t('orchestrator.cohort.provisionTitle', { defaultValue: 'New cohort + coordinator' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.cohort.provisionDesc', {
+              defaultValue: 'Create a cohort and the coordinator who runs it. They log in with this email + password and see only this cohort.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.cohortName', { defaultValue: 'Cohort name' })}
+            </label>
+            <Input
+              value={cohortName}
+              onChange={(e) => setCohortName(e.target.value)}
+              placeholder="Vila Flores"
+              autoFocus
+              data-testid="input-provision-cohort-name"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.coordinatorName', { defaultValue: 'Coordinator name' })}
+            </label>
+            <Input
+              value={coordinatorName}
+              onChange={(e) => setCoordinatorName(e.target.value)}
+              placeholder="Julia"
+              data-testid="input-provision-coordinator-name"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground/80">
+                {t('orchestrator.cohort.coordinatorEmail', { defaultValue: 'Login email' })}
+              </label>
+              <Input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="julia@example.com"
+                data-testid="input-provision-email"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground/80">
+                {t('orchestrator.cohort.coordinatorPassword', { defaultValue: 'Password' })}
+              </label>
+              <Input
+                type="text"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="min. 6 chars"
+                data-testid="input-provision-password"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground/80">
+              {t('orchestrator.cohort.language', { defaultValue: 'Language' })}
+            </label>
+            <div className="inline-flex items-center rounded-md border border-foreground/10 overflow-hidden">
+              {([['auto', null], ['pt', 'pt'], ['en', 'en']] as const).map(([label, val]) => {
+                const on = language === val;
+                const labelText = label === 'auto'
+                  ? t('orchestrator.cohort.langAuto', { defaultValue: 'Auto' })
+                  : label.toUpperCase();
+                return (
+                  <button
+                    key={label}
+                    type="button"
+                    onClick={() => setLanguage(val)}
+                    aria-pressed={on}
+                    data-testid={`button-provision-lang-${label}`}
+                    className={`px-3 py-1 text-[11px] font-semibold transition-colors ${
+                      on ? 'bg-emerald-600 text-white' : 'text-muted-foreground hover:bg-foreground/[0.06]'
+                    }`}
+                  >
+                    {labelText}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400" data-testid="text-provision-error">
+              {error}
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button onClick={submit} disabled={busy || !canSubmit} data-testid="button-confirm-provision-cohort">
+            {busy
+              ? t('common.working', { defaultValue: 'Working…' })
+              : t('orchestrator.cohort.provisionCreate', { defaultValue: 'Create cohort' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // InviteCboDialog — Single (one CBO at a time) or Bulk (paste a list) modes.
 // Bulk is the typical workshop-day flow: Julia comes in with a list of 10
 // orgs, pastes them, hits invite, gets a summary of links to send out.

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -12,12 +12,40 @@ import type { Cohort, CohortMember, WorkshopConfig } from '@shared/cohort-schema
 // for a future cohort switcher (deferred until a 2nd cohort exists).
 // ---------------------------------------------------------------------------
 
+// A row in the admin cohort switcher — every cohort with its coordinator and
+// member count. Mirrors GET /api/cohort/all.
+export interface CohortSummary {
+  id: string;
+  name: string;
+  coordinatorSlug: string;
+  language: 'pt' | 'en' | null;
+  memberCount: number;
+  coordinatorName: string | null;
+  coordinatorEmail: string | null;
+  isDefault: boolean;
+}
+
+export interface ProvisionInput {
+  coordinatorName?: string;
+  email: string;
+  password: string;
+  cohortName: string;
+  language?: 'pt' | 'en' | null;
+}
+
 export interface UseCohortResult {
   loading: boolean;
   cohort: Cohort | null;
   members: CohortMember[];
   isAdmin: boolean;
+  /** Every cohort (admin only — empty for a scoped coordinator). */
+  allCohorts: CohortSummary[];
   refresh: () => Promise<void>;
+  refreshAllCohorts: () => Promise<void>;
+  /** Admin: load a different cohort by its coordinatorSlug into the dashboard. */
+  switchCohort: (coordinatorSlug: string) => Promise<void>;
+  /** Admin: create a coordinator + their cohort in one shot, then load it. */
+  provisionCohort: (input: ProvisionInput) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
   resetCohort: () => Promise<void>;
   invite: (params: { orgName: string; neighborhood?: string; role?: 'priority' | 'alternate' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
@@ -30,11 +58,34 @@ export function useCohort(): UseCohortResult {
   const [cohort, setCohort] = useState<Cohort | null>(null);
   const [members, setMembers] = useState<CohortMember[]>([]);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [allCohorts, setAllCohorts] = useState<CohortSummary[]>([]);
   const [loading, setLoading] = useState(true);
-  // The resolved cohort's slug, kept in a ref so mutation callbacks always use
-  // the current one without re-creating on every cohort change.
+  // The currently-loaded cohort's slug, kept in a ref so mutation callbacks
+  // always target the cohort on screen — even after an admin switches away from
+  // their own default to another cohort — without re-creating on every change.
   const slugRef = useRef<string>('default');
 
+  const refreshAllCohorts = useCallback(async () => {
+    const r = await fetch('/api/cohort/all');
+    if (!r.ok) { setAllCohorts([]); return; }
+    const data = await r.json();
+    setAllCohorts(data.cohorts ?? []);
+  }, []);
+
+  // Load a specific cohort by slug into the dashboard. Works for an admin on any
+  // cohort and for a scoped coordinator on their own (server-side app.param
+  // guard enforces it). Does NOT touch isAdmin — that's established once at boot.
+  const loadCohort = useCallback(async (cohortSlug: string) => {
+    const r = await fetch(`/api/cohort/${cohortSlug}`);
+    if (!r.ok) return;
+    const data = await r.json();
+    setCohort(data.cohort);
+    setMembers(data.members ?? []);
+    if (data.cohort?.coordinatorSlug) slugRef.current = data.cohort.coordinatorSlug;
+  }, []);
+
+  // Boot resolution — /mine establishes who we are (admin vs scoped) and the
+  // starting cohort. Admins additionally pull the full cohort directory.
   const fetchCohort = useCallback(async () => {
     setLoading(true);
     try {
@@ -45,14 +96,35 @@ export function useCohort(): UseCohortResult {
       setMembers(data.members ?? []);
       setIsAdmin(!!data.isAdmin);
       if (data.cohort?.coordinatorSlug) slugRef.current = data.cohort.coordinatorSlug;
+      if (data.isAdmin) void refreshAllCohorts();
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [refreshAllCohorts]);
 
   useEffect(() => { fetchCohort(); }, [fetchCohort]);
 
-  const refresh = useCallback(async () => { await fetchCohort(); }, [fetchCohort]);
+  // Re-load whatever cohort is currently on screen (not always /mine — an admin
+  // may have switched to another cohort). Mutations call this after writing.
+  const refresh = useCallback(async () => { await loadCohort(slugRef.current); }, [loadCohort]);
+
+  const switchCohort = useCallback(async (cohortSlug: string) => {
+    setLoading(true);
+    try { await loadCohort(cohortSlug); } finally { setLoading(false); }
+  }, [loadCohort]);
+
+  const provisionCohort = useCallback<UseCohortResult['provisionCohort']>(async (input) => {
+    const r = await fetch('/api/cohort/create-with-coordinator', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    const data = await r.json().catch(() => ({} as any));
+    if (!r.ok) return { ok: false, error: data?.error || 'Could not create cohort' };
+    await refreshAllCohorts();
+    if (data.cohort?.coordinatorSlug) await switchCohort(data.cohort.coordinatorSlug);
+    return { ok: true, coordinatorEmail: data.coordinator?.email };
+  }, [refreshAllCohorts, switchCohort]);
 
   const resetCohort = useCallback(async () => {
     setLoading(true);
@@ -118,5 +190,9 @@ export function useCohort(): UseCohortResult {
     }
   }, [fetchCohort]);
 
-  return { loading, cohort, members, isAdmin, refresh, resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort };
+  return {
+    loading, cohort, members, isAdmin, allCohorts,
+    refresh, refreshAllCohorts, switchCohort, provisionCohort,
+    resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
+  };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -37,8 +37,12 @@ import {
   BulkInviteSummaryDialog,
   ResetConfirmDialog,
   DeleteCohortConfirmDialog,
+  ProvisionCohortDialog,
   type BulkInviteResult,
 } from '@/core/components/orchestrator/CohortDialogs';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/core/components/ui/select';
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 import { SupportInbox } from '@/core/components/orchestrator/SupportInbox';
 
@@ -734,8 +738,9 @@ export default function OrchestratorLandingPage() {
   };
 
   const {
-    cohort, members, isAdmin,
+    cohort, members, isAdmin, allCohorts,
     invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage, deleteCohort,
+    switchCohort, provisionCohort,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
 
@@ -769,6 +774,7 @@ export default function OrchestratorLandingPage() {
   const [bulkInvitations, setBulkInvitations] = useState<BulkInviteResult[]>([]);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [provisionOpen, setProvisionOpen] = useState(false);
   const [supportInboxOpen, setSupportInboxOpen] = useState(false);
   // Mirrored from /support-requests?status=pending — drives the badge on
   // the inbox trigger. Initialized from member.supportRequests when the
@@ -839,6 +845,38 @@ export default function OrchestratorLandingPage() {
     setDeleteConfirmOpen(false);
     await deleteCohort();
     toast({ title: t('orchestrator.cohort.deleteDone', { defaultValue: 'Cohort deleted' }) });
+  };
+
+  // Admin picked a different cohort from the switcher — load it into the board.
+  const handleSwitchCohort = async (coordinatorSlug: string) => {
+    if (!coordinatorSlug || coordinatorSlug === cohort?.coordinatorSlug) return;
+    await switchCohort(coordinatorSlug);
+    const picked = allCohorts.find(c => c.coordinatorSlug === coordinatorSlug);
+    toast({
+      title: t('orchestrator.cohort.switched', {
+        defaultValue: 'Viewing {{name}}',
+        name: picked?.name ?? '',
+      }),
+    });
+  };
+
+  // Admin created a coordinator + cohort. On success the hook already switched
+  // the board to the new cohort; surface the login email so credentials can be
+  // handed off immediately.
+  const handleProvision = async (input: {
+    coordinatorName?: string; email: string; password: string;
+    cohortName: string; language?: 'pt' | 'en' | null;
+  }) => {
+    const res = await provisionCohort(input);
+    if (res.ok) {
+      toast({
+        title: t('orchestrator.cohort.provisionDone', {
+          defaultValue: 'Cohort created — {{email}} can log in now',
+          email: res.coordinatorEmail ?? input.email,
+        }),
+      });
+    }
+    return res;
   };
 
   const handleInviteOpen = () => setInviteOpen(true);
@@ -937,7 +975,33 @@ export default function OrchestratorLandingPage() {
               <span className="inline-flex items-center text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300">
                 {t('orchestrator.cohort.modePilot', { defaultValue: 'Pilot' })}
               </span>
-              <span className="text-sm font-medium tracking-tight truncate">{cohort?.name ?? 'Vila Flores'}</span>
+              {/* Admin sees a switcher over every cohort; a scoped coordinator
+                  just sees their own cohort's name. */}
+              {isAdmin && allCohorts.length > 0 ? (
+                <Select value={cohort?.coordinatorSlug ?? ''} onValueChange={handleSwitchCohort}>
+                  <SelectTrigger
+                    className="h-7 w-auto min-w-[150px] gap-1 border-foreground/10 text-sm font-medium"
+                    data-testid="select-cohort-switcher"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {allCohorts.map(c => (
+                      <SelectItem
+                        key={c.coordinatorSlug}
+                        value={c.coordinatorSlug}
+                        data-testid={`option-cohort-${c.coordinatorSlug}`}
+                      >
+                        {c.name}
+                        {c.coordinatorName ? ` · ${c.coordinatorName}` : ''}
+                        {` (${c.memberCount})`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <span className="text-sm font-medium tracking-tight truncate">{cohort?.name ?? 'Vila Flores'}</span>
+              )}
               {members.length > 0 && (
                 <span className="text-[11px] text-muted-foreground">
                   {t('orchestrator.cohort.memberCount', {
@@ -1007,6 +1071,18 @@ export default function OrchestratorLandingPage() {
                 >
                   <Trash2 className="w-3.5 h-3.5 mr-1.5" />
                   {t('orchestrator.cohort.delete', { defaultValue: 'Delete cohort' })}
+                </Button>
+              )}
+              {isAdmin && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setProvisionOpen(true)}
+                  data-testid="button-new-cohort"
+                  title={t('orchestrator.cohort.newTooltip', { defaultValue: 'Create a new cohort and its coordinator' })}
+                >
+                  <Plus className="w-3.5 h-3.5 mr-1.5" />
+                  {t('orchestrator.cohort.new', { defaultValue: 'New cohort' })}
                 </Button>
               )}
               <Button size="sm" onClick={handleInviteOpen} data-testid="button-invite-cbo">
@@ -1157,6 +1233,11 @@ export default function OrchestratorLandingPage() {
         open={deleteConfirmOpen}
         onOpenChange={setDeleteConfirmOpen}
         onConfirm={handleDeleteConfirm}
+      />
+      <ProvisionCohortDialog
+        open={provisionOpen}
+        onOpenChange={setProvisionOpen}
+        onSubmit={handleProvision}
       />
       <InviteCboDialog
         open={inviteOpen}

--- a/docs/cougar-runbook.md
+++ b/docs/cougar-runbook.md
@@ -10,9 +10,23 @@ re-issue links, and clean up. For the platform at `https://nbs-project-preparati
 
 ## 1. Provision a coordinator
 
-Coordinators are **admin-provisioned** (no self-signup). Two ways:
+Coordinators are **admin-provisioned** (no self-signup).
 
-### a) Bootstrap endpoint (works against prod without shell access)
+### a) In-app admin panel (the normal way) ⭐
+Once you have **one admin coordinator** (use the bootstrap endpoint below for the
+very first one), everything else is in-app. Log in as the admin → `/orchestrator`:
+
+- **"New cohort"** (header button) → one form: **cohort name, coordinator name,
+  login email, password, language**. Submitting creates the coordinator **and**
+  their cohort, linked, and switches the board to it. Hand the coordinator their
+  email + password — they log in scoped to that cohort.
+- **Cohort switcher** (top-left dropdown): every cohort with its coordinator and
+  member count. Click to load any of them. Scoped coordinators only ever see
+  their own.
+
+No shell, no cohort UUID. The admin stays logged in as themselves throughout.
+
+### b) Bootstrap endpoint (first admin / prod without shell access)
 A secret-gated endpoint creates + (optionally) scopes a coordinator. Set
 `BOOTSTRAP_COORDINATOR_SECRET` in **both** the Replit Workspace and Deployment
 secrets, republish, then:
@@ -33,10 +47,12 @@ curl -sS -X POST "$BASE/api/coordinator/bootstrap" \
 > deployment has its own. The bootstrap call hits whichever URL you point at —
 > use the **prod** URL to create a prod coordinator.
 
-### b) Shell script (local / dev)
+### c) Shell script (local / dev fallback)
 ```bash
-npx tsx scripts/create-coordinator.ts <email> <password> "<Name>" [cohortSlug]
+npx tsx scripts/create-coordinator.ts <email> <password> "<Name>" [cohortId]
 ```
+The 4th arg is the **cohort UUID** (not a slug); omit it for an admin. Prefer the
+in-app panel (a) for everyday work.
 
 Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 
@@ -44,8 +60,11 @@ Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 
 ## 2. Create / configure a cohort
 
-- The pilot uses **one default cohort** ("Vila Flores"); an admin coordinator
-  sees it automatically on `/orchestrator` (created on first load).
+- A **default cohort** ("Vila Flores") exists out of the box; an admin sees it
+  automatically on `/orchestrator` (created on first load).
+- **More cohorts:** use **"New cohort"** (§1a) to add a coordinator + cohort, then
+  hop between them with the cohort switcher. Each scoped coordinator manages only
+  their own.
 - **Language:** set the cohort's forced UI language with the **Auto / PT / EN**
   toggle in the cohort header. PT/EN *overrides* each org's phone language
   (Auto = let the phone decide).

--- a/e2e/cougar-admin-cohort-panel.spec.ts
+++ b/e2e/cougar-admin-cohort-panel.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Admin cohort management — the simpler model (no shell, no UUID dance):
+//  • admin sees a cohort SWITCHER over every cohort
+//  • "New cohort" provisions a coordinator + their cohort in one form, then the
+//    board switches to it
+//  • the new coordinator is SCOPED: logs in with the email/password set here,
+//    sees only their cohort, and is 403'd on the admin directory
+//  • switching between cohorts works; deleting the new one cleans up
+
+test.describe('COUGAR — admin cohort panel', () => {
+  test('admin provisions a coordinator+cohort, switches into it, scoped login is isolated', async ({ page, request }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `admin-${randomUUID()}@e2e.test`, password: 'admin-pass-1', name: 'Joaquin' }); // null cohortId = admin
+
+    await page.goto('/orchestrator');
+
+    // Admin gets a switcher (the default cohort is always present).
+    const switcher = page.getByTestId('select-cohort-switcher');
+    await expect(switcher).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(700);
+    await page.screenshot({ path: 'test-results/admin-01-switcher.png' });
+
+    // ── Provision a new coordinator + cohort from the panel ──
+    const coordEmail = `julia-${randomUUID()}@e2e.test`;
+    const cohortName = `QA Cohort ${randomUUID().slice(0, 6)}`;
+    await page.getByTestId('button-new-cohort').click();
+    await page.getByTestId('input-provision-cohort-name').fill(cohortName);
+    await page.getByTestId('input-provision-coordinator-name').fill('Julia');
+    await page.getByTestId('input-provision-email').fill(coordEmail);
+    await page.getByTestId('input-provision-password').fill('julia-pass-1');
+    await page.getByTestId('button-provision-lang-pt').click();
+    await page.waitForTimeout(700);
+    await page.screenshot({ path: 'test-results/admin-02-provision-form.png' });
+    await page.getByTestId('button-confirm-provision-cohort').click();
+
+    // Board switched to the freshly-created cohort; it shows in the switcher.
+    await expect(switcher).toContainText(cohortName, { timeout: 15_000 });
+    await page.waitForTimeout(900);
+    await page.screenshot({ path: 'test-results/admin-03-after-provision.png' });
+
+    // The directory records the linked coordinator + chosen language.
+    const all = await (await page.request.get('/api/cohort/all')).json();
+    const created = all.cohorts.find((c: any) => c.name === cohortName);
+    expect(created).toBeTruthy();
+    expect(created.coordinatorName).toBe('Julia');
+    expect(created.coordinatorEmail).toBe(coordEmail);
+    expect(created.language).toBe('pt');
+    const newSlug: string = created.coordinatorSlug;
+
+    // ── The new coordinator is scoped (separate request context, NOT admin) ──
+    const loginRes = await request.post('/api/coordinator/login', {
+      data: { email: coordEmail, password: 'julia-pass-1' },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+    const mine = await (await request.get('/api/cohort/mine')).json();
+    expect(mine.isAdmin).toBe(false);
+    expect(mine.cohort.name).toBe(cohortName);
+    // A scoped coordinator cannot read the admin directory.
+    const forbidden = await request.get('/api/cohort/all');
+    expect(forbidden.status()).toBe(403);
+
+    // ── Switch cohorts in the admin UI: → default → back to the new one ──
+    await switcher.click();
+    await page.getByTestId('option-cohort-default').click();
+    await expect(switcher).toContainText('Vila Flores', { timeout: 15_000 }); // default cohort
+    await page.waitForTimeout(700);
+    await page.screenshot({ path: 'test-results/admin-04-switched-default.png' });
+
+    await switcher.click();
+    await page.getByTestId(`option-cohort-${newSlug}`).click();
+    await expect(switcher).toContainText(cohortName, { timeout: 15_000 });
+    await page.waitForTimeout(700);
+
+    // ── Delete the new cohort (admin-only) — also cleans up the test row ──
+    await page.getByTestId('button-delete-cohort').click();
+    await page.getByTestId('button-confirm-delete-cohort').click();
+    // After delete the board falls back to a cohort and the QA one is gone from
+    // the directory.
+    await expect.poll(async () => {
+      const after = await (await page.request.get('/api/cohort/all')).json();
+      return after.cohorts.some((c: any) => c.name === cohortName);
+    }, { timeout: 15_000 }).toBe(false);
+    await page.waitForTimeout(800);
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -13,7 +13,14 @@ import {
   type WorkshopConfig,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
-import { requireCoordinator, type CoordinatorRequest } from '../services/coordinatorAuth';
+import {
+  requireCoordinator,
+  createCoordinator,
+  getCoordinatorByEmail,
+  publicCoordinator,
+  type CoordinatorRequest,
+} from '../services/coordinatorAuth';
+import { coordinators } from '@shared/coordinator-schema';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -194,6 +201,68 @@ export function registerCohortRoutes(app: Express): void {
     if (!cohort) cohort = await getOrCreateDefaultCohort();
     const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
     res.json({ cohort, members, isAdmin: !coordinator?.cohortId });
+  }));
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Admin cohort directory — every cohort with its coordinator + member count,
+  // for the admin's cohort switcher. Admin-only (a scoped coordinator only ever
+  // sees their own cohort via /mine). MUST be registered before the
+  // `/:coordinatorSlug` param route below, or 'all' is read as a slug.
+  // ──────────────────────────────────────────────────────────────────────
+  app.get('/api/cohort/all', wrap(async (req, res) => {
+    if (reqCoordinator(req)?.cohortId) { res.status(403).json({ error: 'admin only' }); return; }
+    const allCohorts = await db.select().from(cohorts);
+    const coords = await db.select().from(coordinators);
+    const coordByCohort = new Map(coords.filter(c => c.cohortId).map(c => [c.cohortId as string, c]));
+    const memberRows = await db.select({ cohortId: cohortMembers.cohortId }).from(cohortMembers);
+    const countByCohort = new Map<string, number>();
+    for (const m of memberRows) countByCohort.set(m.cohortId, (countByCohort.get(m.cohortId) ?? 0) + 1);
+    const items = allCohorts.map(c => ({
+      id: c.id,
+      name: c.name,
+      coordinatorSlug: c.coordinatorSlug,
+      language: (c.settings as CohortSettings | null)?.language ?? null,
+      memberCount: countByCohort.get(c.id) ?? 0,
+      coordinatorName: coordByCohort.get(c.id)?.name ?? null,
+      coordinatorEmail: coordByCohort.get(c.id)?.email ?? null,
+      isDefault: c.coordinatorSlug === DEFAULT_COORDINATOR_SLUG,
+    }));
+    // Default cohort first, then alphabetical — a stable order for the switcher.
+    items.sort((a, b) =>
+      a.isDefault ? -1 : b.isDefault ? 1 : a.name.localeCompare(b.name));
+    res.json({ cohorts: items });
+  }));
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Provision a coordinator AND their cohort in one admin-authed call — the
+  // primary creation path (replaces the create-coordinator shell script + the
+  // cohort-UUID dance). Admin stays logged in as themselves; the new coordinator
+  // gets email + password to log in and is scoped to the freshly-created cohort.
+  // MUST be registered before the `/:coordinatorSlug` param routes.
+  // ──────────────────────────────────────────────────────────────────────
+  app.post('/api/cohort/create-with-coordinator', wrap(async (req, res) => {
+    if (reqCoordinator(req)?.cohortId) { res.status(403).json({ error: 'only an admin can create cohorts' }); return; }
+    const { coordinatorName, email, password, cohortName, language: rawLang } = req.body ?? {};
+    if (!email || !password) { res.status(400).json({ error: 'coordinator email and password are required' }); return; }
+    if (!cohortName || !String(cohortName).trim()) { res.status(400).json({ error: 'cohort name is required' }); return; }
+    if (String(password).length < 6) { res.status(400).json({ error: 'password must be at least 6 characters' }); return; }
+
+    const existing = await getCoordinatorByEmail(String(email));
+    if (existing) { res.status(409).json({ error: 'a coordinator with that email already exists' }); return; }
+
+    const language = rawLang === 'pt' || rawLang === 'en' ? rawLang : undefined;
+    const [cohort] = await db.insert(cohorts).values({
+      coordinatorSlug: slug(),
+      name: String(cohortName).trim(),
+      settings: { workshops: DEFAULT_WORKSHOPS, language },
+    }).returning();
+    const coordinator = await createCoordinator({
+      email: String(email),
+      password: String(password),
+      name: coordinatorName ? String(coordinatorName).trim() : undefined,
+      cohortId: cohort.id,
+    });
+    res.status(201).json({ cohort, coordinator: publicCoordinator(coordinator) });
   }));
 
   // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Makes coordinator/cohort management simple and in-app (per `/refine`). No more `create-coordinator` shell script + cohort-UUID dance.

As admin (Joaquin), inside `/orchestrator`:
- **Cohort switcher** (top-left): a dropdown over every cohort showing `name · coordinator · member count`. Click to load. Scoped coordinators (Julia) still just see their own cohort name.
- **"New cohort"** button → one form: cohort name, coordinator name, login email, password, language. Submitting provisions the coordinator **and** their cohort, linked, and switches the board to it. The new coordinator logs in with that email+password, scoped to that cohort.

Passwords stay (your choice in the interview) — you just set them in the form now instead of in a shell.

## Backend (admin-only)
Registered **before** the `/:coordinatorSlug` param routes so `all` / `create-with-coordinator` aren't read as slugs:
- `GET /api/cohort/all` — cohort directory (coordinator + member count). Scoped coordinator → 403.
- `POST /api/cohort/create-with-coordinator` — create cohort + coordinator atomically; 409 on duplicate email, 400 on short password.

## Client
`useCohort` gains `allCohorts` / `refreshAllCohorts` / `switchCohort` / `provisionCohort`. Key fix: `refresh()` now reloads the cohort **currently on screen** (`slugRef`) rather than always re-resolving `/mine`, so an admin who switched cohorts doesn't snap back to default after an invite/unlock.

## Verify
`e2e/cougar-admin-cohort-panel.spec.ts` (recorded): admin provisions a coordinator+cohort → board switches → the new coordinator logs in **scoped** (sees only their cohort, **403** on `/all`) → switch between cohorts → delete cleans up. Full cougar gate: **10/10 chromium specs pass**. `tsc` clean on changed files (12 pre-existing errors elsewhere, untouched).

> Replit serves the compiled `build/` — **rebuild + republish** after merge for this to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)