### PR TITLE
CBO files: make uploads visible (session-scoped) + file-card chat bubble

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -40,6 +40,15 @@ import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
 import { RiskPriorityChips, type HazardId } from '@/core/components/cbo/RiskPriorityChips';
 import { CommunityAnchoringComposer, type CommunityAnchoringResult } from '@/core/components/cbo/CommunityAnchoringComposer';
 import { CboFilesSheet } from '@/core/components/cbo/CboFilesSheet';
+
+// Upload messages carry the parsed file content inline (so the agent can read
+// it), but in the chat we render them as a tidy file card instead of dumping the
+// raw text. Matches the two prompts the upload handlers send.
+const UPLOAD_MSG_RE = /^(?:I'm uploading: |Uploaded )"(.+?)"/;
+function parseUploadFilename(content: string): string | null {
+  const m = content.match(UPLOAD_MSG_RE);
+  return m ? m[1] : null;
+}
 import { LifeBuoy } from 'lucide-react';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
@@ -1084,15 +1093,29 @@ export default function CboProfilePage() {
               </div>
             )}
 
-            {messages.map((msg, i) => (
+            {messages.map((msg, i) => {
+              const uploadName = msg.role === 'user' ? parseUploadFilename(msg.content) : null;
+              return (
               <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div className={`max-w-[90%] rounded-lg px-4 py-2.5 ${msg.role === 'user' ? 'bg-green-600 text-white' : msg.messageType === 'thinking' ? 'bg-muted/50 border border-dashed border-muted-foreground/20' : 'bg-muted'}`}>
                   {msg.messageType === 'thinking' && <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('cbo.working')}</p>}
                   {msg.role === 'user' ? (
+                    uploadName ? (
+                      <button
+                        type="button"
+                        onClick={() => setFilesSheetOpen(true)}
+                        className="flex items-center gap-2 text-left"
+                        data-testid="chat-file-card"
+                      >
+                        <FileText className="w-4 h-4 shrink-0 opacity-90" />
+                        <span className="text-sm font-medium underline decoration-white/40 underline-offset-2">{uploadName}</span>
+                      </button>
+                    ) : (
                     <p className="text-sm">
                       {msg.viaVoice && <Mic className="w-3 h-3 inline-block mr-1 -mt-0.5 opacity-80" aria-label={lang === 'pt' ? 'mensagem de voz' : 'voice message'} />}
                       {msg.content}
                     </p>
+                    )
                   ) : (
                     <div className={`text-sm prose prose-sm max-w-none ${msg.messageType === 'thinking' ? 'text-muted-foreground italic text-xs' : ''}`}>
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{fixMarkdownTables(msg.content)}</ReactMarkdown>
@@ -1100,7 +1123,8 @@ export default function CboProfilePage() {
                   )}
                 </div>
               </div>
-            ))}
+              );
+            })}
 
             {/* E2 NbsShowcaseCard strip — agent-invoked via show_examples.
                 Rendered inline in chat (not in the right rail) since it's

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -19,8 +19,8 @@ import {
 } from "../services/cboPersistence";
 import { createEmptyCboState, CBO_SECTIONS, type CboState } from "@shared/cbo-schema";
 import {
-  listDocumentsByOrg,
-  getDocumentForOrg,
+  listDocumentsForScope,
+  getDocumentForScope,
   getOrgIdForCboState,
   toDocumentMeta,
 } from "../services/documentPersistence";
@@ -72,16 +72,16 @@ export function registerCboRoutes(app: Express): void {
   // "Seus arquivos" bottom sheet. Open-by-UUID, consistent with the other
   // /api/cbo/:id/* routes (the client resolves the session from its token).
   app.get("/api/cbo/:id/documents", async (req: Request, res: Response) => {
+    // Scope by the session itself (always reliable) + the org if it's linked,
+    // so files show even when org_id hasn't been linked to the session yet.
     const orgId = await getOrgIdForCboState(req.params.id);
-    if (!orgId) return res.json({ documents: [] });
-    const docs = await listDocumentsByOrg(orgId);
+    const docs = await listDocumentsForScope({ cboStateId: req.params.id, orgId });
     res.json({ documents: docs.map(toDocumentMeta) });
   });
 
   app.get("/api/cbo/:id/documents/:docId/text", async (req: Request, res: Response) => {
     const orgId = await getOrgIdForCboState(req.params.id);
-    if (!orgId) return res.status(404).json({ error: "not found" });
-    const doc = await getDocumentForOrg(req.params.docId, orgId);
+    const doc = await getDocumentForScope(req.params.docId, { cboStateId: req.params.id, orgId });
     if (!doc) return res.status(404).json({ error: "not found" });
     res.json({ fullText: doc.fullText ?? "", summary: doc.summary ?? null });
   });

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -3,10 +3,9 @@ import { eq, and } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import {
-  listDocumentsByOrg,
-  getDocumentForOrg,
-  getOrgIdForCboState,
-  countDocumentsByOrgIds,
+  listDocumentsForScope,
+  getDocumentForScope,
+  countDocumentsForMembers,
   toDocumentMeta,
 } from '../services/documentPersistence';
 import {
@@ -171,20 +170,13 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
 
 // Attach each CBO's uploaded-document count to roster rows (one grouped query,
 // no N+1) so the orchestrator cards can show a 📎 file-count chip.
-async function attachDocCounts<T extends { orgId: string | null }>(
+async function attachDocCounts<T extends { id: string; orgId: string | null; cboStateId: string | null }>(
   members: T[],
 ): Promise<(T & { documentCount: number })[]> {
-  const counts = await countDocumentsByOrgIds(
-    members.map(m => m.orgId).filter((x): x is string => !!x),
+  const counts = await countDocumentsForMembers(
+    members.map(m => ({ id: m.id, orgId: m.orgId, cboStateId: m.cboStateId })),
   );
-  return members.map(m => ({ ...m, documentCount: m.orgId ? counts.get(m.orgId) ?? 0 : 0 }));
-}
-
-// Resolve the owning org for a roster member — prefers the member's own org_id
-// (set at invite), falling back to the linked working profile's org.
-async function resolveMemberOrgId(member: typeof cohortMembers.$inferSelect): Promise<string | null> {
-  if (member.orgId) return member.orgId;
-  return member.cboStateId ? getOrgIdForCboState(member.cboStateId) : null;
+  return members.map(m => ({ ...m, documentCount: counts.get(m.id) ?? 0 }));
 }
 
 export function registerCohortRoutes(app: Express): void {
@@ -385,18 +377,14 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/:coordinatorSlug/member/:memberId/documents', wrap(async (req, res) => {
     const member = await memberInCohort(req);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
-    const orgId = await resolveMemberOrgId(member);
-    if (!orgId) { res.json({ documents: [] }); return; }
-    const docs = await listDocumentsByOrg(orgId);
+    const docs = await listDocumentsForScope({ orgId: member.orgId, cboStateId: member.cboStateId });
     res.json({ documents: docs.map(toDocumentMeta) });
   }));
 
   app.get('/api/cohort/:coordinatorSlug/member/:memberId/documents/:docId/text', wrap(async (req, res) => {
     const member = await memberInCohort(req);
     if (!member) { res.status(404).json({ error: 'member not found' }); return; }
-    const orgId = await resolveMemberOrgId(member);
-    if (!orgId) { res.status(404).json({ error: 'not found' }); return; }
-    const doc = await getDocumentForOrg(req.params.docId, orgId);
+    const doc = await getDocumentForScope(req.params.docId, { orgId: member.orgId, cboStateId: member.cboStateId });
     if (!doc) { res.status(404).json({ error: 'not found' }); return; }
     res.json({ fullText: doc.fullText ?? '', summary: doc.summary ?? null });
   }));

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -3,7 +3,40 @@
 import { db } from '../db';
 import { documents, type DocumentRow, type DocumentKind, type DocumentMeta } from '@shared/document-schema';
 import { cboStates } from '@shared/cbo-db-schema';
-import { eq, desc, and, inArray, sql } from 'drizzle-orm';
+import { eq, desc, and, or, inArray, sql } from 'drizzle-orm';
+
+// A document "belongs" to a CBO if it matches the member's org (cross-session
+// evidence locker) OR the specific working-profile/session it was uploaded in.
+// The session match is the reliable one — org_id is linked lazily (at snapshot
+// time) so an upload made before that link, or in a standalone session, lands
+// with org_id = null and would otherwise be invisible.
+export type DocumentScope = { orgId?: string | null; cboStateId?: string | null };
+
+function scopeConds(scope: DocumentScope) {
+  const conds = [];
+  if (scope.orgId) conds.push(eq(documents.orgId, scope.orgId));
+  if (scope.cboStateId) conds.push(eq(documents.cboStateId, scope.cboStateId));
+  return conds;
+}
+
+/** Documents for a CBO scope (org OR session), newest first. */
+export async function listDocumentsForScope(scope: DocumentScope): Promise<DocumentRow[]> {
+  const conds = scopeConds(scope);
+  if (conds.length === 0) return [];
+  return db.select().from(documents)
+    .where(conds.length === 1 ? conds[0] : or(...conds))
+    .orderBy(desc(documents.createdAt));
+}
+
+/** A single document, accepted only if it falls within the given scope. */
+export async function getDocumentForScope(id: string, scope: DocumentScope): Promise<DocumentRow | null> {
+  const doc = await getDocumentById(id);
+  if (!doc) return null;
+  const ok =
+    (!!scope.orgId && doc.orgId === scope.orgId) ||
+    (!!scope.cboStateId && doc.cboStateId === scope.cboStateId);
+  return ok ? doc : null;
+}
 
 /** Strip a document row down to the client-facing metadata (no fullText/blob key). */
 export function toDocumentMeta(d: DocumentRow): DocumentMeta {
@@ -71,6 +104,35 @@ export async function countDocumentsByOrgIds(orgIds: string[]): Promise<Map<stri
   const counts = new Map<string, number>();
   for (const r of rows) if (r.orgId) counts.set(r.orgId, Number(r.n));
   return counts;
+}
+
+/** Per-member document counts, matching by org OR session (one query, no N+1).
+ *  Returns a Map keyed by the member's id. A document that matches a member on
+ *  both org and session is counted once. */
+export async function countDocumentsForMembers(
+  members: { id: string; orgId: string | null; cboStateId: string | null }[],
+): Promise<Map<string, number>> {
+  const orgIds = Array.from(new Set(members.map(m => m.orgId).filter((x): x is string => !!x)));
+  const stateIds = Array.from(new Set(members.map(m => m.cboStateId).filter((x): x is string => !!x)));
+  const result = new Map<string, number>();
+  if (orgIds.length === 0 && stateIds.length === 0) return result;
+  const conds = [];
+  if (orgIds.length) conds.push(inArray(documents.orgId, orgIds));
+  if (stateIds.length) conds.push(inArray(documents.cboStateId, stateIds));
+  const rows = await db
+    .select({ id: documents.id, orgId: documents.orgId, cboStateId: documents.cboStateId })
+    .from(documents)
+    .where(conds.length === 1 ? conds[0] : or(...conds));
+  for (const m of members) {
+    const seen = new Set<string>();
+    for (const r of rows) {
+      if ((m.orgId && r.orgId === m.orgId) || (m.cboStateId && r.cboStateId === m.cboStateId)) {
+        seen.add(r.id);
+      }
+    }
+    result.set(m.id, seen.size);
+  }
+  return result;
 }
 
 /** A single document, scoped to its org so one org can't read another's files. */


### PR DESCRIPTION
Follow-up to #281/#282 — fixes "I uploaded a file but it shows nowhere", plus the raw-text-in-chat ask.

## 1. Uploads were invisible (session scoping)
Every upload is tagged with **both** `org_id` and `cbo_state_id`, but `org_id` is linked lazily (at snapshot time). A file uploaded in a standalone session, or before that link, lands with `org_id = null` → invisible to the org-scoped list/count endpoints (so no chip, empty drawer).

Now documents resolve by **org OR session**:
- `listDocumentsForScope` / `getDocumentForScope` / `countDocumentsForMembers` in `documentPersistence`.
- CBO endpoint scopes by the **session id** (always reliable) + org.
- Coordinator endpoint + card counts scope by the member's **org OR linked session**.

## 2. Upload shows as a file card, not raw text
Upload messages still carry the parsed text inline (the agent needs it), but the chat now renders them as a compact **file card** (filename + icon, tap → opens the files sheet). Pattern-matched so it also applies to history on reload.

## Verified
tsc clean on changed files; production build succeeds.

## ⚠️ Deploy note
Prod is currently NOT republished with #281/#282 (confirmed: `documentCount` absent from the prod API). After merging this, **click Republish** so all three land on prod. Dev preview only needs a server restart.