### PR TITLE
Orchestrator: unify invite into the per-CBO panel (Convite as first tab)

### DIFF
--- a/client/src/core/components/orchestrator/CboFilesDrawer.tsx
+++ b/client/src/core/components/orchestrator/CboFilesDrawer.tsx
@@ -1,8 +1,8 @@
 /**
- * Coordinator-side per-CBO drawer — everything about one CBO in three tabs:
- *   Arquivos (uploaded files) · Conversa (chat transcript) · Perfil (profile doc).
- * Opens from an orchestrator card; all reads are ownership-gated server-side
- * (/api/cohort/:slug/member/:id/...). Snapshot on open + a manual refresh.
+ * Coordinator-side per-CBO drawer — everything about one CBO in four tabs:
+ *   Convite (invite link + WhatsApp message) · Arquivos (files) · Conversa
+ *   (chat transcript) · Perfil (profile doc). Opens from an orchestrator card;
+ *   reads are ownership-gated server-side. Snapshot on open + a manual refresh.
  */
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,21 +13,24 @@ import {
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/core/components/ui/tabs';
 import { Button } from '@/core/components/ui/button';
 import { CboFilesView } from '@/core/components/cbo-files/CboFilesView';
+import { CboInviteView } from '@/core/components/orchestrator/CboInviteView';
 import { CboChatTranscript } from '@/core/components/orchestrator/CboChatTranscript';
 import { CboProfileSummary } from '@/core/components/orchestrator/CboProfileSummary';
 import type { DocumentMeta } from '@shared/document-schema';
 
-export type CboDrawerTab = 'arquivos' | 'conversa' | 'perfil';
-export type FilesDrawerMember = { id: string; orgName: string };
+export type CboDrawerTab = 'convite' | 'arquivos' | 'conversa' | 'perfil';
+export type FilesDrawerMember = { id: string; orgName: string; inviteUrl: string };
 
 export function CboFilesDrawer({
   cohortSlug,
   member,
-  initialTab = 'arquivos',
+  cohortLanguage,
+  initialTab = 'convite',
   onClose,
 }: {
   cohortSlug: string | null;
   member: FilesDrawerMember | null;
+  cohortLanguage?: 'pt' | 'en' | null;
   initialTab?: CboDrawerTab;
   onClose: () => void;
 }) {
@@ -83,12 +86,16 @@ export function CboFilesDrawer({
 
         {member && cohortSlug && (
           <Tabs value={tab} onValueChange={v => setTab(v as CboDrawerTab)} className="flex-1 min-h-0 flex flex-col mt-2">
-            <TabsList className="grid grid-cols-3">
+            <TabsList className="grid grid-cols-4">
+              <TabsTrigger value="convite" data-testid="cbo-tab-convite">{t('cboView.tabInvite', { defaultValue: 'Invite' })}</TabsTrigger>
               <TabsTrigger value="arquivos" data-testid="cbo-tab-arquivos">{t('cboView.tabFiles', { defaultValue: 'Files' })}</TabsTrigger>
               <TabsTrigger value="conversa" data-testid="cbo-tab-conversa">{t('cboView.tabChat', { defaultValue: 'Chat' })}</TabsTrigger>
               <TabsTrigger value="perfil" data-testid="cbo-tab-perfil">{t('cboView.tabProfile', { defaultValue: 'Profile' })}</TabsTrigger>
             </TabsList>
 
+            <TabsContent value="convite" className="flex-1 min-h-0 overflow-auto mt-2">
+              <CboInviteView url={member.inviteUrl} orgName={member.orgName} cohortLanguage={cohortLanguage} />
+            </TabsContent>
             <TabsContent value="arquivos" className="flex-1 min-h-0 overflow-auto mt-2">
               <CboFilesView
                 documents={docs}

--- a/client/src/core/components/orchestrator/CboInviteView.tsx
+++ b/client/src/core/components/orchestrator/CboInviteView.tsx
@@ -1,0 +1,77 @@
+/**
+ * CBO invite content — the link + the ready-to-send WhatsApp message. Extracted
+ * from ShareLinkDialog so it can live as the first tab of the per-CBO drawer
+ * when inspecting an existing CBO. (New single invites still use the modal.)
+ * Reuses the shared invite helpers so the message matches exactly.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MessageCircle, ExternalLink, Copy, Check } from 'lucide-react';
+import { Button } from '@/core/components/ui/button';
+import { cboGreetingMessage, whatsappDeepLink, inviteIsPt } from '@/core/components/orchestrator/CohortDialogs';
+
+export function CboInviteView({
+  url,
+  orgName,
+  cohortLanguage,
+}: {
+  url: string;
+  orgName: string;
+  cohortLanguage?: 'pt' | 'en' | null;
+}) {
+  const { t, i18n } = useTranslation();
+  const message = cboGreetingMessage(orgName, url, inviteIsPt(cohortLanguage, i18n.language));
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedMessage, setCopiedMessage] = useState(false);
+
+  const copy = async (text: string, set: (v: boolean) => void) => {
+    try { await navigator.clipboard.writeText(text); set(true); setTimeout(() => set(false), 2000); } catch {}
+  };
+
+  return (
+    <div className="space-y-3 py-1">
+      <p className="text-xs text-muted-foreground">
+        {t('orchestrator.cohort.cboLinkDesc', {
+          defaultValue: "Share this link with {{org}}. They'll land on the chat with Phase 1 unlocked.",
+          org: orgName,
+        })}
+      </p>
+
+      <div className="rounded-md border border-foreground/10 bg-muted/50 px-3 py-2 break-all text-xs font-mono text-foreground/80">
+        {url}
+      </div>
+
+      <a
+        href={whatsappDeepLink(message)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-[#25D366] hover:bg-[#1ebd5a] text-white font-medium text-sm h-10 transition-colors"
+        data-testid="button-open-whatsapp"
+      >
+        <MessageCircle className="w-4 h-4" />
+        {t('orchestrator.cohort.openWhatsApp', { defaultValue: 'Open in WhatsApp' })}
+        <ExternalLink className="w-3 h-3 opacity-70" />
+      </a>
+
+      <div className="grid grid-cols-2 gap-2">
+        <Button variant="outline" onClick={() => copy(url, setCopiedLink)} data-testid="button-copy-link">
+          {copiedLink ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <Copy className="w-3.5 h-3.5 mr-1.5" />}
+          {copiedLink ? t('common.copied', { defaultValue: 'Copied!' }) : t('orchestrator.cohort.copyLink', { defaultValue: 'Copy link' })}
+        </Button>
+        <Button variant="outline" onClick={() => copy(message, setCopiedMessage)} data-testid="button-copy-message">
+          {copiedMessage ? <Check className="w-3.5 h-3.5 mr-1.5" /> : <Copy className="w-3.5 h-3.5 mr-1.5" />}
+          {copiedMessage ? t('common.copied', { defaultValue: 'Copied!' }) : t('orchestrator.cohort.copyMessage', { defaultValue: 'Copy message' })}
+        </Button>
+      </div>
+
+      <details className="text-xs text-muted-foreground">
+        <summary className="cursor-pointer select-none hover:text-foreground/80">
+          {t('orchestrator.cohort.previewMessage', { defaultValue: 'Preview message' })}
+        </summary>
+        <pre className="mt-2 whitespace-pre-wrap rounded-md border border-foreground/10 bg-muted/30 px-3 py-2 text-[11px] leading-relaxed font-sans">
+          {message}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -864,18 +864,13 @@ export default function OrchestratorLandingPage() {
     setShareOpen(true);
   };
 
-  const openProject = (p: CboDemoProject) => {
-    const member = memberById.get(p.id);
-    if (member?.capabilityToken || member?.memberSlug) {
-      openShare(
-        memberInviteUrl(member),
-        { kind: 'cbo', orgName: member.orgName }
-      );
-    }
-  };
-
+  // Open the unified per-CBO panel. The invite link/message now lives in the
+  // panel's Convite tab, so clicking a CBO card opens here (not the share modal).
+  // The share modal is kept only for the just-created new-invite moment.
   const openCbo = (p: CboDemoProject, tab: CboDrawerTab) => {
-    setFilesMember({ id: p.id, orgName: p.name[locale] });
+    const member = memberById.get(p.id);
+    const inviteUrl = member ? memberInviteUrl(member) : '';
+    setFilesMember({ id: p.id, orgName: p.name[locale], inviteUrl });
     setFilesTab(tab);
   };
 
@@ -1053,6 +1048,7 @@ export default function OrchestratorLandingPage() {
       <CboFilesDrawer
         cohortSlug={cohort?.coordinatorSlug ?? null}
         member={filesMember}
+        cohortLanguage={cohortLanguage}
         initialTab={filesTab}
         onClose={() => setFilesMember(null)}
       />
@@ -1265,7 +1261,7 @@ export default function OrchestratorLandingPage() {
                     locale={locale}
                     selected={selectedId === p.id}
                     onHover={setSelectedId}
-                    onOpen={openProject}
+                    onOpen={(p) => openCbo(p, 'convite')}
                     onOpenCbo={openCbo}
                   />
                   {member && (

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -2081,6 +2081,7 @@
     "refresh": "Atualizar",
     "tabFiles": "Arquivos",
     "tabChat": "Conversa",
-    "tabProfile": "Perfil"
+    "tabProfile": "Perfil",
+    "tabInvite": "Convite"
   }
 }


### PR DESCRIPTION
Clicking an already-invited CBO card used to pop a separate **share modal**, while the side panel (files/chat/profile) was a different click. This unifies them: **the card opens the panel**, and the invite link + WhatsApp message become its **first tab**.

## Changes
- New **Convite** tab (first) — `CboInviteView`: invite link, Open in WhatsApp, copy link/message, message preview. Extracted from `ShareLinkDialog`, reusing the shared helpers so the message is byte-identical.
- Tabs: **Convite · Arquivos · Conversa · Perfil**. Card click → Convite; 📎 chip → Arquivos; Ver → Perfil.
- **New single invites still use the share modal** (a brand-new CBO has no files/chat/profile yet) — `ShareLinkDialog` untouched for that + the coordinator-link case.
- `FilesDrawerMember` carries `inviteUrl`; drawer takes `cohortLanguage` so the message matches the org's forced language. `cboView.tabInvite` pt key.

## e2e
The two invite tests click the card → the panel opens on Convite (default), which has the `wa.me` link + "Preview message", and a Sheet is `role="dialog"` — so they stay green.

## Verified
tsc clean on changed files; production build succeeds. Built on current `main` (post #284/#286/#288/#289).