### PR TITLE
Orchestrator: per-CBO drawer with chat transcript + live profile tabs

### DIFF
--- a/client/src/core/components/orchestrator/CboChatTranscript.tsx
+++ b/client/src/core/components/orchestrator/CboChatTranscript.tsx
@@ -1,0 +1,86 @@
+/**
+ * Coordinator-side read-only view of a CBO's encontro chat transcript.
+ * Snapshot-on-open (re-fetches when `reloadKey` changes). Uploads render as a
+ * file card rather than the raw extracted-text dump.
+ */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Loader2, FileText, MessagesSquare } from 'lucide-react';
+
+type Msg = { role: 'user' | 'assistant'; content: string; messageType?: string };
+
+const UPLOAD_MSG_RE = /^(?:I'm uploading: |Uploaded )"(.+?)"/;
+
+export function CboChatTranscript({
+  cohortSlug,
+  memberId,
+  reloadKey,
+}: {
+  cohortSlug: string;
+  memberId: string;
+  reloadKey: number;
+}) {
+  const { t } = useTranslation();
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/cohort/${cohortSlug}/member/${memberId}/chat`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then(data => { if (!cancelled) setMessages(data.messages ?? []); })
+      .catch(() => { if (!cancelled) setError(t('cboView.loadError', { defaultValue: 'Could not load.' })); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [cohortSlug, memberId, reloadKey, t]);
+
+  if (loading) return <Centered><Loader2 className="w-5 h-5 animate-spin" /></Centered>;
+  if (error) return <div className="py-12 text-center text-sm text-destructive">{error}</div>;
+
+  const visible = messages.filter(m => m.messageType !== 'thinking' && m.messageType !== 'tool_status');
+  if (visible.length === 0) {
+    return (
+      <Centered>
+        <div className="text-center text-muted-foreground">
+          <MessagesSquare className="w-7 h-7 mx-auto mb-2 opacity-40" />
+          <p className="text-sm">{t('cboView.noChat', { defaultValue: 'No conversation yet.' })}</p>
+        </div>
+      </Centered>
+    );
+  }
+
+  return (
+    <div className="space-y-2.5 py-1">
+      {visible.map((m, i) => {
+        const uploadName = m.role === 'user' ? m.content.match(UPLOAD_MSG_RE)?.[1] : undefined;
+        return (
+          <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div className={`max-w-[88%] rounded-lg px-3 py-2 text-sm ${m.role === 'user' ? 'bg-emerald-600 text-white' : 'bg-muted'}`}>
+              {uploadName ? (
+                <span className="flex items-center gap-2">
+                  <FileText className="w-4 h-4 shrink-0 opacity-90" />
+                  <span className="font-medium">{uploadName}</span>
+                </span>
+              ) : m.role === 'user' ? (
+                <span className="whitespace-pre-wrap">{m.content}</span>
+              ) : (
+                <div className="prose prose-sm max-w-none dark:prose-invert">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.content}</ReactMarkdown>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return <div className="flex items-center justify-center py-16 text-muted-foreground">{children}</div>;
+}

--- a/client/src/core/components/orchestrator/CboFilesDrawer.tsx
+++ b/client/src/core/components/orchestrator/CboFilesDrawer.tsx
@@ -1,75 +1,111 @@
 /**
- * Coordinator-side evidence drawer — the files a single CBO has uploaded.
- * Opens from the 📎 file-count chip on an orchestrator card; renders the shared
- * <CboFilesView> inside a right-hand Sheet. Reads are scoped + ownership-gated
- * server-side (/api/cohort/:slug/member/:id/documents).
+ * Coordinator-side per-CBO drawer — everything about one CBO in three tabs:
+ *   Arquivos (uploaded files) · Conversa (chat transcript) · Perfil (profile doc).
+ * Opens from an orchestrator card; all reads are ownership-gated server-side
+ * (/api/cohort/:slug/member/:id/...). Snapshot on open + a manual refresh.
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { RefreshCw } from 'lucide-react';
 import {
   Sheet, SheetContent, SheetHeader, SheetTitle,
 } from '@/core/components/ui/sheet';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/core/components/ui/tabs';
+import { Button } from '@/core/components/ui/button';
 import { CboFilesView } from '@/core/components/cbo-files/CboFilesView';
+import { CboChatTranscript } from '@/core/components/orchestrator/CboChatTranscript';
+import { CboProfileSummary } from '@/core/components/orchestrator/CboProfileSummary';
 import type { DocumentMeta } from '@shared/document-schema';
 
+export type CboDrawerTab = 'arquivos' | 'conversa' | 'perfil';
 export type FilesDrawerMember = { id: string; orgName: string };
 
 export function CboFilesDrawer({
   cohortSlug,
   member,
+  initialTab = 'arquivos',
   onClose,
 }: {
   cohortSlug: string | null;
   member: FilesDrawerMember | null;
+  initialTab?: CboDrawerTab;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
+  const [tab, setTab] = useState<CboDrawerTab>(initialTab);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // Files tab data (lives here so the refresh button can re-pull it too).
   const [docs, setDocs] = useState<DocumentMeta[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [docsLoading, setDocsLoading] = useState(false);
+  const [docsError, setDocsError] = useState<string | null>(null);
+
+  // Reset to the requested tab each time the drawer opens for a member.
+  useEffect(() => { if (member) setTab(initialTab); }, [member, initialTab]);
 
   useEffect(() => {
     if (!member || !cohortSlug) return;
     let cancelled = false;
-    setLoading(true);
-    setError(null);
+    setDocsLoading(true);
+    setDocsError(null);
     fetch(`/api/cohort/${cohortSlug}/member/${member.id}/documents`, { credentials: 'include' })
       .then(r => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then(data => { if (!cancelled) setDocs(data.documents ?? []); })
-      .catch(() => { if (!cancelled) setError(t('files.loadError', { defaultValue: 'Could not load files.' })); })
-      .finally(() => { if (!cancelled) setLoading(false); });
+      .catch(() => { if (!cancelled) setDocsError(t('files.loadError', { defaultValue: 'Could not load files.' })); })
+      .finally(() => { if (!cancelled) setDocsLoading(false); });
     return () => { cancelled = true; };
-  }, [member, cohortSlug, t]);
+  }, [member, cohortSlug, reloadKey, t]);
 
   const fetchText = async (docId: string): Promise<string> => {
     if (!member || !cohortSlug) return '';
-    const r = await fetch(
-      `/api/cohort/${cohortSlug}/member/${member.id}/documents/${docId}/text`,
-      { credentials: 'include' },
-    );
+    const r = await fetch(`/api/cohort/${cohortSlug}/member/${member.id}/documents/${docId}/text`, { credentials: 'include' });
     if (!r.ok) return '';
-    const data = await r.json();
-    return data.fullText ?? '';
+    return (await r.json()).fullText ?? '';
   };
 
   return (
     <Sheet open={!!member} onOpenChange={open => { if (!open) onClose(); }}>
       <SheetContent side="right" className="w-full sm:max-w-md flex flex-col" data-testid="cbo-files-drawer">
         <SheetHeader>
-          <SheetTitle className="flex items-center gap-2">
-            {t('files.title', { defaultValue: 'Files' })}
-            {member && <span className="text-muted-foreground font-normal">· {member.orgName}</span>}
+          <SheetTitle className="flex items-center gap-2 pr-8">
+            <span className="truncate">{member?.orgName}</span>
+            <Button
+              variant="ghost" size="sm"
+              className="ml-auto shrink-0 h-7 px-2"
+              onClick={() => setReloadKey(k => k + 1)}
+              title={t('cboView.refresh', { defaultValue: 'Refresh' }) as string}
+              data-testid="cbo-drawer-refresh"
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+            </Button>
           </SheetTitle>
         </SheetHeader>
-        <div className="flex-1 min-h-0 overflow-auto mt-2">
-          <CboFilesView
-            documents={docs}
-            loading={loading}
-            error={error}
-            originalUrl={docId => `/api/documents/${docId}/original`}
-            fetchText={fetchText}
-          />
-        </div>
+
+        {member && cohortSlug && (
+          <Tabs value={tab} onValueChange={v => setTab(v as CboDrawerTab)} className="flex-1 min-h-0 flex flex-col mt-2">
+            <TabsList className="grid grid-cols-3">
+              <TabsTrigger value="arquivos" data-testid="cbo-tab-arquivos">{t('cboView.tabFiles', { defaultValue: 'Files' })}</TabsTrigger>
+              <TabsTrigger value="conversa" data-testid="cbo-tab-conversa">{t('cboView.tabChat', { defaultValue: 'Chat' })}</TabsTrigger>
+              <TabsTrigger value="perfil" data-testid="cbo-tab-perfil">{t('cboView.tabProfile', { defaultValue: 'Profile' })}</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="arquivos" className="flex-1 min-h-0 overflow-auto mt-2">
+              <CboFilesView
+                documents={docs}
+                loading={docsLoading}
+                error={docsError}
+                originalUrl={docId => `/api/documents/${docId}/original`}
+                fetchText={fetchText}
+              />
+            </TabsContent>
+            <TabsContent value="conversa" className="flex-1 min-h-0 overflow-auto mt-2">
+              <CboChatTranscript cohortSlug={cohortSlug} memberId={member.id} reloadKey={reloadKey} />
+            </TabsContent>
+            <TabsContent value="perfil" className="flex-1 min-h-0 overflow-auto mt-2">
+              <CboProfileSummary cohortSlug={cohortSlug} memberId={member.id} reloadKey={reloadKey} />
+            </TabsContent>
+          </Tabs>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/client/src/core/components/orchestrator/CboProfileSummary.tsx
+++ b/client/src/core/components/orchestrator/CboProfileSummary.tsx
@@ -1,0 +1,110 @@
+/**
+ * Coordinator-side read-only summary of a CBO's profile document as it's built —
+ * sections (field: value) + the maturity scorecard (coordinator-only). Compact;
+ * snapshot-on-open (re-fetches on `reloadKey`).
+ */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, FileText } from 'lucide-react';
+import { CBO_SECTIONS, type CboState } from '@shared/cbo-schema';
+
+type Profile = Pick<CboState, 'phase' | 'sections' | 'maturityScores' | 'totalMaturityScore' | 'gaps'>;
+
+export function CboProfileSummary({
+  cohortSlug,
+  memberId,
+  reloadKey,
+}: {
+  cohortSlug: string;
+  memberId: string;
+  reloadKey: number;
+}) {
+  const { t } = useTranslation();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/cohort/${cohortSlug}/member/${memberId}/profile`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then(data => { if (!cancelled) setProfile(data.profile ?? null); })
+      .catch(() => { if (!cancelled) setError(t('cboView.loadError', { defaultValue: 'Could not load.' })); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [cohortSlug, memberId, reloadKey, t]);
+
+  if (loading) return <div className="flex items-center justify-center py-16 text-muted-foreground"><Loader2 className="w-5 h-5 animate-spin" /></div>;
+  if (error) return <div className="py-12 text-center text-sm text-destructive">{error}</div>;
+  if (!profile) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+        <FileText className="w-7 h-7 mb-2 opacity-40" />
+        <p className="text-sm">{t('cboView.noProfile', { defaultValue: 'Nothing captured yet.' })}</p>
+      </div>
+    );
+  }
+
+  const label = (key: string) => t(`cbo.fields.${key}`, key.replace(/_/g, ' '));
+  const fmt = (v: string | number | null) => (v === null || v === undefined || v === '' ? null : String(v));
+
+  return (
+    <div className="space-y-4 py-1 text-sm">
+      {/* Maturity total */}
+      <div className="rounded-lg border border-foreground/10 bg-foreground/[0.02] px-3 py-2 flex items-center justify-between">
+        <span className="text-muted-foreground">{t('cboView.maturity', { defaultValue: 'Maturity' })}</span>
+        <span className="font-semibold">{profile.totalMaturityScore}/27</span>
+      </div>
+
+      {/* Sections → fields */}
+      {CBO_SECTIONS.map(sec => {
+        const section = profile.sections?.[sec.id];
+        if (!section) return null;
+        const rows = Object.entries(section.fields)
+          .map(([k, f]) => [k, fmt(f?.value)] as const)
+          .filter(([, v]) => v !== null);
+        return (
+          <div key={sec.id}>
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">{section.title}</h4>
+            {rows.length === 0 ? (
+              <p className="text-xs text-muted-foreground/70 italic">{t('cboView.empty', { defaultValue: '—' })}</p>
+            ) : (
+              <dl className="space-y-1">
+                {rows.map(([k, v]) => (
+                  <div key={k} className="flex gap-2">
+                    <dt className="text-muted-foreground shrink-0 min-w-[42%]">{label(k)}</dt>
+                    <dd className="font-medium break-words">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Maturity scorecard */}
+      {profile.maturityScores?.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+            {t('cboView.scorecard', { defaultValue: 'Maturity scorecard' })}
+          </h4>
+          <ul className="space-y-1.5">
+            {profile.maturityScores.map(s => (
+              <li key={s.metric} className="flex items-start gap-2">
+                <span className="shrink-0 inline-flex items-center justify-center min-w-[34px] h-5 px-1 rounded text-[11px] font-semibold bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 border border-emerald-200/60 dark:border-emerald-900/40">
+                  {s.score}/3
+                </span>
+                <span className="min-w-0">
+                  <span className="font-medium">{label(s.metric)}</span>
+                  {s.justification && <span className="block text-xs text-muted-foreground">{s.justification}</span>}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,7 +19,7 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
+  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Eye, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
   Mountain, Network, Paperclip, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
@@ -46,7 +46,7 @@ import {
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 import { SupportInbox } from '@/core/components/orchestrator/SupportInbox';
 import { LanguageSwitcher } from '@/core/components/i18n/language-switcher';
-import { CboFilesDrawer, type FilesDrawerMember } from '@/core/components/orchestrator/CboFilesDrawer';
+import { CboFilesDrawer, type FilesDrawerMember, type CboDrawerTab } from '@/core/components/orchestrator/CboFilesDrawer';
 
 // ---------------------------------------------------------------------------
 // Data model — mirrors shared/cbo-schema.ts fields relevant to a portfolio
@@ -546,14 +546,14 @@ function ProjectCard({
   selected,
   onHover,
   onOpen,
-  onOpenFiles,
+  onOpenCbo,
 }: {
   project: CboDemoProject;
   locale: 'en' | 'pt';
   selected: boolean;
   onHover: (id: string | null) => void;
   onOpen: (p: CboDemoProject) => void;
-  onOpenFiles: (p: CboDemoProject) => void;
+  onOpenCbo: (p: CboDemoProject, tab: 'arquivos' | 'conversa' | 'perfil') => void;
 }) {
   const { t } = useTranslation();
   const hasIntervention = project.interventionKey !== null;
@@ -652,7 +652,7 @@ function ProjectCard({
             {project.documentCount > 0 && (
               <button
                 type="button"
-                onClick={e => { e.stopPropagation(); onOpenFiles(project); }}
+                onClick={e => { e.stopPropagation(); onOpenCbo(project, 'arquivos'); }}
                 className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-sky-50 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300 border border-sky-200/60 dark:border-sky-900/40 hover:bg-sky-100 dark:hover:bg-sky-900/50 transition-colors"
                 title={t('orchestrator.files.chipTooltip', { defaultValue: '{{n}} file(s) shared — tap to view', n: project.documentCount })}
                 data-testid={`button-cbo-files-${project.id}`}
@@ -661,6 +661,16 @@ function ProjectCard({
                 {project.documentCount}
               </button>
             )}
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); onOpenCbo(project, 'perfil'); }}
+              className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full border border-foreground/15 text-foreground/70 hover:bg-foreground/5 transition-colors"
+              title={t('orchestrator.cboView.openTooltip', { defaultValue: 'View conversation + profile' })}
+              data-testid={`button-cbo-view-${project.id}`}
+            >
+              <Eye className="w-3 h-3" strokeWidth={2} />
+              {t('orchestrator.cboView.open', { defaultValue: 'View' })}
+            </button>
             {hasIntervention ? (
               <span
                 className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}
@@ -839,8 +849,9 @@ export default function OrchestratorLandingPage() {
   // the inbox trigger. Initialized from member.supportRequests when the
   // cohort loads (below).
   const [supportInboxPendingCount, setSupportInboxPendingCount] = useState(0);
-  // Which CBO's uploaded files the coordinator is viewing (null = drawer closed).
+  // Which CBO the coordinator is inspecting (null = drawer closed) + which tab.
   const [filesMember, setFilesMember] = useState<FilesDrawerMember | null>(null);
+  const [filesTab, setFilesTab] = useState<CboDrawerTab>('arquivos');
 
   const openShare = (url: string, ctx: typeof shareContext) => {
     setShareUrl(url);
@@ -858,8 +869,9 @@ export default function OrchestratorLandingPage() {
     }
   };
 
-  const openFiles = (p: CboDemoProject) => {
+  const openCbo = (p: CboDemoProject, tab: CboDrawerTab) => {
     setFilesMember({ id: p.id, orgName: p.name[locale] });
+    setFilesTab(tab);
   };
 
   const handleUnlockNext = async (member: CohortMember) => {
@@ -1036,6 +1048,7 @@ export default function OrchestratorLandingPage() {
       <CboFilesDrawer
         cohortSlug={cohort?.coordinatorSlug ?? null}
         member={filesMember}
+        initialTab={filesTab}
         onClose={() => setFilesMember(null)}
       />
 
@@ -1248,7 +1261,7 @@ export default function OrchestratorLandingPage() {
                     selected={selectedId === p.id}
                     onHover={setSelectedId}
                     onOpen={openProject}
-                    onOpenFiles={openFiles}
+                    onOpenCbo={openCbo}
                   />
                   {member && (
                     <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -296,6 +296,10 @@
     },
     "files": {
       "chipTooltip": "{{n}} arquivo(s) compartilhado(s) — toque para ver"
+    },
+    "cboView": {
+      "open": "Ver",
+      "openTooltip": "Ver conversa + perfil"
     }
   },
   "citySelection": {
@@ -2066,5 +2070,17 @@
     "noOriginalNote": "Original não armazenado — mostrando o texto extraído.",
     "loadError": "Não foi possível carregar os arquivos.",
     "mine": "Seus arquivos"
+  },
+  "cboView": {
+    "loadError": "Não foi possível carregar.",
+    "noChat": "Nenhuma conversa ainda.",
+    "noProfile": "Nada preenchido ainda.",
+    "maturity": "Maturidade",
+    "empty": "—",
+    "scorecard": "Quadro de maturidade",
+    "refresh": "Atualizar",
+    "tabFiles": "Arquivos",
+    "tabChat": "Conversa",
+    "tabProfile": "Perfil"
   }
 }

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -20,6 +20,7 @@ import {
   type MemberSite,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { getCboMessages, getCboState, loadCboFromDb } from '../services/cboAgent';
 import {
   requireCoordinator,
   createCoordinator,
@@ -387,6 +388,39 @@ export function registerCohortRoutes(app: Express): void {
     const doc = await getDocumentForScope(req.params.docId, { orgId: member.orgId, cboStateId: member.cboStateId });
     if (!doc) { res.status(404).json({ error: 'not found' }); return; }
     res.json({ fullText: doc.fullText ?? '', summary: doc.summary ?? null });
+  }));
+
+  // The CBO's encontro chat transcript (read-only, coordinator side).
+  app.get('/api/cohort/:coordinatorSlug/member/:memberId/chat', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    if (!member.cboStateId) { res.json({ messages: [] }); return; }
+    let messages = getCboMessages(member.cboStateId);
+    if (messages.length === 0) {
+      const persisted = await loadCboFromDb(member.cboStateId);
+      if (persisted?.messages?.length) messages = persisted.messages;
+    }
+    res.json({ messages });
+  }));
+
+  // The CBO's profile document being built — sections + maturity scores. Compact
+  // read-only snapshot for the coordinator (they see scores; the CBO doesn't).
+  app.get('/api/cohort/:coordinatorSlug/member/:memberId/profile', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    if (!member.cboStateId) { res.json({ profile: null }); return; }
+    let state = getCboState(member.cboStateId);
+    if (!state) state = (await loadCboFromDb(member.cboStateId))?.state;
+    if (!state) { res.json({ profile: null }); return; }
+    res.json({
+      profile: {
+        phase: state.phase,
+        sections: state.sections,
+        maturityScores: state.maturityScores,
+        totalMaturityScore: state.totalMaturityScore,
+        gaps: state.gaps,
+      },
+    });
   }));
 
   // Invite a CBO — slugs are human-readable, derived from the org name.


### PR DESCRIPTION
Builds the backlog item — coordinators can now inspect each CBO's **conversation** and the **profile document being built**, not just files. The per-CBO drawer becomes three tabs: **Arquivos · Conversa · Perfil**.

## Backend (ownership-gated; resolves `cboStateId` from `memberId` server-side)
- `GET /api/cohort/:slug/member/:memberId/chat` — read-only transcript.
- `GET /api/cohort/:slug/member/:memberId/profile` — sections + maturity scores + total + gaps (coordinator sees scores; CBOs don't).

## Frontend
- `CboFilesDrawer` → tabbed: **Arquivos** (existing files view), **Conversa** (new read-only transcript — uploads render as file cards, not raw text), **Perfil** (new compact summary: section `field: value` + maturity scorecard).
- Always-present **"Ver"** button on each card opens the drawer (default Perfil) — so chat/profile are reachable even with 0 files; the 📎 chip opens the Files tab.
- **Card click still opens the share dialog** (unchanged → existing e2e stays green).
- **Refresh** button re-pulls the active tab (snapshot model, no polling). pt.json keys.

## Decisions (from /refine)
Tabbed drawer · compact read-only profile · snapshot-on-open + manual refresh.

## Verified
tsc clean on changed files; production build succeeds.

## Independent
Touches the orchestrator drawer + 2 read-only endpoints; no overlap with #284/#286. Republish after merge.