### PR TITLE
fix(cbo): localize workshop names by position in PT cohorts

### DIFF
--- a/client/src/core/components/cbo/CboProgress.tsx
+++ b/client/src/core/components/cbo/CboProgress.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/core/components/ui/popover';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { formatCalendarDate } from '@/lib/dateHelpers';
+import { localizedWorkshopName } from '@/lib/workshopHelpers';
 
 // ---------------------------------------------------------------------------
 // CboProgress — friendly progress display that replaces the
@@ -89,6 +90,7 @@ export function CboProgress({
 
           if (!isUnlocked) {
             const workshop = workshops.find(w => w.unlocksPhase === p.num);
+            const workshopName = localizedWorkshopName(t, workshops, workshop);
             const workshopDate = workshop?.date
               ? formatCalendarDate(workshop.date, isPt ? 'pt-BR' : 'en-US', { weekday: 'long', day: 'numeric', month: 'short' })
               : null;
@@ -109,8 +111,8 @@ export function CboProgress({
                     <p className="text-muted-foreground">
                       {workshop
                         ? t('cbo.progress.lockedWithWorkshop', {
-                            defaultValue: `Opens after ${workshop.name}${workshopDate ? ` · ${workshopDate}` : ''}`,
-                            workshop: workshop.name,
+                            defaultValue: `Opens after ${workshopName}${workshopDate ? ` · ${workshopDate}` : ''}`,
+                            workshop: workshopName,
                             date: workshopDate ?? '',
                           })
                         : t('cbo.progress.lockedNoWorkshop', { defaultValue: 'Your coordinator will open this section.' })}

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -4,6 +4,7 @@ import { Calendar, Clock, Leaf, Sprout } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { formatCalendarDate } from '@/lib/dateHelpers';
+import { localizedWorkshopName } from '@/lib/workshopHelpers';
 
 // ---------------------------------------------------------------------------
 // CBO welcome screen — the first thing a community leader sees after tapping
@@ -15,6 +16,7 @@ export function CboWelcome({
   orgName,
   neighborhood,
   cohortName,
+  workshops,
   focusWorkshop,
   focusWorkshopIsCurrent,
   unlockedPhases,
@@ -25,6 +27,9 @@ export function CboWelcome({
   orgName: string;
   neighborhood: string | null;
   cohortName: string | null;
+  /** The cohort's full workshop list — used to localize the focus workshop's
+   *  name by position (the stored name is English regardless of cohort lang). */
+  workshops: WorkshopConfig[];
   /** The workshop to feature on the welcome card. Either the currently-active
    *  one (if the coordinator has opened any) or the first upcoming one. */
   focusWorkshop: WorkshopConfig | null;
@@ -108,7 +113,9 @@ export function CboWelcome({
                   ? t('cbo.welcome.currentWorkshopLabel', { defaultValue: 'Current workshop' })
                   : t('cbo.welcome.nextWorkshopLabel', { defaultValue: 'Next workshop' })}
               </p>
-              <p className="text-sm font-medium text-foreground/90">{focusWorkshop.name}</p>
+              <p className="text-sm font-medium text-foreground/90">
+                {localizedWorkshopName(t, workshops, focusWorkshop)}
+              </p>
               {workshopDateLabel && (
                 <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
                   <Calendar className="w-3 h-3" />

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -52,6 +52,7 @@ function parseUploadFilename(content: string): string | null {
 import { LifeBuoy } from 'lucide-react';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
+import { localizedWorkshopName } from '@/lib/workshopHelpers';
 
 const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
 const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
@@ -906,6 +907,7 @@ export default function CboProfilePage() {
         orgName={memberInfo.orgName}
         neighborhood={memberInfo.neighborhood}
         cohortName={cohortName}
+        workshops={workshops}
         focusWorkshop={focusWorkshop ?? nextWorkshop}
         focusWorkshopIsCurrent={focusWorkshopIsCurrent}
         unlockedPhases={unlockedPhases}
@@ -1291,7 +1293,9 @@ export default function CboProfilePage() {
               const nextUnlockedPhase = unlockedPhases.find(p => p > state.phase);
               if (nextUnlockedPhase == null) return null;
               const ws = workshops.find(w => w.unlocksPhase === nextUnlockedPhase);
-              const wsName = ws?.name ?? `Workshop ${nextUnlockedPhase}`;
+              const wsName = ws
+                ? localizedWorkshopName(t, workshops, ws)
+                : `Workshop ${nextUnlockedPhase}`;
               return (
                 <div className="text-center py-4">
                   <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-700 max-w-md">

--- a/client/src/lib/workshopHelpers.ts
+++ b/client/src/lib/workshopHelpers.ts
@@ -1,0 +1,41 @@
+import type { TFunction } from 'i18next';
+import type { WorkshopConfig } from '@shared/cohort-schema';
+
+// ---------------------------------------------------------------------------
+// Workshop names are stored in the DB as English strings (seeded from
+// DEFAULT_WORKSHOPS at cohort creation) and are NOT re-translated per cohort
+// language. The CBO + orchestrator UIs localize them BY POSITION instead:
+// the canonical PT names live under `orchestrator.workshops.wN.name`, keyed on
+// the workshop's index in the cohort's workshops array (EN has no keys, so it
+// falls back to the stored English `name`). This keeps a single source of truth
+// for translated workshop names and stops English leaking into a PT cohort.
+// See WorkshopCadence.tsx (orchestrator) for the original of this pattern.
+// ---------------------------------------------------------------------------
+
+/** Index of `workshop` within `workshops`. Tolerates the workshop being a
+ *  distinct object (e.g. the server sends `focusWorkshop` separately) by
+ *  matching on name + unlocksPhase. Returns -1 if not found. */
+export function workshopIndex(
+  workshops: WorkshopConfig[],
+  workshop: WorkshopConfig | null | undefined,
+): number {
+  if (!workshop) return -1;
+  const byRef = workshops.indexOf(workshop);
+  if (byRef >= 0) return byRef;
+  return workshops.findIndex(
+    w => w.name === workshop.name && w.unlocksPhase === workshop.unlocksPhase,
+  );
+}
+
+/** Localized workshop name keyed by position, falling back to the stored name. */
+export function localizedWorkshopName(
+  t: TFunction,
+  workshops: WorkshopConfig[],
+  workshop: WorkshopConfig | null | undefined,
+): string {
+  if (!workshop) return '';
+  const i = workshopIndex(workshops, workshop);
+  return i >= 0
+    ? (t(`orchestrator.workshops.w${i + 1}.name`, { defaultValue: workshop.name }) as string)
+    : workshop.name;
+}

--- a/e2e/cougar-cohort-language.spec.ts
+++ b/e2e/cougar-cohort-language.spec.ts
@@ -30,6 +30,9 @@ test.describe('COUGAR #4 — cohort-level forced language', () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'en', { timeout: 20_000 });
     await page.waitForTimeout(1500);
 
+    // The focus-workshop card shows the English (stored) name in an EN cohort.
+    await expect(page.getByText('Workshop 1 — Who We Are')).toBeVisible({ timeout: 10_000 });
+
     // Switch the cohort to PORTUGUESE.
     await page.goto('/orchestrator');
     await page.getByTestId('button-cohort-lang-pt').click();
@@ -40,5 +43,11 @@ test.describe('COUGAR #4 — cohort-level forced language', () => {
     await page.goto(invite);
     await expect(page.locator('html')).toHaveAttribute('lang', 'pt', { timeout: 20_000 });
     await page.waitForTimeout(1500);
+
+    // The focus-workshop card must localize the workshop name by position — the
+    // stored name is English regardless of cohort language. In a PT cohort it
+    // shows "Encontro 1 — Quem somos" and the English name must NOT leak.
+    await expect(page.getByText('Encontro 1 — Quem somos')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Workshop 1 — Who We Are')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What

The CBO invite/welcome surface showed the workshop name in **English** (e.g. "Workshop 1 — Who We Are") even when the cohort is forced to PT and everything around it is Portuguese (see the reported screenshot).

## Why

Workshop names are stored in the DB as English strings — seeded from `DEFAULT_WORKSHOPS` at cohort creation — and are **never re-translated** per cohort language. The section list on the welcome card looks translated because it uses position-based i18n keys; the workshop *name* was rendered raw from stored data.

The orchestrator already solved this (`WorkshopCadence.tsx` → `t(\`orchestrator.workshops.wN.name\`, { defaultValue })`, keyed by position, EN falls back to the stored name). The CBO surface just never adopted it.

## Fix

- New shared helper `client/src/lib/workshopHelpers.ts` → `localizedWorkshopName(t, workshops, workshop)` — finds the workshop's index (tolerates the server sending `focusWorkshop` as a distinct object by matching name + unlocksPhase) and returns the PT key with the English `name` as fallback.
- Applied to the **three** places that leaked the stored English name in the CBO surface:
  1. `CboWelcome.tsx` — the focus-workshop card (the reported one)
  2. `cbo-profile.tsx` — the "next workshop unlocked" banner
  3. `CboProgress.tsx` — the locked-section "Opens after …" popover

No new strings — reuses the existing `orchestrator.workshops.wN.name` PT translations.

## Verify

- `cougar-cohort-language` e2e extended: PT cohort welcome card now asserts **"Encontro 1 — Quem somos"** is visible and **"Workshop 1 — Who We Are"** has count 0; EN cohort still shows the stored English name. ✅ passing.
- tsc clean (14 pre-existing errors, none in changed files); build clean.

Needs the usual rebuild + republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)