### PR TITLE
feat(cougar): E2 — persist the chosen site as structured data + link photos

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1362,7 +1362,18 @@ export default function CboProfilePage() {
                     formData.append('file', file);
                     fetch(`/api/upload/cbo/${cboId}`, { method: 'POST', body: formData })
                       .then(r => r.json())
-                      .then(data => sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${(data.content || '').slice(0, 8000)}\n\nPlease extract info, auto-fill sections, and score maturity.`))
+                      .then(data => {
+                        // Gap 4 — link a site photo to the chosen site (best-effort;
+                        // the server no-ops until a site exists). Images only.
+                        if (file.type.startsWith('image/') && data.savedPath && memberSlug) {
+                          fetch(`/api/cbo-member/${memberSlug}/site/photo`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ path: data.savedPath }),
+                          }).catch(() => {});
+                        }
+                        sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${(data.content || '').slice(0, 8000)}\n\nPlease extract info, auto-fill sections, and score maturity.`);
+                      })
                       .catch(() => sendMessage(`Uploaded "${file.name}" but could not parse.`));
                   }
                   e.target.value = '';
@@ -1522,6 +1533,26 @@ export default function CboProfilePage() {
                     params={openMapParams}
                     onConfirm={(result: MapSelectionResult) => {
                       const message = formatMapResult(result);
+                      // Gap 1 — persist the chosen site as STRUCTURED data, not just
+                      // a chat string. The intervention site is the last non-zone
+                      // asset; the zone (if any) gives the neighborhood.
+                      const siteAsset = [...result.selectedAssets].reverse().find(a => a.type !== 'zone');
+                      const zoneAsset = result.selectedAssets.find(a => a.type === 'zone');
+                      if (siteAsset && memberSlug) {
+                        const poly = siteAsset.geometry?.type === 'Polygon' ? siteAsset.geometry : null;
+                        fetch(`/api/cbo-member/${memberSlug}/site`, {
+                          method: 'PUT',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({
+                            name: siteAsset.name,
+                            kind: siteAsset.type,
+                            coordinates: siteAsset.coordinates,
+                            geometry: siteAsset.geometry ?? null,
+                            source: (siteAsset.properties as any)?.source ?? siteAsset.source ?? null,
+                            neighborhood: zoneAsset?.name ?? null,
+                          }),
+                        }).catch(() => {});
+                      }
                       if (currentQuestion) handleSelectOption(message); else sendMessage(message);
                       setOpenMapParams(null);
                       setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');

--- a/e2e/cougar-e2-site-persist.spec.ts
+++ b/e2e/cougar-e2-site-persist.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// E2 site persistence (gaps 1 & 4) — the chosen intervention site is stored as
+// STRUCTURED data (GeoJSON geometry + coordinates) instead of dissolving into a
+// chat string, and uploaded photos link to that site.
+
+test.describe('COUGAR — E2 persist the chosen site + link photos', () => {
+  test('site routes: PUT a polygon site, link a photo, and 409 before any site', async ({ request }) => {
+    const api = new TestApi(request);
+    const { cohort } = await api.createCohort('e2e site api');
+    const { member } = await api.inviteMember(cohort.id, { orgName: 'Org Poly' });
+    const slug: string = member.memberSlug;
+
+    // No site yet → linking a photo is a no-op 409.
+    const early = await request.post(`/api/cbo-member/${slug}/site/photo`, { data: { path: '/x/early.jpg' } });
+    expect(early.status()).toBe(409);
+
+    // PUT a drawn-polygon site.
+    const put = await request.put(`/api/cbo-member/${slug}/site`, {
+      data: {
+        name: 'Praça da Horta', kind: 'custom', coordinates: [-30.05, -51.21],
+        geometry: { type: 'Polygon', coordinates: [[[-51.21, -30.05], [-51.20, -30.05], [-51.20, -30.04], [-51.21, -30.05]]] },
+        source: 'user-added', neighborhood: 'Cascata',
+      },
+    });
+    expect(put.ok()).toBeTruthy();
+    const saved = (await put.json()).site;
+    expect(saved.geometry.type).toBe('Polygon');
+    expect(saved.neighborhood).toBe('Cascata');
+
+    // Now linking a photo appends it to the site.
+    const link = await request.post(`/api/cbo-member/${slug}/site/photo`, { data: { path: '/uploads/site1.jpg' } });
+    expect(link.ok()).toBeTruthy();
+    expect((await link.json()).site.photos).toContain('/uploads/site1.jpg');
+
+    // It surfaces on the member payload.
+    const payload = await (await request.get(`/api/cbo-member/${slug}`)).json();
+    expect(payload.site.name).toBe('Praça da Horta');
+    expect(payload.site.photos).toContain('/uploads/site1.jpg');
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -11,6 +11,7 @@ import {
   type SupportRequest,
   type SupportRequestType,
   type WorkshopConfig,
+  type MemberSite,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
 import {
@@ -150,6 +151,7 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
     unlockedPhases: unlocked,
     cboStateId: member.cboStateId,
     cohort: cohort ? { id: cohort.id, name: cohort.name, language: (cohort.settings as CohortSettings | null)?.language ?? null } : null,
+    site: (member.site as MemberSite | null) ?? null,
     workshops,
     nextWorkshop,
     focusWorkshop,
@@ -639,5 +641,53 @@ export function registerCohortRoutes(app: Express): void {
         (e: any) => console.error('[cohort] link cbo_state→org failed:', e?.message || e));
     }
     res.json({ ok: true });
+  }));
+
+  // CBO commits its chosen intervention site (E2). Stores the STRUCTURED site —
+  // GeoJSON geometry + coordinates + name — instead of letting the drawn shape
+  // dissolve into a chat string. Preserves any already-attached photos.
+  app.put('/api/cbo-member/:memberSlug/site', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    const b = req.body ?? {};
+    const coords = Array.isArray(b.coordinates) && b.coordinates.length === 2
+      ? [Number(b.coordinates[0]), Number(b.coordinates[1])] as [number, number]
+      : null;
+    if (!b.name || !coords || coords.some((n: number) => !Number.isFinite(n))) {
+      res.status(400).json({ error: 'name and [lat,lng] coordinates required' });
+      return;
+    }
+    const prev = (member.site as MemberSite | null) ?? null;
+    const site: MemberSite = {
+      name: String(b.name),
+      kind: b.kind === 'osm' || b.kind === 'zone' ? b.kind : 'custom',
+      coordinates: coords,
+      geometry: b.geometry && (b.geometry.type === 'Point' || b.geometry.type === 'Polygon')
+        ? { type: b.geometry.type, coordinates: b.geometry.coordinates } : null,
+      source: typeof b.source === 'string' ? b.source : null,
+      areaM2: typeof b.areaM2 === 'number' ? b.areaM2 : null,
+      neighborhood: typeof b.neighborhood === 'string' ? b.neighborhood : (member.neighborhood ?? null),
+      photos: prev?.photos ?? [], // keep photos attached before the site was (re)saved
+      savedAt: new Date().toISOString(),
+    };
+    await db.update(cohortMembers).set({ site }).where(eq(cohortMembers.id, member.id));
+    res.json({ site });
+  }));
+
+  // Link an uploaded photo to the chosen site (E2). Appends a file path to
+  // member.site.photos so site photos are associated, not just dumped in the
+  // flat per-CBO upload list. No-op (409) until a site exists.
+  app.post('/api/cbo-member/:memberSlug/site/photo', wrap(async (req, res) => {
+    const member = await findMemberBySlug(req.params.memberSlug);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    const path = req.body?.path;
+    if (!path || typeof path !== 'string') { res.status(400).json({ error: 'path required' }); return; }
+    const site = (member.site as MemberSite | null);
+    if (!site) { res.status(409).json({ error: 'no site selected yet' }); return; }
+    if (site.photos.includes(path)) { res.json({ site }); return; } // idempotent
+    const next: MemberSite = { ...site, photos: [...site.photos, path].slice(-20) };
+    await db.update(cohortMembers).set({ site: next }).where(eq(cohortMembers.id, member.id));
+    res.json({ site: next });
   }));
 }

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -49,6 +49,23 @@ export type SupportRequest = {
   resolvedNote: string | null;
 };
 
+// The CBO's chosen intervention site (E2 / Workshop 2). Persisted as STRUCTURED
+// data — previously the map selection was flattened into a chat string and the
+// drawn geometry was lost. `geometry` is the GeoJSON point/polygon; `photos`
+// are file paths of site photos the CBO uploaded (linked here, not just dumped
+// in the flat upload list).
+export type MemberSite = {
+  name: string;
+  kind: 'osm' | 'custom' | 'zone';           // how it was chosen
+  coordinates: [number, number];             // [lat, lng] centroid
+  geometry: { type: 'Point' | 'Polygon'; coordinates: any } | null;
+  source?: string | null;                    // e.g. 'osm_parks', 'user-added'
+  areaM2?: number | null;                    // for drawn polygons
+  neighborhood?: string | null;
+  photos: string[];                          // uploaded site-photo file paths
+  savedAt: string;                           // ISO timestamp
+};
+
 export const cohorts = pgTable('cohorts', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
   coordinatorSlug: text('coordinator_slug').notNull().unique(),
@@ -103,6 +120,10 @@ export const cohortMembers = pgTable('cohort_members', {
   snapshotFlagsMet: integer('snapshot_flags_met'),
   snapshotIntervention: text('snapshot_intervention'),
   snapshotUpdatedAt: timestamp('snapshot_updated_at'),
+
+  // The chosen intervention site (E2). Structured GeoJSON + photos, so the
+  // geometry the CBO drew/picked survives instead of being lost to a chat string.
+  site: jsonb('site').$type<MemberSite | null>(),
 });
 
 export type Cohort = typeof cohorts.$inferSelect;


### PR DESCRIPTION
Closes **gaps 1 & 4** of the workshop-2 (E2) card — the last of the card's four gaps.

### Gap 1 — persist the site (structured, not a chat string)
The map selection was flattened into a chat message and the drawn point/polygon **geometry was lost**. Added:
- A `site` jsonb column on `cohort_members` — `MemberSite` = `{ name, kind, [lat,lng], GeoJSON geometry, source, areaM2, neighborhood, photos[], savedAt }`.
- `PUT /api/cbo-member/:slug/site`.
- On map confirm, `cbo-profile` persists the chosen site (the last non-zone asset; the picked zone becomes the neighborhood) **alongside** the existing chat message — so nothing about the existing agent flow changes.

### Gap 4 — link photos to the site
- `POST /api/cbo-member/:slug/site/photo` appends an uploaded file path to `site.photos` (idempotent, capped at 20, **409 until a site exists**).
- On an image upload, `cbo-profile` best-effort links the file to the site, so site photos are associated rather than only landing in the flat per-CBO upload list.

`buildMemberPayload` now returns `site`, so the orchestrator can surface the chosen site later.

### Verify
`e2e/cougar-e2-site-persist.spec.ts` (API-level, deterministic): 409 before any site; PUT a polygon site persists the geometry + neighborhood; linking a photo appends it; the site surfaces on the member payload. `cbo-golden-path` + `cbo-upload` green (no regression from the map/upload handler edits). `tsc` + build clean.

> ⚠️ **New DB column** — run `npm run db:push` (or the Replit DB SQL editor) against prod before this serves. Rebuild + republish.

### Card 3 complete
All four E2 gaps now shipped: gap 2 (#274 add site by name/coordinate), gap 3 (#275 render risk overlays + simple legend), gaps 1 & 4 (this). Independent of #273/#274/#275 — touches `cbo-profile` + `cohortRoutes` + `cohort-schema` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)