### PR TITLE
fix(cougar): restore landslide HAZARD overlay — catalog tiles are now public

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -194,15 +194,13 @@ const BAND_CHIP: Record<ReturnType<typeof maturityBand>, string> = {
 type RiskView = 'flood' | 'heat' | 'landslide' | 'risk';
 
 // Hazard raster overlays, fed LIVE from the data catalog via the tile proxy.
-// Flood + heat = the catalog poa_<haz>_HAZARD (gap-free, covers the whole
-// territory). Landslide uses poa_landslide_RISK — the catalog only publishes
-// landslide RISK (the hazard tile 403s for everyone), so risk is the only
-// available landslide layer. It's the validated H×E×V composite, masked to the
-// hillside/morro footprint (the rest reads as low/green).
+// All three = the catalog poa_<haz>_HAZARD (gap-free, covers the whole territory,
+// unlike the sparse H×E×V risk composite). The landslide hazard tiles are now
+// published publicly (they were briefly 403 — fixed on the catalog side).
 const HAZARD_RASTER: Record<'flood' | 'heat' | 'landslide', { url: string; attribution: string }> = {
-  flood:     { url: '/api/geospatial/tiles/poa_flood_hazard/{z}/{x}/{y}.png',   attribution: 'OEF catalog · flood hazard (interpolated)' },
-  heat:      { url: '/api/geospatial/tiles/poa_heat_hazard/{z}/{x}/{y}.png',    attribution: 'OEF catalog · heat hazard' },
-  landslide: { url: '/api/geospatial/tiles/poa_landslide_risk/{z}/{x}/{y}.png', attribution: 'OEF catalog · landslide risk (H×E×V)' },
+  flood:     { url: '/api/geospatial/tiles/poa_flood_hazard/{z}/{x}/{y}.png',     attribution: 'OEF catalog · flood hazard (interpolated)' },
+  heat:      { url: '/api/geospatial/tiles/poa_heat_hazard/{z}/{x}/{y}.png',      attribution: 'OEF catalog · heat hazard' },
+  landslide: { url: '/api/geospatial/tiles/poa_landslide_hazard/{z}/{x}/{y}.png', attribution: 'OEF catalog · landslide hazard' },
 };
 
 // Legend color ramps that MATCH each catalog overlay's actual colormap (sampled

--- a/client/src/core/pages/site-explorer.tsx
+++ b/client/src/core/pages/site-explorer.tsx
@@ -36,7 +36,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS } from '@shared/geospatial-layers';
+import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS, LANDSLIDE_INDEX_LAYERS } from '@shared/geospatial-layers';
 import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, TYPOLOGY_COLORS, type HazardKey } from '@shared/risk-display';
 import { LayerLegend } from '@/core/components/map/LayerLegend';
 import type { LegendIndex } from '@shared/legend-types';
@@ -81,7 +81,7 @@ interface CityInfo {
 }
 
 type LayerSource = 'geojson' | 'tiles';
-type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'flood_indices' | 'heat_indices' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
+type LayerGroupId = 'analysis' | 'environment' | 'reference_data' | 'osm_reference' | 'spatial_queries' | 'risk_250m' | 'flood_indices' | 'heat_indices' | 'landslide_indices' | 'urban_land' | 'ecology' | 'population' | 'hydrology' | 'climate_extreme' | 'climate_projections';
 
 interface LayerState {
   id: string;
@@ -171,8 +171,19 @@ const LAYER_CONFIGS: LayerConfig[] = [
     hasValueTiles: l.hasValueTiles,
     valueEncoding: l.valueEncoding,
   })),
-  // (No landslide hazard overlay — the catalog only publishes landslide RISK,
-  //  which appears as the "Landslide Risk (H×E×V)" card in the risk_250m group.)
+  // Landslide hazard overlay (catalog poa_landslide_hazard)
+  ...LANDSLIDE_INDEX_LAYERS.map(l => ({
+    id: l.id,
+    name: l.name,
+    icon: AlertTriangle,
+    color: l.color,
+    source: 'tiles' as LayerSource,
+    group: 'landslide_indices' as LayerGroupId,
+    available: true,
+    tileLayerId: l.tileLayerId,
+    hasValueTiles: l.hasValueTiles,
+    valueEncoding: l.valueEncoding,
+  })),
   // OEF tile layers — generated from shared catalog (48 layers)
   ...TILE_LAYERS.filter(l => l.available).map(l => ({
     id: l.id,
@@ -192,6 +203,7 @@ const LAYER_GROUPS: readonly { id: LayerGroupId; label: string }[] = [
   { id: 'risk_250m', label: 'Risk Analysis (250m)' },
   { id: 'flood_indices', label: 'Flood Indices' },
   { id: 'heat_indices', label: 'Heat Indices' },
+  { id: 'landslide_indices', label: 'Landslide Indices' },
   { id: 'reference_data', label: 'Reference Data' },
   { id: 'analysis', label: 'Intervention Zones' },
   { id: 'environment', label: 'Environment' },

--- a/e2e/cougar-e2-risk-legend.spec.ts
+++ b/e2e/cougar-e2-risk-legend.spec.ts
@@ -6,7 +6,7 @@ import { TestApi } from './helpers/testApi';
 // silently dropped because the microapp only resolved TILE_LAYERS). With
 // showLegendSimple the full toolkit collapses to a 3-chip hazard legend, each
 // chip toggling its overlay. The three chips only appear if the combined layer
-// registry resolves poa_flood_hazard / poa_heat_hazard / risk_landslide_250m.
+// registry resolves poa_flood_hazard / poa_heat_hazard / poa_landslide_hazard.
 
 test.describe('COUGAR — E2 simplified flood/heat/landslide risk legend', () => {
   test('the 3-risk legend renders, overlays auto-enable, and the landslide tile loads', async ({ page, request }) => {
@@ -19,7 +19,7 @@ test.describe('COUGAR — E2 simplified flood/heat/landslide risk legend', () =>
     // flood + heat — the old local /tiles/landslide_risk/ is gone).
     let landslideTileRequested = false;
     page.on('request', (r) => {
-      if (r.url().includes('/api/geospatial/tiles/poa_landslide_risk/')) landslideTileRequested = true;
+      if (r.url().includes('/api/geospatial/tiles/poa_landslide_hazard/')) landslideTileRequested = true;
     });
 
     await page.goto('/cbo-profile');
@@ -31,7 +31,7 @@ test.describe('COUGAR — E2 simplified flood/heat/landslide risk legend', () =>
       { op: 'say', text: 'Olha os riscos do seu bairro.' },
       { op: 'open_map', params: {
         selectionMode: 'browse-only',
-        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
+        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
         showLegendSimple: true,
         prompt: 'As cores mostram os riscos.',
         narrationOverlay: 'Azul = enchente · Vermelho = calor · Marrom = deslizamento.',

--- a/e2e/cougar-landslide-catalog.spec.ts
+++ b/e2e/cougar-landslide-catalog.spec.ts
@@ -2,21 +2,20 @@ import { test, expect } from '@playwright/test';
 import { TestApi } from './helpers/testApi';
 
 // Landslide catalog migration — the final hazard. The map overlays + tile proxy
-// now serve the catalog landslide layer (poa_landslide_risk H×E×V — the catalog
-// only publishes landslide RISK, not hazard), so all three hazards are catalog-
-// backed and the local landslide tiles are gone.
+// now serve the catalog landslide layers (poa_landslide_hazard overlay +
+// poa_landslide_risk H×E×V), so all three hazards are catalog-backed and the
+// local landslide tiles are gone.
 
 test.describe('COUGAR — map overlays use the catalog landslide layer', () => {
-  test('the tile proxy serves the catalog landslide risk layer', async ({ request }) => {
-    // Risk is publicly readable (200). Hazard is 403 outside the deploy network
-    // (same as flood/heat E/V) — it still serves via the proxy in production, so
-    // we don't assert it here.
-    const r = await request.get('/api/geospatial/tiles/poa_landslide_risk/13/2930/4813.png');
-    expect(r.status(), 'poa_landslide_risk should proxy 200 from the catalog').toBe(200);
-    expect((r.headers()['content-type'] || '')).toContain('image/png');
+  test('the tile proxy serves the catalog landslide hazard + risk layers', async ({ request }) => {
+    for (const id of ['poa_landslide_hazard', 'poa_landslide_risk']) {
+      const r = await request.get(`/api/geospatial/tiles/${id}/13/2930/4813.png`);
+      expect(r.status(), `${id} should proxy 200 from the catalog`).toBe(200);
+      expect((r.headers()['content-type'] || '')).toContain('image/png');
+    }
   });
 
-  test('a CBO open_map with the landslide risk layer renders the catalog overlay', async ({ page, request }) => {
+  test('a CBO open_map with poa_landslide_hazard renders the catalog overlay', async ({ page, request }) => {
     const api = new TestApi(request);
     const ping = await api.ping();
     test.skip(!ping.fakeModel, 'needs the fake model');
@@ -31,7 +30,7 @@ test.describe('COUGAR — map overlays use the catalog landslide layer', () => {
       { op: 'say', text: 'Olha os riscos do seu bairro.' },
       { op: 'open_map', params: {
         selectionMode: 'browse-only',
-        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
+        tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
         showLegendSimple: true,
         prompt: 'As cores mostram os riscos.',
       } },

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -108,7 +108,7 @@ open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
   layers: ['osm_parks', 'osm_schools', 'osm_wetlands'],
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
   showLegendSimple: true,
   prompt: 'Marca onde vocês querem atuar — primeiro o bairro, depois o lugar específico.'
 })
@@ -121,7 +121,7 @@ First, exploration mode with a narration banner. The user can scroll the map, to
 ```
 open_map({
   selectionMode: 'browse-only',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
   showLegendSimple: true,
   prompt: 'Olha o seu bairro. As cores mostram os riscos.',
   narrationOverlay: 'Azul = enchente. Vermelho = calor. Marrom = deslizamento. Toque "Voltar ao chat" quando quiser.'
@@ -140,7 +140,7 @@ Listen for cues. If they name a spot, transition to Beat 2b. If they're still un
 open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhoods',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'risk_landslide_250m'],
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
   showLegendSimple: true,
   prompt: 'Agora marca o lugar específico onde vocês querem atuar.'
 })

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -120,8 +120,7 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
   poa_heat_risk:         { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_hazard:       { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/hazard/tiles_visual/{z}/{x}/{y}.png" },
   poa_landslide_risk:    { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/risk/tiles_visual/{z}/{x}/{y}.png" },
-  // NOTE: landslide HAZARD is intentionally absent — the catalog only publishes
-  // landslide risk (the hazard tile 403s for everyone). Landslide uses risk.
+  poa_landslide_hazard:  { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/hazard/tiles_visual/{z}/{x}/{y}.png" },
 };
 
 // Track failed tile URLs to avoid repeated 404s (cache for 1 hour)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -426,13 +426,13 @@ Include showMap: true on a question only when the user genuinely needs the map t
 
 ## Available layers
 OSM (vector): osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles (raster): poa_flood_hazard (Flood Hazard), poa_heat_hazard (Heat Hazard), risk_landslide_250m (Landslide Risk), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
+Tiles (raster): poa_flood_hazard (Flood Hazard), poa_heat_hazard (Heat Hazard), poa_landslide_hazard (Landslide Hazard), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_schools_heat_250m, sq_schools_landslide_250m
 
 ## Recipes
-- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
-- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
-- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
+- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+- CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+- Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
 - Environmental analysis: sample + [] + [poa_flood_hazard, poa_heat_hazard, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
@@ -1159,12 +1159,12 @@ Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
     case 2:
       return isPt
         ? `**Fase 2: Onde Atuamos** (intervention_site)
-Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","risk_landslide_250m"], showLegendSimple: true, prompt: "Selecione seu bairro, depois escolha os locais" }).
+Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Selecione seu bairro, depois escolha os locais" }).
 Após seleção: perguntar condições atuais, população, posse do terreno, engajamento comunitário.
 Se desenharem ponto/área customizada: perguntar "Esse local tem um nome?"
 Pedir fotos do local. Avaliar: Controle do Local (0-3), Ancoragem Comunitária (0-3).`
         : `**Phase 2: Where We Work** (intervention_site)
-Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","risk_landslide_250m"], showLegendSimple: true, prompt: "Select your neighborhood, then pick sites" }).
+Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Select your neighborhood, then pick sites" }).
 After selection: ask current conditions, population, land tenure, community engagement.
 If they draw custom point/area: ask "Does this site have a name?"
 Ask for site photos. Score: Site Control (0-3), Community Anchoring (0-3).`;

--- a/server/services/conceptNoteAgent.ts
+++ b/server/services/conceptNoteAgent.ts
@@ -224,13 +224,13 @@ function createConceptNoteToolsForSdk(noteId: string) {
 
 ## Available layers
 OSM: osm_parks, osm_schools, osm_hospitals, osm_wetlands
-Tiles: poa_flood_hazard, poa_heat_hazard, risk_landslide_250m, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
+Tiles: poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard, oef_dynamic_world, oef_copernicus_dem, oef_ghsl_population, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_schools_heat_250m, sq_schools_landslide_250m
 
 ## Recipes
-- Territorial scope (Phase 2): zones + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
-- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m]
-- Environmental evidence: sample + [] + [poa_flood_hazard, poa_heat_hazard, risk_landslide_250m, oef_copernicus_dem]
+- Territorial scope (Phase 2): zones + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+- Intervention sites (Phase 3): composite + [osm_parks, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+- Environmental evidence: sample + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
     {

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -8,6 +8,7 @@ export type LayerGroup =
   | 'risk_analysis'    // Existing: flood/heat/landslide from grid
   | 'flood_indices'    // Catalog poa_flood_hazard overlay
   | 'heat_indices'     // Catalog poa_heat_hazard overlay
+  | 'landslide_indices' // Catalog poa_landslide_hazard overlay
   | 'environment'      // Existing: elevation, landcover, water, rivers, forest
   | 'urban_land'       // New: Dynamic World, GHSL, VIIRS
   | 'ecology'          // New: NDVI, Hansen, Solar
@@ -109,10 +110,14 @@ export const HEAT_INDEX_LAYERS: TileLayerDef[] = [
   },
 ];
 
-// Landslide has NO hazard overlay — the catalog only publishes landslide RISK
-// (the hazard tile 403s for everyone). So landslide is represented solely by its
-// risk card (risk_landslide_250m → poa_landslide_risk) in LOCAL_RISK_LAYERS; there
-// is no LANDSLIDE_INDEX_LAYERS. (catalog path is `landslides`, PLURAL like `floods`.)
+// Landslide hazard overlay — catalog path is `landslides` (PLURAL, like `floods`).
+export const LANDSLIDE_INDEX_LAYERS: TileLayerDef[] = [
+  {
+    id: 'poa_landslide_hazard', name: 'Landslide Hazard', group: 'landslide_indices', color: '#a16207',
+    tileLayerId: 'poa_landslide_hazard', available: true, hasValueTiles: true,
+    valueEncoding: hazardIndexEncoding('landslides', 'hazard'),
+  },
+];
 
 // Groups for the layer selector UI
 export const TILE_LAYER_GROUPS: Array<{ id: LayerGroup; label: string }> = [
@@ -247,6 +252,7 @@ export const ALL_TILE_LAYERS: TileLayerDef[] = [
   ...LOCAL_RISK_LAYERS,
   ...FLOOD_INDEX_LAYERS,
   ...HEAT_INDEX_LAYERS,
+  ...LANDSLIDE_INDEX_LAYERS,
 ];
 
 /** The visual (RGB) tile URL template for a layer — its local override when set,


### PR DESCRIPTION
**The catalog now serves the landslide hazard tiles publicly** — verified just now: `poa_landslide_hazard` returns **200 on 106/120 tiles** across z11–13 (the same coverage as flood/heat hazard + landslide risk; the 14 edge tiles 403 like every layer). The ACL gap was fixed on the catalog side (tile re-uploaded 23 Jun 21:08 GMT).

So landslide goes back to its **gap-free hazard overlay**, consistent with flood/heat — reverting the interim #278 "use risk" workaround:
- **orchestrator** `HAZARD_RASTER.landslide` → `poa_landslide_hazard`.
- **tileProxyRoutes** — `poa_landslide_hazard` restored.
- **geospatial-layers** — `LANDSLIDE_INDEX_LAYERS` + the `landslide_indices` group restored (LayerGroup, ALL_TILE_LAYERS).
- **site-explorer** — `landslide_indices` plumbing restored (the "Landslide Hazard" toggle).
- **agents / skill** — landslide overlay `risk_landslide_250m` → `poa_landslide_hazard`.
- **e2e** — proxy test now asserts `poa_landslide_hazard` → **200**; the CBO `open_map` uses it.

The **"Hazard intensity" legend** added in #278 stays — landslide's ramp (green→yellow→red) already matches the hazard colormap (I re-sampled the now-live hazard tiles to confirm). Zone scores/ranks are **unaffected** (those are sampled from landslide *risk*; the hazard is purely the visual overlay), so no pipeline re-run needed.

Verify: full cougar gate **20/20** (incl. the proxy serving the live hazard tile + the CBO overlay), `tsc` + build clean.

> Rebuild + republish to see it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)