### PR TITLE
CBO skills: teach E1/E2 to use the search tools before asking cold

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -271,6 +271,15 @@ Files auto-parse via the existing fileParser flow. Use the parsed content to:
 - Triangulate `prior_project_scale` (a real grant approval bumps score 2→3)
 - Fill `mission_summary` if the doc is more articulate than the user's own words (it's part of the bulk-confirm, so they validate it)
 
+### Search the org's files, don't just hope you read them
+
+A document may already be on file from the invite or a previous attempt (the DOCUMENTS ON FILE block lists what exists), and a long proposal won't fully fit in one read. **Before re-asking for something a document likely contains, search for it.** Use `search_org_documents(query)` — it returns the relevant passage with the document `[id]`; `read_org_document([id])` gets the full text only if you need more. Silent, between turns; if nothing matches, just ask normally.
+
+- Corroborate delivery capacity for scoring — `search_org_documents("financiamento aprovação carta parceria convênio edital")` finds a grant approval / partnership letter that bumps `org_delivery_capacity` 2→3.
+- Fill a gap a batch left open — e.g. `search_org_documents("fundação ano equipe missão projetos")` before re-asking org age, team size, or past projects.
+
+A doc-sourced value is still **confirmed with the user, not asserted** (keep `source: 'document'` until they validate).
+
 ## Closing
 
 After both batches are answered (Step 2) and the path triage is done:
@@ -315,7 +324,7 @@ The conversation ending quietly is correct and expected — silence after the cl
 
 ## KB grounding the agent has access to
 
-`read_knowledge` is allowed for:
+`search_knowledge(query)` finds the right KB passage by topic; `read_knowledge(folder, file)` reads a known file. Relevant files:
 
 - `knowledge/_cougar/nbs-mapping-criteria.md` — the scoring rubric (use to corroborate your inference)
 - `knowledge/_cougar/ecosystem-assessment-summary.md` — for benchmarking ("orgs like CEA Bom Jesus, Translab, Vila Flores are in your range" — but only mention if the user asks)
@@ -341,7 +350,8 @@ Common stuck patterns + responses:
 - `score_maturity(metric, score, justification)` — after capacity questions
 - `set_path('has-project' | 'has-idea' | 'needs-help')` — after triage answer. has-project = a selected/scoped project; has-idea = a direction not yet locked; needs-help = no project yet
 - `score_maturity` — both metrics at end (no separate phase-complete tool exists; scoring + closing message is the signal that E1 is done)
-- `read_knowledge(path)` — silently, to inform scoring
+- `read_knowledge(folder, file)` — exact-path KB read; `search_knowledge(query)` — search the KB by topic (prefer when you don't know the file). Both silent, to inform scoring
+- `search_org_documents(query)`, `list_org_documents()`, `read_org_document([id])` — the org's uploaded files (see "Search the org's files, don't just hope you read them" above)
 - `flag_gap(section, field, reason, severity)` — if the user skips something important; not exposed to user
 
 ## Estimated runtime & turn budget

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -53,6 +53,19 @@ If you call `update_section` and end the turn with no further tool call, the use
 
 The CURRENT STATE block of this prompt has E1's answers. Reference them naturally — *"você mencionou que trabalham com hortas em Cascata…"* — before pushing forward. Do not re-ask anything that's already in state.
 
+## ⚠️ Mine the org's documents before each beat — don't ask cold
+
+By E2 the org has usually dropped a proposal, report, or photos (in E1 or at invite). Those documents often **already state the site, the hazards they live with, and who owns the land** — exactly what this encontro captures. The DOCUMENTS ON FILE block lists what exists. **Before running a beat from zero, search the docs and turn whatever you find into a confirmation, not a question.** Do it silently between turns (never narrate *"deixa eu procurar nos documentos"*); if a search returns nothing, just ask normally.
+
+Use `search_org_documents(query)` — it returns the relevant passage from anywhere in a file with its `[id]` (only `read_org_document([id])` if you need more than the excerpt). Concrete checks for this encontro:
+
+- **Before `open_map` (Beat 2):** `search_org_documents("endereço localização terreno área lote rua bairro")`. If it names a place, open the map framed on it and confirm — *"Na proposta vocês falam do terreno na {local} — é lá que querem atuar?"* — instead of "onde vocês querem atuar?".
+- **Before `ask_priority_rank` (Beat 3a):** `search_org_documents("enchente alagamento calor deslizamento risco")`. If the doc names the hazards, pre-rank them and ask to confirm the order rather than starting blank.
+- **Before the tenure question (Beat 3b):** `search_org_documents("propriedade posse terreno cessão comodato aluguel prefeitura")`. If ownership is stated, confirm the matching chip instead of asking cold.
+- **Before `ask_community_anchoring` (Beat 3c):** `search_org_documents("comunidade famílias beneficiários voluntários mutirão lideranças")` to pre-fill lead / volunteers / beneficiaries.
+
+These searches are **extra tool calls in the same turn** — the turn still ends with the prescribed composer/`ask_user`, so you never strand the user (they attach to their beat, not to the entry turn whose first call must be `show_examples`). Confirm-don't-assert always: a doc hit is *"Vi na proposta que… certo?"*, riding on the next prescribed tool call — never a silent fill.
+
 ## ⚠️ First action on entering E2 — non-negotiable
 
 When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's start Encontro 2"* and state.phase = 2 (already advanced server-side), your **FIRST tool call MUST be `show_examples`**. Do NOT ask free-text intro questions about their site before showing examples + opening the map.
@@ -284,12 +297,16 @@ Already wired in cboAgent.ts:
 - `ask_priority_rank({prompt, minRanked?})` — NEW, E2 Beat 3a
 - `ask_community_anchoring({prompt})` — NEW, E2 Beat 3c
 - `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})` — existing
-- `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`, `read_knowledge`
+- `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`
+- `read_knowledge(folder, file)` — exact-path KB read; `search_knowledge(query)` — search the KB by topic when you don't know the filename (prefer this)
+- `search_org_documents(query)`, `list_org_documents()`, `read_org_document([id])` — the org's uploaded files (see "Mine the org's documents before each beat" above)
 
 NOT yet wired (DO NOT call):
 - `set_phase_complete` → no separate complete tool; just don't call `set_phase(3)` (P-8 gate refuses it anyway)
 
-## KB grounding (read_knowledge)
+## KB grounding (search_knowledge / read_knowledge)
+
+Prefer `search_knowledge(query)` to find the right passage by topic; use `read_knowledge(folder, file)` when you already know the exact file. Useful files:
 
 - `_success-cases/brazilian-municipal.md` — for additional Brazilian context if asked
 - `_interventions/*.md` — full intervention specs (useful for the closing hint)


### PR DESCRIPTION
## What
The lexical retrieval tools merged in #292 (`search_org_documents`, `search_knowledge`) + the doc-readers (`list_org_documents`, `read_org_document`) are wired into `cboAgent.ts` — but the two hardened skills (`encontro-1.md`, `encontro-2.md`) only ever referenced `read_knowledge`. So in W2, when an org dropped a proposal in W1 that literally states their site, hazards, and land ownership, the agent had no instruction to go *find* it before running the map/tenure beats cold. The tool was in the box; the playbook never reached for it.

## Changes (docs-only)
- **encontro-2** — new **“Mine the org’s documents before each beat”** rule with a concrete PT `search_org_documents` query per beat (map / priority-rank / tenure / anchoring), confirm-don’t-assert framing, and an explicit note that the search rides in the *same turn* as the prescribed composer so it never strands the user or violates the “first call must be `show_examples`” rule. Tool inventory + KB-grounding sections now list `search_knowledge` and the three doc tools.
- **encontro-1** — **“Search the org’s files”** subsection (corroborate delivery capacity for scoring via a grant/partnership-letter search; fill gaps a batch left open). Tool list + KB grounding updated the same way.

## Guardrails baked into the wording
- Confirm, never assert (`source: 'document'` until the user validates).
- Silent between turns — no “deixa eu procurar nos documentos” narration.
- No-match → fall through to asking normally.
- Prefer `search_knowledge` over guessing a filename for `read_knowledge`.

## Notes
- Skills are read at runtime from `knowledge/` — no build needed beyond the usual republish.
- All five referenced tool names verified against the registered tools in `cboAgent.ts`.
- Out of scope (flagged): the *other* agent’s `agentService.ts` “semantic search” uses hash bag-of-words, not real embeddings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)