### PR TITLE
fix(cougar): landslide uses RISK (no public hazard tile) + orchestrator legend matches each hazard

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -193,12 +193,15 @@ const BAND_CHIP: Record<ReturnType<typeof maturityBand>, string> = {
 type RiskView = 'flood' | 'heat' | 'landslide' | 'risk';
 
 // Hazard raster overlays, fed LIVE from the data catalog via the tile proxy.
-// All three = the catalog poa_<haz>_HAZARD (the gap-free hazard layer covers the
-// whole territory, unlike the sparse H×E×V risk composite).
+// Flood + heat = the catalog poa_<haz>_HAZARD (gap-free, covers the whole
+// territory). Landslide uses poa_landslide_RISK — the catalog only publishes
+// landslide RISK (the hazard tile 403s for everyone), so risk is the only
+// available landslide layer. It's the validated H×E×V composite, masked to the
+// hillside/morro footprint (the rest reads as low/green).
 const HAZARD_RASTER: Record<'flood' | 'heat' | 'landslide', { url: string; attribution: string }> = {
-  flood:     { url: '/api/geospatial/tiles/poa_flood_hazard/{z}/{x}/{y}.png',     attribution: 'OEF catalog · flood hazard (interpolated)' },
-  heat:      { url: '/api/geospatial/tiles/poa_heat_hazard/{z}/{x}/{y}.png',      attribution: 'OEF catalog · heat hazard' },
-  landslide: { url: '/api/geospatial/tiles/poa_landslide_hazard/{z}/{x}/{y}.png', attribution: 'OEF catalog · landslide hazard' },
+  flood:     { url: '/api/geospatial/tiles/poa_flood_hazard/{z}/{x}/{y}.png',   attribution: 'OEF catalog · flood hazard (interpolated)' },
+  heat:      { url: '/api/geospatial/tiles/poa_heat_hazard/{z}/{x}/{y}.png',    attribution: 'OEF catalog · heat hazard' },
+  landslide: { url: '/api/geospatial/tiles/poa_landslide_risk/{z}/{x}/{y}.png', attribution: 'OEF catalog · landslide risk (H×E×V)' },
 };
 
 // City-wide min/max of the per-zone max-hazard mean, for normalizing the 'risk'

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -204,6 +204,15 @@ const HAZARD_RASTER: Record<'flood' | 'heat' | 'landslide', { url: string; attri
   landslide: { url: '/api/geospatial/tiles/poa_landslide_risk/{z}/{x}/{y}.png', attribution: 'OEF catalog · landslide risk (H×E×V)' },
 };
 
+// Legend color ramps that MATCH each catalog overlay's actual colormap (sampled
+// from the tiles), so the intensity bar reflects what's painted on the map:
+// flood = viridis (purple→yellow); heat + landslide = green→yellow→red (RdYlGn).
+const HAZARD_RAMPS: Record<'flood' | 'heat' | 'landslide', string[]> = {
+  flood:     ['#440154', '#414487', '#2a788e', '#22a884', '#7ad151', '#fde725'],
+  heat:      ['#1a9850', '#a6d96a', '#ffffbf', '#fdae61', '#d73027'],
+  landslide: ['#1a9641', '#a6d96a', '#ffffbf', '#fdae61', '#d7191c'],
+};
+
 // City-wide min/max of the per-zone max-hazard mean, for normalizing the 'risk'
 // choropleth opacity (same approach as the site-explorer). Filled when the
 // bairro layer is built.
@@ -497,9 +506,14 @@ function MapLayerControls({
       {active && active !== 'risk' && (
         <div className="pt-1.5 mt-1.5 border-t border-foreground/5">
           <div className="text-[9px] uppercase tracking-wide text-muted-foreground mb-1">
-            {t('orchestrator.map.intensity', { defaultValue: 'Risk intensity' })}
+            {t('orchestrator.map.hazardIntensity', { defaultValue: 'Hazard intensity' })}
           </div>
-          <div className="h-2 rounded-full" style={{ background: 'linear-gradient(to right, #fef3c7, #fb923c, #b91c1c)' }} />
+          {/* Gradient mirrors the selected overlay's actual colormap (flood = viridis,
+              heat/landslide = green→red) so the legend matches the map. */}
+          <div
+            className="h-2 rounded-full"
+            style={{ background: `linear-gradient(to right, ${HAZARD_RAMPS[active].join(', ')})` }}
+          />
           <div className="flex justify-between text-[9px] text-muted-foreground mt-0.5">
             <span>{t('orchestrator.map.low', { defaultValue: 'low' })}</span>
             <span>{t('orchestrator.map.high', { defaultValue: 'high' })}</span>

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -36,7 +36,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS, LANDSLIDE_INDEX_LAYERS } from '@shared/geospatial-layers';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS } from '@shared/geospatial-layers';
 import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, TYPOLOGY_COLORS, type HazardKey } from '@shared/risk-display';
 import { LayerLegend } from '@/core/components/map/LayerLegend';
 import type { LegendIndex } from '@shared/legend-types';
@@ -81,7 +81,7 @@ interface CityInfo {
 }
 
 type LayerSource = 'geojson' | 'tiles';
-type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'flood_indices' | 'heat_indices' | 'landslide_indices' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
+type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'flood_indices' | 'heat_indices' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
 
 interface LayerState {
   id: string;
@@ -171,19 +171,8 @@ const LAYER_CONFIGS: LayerConfig[] = [
     hasValueTiles: l.hasValueTiles,
     valueEncoding: l.valueEncoding,
   })),
-  // Landslide hazard overlay (catalog poa_landslide_hazard)
-  ...LANDSLIDE_INDEX_LAYERS.map(l => ({
-    id: l.id,
-    name: l.name,
-    icon: AlertTriangle,
-    color: l.color,
-    source: 'tiles' as LayerSource,
-    group: 'landslide_indices' as LayerGroupId,
-    available: true,
-    tileLayerId: l.tileLayerId,
-    hasValueTiles: l.hasValueTiles,
-    valueEncoding: l.valueEncoding,
-  })),
+  // (No landslide hazard overlay — the catalog only publishes landslide RISK,
+  //  which appears as the "Landslide Risk (H×E×V)" card in the risk_250m group.)
   // OEF tile layers — generated from shared catalog (48 layers)
   ...TILE_LAYERS.filter(l => l.available).map(l => ({
     id: l.id,
@@ -203,7 +192,6 @@ const LAYER_GROUPS: readonly { id: LayerGroupId; label: string }[] = [
   { id: 'risk_250m', label: 'Risk Analysis (250m)' },
   { id: 'flood_indices', label: 'Flood Indices' },
   { id: 'heat_indices', label: 'Heat Indices' },
-  { id: 'landslide_indices', label: 'Landslide Indices' },
   { id: 'reference_data', label: 'Reference Data' },
   { id: 'analysis', label: 'Intervention Zones' },
   { id: 'environment', label: 'Environment' },

--- a/e2e/cougar-e2-risk-legend.spec.ts
+++ b/e2e/cougar-e2-risk-legend.spec.ts
@@ -19,7 +19,7 @@ test.describe('COUGAR — E2 simplified flood/heat/landslide risk legend', () =>
     // flood + heat — the old local /tiles/landslide_risk/ is gone).
     let landslideTileRequested = false;
     page.on('request', (r) => {
-      if (r.url().includes('/api/geospatial/tiles/poa_landslide_hazard/')) landslideTileRequested = true;
+      if (r.url().includes('/api/geospatial/tiles/poa_landslide_risk/')) landslideTileRequested = true;
     });
 
     await page.goto('/cbo-profile');
@@ -31,7 +31,7 @@ test.describe('COUGAR — E2 simplified flood/heat/landslide risk legend', () =>
       { op: 'say', text: 'Olha os riscos do seu bairro.' },
       { op: 'open_map', params: {
         selectionMode: 'browse-only',
-        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
         showLegendSimple: true,
         prompt: 'As cores mostram os riscos.',
         narrationOverlay: 'Azul = enchente · Vermelho = calor · Marrom = deslizamento.',

--- a/e2e/cougar-landslide-catalog.spec.ts
+++ b/e2e/cougar-landslide-catalog.spec.ts
@@ -2,9 +2,9 @@ import { test, expect } from '@playwright/test';
 import { TestApi } from './helpers/testApi';
 
 // Landslide catalog migration — the final hazard. The map overlays + tile proxy
-// now serve the catalog landslide layers (poa_landslide_hazard overlay +
-// poa_landslide_risk H×E×V), so ALL THREE hazards are catalog-backed and the
-// local landslide tiles are gone.
+// now serve the catalog landslide layer (poa_landslide_risk H×E×V — the catalog
+// only publishes landslide RISK, not hazard), so all three hazards are catalog-
+// backed and the local landslide tiles are gone.
 
 test.describe('COUGAR — map overlays use the catalog landslide layer', () => {
   test('the tile proxy serves the catalog landslide risk layer', async ({ request }) => {
@@ -16,7 +16,7 @@ test.describe('COUGAR — map overlays use the catalog landslide layer', () => {
     expect((r.headers()['content-type'] || '')).toContain('image/png');
   });
 
-  test('a CBO open_map with poa_landslide_hazard renders the catalog overlay', async ({ page, request }) => {
+  test('a CBO open_map with the landslide risk layer renders the catalog overlay', async ({ page, request }) => {
     const api = new TestApi(request);
     const ping = await api.ping();
     test.skip(!ping.fakeModel, 'needs the fake model');
@@ -31,7 +31,7 @@ test.describe('COUGAR — map overlays use the catalog landslide layer', () => {
       { op: 'say', text: 'Olha os riscos do seu bairro.' },
       { op: 'open_map', params: {
         selectionMode: 'browse-only',
-        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
         showLegendSimple: true,
         prompt: 'As cores mostram os riscos.',
       } },

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -108,7 +108,7 @@ open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
   layers: ['osm_parks', 'osm_schools', 'osm_wetlands'],
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
   showLegendSimple: true,
   prompt: 'Marca onde vocês querem atuar — primeiro o bairro, depois o lugar específico.'
 })
@@ -121,7 +121,7 @@ First, exploration mode with a narration banner. The user can scroll the map, to
 ```
 open_map({
   selectionMode: 'browse-only',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
   showLegendSimple: true,
   prompt: 'Olha o seu bairro. As cores mostram os riscos.',
   narrationOverlay: 'Azul = enchente. Vermelho = calor. Marrom = deslizamento. Toque "Voltar ao chat" quando quiser.'
@@ -140,7 +140,7 @@ Listen for cues. If they name a spot, transition to Beat 2b. If they're still un
 open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
   showLegendSimple: true,
   prompt: 'Agora marca o lugar específico onde vocês querem atuar.'
 })

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -120,7 +120,8 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
   poa_heat_risk:         { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_hazard:       { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/hazard/tiles_visual/{z}/{x}/{y}.png" },
   poa_landslide_risk:    { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/risk/tiles_visual/{z}/{x}/{y}.png" },
-  poa_landslide_hazard:  { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/hazard/tiles_visual/{z}/{x}/{y}.png" },
+  // NOTE: landslide HAZARD is intentionally absent — the catalog only publishes
+  // landslide risk (the hazard tile 403s for everyone). Landslide uses risk.
 };
 
 // Track failed tile URLs to avoid repeated 404s (cache for 1 hour)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -426,13 +426,13 @@ Include showMap: true on a question only when the user genuinely needs the map t
 
 ## Available layers
 OSM (vector): osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles (raster): poa_flood_hazard (Flood Hazard), poa_heat_hazard (Heat Hazard), poa_landslide_hazard (Landslide Hazard), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
+Tiles (raster): poa_flood_hazard (Flood Hazard), poa_heat_hazard (Heat Hazard), risk_landslide_250m (Landslide Risk), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_schools_heat_250m, sq_schools_landslide_250m
 
 ## Recipes
-- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
-- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
-- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
+- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
+- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
 - Environmental analysis: sample + [] + [poa_flood_hazard, poa_heat_hazard, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
@@ -1159,12 +1159,12 @@ Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
     case 2:
       return isPt
         ? `**Fase 2: Onde Atuamos** (intervention_site)
-Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Selecione seu bairro, depois escolha os locais" }).
+Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","risk_landslide_250m"], showLegendSimple: true, prompt: "Selecione seu bairro, depois escolha os locais" }).
 Após seleção: perguntar condições atuais, população, posse do terreno, engajamento comunitário.
 Se desenharem ponto/área customizada: perguntar "Esse local tem um nome?"
 Pedir fotos do local. Avaliar: Controle do Local (0-3), Ancoragem Comunitária (0-3).`
         : `**Phase 2: Where We Work** (intervention_site)
-Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Select your neighborhood, then pick sites" }).
+Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","risk_landslide_250m"], showLegendSimple: true, prompt: "Select your neighborhood, then pick sites" }).
 After selection: ask current conditions, population, land tenure, community engagement.
 If they draw custom point/area: ask "Does this site have a name?"
 Ask for site photos. Score: Site Control (0-3), Community Anchoring (0-3).`;

--- a/server/services/conceptNoteAgent.ts
+++ b/server/services/conceptNoteAgent.ts
@@ -224,13 +224,13 @@ function createConceptNoteToolsForSdk(noteId: string) {
 
 ## Available layers
 OSM: osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles: poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
+Tiles: poa_flood_hazard, poa_heat_hazard, risk_landslide_250m, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_schools_heat_250m, sq_schools_landslide_250m
 
 ## Recipes
-- Territorial scope (Phase 2): zones + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
-- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
-- Environmental evidence: sample + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard, oef_copernicus_dem]
+- Territorial scope (Phase 2): zones + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
+- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
+- Environmental evidence: sample + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
     {

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -8,7 +8,6 @@ export type LayerGroup =
   | 'risk_analysis'    // Existing: flood/heat/landslide from grid
   | 'flood_indices'    // Catalog poa_flood_hazard overlay
   | 'heat_indices'     // Catalog poa_heat_hazard overlay
-  | 'landslide_indices' // Catalog poa_landslide_hazard overlay
   | 'environment'      // Existing: elevation, landcover, water, rivers, forest
   | 'urban_land'       // New: Dynamic World, GHSL, VIIRS
   | 'ecology'          // New: NDVI, Hansen, Solar
@@ -110,14 +109,10 @@ export const HEAT_INDEX_LAYERS: TileLayerDef[] = [
   },
 ];
 
-// Landslide — catalog path is `landslides` (PLURAL, like `floods`).
-export const LANDSLIDE_INDEX_LAYERS: TileLayerDef[] = [
-  {
-    id: 'poa_landslide_hazard', name: 'Landslide Hazard', group: 'landslide_indices', color: '#a16207',
-    tileLayerId: 'poa_landslide_hazard', available: true, hasValueTiles: true,
-    valueEncoding: hazardIndexEncoding('landslides', 'hazard'),
-  },
-];
+// Landslide has NO hazard overlay — the catalog only publishes landslide RISK
+// (the hazard tile 403s for everyone). So landslide is represented solely by its
+// risk card (risk_landslide_250m → poa_landslide_risk) in LOCAL_RISK_LAYERS; there
+// is no LANDSLIDE_INDEX_LAYERS. (catalog path is `landslides`, PLURAL like `floods`.)
 
 // Groups for the layer selector UI
 export const TILE_LAYER_GROUPS: Array<{ id: LayerGroup; label: string }> = [
@@ -252,7 +247,6 @@ export const ALL_TILE_LAYERS: TileLayerDef[] = [
   ...LOCAL_RISK_LAYERS,
   ...FLOOD_INDEX_LAYERS,
   ...HEAT_INDEX_LAYERS,
-  ...LANDSLIDE_INDEX_LAYERS,
 ];
 
 /** The visual (RGB) tile URL template for a layer — its local override when set,


### PR DESCRIPTION
## Why the landslide hazard didn't load

Verified against S3: the catalog publishes landslide **risk** (`poa_landslide_risk`, 200) but **not** landslide **hazard** — `poa_landslide_hazard` returns **403 to everyone**, including the deploy. Flood and heat have *both* risk and hazard public; landslide only has risk. So the "Landslide hazard" overlay rendered **nothing** in the orchestrator and in site-explorer, while the risk card rendered fine. Nothing was wrong on our side — that tile just isn't available.

## Fix — point landslide at its risk layer, drop the dead hazard
- **orchestrator** `HAZARD_RASTER.landslide` → `poa_landslide_risk`.
- **geospatial-layers** — removed `LANDSLIDE_INDEX_LAYERS` + the `landslide_indices` group; landslide is now represented solely by its risk card (`risk_landslide_250m` → `poa_landslide_risk`), the same way flood/heat have risk cards. Removed from `ALL_TILE_LAYERS`.
- **tileProxyRoutes** — removed the dead `poa_landslide_hazard` entry.
- **site-explorer** — removed the `landslide_indices` group (the "Landslide Hazard" toggle that painted nothing); the "Landslide Risk (H×E×V)" card stays in Risk Analysis.
- **agents / skill** (encontro-2, cboAgent, conceptNoteAgent) — landslide overlay `poa_landslide_hazard` → `risk_landslide_250m`.
- e2e updated to the risk layer.

## On the green / legend
The landslide **risk** visual tile is fully opaque with the catalog's colormap (low = **green** → high = red), exactly like flood risk paints low = purple. So the city reads green = "low landslide risk", with the real signal concentrated on the hillsides. The legend cutting off the green low-end is a presentation quirk of using *risk* instead of a gap-free *hazard*. **If you want a clean gap-free landslide overlay, Mau needs to publish landslide HAZARD publicly** (like flood/heat).

## Separately — the `api/cohort/mine` 500 in your screenshot
That's unrelated to landslide: the `site` column added in #276 isn't in the deploy DB yet. **Run `npm run db:push`** (or the Replit DB SQL editor) against the deployment DB and the 500 clears.

Verify: `tsc` + build clean; landslide + risk-legend e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)