### PR TITLE
knowledge: add whenToUse frontmatter to KB files (sharpens search_knowledge)

### DIFF
--- a/knowledge/_co-benefits/biodiversity.md
+++ b/knowledge/_co-benefits/biodiversity.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Biodiversity co-benefits of NBS — habitat, species, pollinators."
 co_benefit: "biodiversity"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_co-benefits/carbon-sequestration.md
+++ b/knowledge/_co-benefits/carbon-sequestration.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Carbon sequestration and climate-mitigation co-benefits of NBS."
 co_benefit: "carbon sequestration"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_co-benefits/economic-social.md
+++ b/knowledge/_co-benefits/economic-social.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Economic and social co-benefits — jobs, income, property value, community, equity."
 co_benefit: "economic-social"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_co-benefits/flood-risk-reduction.md
+++ b/knowledge/_co-benefits/flood-risk-reduction.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Flood-risk-reduction benefits of NBS — runoff, infiltration, damage avoided."
 co_benefit: "flood risk reduction"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_co-benefits/heat-island-mitigation.md
+++ b/knowledge/_co-benefits/heat-island-mitigation.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Urban heat-island mitigation — temperature, shade, cooling."
 co_benefit: "heat island mitigation"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_co-benefits/public-health.md
+++ b/knowledge/_co-benefits/public-health.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Public-health co-benefits — air quality, mental health, heat-related illness."
 co_benefit: "public health"
 last_updated: 2026-03-26
 source: "web research - peer reviewed literature"

--- a/knowledge/_cougar/cohort-org-profiles.md
+++ b/knowledge/_cougar/cohort-org-profiles.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Vila Flores / COUGAR cohort participant org profiles — the 9 community organizations."
 last_updated: 2026-06-15
 source: "Web research (public sources) — grounding for test personas + light invite pre-fill"
 status: draft — real public info only; gaps marked "(não encontrado)", never invented

--- a/knowledge/_cougar/cougar-y2-plan.md
+++ b/knowledge/_cougar/cougar-y2-plan.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "COUGAR Year-2 plan and program context (Porto Alegre resilience accelerator)."
 last_updated: 2026-03-31
 source: "COUGAR.Y2_CommunityEngagement_October25.docx"
 ---

--- a/knowledge/_cougar/ecosystem-assessment-summary.md
+++ b/knowledge/_cougar/ecosystem-assessment-summary.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre climate-resilience innovation ecosystem and actors — benchmarking org maturity."
 last_updated: 2026-03-31
 source: "COUGAR_Pyxera Global Ecosystem Assessment (Sept 2025)"
 ---

--- a/knowledge/_cougar/nbs-mapping-criteria.md
+++ b/knowledge/_cougar/nbs-mapping-criteria.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "COUGAR NBS project mapping/scoring criteria and maturity rubric — eligibility and scoring."
 last_updated: 2026-03-31
 source: "COUGAR 2.0 NBS Mapping Criteria.xlsx"
 ---

--- a/knowledge/_cougar/sample-cbo-vilaflores.md
+++ b/knowledge/_cougar/sample-cbo-vilaflores.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Sample/calibration CBO profile (Vila Flores) — reference example."
 organization: Associação Cultural Vila Flores
 type: sample_cbo_profile
 last_updated: 2026-03-31

--- a/knowledge/_evidence/funded-projects-brazil.md
+++ b/knowledge/_evidence/funded-projects-brazil.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Real funded NBS-relevant projects in Brazil (GCF, World Bank, GEF) — precedents and funding benchmarks."
 last_updated: 2026-03-26
 source: "Project Evidence spreadsheet (1LuFTd9rJSX099bHNU4G6ehNUyN8px-4fnO6Aeq_DPyg)"
 ---

--- a/knowledge/_evidence/impact-benchmarks.md
+++ b/knowledge/_evidence/impact-benchmarks.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Quantitative NBS impact benchmarks and ranges (with vs without) for expected-impact estimates."
 last_updated: 2026-03-26
 source: "literature review + Project Evidence spreadsheet"
 ---

--- a/knowledge/_financing-sources/brazilian-domestic.md
+++ b/knowledge/_financing-sources/brazilian-domestic.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Brazilian domestic funding for municipal NBS/climate — federal/state programs, BNDES, FNMC."
 last_updated: 2026-03-26
 source: "Project Evidence spreadsheet + web research"
 ---

--- a/knowledge/_financing-sources/cbo-grants.md
+++ b/knowledge/_financing-sources/cbo-grants.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Funding for community/CBO-scale NBS in Brazil — small grants (Teia, Fundo Casa RS, GEF SGP, Periferias Verdes)."
 last_updated: 2026-04-07
 source: "web research — verified funding sources for small CBOs"
 audience: "Community-based organizations (5-50 people, budgets R$50K-2M)"

--- a/knowledge/_financing-sources/international.md
+++ b/knowledge/_financing-sources/international.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "International financing for NBS/urban climate in Brazil — GCF, World Bank, IDB, GEF."
 last_updated: 2026-03-26
 source: "Project Evidence spreadsheet + web research"
 ---

--- a/knowledge/_financing-sources/preparation-facilities.md
+++ b/knowledge/_financing-sources/preparation-facilities.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Project preparation facilities and technical assistance for NBS/climate projects."
 last_updated: 2026-03-26
 source: "Project Evidence spreadsheet + web research"
 ---

--- a/knowledge/_interventions/bioswales-rain-gardens.md
+++ b/knowledge/_interventions/bioswales-rain-gardens.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Choosing or sizing bioswales, rain gardens, or bioretention for stormwater and flooding — design, cost, maintenance."
 intervention_type: "bioswales-rain-gardens"
 primary_benefit: "adaptation"
 last_updated: 2026-03-26

--- a/knowledge/_interventions/flood-parks.md
+++ b/knowledge/_interventions/flood-parks.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Flood retention parks, water plazas, detention basins for flood control — design, cost, expected impact."
 intervention_type: "flood-parks"
 primary_benefit: "adaptation"
 last_updated: 2026-03-26

--- a/knowledge/_interventions/green-corridors.md
+++ b/knowledge/_interventions/green-corridors.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Green corridors, ecological connectivity, linear parks — biodiversity, heat, mobility."
 intervention_type: "green-corridors"
 primary_benefit: "both"
 last_updated: 2026-03-26

--- a/knowledge/_interventions/green-roofs-walls.md
+++ b/knowledge/_interventions/green-roofs-walls.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Green roofs, living walls, vertical gardens — heat, stormwater, building-scale NBS."
 intervention_type: "green-roofs-walls"
 primary_benefit: "both"
 last_updated: 2026-03-26

--- a/knowledge/_interventions/urban-forests.md
+++ b/knowledge/_interventions/urban-forests.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Urban forests and tree planting — heat-island, shade, slope stabilization, carbon."
 intervention_type: "urban-forests"
 primary_benefit: "both"
 last_updated: 2026-03-26

--- a/knowledge/_interventions/wetland-restoration.md
+++ b/knowledge/_interventions/wetland-restoration.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Wetland restoration or constructed wetlands — flooding, water quality, biodiversity."
 intervention_type: "wetland-restoration"
 primary_benefit: "both"
 last_updated: 2026-03-26

--- a/knowledge/_success-cases/brazilian-municipal.md
+++ b/knowledge/_success-cases/brazilian-municipal.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Brazilian municipal NBS success stories (Curitiba, Recife, BH, São Paulo, Salvador) — inspiration and examples."
 last_updated: 2026-03-26
 source: "web research"
 ---

--- a/knowledge/porto-alegre/baseline-data.md
+++ b/knowledge/porto-alegre/baseline-data.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre baseline data (population, land, environment) for NBS planning."
 city: "Porto Alegre"
 state: "Rio Grande do Sul"
 locode: "BR POA"

--- a/knowledge/porto-alegre/city-profile.md
+++ b/knowledge/porto-alegre/city-profile.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre city profile and general context."
 city: Porto Alegre
 state: Rio Grande do Sul
 country: Brazil

--- a/knowledge/porto-alegre/climate-risks.md
+++ b/knowledge/porto-alegre/climate-risks.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre climate risks — Guaíba flooding, heat islands, landslides on the morros."
 city: Porto Alegre
 state: Rio Grande do Sul
 country: Brazil

--- a/knowledge/porto-alegre/existing-plans.md
+++ b/knowledge/porto-alegre/existing-plans.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre existing plans and commitments (PCVR, World Bank, municipal)."
 city: "Porto Alegre"
 state: "Rio Grande do Sul"
 locode: "BR POA"

--- a/knowledge/porto-alegre/local-precedents.md
+++ b/knowledge/porto-alegre/local-precedents.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre local NBS precedents and green infrastructure (Orla do Guaíba, Regenera Dilúvio)."
 city: "Porto Alegre"
 state: "Rio Grande do Sul"
 locode: "BR POA"

--- a/knowledge/porto-alegre/regulatory-context.md
+++ b/knowledge/porto-alegre/regulatory-context.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre regulatory context — permits, land use, tenure for NBS."
 city: "Porto Alegre"
 state: "Rio Grande do Sul"
 locode: "BR POA"

--- a/knowledge/porto-alegre/stakeholders.md
+++ b/knowledge/porto-alegre/stakeholders.md
@@ -1,4 +1,5 @@
 ---
+whenToUse: "Porto Alegre stakeholders, partners, and institutions for NBS projects."
 city: "Porto Alegre"
 state: "Rio Grande do Sul"
 locode: "BR POA"


### PR DESCRIPTION
Adds a one-line `whenToUse:` hint to all 31 knowledge files in the agent-searched folders. `search_knowledge` (#292) boosts ranking on this curated hint — the same high-signal frontmatter Funga relies on. Docs-only, purely additive (harmless without #292 since `read_knowledge` strips frontmatter). Follow-up to #292.