### PR TITLE
feat(cougar): remove the co-design empty-state from the orchestrator

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
-  Mountain, Network, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Users, Waves,
+  Mountain, Network, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -1202,25 +1202,6 @@ export default function OrchestratorLandingPage() {
             })}
           </div>
         </div>
-
-        {/* Feedback prompt */}
-        <motion.div
-          className="mt-10 rounded-xl border border-dashed border-foreground/15 bg-card/40 p-6 text-center"
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
-        >
-          <div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-foreground/5 mb-3">
-            <Users className="w-4 h-4 text-foreground/60" />
-          </div>
-          <TitleLarge className="!text-base tracking-tight mb-1">
-            {t('orchestrator.demo.feedbackTitle')}
-          </TitleLarge>
-          <BodySmall className="text-muted-foreground max-w-xl mx-auto">
-            {t('orchestrator.demo.feedbackBody')}
-          </BodySmall>
-        </motion.div>
       </main>
 
       {/* Cohort flow dialogs */}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -128,9 +128,7 @@
         "beginProfile": "Begin Phase 1 — Who We Are"
       },
       "toastTitle": "Prototype view",
-      "toastBody": "In Phase 3, clicking here would open {{project}}'s workspace.",
-      "feedbackTitle": "What would you want to see here?",
-      "feedbackBody": "This view is deliberately sparse. Tell us which metrics, alerts, or actions a coordinator would actually use day to day — that's what we'll build next."
+      "toastBody": "In Phase 3, clicking here would open {{project}}'s workspace."
     }
   },
   "citySelection": {

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -136,9 +136,7 @@
         "beginProfile": "Começar a Fase 1 — Quem Somos"
       },
       "toastTitle": "Visão protótipo",
-      "toastBody": "Na Fase 3, clicar aqui abriria o espaço de {{project}}.",
-      "feedbackTitle": "O que você gostaria de ver aqui?",
-      "feedbackBody": "Essa visão é propositalmente enxuta. Nos conte quais métricas, alertas ou ações uma articuladora realmente usaria no dia a dia — é isso que vamos construir a seguir."
+      "toastBody": "Na Fase 3, clicar aqui abriria o espaço de {{project}}."
     }
   },
   "citySelection": {

--- a/e2e/cougar-remove-codesign-empty-state.spec.ts
+++ b/e2e/cougar-remove-codesign-empty-state.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// The dashed "O que você gostaria de ver aqui? / What would you want to see
+// here?" co-design empty-state is removed from the orchestrator (a separate
+// block from the "Early prototype" banner already dropped in round 2). The
+// dashboard should end at the participants grid — no feedback prompt below it.
+
+test.describe('COUGAR — remove co-design empty-state', () => {
+  test('the orchestrator has no "what would you want to see here" feedback block', async ({ page }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({ email: `nofeedback-${randomUUID()}@e2e.test`, password: 'pw-123456', name: 'NoFeedback' }); // admin
+
+    await page.goto('/orchestrator');
+    // Wait for the dashboard to actually render (cohort header present).
+    await expect(page.getByTestId('button-invite-cbo')).toBeVisible({ timeout: 20_000 });
+
+    const body = await page.locator('main').innerText();
+    expect(body).not.toContain('gostaria de ver aqui');
+    expect(body).not.toContain('deliberately sparse');
+    expect(body).not.toContain('What would you want to see here');
+    await page.waitForTimeout(600);
+    await page.screenshot({ path: 'test-results/no-feedback-block.png' });
+  });
+});


### PR DESCRIPTION
Removes the dashed **"O que você gostaria de ver aqui? / What would you want to see here?"** co-design empty-state below the participants grid. This is a **separate** block from the "Early prototype — help us design this" banner already dropped in round 2 (PR #269).

- Deletes the `motion.div` feedback prompt in `orchestrator-landing.tsx`.
- Removes the now-unused `feedbackTitle` / `feedbackBody` i18n keys (en + pt) and the orphaned `Users` icon import.

**Verify:** `e2e/cougar-remove-codesign-empty-state.spec.ts` — admin on `/orchestrator`, the feedback copy is absent. `tsc` clean.

> Rebuild + republish on Replit to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)