### PR TITLE
fix(cbo): drop hardcoded coordinator names from support dialog

### DIFF
--- a/client/src/core/components/cbo/RequestSupportDialog.tsx
+++ b/client/src/core/components/cbo/RequestSupportDialog.tsx
@@ -24,8 +24,8 @@ const OPTIONS: OptionDef[] = [
   {
     value: 'coordinator-chat',
     icon: Users,
-    pt: { label: 'Conversa com a coordenadora', hint: 'Falar com Julia/Antônia sobre dúvidas, decisões ou bloqueios.' },
-    en: { label: 'Chat with the coordinator', hint: 'Talk to Julia/Antônia about questions, decisions, or blockers.' },
+    pt: { label: 'Conversa com a coordenadora', hint: 'Falar com a coordenadora sobre dúvidas, decisões ou bloqueios.' },
+    en: { label: 'Chat with the coordinator', hint: 'Talk to your coordinator about questions, decisions, or blockers.' },
   },
   {
     value: 'oef-technical',

--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -257,7 +257,7 @@ export function ProvisionCohortDialog({
             <Input
               value={coordinatorName}
               onChange={(e) => setCoordinatorName(e.target.value)}
-              placeholder="Julia"
+              placeholder={t('orchestrator.cohort.coordinatorNamePlaceholder', { defaultValue: 'Ex.: Maria Silva' }) as string}
               data-testid="input-provision-coordinator-name"
             />
           </div>
@@ -270,7 +270,7 @@ export function ProvisionCohortDialog({
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                placeholder="julia@example.com"
+                placeholder="maria@example.com"
                 data-testid="input-provision-email"
               />
             </div>

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -102,6 +102,7 @@
       "coordLinkTitle": "Seu link de coordenação",
       "coordinatorEmail": "E-mail de acesso",
       "coordinatorName": "Nome da coordenação",
+      "coordinatorNamePlaceholder": "Ex.: Maria Silva",
       "coordinatorPassword": "Senha",
       "copyAllMessages": "Copiar todas as mensagens",
       "copyLink": "Copiar link",


### PR DESCRIPTION
## What

The CBO **"Pedir apoio"** dialog hint hardcoded **"Julia/Antônia"** (see screenshot) — pilot-specific coordinator names that are wrong for any other cohort or coordinator.

## Fix

- `RequestSupportDialog.tsx` — the "Conversa com a coordenadora" hint now reads **"Falar com a coordenadora…"** / **"Talk to your coordinator…"**, matching the rest of the *same* dialog, which already refers to the coordinator generically (the confirmation + lead copy say "a coordenadora" with no name).

## Other cases like this (swept the codebase)

The only other person-name hardcodes were **example placeholders** in the orchestrator's provision dialog — genericized for consistency:
- coordinator-name input `"Julia"` → `"Ex.: Maria Silva"` (new PT-keyed string `orchestrator.cohort.coordinatorNamePlaceholder`)
- email input `"julia@example.com"` → `"maria@example.com"`

**Deliberately left alone:** `"COUGAR · Vila Flores"` brand mark + the WhatsApp invite template — that's the *program/pilot* name, not a per-cohort coordinator, and reads as intentional branding. Flagging it in case you want those parameterized by cohort too; happy to do it as a follow-up.

## Verify
tsc clean (no errors in changed files), build clean, pt.json valid.

Needs the usual rebuild + republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)