### PR TITLE
fix(cbo): correct client-side session + map state restoration

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -169,8 +169,10 @@ function migrateCboState(state: CboState): CboState {
 // invite (?t=tokenB) on a phone that already has org A's session cached and the
 // chat resumes A's conversation instead of starting B's. Per-token keys keep
 // each invited org's session separate; the standalone /cbo-profile flow (no
-// token) keeps the plain key. (The member's server-side cboStateId remains the
-// cross-device source of truth via the snapshot binding.)
+// token) keeps the plain key. For token/slug links the member's server-side
+// cboStateId IS read back on load (see resolveSession) and wins over this cache,
+// so the working session is the cross-device source of truth — this localStorage
+// entry is only a same-device fast path that converges onto the server id.
 function sessionStorageKey(): string {
   try {
     const p = new URLSearchParams(window.location.search);
@@ -304,6 +306,47 @@ export default function CboProfilePage() {
   // the chat. State is encontro number 1-6 OR null (no preamble showing).
   const [preambleEncontro, setPreambleEncontro] = useState<number | null>(null);
 
+  // One-time session-resolution latch shared by the standalone init() effect
+  // and the token-driven resolveSession() below — guarantees exactly one
+  // session is loaded/created across StrictMode double-invokes and member
+  // re-fetches (focus/poll).
+  const initRef = useRef(false);
+
+  // Resolve THIS link's working session. The server binding (member.cboStateId)
+  // is the source of truth, so a token link resumes the SAME conversation +
+  // files + progress on any device — not just the browser that created it.
+  // Falls back to a same-device cached id, then to creating a fresh session
+  // (which the snapshot effect binds to the member). Runs once, guarded by
+  // initRef. Used only by the token/slug (cohort) path; standalone /cbo-profile
+  // self-inits in the init() effect below.
+  const resolveSession = useCallback(async (serverStateId: string | null) => {
+    if (initRef.current) return;
+    initRef.current = true;
+    const candidate = serverStateId || getSavedId();
+    if (candidate) {
+      try {
+        const res = await fetch(`/api/cbo/${candidate}`);
+        if (res.ok) {
+          const data = await res.json();
+          setCboId(candidate);
+          setState(migrateCboState(data.state));
+          const msgRes = await fetch(`/api/cbo/${candidate}/messages`);
+          if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) setMessages(msgs); }
+          saveId(candidate); // converge the same-device cache onto the server id
+          return;
+        }
+        // 404 → the binding/cache points at a state that no longer exists
+        // (DB wiped, container recycled). Drop the stale cache and start fresh.
+        if (res.status === 404) clearId();
+      } catch {}
+    }
+    const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
+    const data = await res.json();
+    setCboId(data.cboId);
+    setState(data.state);
+    saveId(data.cboId);
+  }, []);
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     // Preferred: unguessable capability token (?t=). Legacy: org-name slug
@@ -340,13 +383,24 @@ export default function CboProfilePage() {
       setFocusWorkshop(data.focusWorkshop ?? null);
       setFocusWorkshopIsCurrent(!!data.focusWorkshopIsCurrent);
     };
-    const refetch = () => fetch(memberUrl).then(r => r.ok ? r.json() : null).then(applyMember).catch(() => {});
+    const refetch = () => fetch(memberUrl).then(r => r.ok ? r.json() : null).then(data => {
+      applyMember(data);
+      // Recover session resolution if the initial fetch failed (transient
+      // network) and left initRef unset; idempotent once resolved.
+      if (data) resolveSession(data.cboStateId ?? null);
+    }).catch(() => {});
 
     fetch(memberUrl)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         applyMember(data);
-        if (data) setWelcomeMode(true);
+        if (data) {
+          setWelcomeMode(true);
+          // Resolve the working session from the server binding — this is what
+          // makes the token link device-independent. Guarded by initRef so the
+          // focus/poll refetch (which also calls applyMember) never re-resolves.
+          resolveSession(data.cboStateId ?? null);
+        }
       })
       .catch(() => {});
 
@@ -498,9 +552,14 @@ export default function CboProfilePage() {
   // The active id ends up being the second (no-prefill) CBO and the prefilled
   // one orphans. Symptoms: agent re-asks org_name despite the doc panel showing
   // it, "starting fresh" messages, language flipping, etc.
-  const initRef = useRef(false);
   useEffect(() => {
     if (initRef.current) return;
+    // Token / cohort links (?t= / ?cbo=) resolve their session from the server
+    // binding via resolveSession() in the member effect above — the server is
+    // the source of truth so the link resumes on any device. Only the
+    // standalone /cbo-profile flow (no token) self-inits from localStorage here.
+    const p = new URLSearchParams(window.location.search);
+    if (p.get('t') || p.get('cbo')) return;
     initRef.current = true;
     async function init() {
       const saved = getSavedId();

--- a/e2e/cougar-invite-session.spec.ts
+++ b/e2e/cougar-invite-session.spec.ts
@@ -62,7 +62,9 @@ test.describe('COUGAR — token link resumes on a fresh device', () => {
 
     // First device establishes the session and the server binding.
     const idA = await openInvite(page);
-    const token = new URL(a.inviteUrl).searchParams.get('t')!;
+    // inviteUrl is relative (page.goto resolves it against baseURL); new URL()
+    // would throw, so parse the query string directly.
+    const token = new URLSearchParams(a.inviteUrl.split('?')[1] ?? '').get('t')!;
     await expect
       .poll(async () => (await (await request.get(`/api/cbo-member/by-token/${token}`)).json()).cboStateId, {
         timeout: 15_000,

--- a/e2e/cougar-invite-session.spec.ts
+++ b/e2e/cougar-invite-session.spec.ts
@@ -39,3 +39,44 @@ test.describe('COUGAR #7 — new invite never resumes a prior org session', () =
     expect(keys.filter(k => k.includes(':')).length, 'per-token session keys exist').toBeGreaterThanOrEqual(2);
   });
 });
+
+// The token link is a credential to the ORG's working session — opening it on a
+// fresh device (empty localStorage) must resume the SAME conversation, not mint
+// a new empty session. Regression guard: server binding (member.cboStateId) is
+// read back on load (resolveSession), not just written.
+test.describe('COUGAR — token link resumes on a fresh device', () => {
+  test('clean localStorage resolves the same session from the server binding', async ({ page, browser, request }) => {
+    const api = new TestApi(request);
+    const { cohort } = await api.createCohort('e2e cross-device');
+    const a = await api.inviteMember(cohort.id, { orgName: 'Org Cross' });
+
+    const openInvite = async (p: typeof page): Promise<string> => {
+      await p.goto(a.inviteUrl);
+      await p.getByTestId('button-cbo-welcome-cta').click({ timeout: 30_000 });
+      const pre = p.getByTestId('button-encontro-1-start');
+      if (await pre.isVisible({ timeout: 8_000 }).catch(() => false)) await pre.click();
+      const marker = p.getByTestId('cbo-stream-status');
+      await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+      return (await marker.getAttribute('data-cbo-id'))!;
+    };
+
+    // First device establishes the session and the server binding.
+    const idA = await openInvite(page);
+    const token = new URL(a.inviteUrl).searchParams.get('t')!;
+    await expect
+      .poll(async () => (await (await request.get(`/api/cbo-member/by-token/${token}`)).json()).cboStateId, {
+        timeout: 15_000,
+      })
+      .toBe(idA);
+
+    // Second "device": a brand-new context has no localStorage — exactly the
+    // case that used to mint a fresh empty session and orphan the real one.
+    const ctx = await browser.newContext();
+    try {
+      const idA2 = await openInvite(await ctx.newPage());
+      expect(idA2, 'a clean device must resume the same session, not create a new one').toBe(idA);
+    } finally {
+      await ctx.close();
+    }
+  });
+});


### PR DESCRIPTION
Two related fixes to how the CBO page restores client-side state — both cases where the wrong thing got resurrected from browser storage.

## 1. Token link now resumes the session on any device

A CBO invite link (`/cbo-profile?t=<token>`) is meant to be the org's **sole credential** — opening it on any browser/device should resume the same conversation, files, and progress. It didn't: a fresh browser showed an empty session.

**Cause:** the working session was keyed by browser `localStorage`, not the token. `init()` created a fresh empty `cbo_state` whenever localStorage was empty (any new device), then the snapshot effect repointed the member to that empty state — orphaning the real one. The server already had the right binding (`member.cboStateId`) and returned it from `/api/cbo-member/by-token`, but the client never read it back.

**Fix:** new `resolveSession()` makes the server binding the source of truth — loads `member.cboStateId` on entry (any device), falls back to the same-device cache, only creates fresh when the member has no binding. `init()` early-returns for `?t=`/`?cbo=` links so it can't mint an orphan first. Standalone `/cbo-profile` unchanged. A shared `initRef` latch keeps exactly one session across StrictMode double-mounts and the focus/poll refetch.

Adds an e2e regression test: open an invite, wait for the binding, reopen the same token in a fresh `browser.newContext()` (empty localStorage = different device) and assert the **same** `cbo-id` resumes.

## 2. Map opens only when the agent calls `open_map`

The right panel auto-switched to the map and pre-loaded a stale view even in **E1 (Quem Somos)**, where the agent never opens a map.

**Cause:** `open_map` cached its params under a global, non-token/non-phase-scoped `sessionStorage` key (`cbo-map-params`), and four initial-state values read it back on every load — so a map opened once (in E2, or for another org in the same tab) leaked into unrelated contexts.

**Fix:** map visibility is live-session only — it opens solely from the agent's `open_map` event. The Mapa tab stays available for manual viewing. Tradeoff: reloading mid-E2 with the map open closes it until reopened; can be re-added scoped by token + phase if we want reload-resilience back.

---

Both changed files typecheck clean (`tsc --noEmit`). e2e not run locally (harness needs a `DATABASE_URL` not configured in this checkout).

**Deploy note:** rebuild + republish the Repl after merge — it serves the compiled `build/`.

**Data:** no loss. Original `cbo_state` rows are intact; only the member→state pointer was repointed.