### PR TITLE
Orchestrator: per-CBO files drawer + file-count chip (PR 1/2)

### DIFF
--- a/client/src/core/components/cbo-files/CboFilesView.tsx
+++ b/client/src/core/components/cbo-files/CboFilesView.tsx
@@ -1,0 +1,236 @@
+/**
+ * Shared evidence viewer — lists a CBO's uploaded files and previews/opens them.
+ *
+ * Presentational + self-contained: the caller supplies the document list and two
+ * URL/loader callbacks, so the SAME component powers the coordinator drawer
+ * (orchestrator) and the CBO's own bottom sheet (mobile chat). Master-detail:
+ * a file list; tapping a file opens its preview with a back affordance — which
+ * reads cleanly in both a narrow side-drawer and a mobile bottom sheet.
+ *
+ * Preview strategy (graceful degradation):
+ *   - image/*           → inline <img>
+ *   - application/pdf    → inline <iframe> on desktop; "open" button on mobile
+ *                          (iOS Safari renders PDF-in-iframe unreliably)
+ *   - everything else    → the agent's extracted text (fetched on demand)
+ *   - no original blob   → extracted text only, with a note
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Paperclip, FileText, Image as ImageIcon, FileSpreadsheet, Music, File,
+  Download, ExternalLink, ChevronLeft, Loader2,
+} from 'lucide-react';
+import type { DocumentMeta, DocumentKind } from '@shared/document-schema';
+import { Button } from '@/core/components/ui/button';
+
+const KIND_ICON: Record<DocumentKind, typeof FileText> = {
+  pdf: FileText,
+  docx: FileText,
+  xlsx: FileSpreadsheet,
+  text: FileText,
+  image: ImageIcon,
+  audio: Music,
+  other: File,
+};
+
+function iconFor(doc: DocumentMeta) {
+  return (doc.kind && KIND_ICON[doc.kind]) || File;
+}
+
+function formatSize(bytes: number | null): string {
+  if (!bytes || bytes <= 0) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export type CboFilesViewProps = {
+  documents: DocumentMeta[];
+  loading?: boolean;
+  error?: string | null;
+  /** Builds the URL that streams a document's original blob. */
+  originalUrl: (docId: string) => string;
+  /** Fetches the agent's extracted text for a document (fallback / non-previewable). */
+  fetchText: (docId: string) => Promise<string>;
+  /** On mobile, prefer an "open" button over an inline PDF iframe. */
+  preferOpenOverIframe?: boolean;
+};
+
+export function CboFilesView({
+  documents,
+  loading,
+  error,
+  originalUrl,
+  fetchText,
+  preferOpenOverIframe = false,
+}: CboFilesViewProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language?.startsWith('pt') ? 'pt-BR' : 'en-US';
+  const [selected, setSelected] = useState<DocumentMeta | null>(null);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+  if (error) {
+    return <div className="py-12 text-center text-sm text-destructive">{error}</div>;
+  }
+  if (documents.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+        <Paperclip className="w-7 h-7 mb-2 opacity-40" />
+        <p className="text-sm">
+          {t('files.empty', { defaultValue: 'No files shared yet.' })}
+        </p>
+      </div>
+    );
+  }
+
+  if (selected) {
+    return (
+      <FilePreview
+        doc={selected}
+        onBack={() => setSelected(null)}
+        originalUrl={originalUrl}
+        fetchText={fetchText}
+        preferOpenOverIframe={preferOpenOverIframe}
+      />
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-foreground/5">
+      {documents.map(doc => {
+        const Icon = iconFor(doc);
+        const date = doc.createdAt
+          ? new Date(doc.createdAt).toLocaleDateString(locale, { day: '2-digit', month: 'short' })
+          : '';
+        return (
+          <li key={doc.id}>
+            <button
+              type="button"
+              onClick={() => setSelected(doc)}
+              className="w-full flex items-center gap-3 py-2.5 px-1 text-left hover:bg-foreground/5 rounded-md transition-colors"
+              data-testid={`file-row-${doc.id}`}
+            >
+              <span className="shrink-0 w-9 h-9 rounded-lg bg-foreground/[0.04] flex items-center justify-center text-foreground/60">
+                <Icon className="w-4 h-4" strokeWidth={1.75} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium truncate">{doc.filename}</span>
+                <span className="block text-[11px] text-muted-foreground truncate">
+                  {[
+                    formatSize(doc.sizeBytes),
+                    doc.droppedInPhase
+                      ? t('files.fromEncontro', { defaultValue: 'Encontro {{n}}', n: doc.droppedInPhase })
+                      : '',
+                    date,
+                  ].filter(Boolean).join(' · ')}
+                </span>
+              </span>
+              <ChevronLeft className="w-4 h-4 text-muted-foreground rotate-180 shrink-0" />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function FilePreview({
+  doc,
+  onBack,
+  originalUrl,
+  fetchText,
+  preferOpenOverIframe,
+}: {
+  doc: DocumentMeta;
+  onBack: () => void;
+  originalUrl: (docId: string) => string;
+  fetchText: (docId: string) => Promise<string>;
+  preferOpenOverIframe: boolean;
+}) {
+  const { t } = useTranslation();
+  const [text, setText] = useState<string | null>(null);
+  const [loadingText, setLoadingText] = useState(false);
+  const url = originalUrl(doc.id);
+  const isImage = doc.mimeType?.startsWith('image/') || doc.kind === 'image';
+  const isPdf = doc.mimeType === 'application/pdf' || doc.kind === 'pdf';
+  const canInlinePdf = isPdf && doc.hasOriginal && !preferOpenOverIframe;
+  // Anything we can't render visually → show the extracted text.
+  const needsText = !doc.hasOriginal || (!isImage && !canInlinePdf);
+
+  const loadText = async () => {
+    if (text !== null || loadingText) return;
+    setLoadingText(true);
+    try {
+      setText(await fetchText(doc.id));
+    } catch {
+      setText('');
+    } finally {
+      setLoadingText(false);
+    }
+  };
+  if (needsText) void loadText();
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-2 pb-2 mb-2 border-b border-foreground/5">
+        <Button variant="ghost" size="sm" onClick={onBack} className="shrink-0 -ml-2" data-testid="file-preview-back">
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          {t('files.back', { defaultValue: 'Files' })}
+        </Button>
+        <span className="text-sm font-medium truncate flex-1">{doc.filename}</span>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {isImage && doc.hasOriginal && (
+          <img src={url} alt={doc.filename} className="max-w-full max-h-[60vh] mx-auto object-contain rounded-lg" />
+        )}
+        {canInlinePdf && (
+          <iframe src={url} title={doc.filename} className="w-full h-[60vh] rounded-lg border border-foreground/10" />
+        )}
+        {needsText && (
+          <div className="text-sm">
+            {!doc.hasOriginal && (
+              <p className="text-[11px] text-muted-foreground mb-2">
+                {t('files.noOriginalNote', { defaultValue: 'Original not stored — showing the extracted text.' })}
+              </p>
+            )}
+            {loadingText ? (
+              <div className="flex items-center justify-center py-10 text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+              </div>
+            ) : text ? (
+              <pre className="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-foreground/85">{text}</pre>
+            ) : (
+              <p className="text-muted-foreground py-6 text-center">
+                {t('files.noPreview', { defaultValue: 'No preview available.' })}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {doc.hasOriginal && (
+        <div className="flex items-center gap-2 pt-3 mt-2 border-t border-foreground/5">
+          <Button asChild variant="outline" size="sm" className="flex-1">
+            <a href={url} target="_blank" rel="noopener noreferrer" data-testid="file-open">
+              <ExternalLink className="w-4 h-4 mr-1.5" />
+              {t('files.open', { defaultValue: 'Open' })}
+            </a>
+          </Button>
+          <Button asChild variant="outline" size="sm" className="flex-1">
+            <a href={url} download={doc.filename} data-testid="file-download">
+              <Download className="w-4 h-4 mr-1.5" />
+              {t('files.download', { defaultValue: 'Download' })}
+            </a>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/core/components/orchestrator/CboFilesDrawer.tsx
+++ b/client/src/core/components/orchestrator/CboFilesDrawer.tsx
@@ -1,0 +1,76 @@
+/**
+ * Coordinator-side evidence drawer — the files a single CBO has uploaded.
+ * Opens from the 📎 file-count chip on an orchestrator card; renders the shared
+ * <CboFilesView> inside a right-hand Sheet. Reads are scoped + ownership-gated
+ * server-side (/api/cohort/:slug/member/:id/documents).
+ */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle,
+} from '@/core/components/ui/sheet';
+import { CboFilesView } from '@/core/components/cbo-files/CboFilesView';
+import type { DocumentMeta } from '@shared/document-schema';
+
+export type FilesDrawerMember = { id: string; orgName: string };
+
+export function CboFilesDrawer({
+  cohortSlug,
+  member,
+  onClose,
+}: {
+  cohortSlug: string | null;
+  member: FilesDrawerMember | null;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const [docs, setDocs] = useState<DocumentMeta[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!member || !cohortSlug) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/cohort/${cohortSlug}/member/${member.id}/documents`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then(data => { if (!cancelled) setDocs(data.documents ?? []); })
+      .catch(() => { if (!cancelled) setError(t('files.loadError', { defaultValue: 'Could not load files.' })); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [member, cohortSlug, t]);
+
+  const fetchText = async (docId: string): Promise<string> => {
+    if (!member || !cohortSlug) return '';
+    const r = await fetch(
+      `/api/cohort/${cohortSlug}/member/${member.id}/documents/${docId}/text`,
+      { credentials: 'include' },
+    );
+    if (!r.ok) return '';
+    const data = await r.json();
+    return data.fullText ?? '';
+  };
+
+  return (
+    <Sheet open={!!member} onOpenChange={open => { if (!open) onClose(); }}>
+      <SheetContent side="right" className="w-full sm:max-w-md flex flex-col" data-testid="cbo-files-drawer">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            {t('files.title', { defaultValue: 'Files' })}
+            {member && <span className="text-muted-foreground font-normal">· {member.orgName}</span>}
+          </SheetTitle>
+        </SheetHeader>
+        <div className="flex-1 min-h-0 overflow-auto mt-2">
+          <CboFilesView
+            documents={docs}
+            loading={loading}
+            error={error}
+            originalUrl={docId => `/api/documents/${docId}/original`}
+            fetchText={fetchText}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
-  Mountain, Network, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
+  Mountain, Network, Paperclip, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
@@ -46,6 +46,7 @@ import {
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 import { SupportInbox } from '@/core/components/orchestrator/SupportInbox';
 import { LanguageSwitcher } from '@/core/components/i18n/language-switcher';
+import { CboFilesDrawer, type FilesDrawerMember } from '@/core/components/orchestrator/CboFilesDrawer';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -92,6 +93,8 @@ type CboDemoProject = {
   /** Count of unresolved RequestSupport entries — surfaces an amber chip
    *  on the card so the coordinator can sweep pendencies daily. */
   supportPendingCount: number;
+  /** How many files this CBO has uploaded — drives the 📎 chip + files drawer. */
+  documentCount: number;
 };
 
 const TOTAL_SECTIONS = 7;
@@ -146,6 +149,7 @@ function memberToView(m: CohortMember): CboDemoProject {
     supportPendingCount: Array.isArray((m as any).supportRequests)
       ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
       : 0,
+    documentCount: (m as any).documentCount ?? 0,
   };
 }
 
@@ -534,12 +538,14 @@ function ProjectCard({
   selected,
   onHover,
   onOpen,
+  onOpenFiles,
 }: {
   project: CboDemoProject;
   locale: 'en' | 'pt';
   selected: boolean;
   onHover: (id: string | null) => void;
   onOpen: (p: CboDemoProject) => void;
+  onOpenFiles: (p: CboDemoProject) => void;
 }) {
   const { t } = useTranslation();
   const hasIntervention = project.interventionKey !== null;
@@ -554,13 +560,15 @@ function ProjectCard({
   const sectionsPct = Math.round((project.sectionsComplete / TOTAL_SECTIONS) * 100);
 
   return (
-    <button
-      type="button"
-      className="group text-left w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 rounded-xl"
+    <div
+      role="button"
+      tabIndex={0}
+      className="group text-left w-full cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 rounded-xl"
       onMouseEnter={() => onHover(project.id)}
       onMouseLeave={() => onHover(null)}
       onFocus={() => onHover(project.id)}
       onClick={() => onOpen(project)}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpen(project); } }}
       data-testid={`card-orchestrator-project-${project.id}`}
     >
       <Card
@@ -633,6 +641,18 @@ function ProjectCard({
                 })}
               </span>
             )}
+            {project.documentCount > 0 && (
+              <button
+                type="button"
+                onClick={e => { e.stopPropagation(); onOpenFiles(project); }}
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-sky-50 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300 border border-sky-200/60 dark:border-sky-900/40 hover:bg-sky-100 dark:hover:bg-sky-900/50 transition-colors"
+                title={t('orchestrator.files.chipTooltip', { defaultValue: '{{n}} file(s) shared — tap to view', n: project.documentCount })}
+                data-testid={`button-cbo-files-${project.id}`}
+              >
+                <Paperclip className="w-3 h-3" strokeWidth={2} />
+                {project.documentCount}
+              </button>
+            )}
             {hasIntervention ? (
               <span
                 className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}
@@ -701,7 +721,7 @@ function ProjectCard({
           </div>
         </CardContent>
       </Card>
-    </button>
+    </div>
   );
 }
 
@@ -811,6 +831,8 @@ export default function OrchestratorLandingPage() {
   // the inbox trigger. Initialized from member.supportRequests when the
   // cohort loads (below).
   const [supportInboxPendingCount, setSupportInboxPendingCount] = useState(0);
+  // Which CBO's uploaded files the coordinator is viewing (null = drawer closed).
+  const [filesMember, setFilesMember] = useState<FilesDrawerMember | null>(null);
 
   const openShare = (url: string, ctx: typeof shareContext) => {
     setShareUrl(url);
@@ -826,6 +848,10 @@ export default function OrchestratorLandingPage() {
         { kind: 'cbo', orgName: member.orgName }
       );
     }
+  };
+
+  const openFiles = (p: CboDemoProject) => {
+    setFilesMember({ id: p.id, orgName: p.name[locale] });
   };
 
   const handleUnlockNext = async (member: CohortMember) => {
@@ -999,6 +1025,11 @@ export default function OrchestratorLandingPage() {
           onCountChange={setSupportInboxPendingCount}
         />
       )}
+      <CboFilesDrawer
+        cohortSlug={cohort?.coordinatorSlug ?? null}
+        member={filesMember}
+        onClose={() => setFilesMember(null)}
+      />
 
       <main className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
         {/* Cohort header — singleton model. One cohort for the pilot,
@@ -1209,6 +1240,7 @@ export default function OrchestratorLandingPage() {
                     selected={selectedId === p.id}
                     onHover={setSelectedId}
                     onOpen={openProject}
+                    onOpenFiles={openFiles}
                   />
                   {member && (
                     <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -293,6 +293,9 @@
         "description": "Revisão final do perfil do projeto com a coordenação. O CBO ajusta o que quiser antes de exportar e recebe a nota conceito do projeto, que pode ser compartilhada com financiadores e parceiros.",
         "expectedOutput": "Uma nota conceito do projeto exportada (PDF ou markdown) pronta para compartilhar. Um plano claro de próximos passos: quais financiadores procurar, quais autorizações buscar, quais parceiros técnicos envolver."
       }
+    },
+    "files": {
+      "chipTooltip": "{{n}} arquivo(s) compartilhado(s) — toque para ver"
     }
   },
   "citySelection": {
@@ -2051,5 +2054,16 @@
     "nextSites": "Próximo: Selecionar locais",
     "loading": "Carregando...",
     "clickToSelect": "clique para selecionar"
+  },
+  "files": {
+    "title": "Arquivos",
+    "back": "Arquivos",
+    "empty": "Nenhum arquivo compartilhado ainda.",
+    "fromEncontro": "Encontro {{n}}",
+    "open": "Abrir",
+    "download": "Baixar",
+    "noPreview": "Sem pré-visualização.",
+    "noOriginalNote": "Original não armazenado — mostrando o texto extraído.",
+    "loadError": "Não foi possível carregar os arquivos."
   }
 }

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,7 +1,14 @@
 import type { Express, Request, Response, RequestHandler } from 'express';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
+import {
+  listDocumentsByOrg,
+  getDocumentForOrg,
+  getOrgIdForCboState,
+  countDocumentsByOrgIds,
+  toDocumentMeta,
+} from '../services/documentPersistence';
 import {
   cohorts,
   cohortMembers,
@@ -162,6 +169,24 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
   };
 }
 
+// Attach each CBO's uploaded-document count to roster rows (one grouped query,
+// no N+1) so the orchestrator cards can show a 📎 file-count chip.
+async function attachDocCounts<T extends { orgId: string | null }>(
+  members: T[],
+): Promise<(T & { documentCount: number })[]> {
+  const counts = await countDocumentsByOrgIds(
+    members.map(m => m.orgId).filter((x): x is string => !!x),
+  );
+  return members.map(m => ({ ...m, documentCount: m.orgId ? counts.get(m.orgId) ?? 0 : 0 }));
+}
+
+// Resolve the owning org for a roster member — prefers the member's own org_id
+// (set at invite), falling back to the linked working profile's org.
+async function resolveMemberOrgId(member: typeof cohortMembers.$inferSelect): Promise<string | null> {
+  if (member.orgId) return member.orgId;
+  return member.cboStateId ? getOrgIdForCboState(member.cboStateId) : null;
+}
+
 export function registerCohortRoutes(app: Express): void {
   // Phase 3c-ii — gate the entire coordinator surface behind a coordinator
   // session. Every /api/cohort/* route is coordinator-facing (the CBO-facing
@@ -201,7 +226,7 @@ export function registerCohortRoutes(app: Express): void {
       cohort = c;
     }
     if (!cohort) cohort = await getOrCreateDefaultCohort();
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     res.json({ cohort, members, isAdmin: !coordinator?.cohortId });
   }));
 
@@ -274,7 +299,7 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/default', wrap(async (req, res) => {
     const cohort = await getOrCreateDefaultCohort();
     if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     res.json({ cohort, members });
   }));
 
@@ -338,8 +363,42 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     res.json({ cohort, members });
+  }));
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Evidence locker (coordinator side) — list / read a CBO's uploaded files.
+  // Ownership-enforced by the :coordinatorSlug app.param guard above; we also
+  // confirm the member belongs to THIS cohort, then scope documents to the
+  // member's org so one cohort can't read another's files.
+  // ──────────────────────────────────────────────────────────────────────
+  async function memberInCohort(req: Request): Promise<typeof cohortMembers.$inferSelect | null> {
+    const cohort = (req as any).cohort as { id: string } | undefined;
+    if (!cohort) return null;
+    const [member] = await db.select().from(cohortMembers)
+      .where(and(eq(cohortMembers.id, req.params.memberId), eq(cohortMembers.cohortId, cohort.id)))
+      .limit(1);
+    return member ?? null;
+  }
+
+  app.get('/api/cohort/:coordinatorSlug/member/:memberId/documents', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    const orgId = await resolveMemberOrgId(member);
+    if (!orgId) { res.json({ documents: [] }); return; }
+    const docs = await listDocumentsByOrg(orgId);
+    res.json({ documents: docs.map(toDocumentMeta) });
+  }));
+
+  app.get('/api/cohort/:coordinatorSlug/member/:memberId/documents/:docId/text', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    const orgId = await resolveMemberOrgId(member);
+    if (!orgId) { res.status(404).json({ error: 'not found' }); return; }
+    const doc = await getDocumentForOrg(req.params.docId, orgId);
+    if (!doc) { res.status(404).json({ error: 'not found' }); return; }
+    res.json({ fullText: doc.fullText ?? '', summary: doc.summary ?? null });
   }));
 
   // Invite a CBO — slugs are human-readable, derived from the org name.
@@ -437,7 +496,7 @@ export function registerCohortRoutes(app: Express): void {
     const phaseNum = Number(phase);
     if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
 
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     const targets = memberIds === 'all'
       ? members
       : members.filter(m => Array.isArray(memberIds) && memberIds.includes(m.id));
@@ -508,7 +567,7 @@ export function registerCohortRoutes(app: Express): void {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
     const filter = String(req.query.status ?? 'all');
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     const items: Array<{
       requestId: string;
       memberId: string;
@@ -577,7 +636,7 @@ export function registerCohortRoutes(app: Express): void {
     const { resolvedNote } = req.body ?? {};
     const note = typeof resolvedNote === 'string' && resolvedNote.trim() ? resolvedNote.trim().slice(0, 1000) : null;
 
-    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
     for (const m of members) {
       const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
       const idx = arr.findIndex(r => r.id === req.params.requestId);

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -1,9 +1,24 @@
 // Per-org document store persistence (see docs/cbo-platform-architecture.md).
 
 import { db } from '../db';
-import { documents, type DocumentRow, type DocumentKind } from '@shared/document-schema';
+import { documents, type DocumentRow, type DocumentKind, type DocumentMeta } from '@shared/document-schema';
 import { cboStates } from '@shared/cbo-db-schema';
-import { eq, desc, and } from 'drizzle-orm';
+import { eq, desc, and, inArray, sql } from 'drizzle-orm';
+
+/** Strip a document row down to the client-facing metadata (no fullText/blob key). */
+export function toDocumentMeta(d: DocumentRow): DocumentMeta {
+  return {
+    id: d.id,
+    filename: d.filename,
+    mimeType: d.mimeType,
+    kind: d.kind,
+    sizeBytes: d.sizeBytes,
+    droppedInPhase: d.droppedInPhase,
+    summary: d.summary,
+    createdAt: d.createdAt ? new Date(d.createdAt).toISOString() : null,
+    hasOriginal: !!d.storageKey,
+  };
+}
 
 /** The owning org of a CBO working profile (org_id was linked in Phase 1). */
 export async function getOrgIdForCboState(cboStateId: string): Promise<string | null> {
@@ -41,6 +56,21 @@ export async function createDocument(input: {
 /** All of an org's documents, newest first. The evidence locker for the agent. */
 export async function listDocumentsByOrg(orgId: string): Promise<DocumentRow[]> {
   return db.select().from(documents).where(eq(documents.orgId, orgId)).orderBy(desc(documents.createdAt));
+}
+
+/** Document counts for a set of orgs, in one grouped query — powers the per-CBO
+ *  file-count chip on the orchestrator cards without an N+1. */
+export async function countDocumentsByOrgIds(orgIds: string[]): Promise<Map<string, number>> {
+  const ids = orgIds.filter((id): id is string => !!id);
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .select({ orgId: documents.orgId, n: sql<number>`count(*)::int` })
+    .from(documents)
+    .where(inArray(documents.orgId, ids))
+    .groupBy(documents.orgId);
+  const counts = new Map<string, number>();
+  for (const r of rows) if (r.orgId) counts.set(r.orgId, Number(r.n));
+  return counts;
 }
 
 /** A single document, scoped to its org so one org can't read another's files. */

--- a/shared/document-schema.ts
+++ b/shared/document-schema.ts
@@ -42,3 +42,19 @@ export const documents = pgTable('documents', {
 
 export type DocumentRow = typeof documents.$inferSelect;
 export type NewDocument = typeof documents.$inferInsert;
+
+// Lightweight, client-facing view of a document — what the evidence viewers
+// (coordinator drawer + CBO bottom sheet) list. Deliberately omits `fullText`
+// (fetched on demand) and `storageKey` (surfaced only as `hasOriginal`).
+export type DocumentMeta = {
+  id: string;
+  filename: string;
+  mimeType: string | null;
+  kind: DocumentKind | null;
+  sizeBytes: number | null;
+  droppedInPhase: number | null;
+  summary: string | null;
+  createdAt: string | null;
+  /** Whether a durable original blob exists to preview/open (Phase 2b). */
+  hasOriginal: boolean;
+};


### PR DESCRIPTION
**PR 1 of 2** — coordinator side. (PR 2 adds the CBO's own files view in their mobile chat, reusing `CboFilesView`.)

## What
Coordinators can see + open the files each CBO uploaded, from the orchestrator. A `📎 N` chip on each CBO card opens a right-hand drawer listing that org's files with preview/open/download.

## Backend (ownership-gated by the existing `:coordinatorSlug` guard)
- `GET /api/cohort/:slug/member/:memberId/documents` — metadata list (resolves `member.orgId`, falls back to the linked `cbo_state` org; scoped via `listDocumentsByOrg`).
- `GET .../documents/:docId/text` — extracted-text fallback.
- `documentCount` on every roster row via one grouped `count(*)` query (`countDocumentsByOrgIds`, no N+1).
- `toDocumentMeta` + shared `DocumentMeta` type (omits `fullText`/`storageKey`; exposes `hasOriginal`).

## Frontend
- `CboFilesView` — shared master-detail viewer (list → preview): images inline, PDF iframe on desktop, **extracted-text fallback** when no original blob. Reused by PR 2.
- `CboFilesDrawer` — coordinator Sheet wrapper.
- `📎` chip on each card → drawer. Card outer became a keyboard-accessible `div` so the chip button nests validly (card click still opens the share dialog).
- pt.json keys (en uses inline defaults, per the language architecture).

## Notes
- Opening the *original* file needs blob storage (`BLOB_BUCKET_ID`) on prod; without it the drawer shows filename + extracted text (graceful).
- `GET /api/documents/:id/original` remains open-by-UUID (Phase-3 gating deferred); the new list endpoints are scoped.

## Verified
tsc clean on changed files; production build succeeds.

## After merge
Rebuild + republish.