### PR TITLE
fix(cbo): map opens only on explicit agent signal (drop keyword regex + sessionStorage restore)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -142,7 +142,6 @@ function EditableField({ value, onSave, userEdited }: { value: string; onSave: (
 }
 
 const STORAGE_KEY = 'cbo-session-id';
-const MAP_PARAMS_KEY = 'cbo-map-params';
 // Migrate old 5-section states to 7 sections (adds intervention_type, impact_monitoring, operations_sustain)
 function migrateCboState(state: CboState): CboState {
   for (const sec of CBO_SECTIONS) {
@@ -183,8 +182,11 @@ function sessionStorageKey(): string {
 function getSavedId(): string | null { try { return localStorage.getItem(sessionStorageKey()); } catch { return null; } }
 function saveId(id: string) { try { localStorage.setItem(sessionStorageKey(), id); } catch {} }
 function clearId() { try { localStorage.removeItem(sessionStorageKey()); } catch {} }
-function getSavedMapParams(): OpenMapParams | null { try { const s = sessionStorage.getItem(MAP_PARAMS_KEY); return s ? JSON.parse(s) : null; } catch { return null; } }
-function saveMapParams(p: OpenMapParams | null) { try { if (p) sessionStorage.setItem(MAP_PARAMS_KEY, JSON.stringify(p)); else sessionStorage.removeItem(MAP_PARAMS_KEY); } catch {} }
+// NOTE: the map is intentionally NOT persisted across reloads. It opens only
+// when the agent fires `open_map` in the live session (E2). Restoring it from
+// sessionStorage used to leak a previously-opened map into unrelated contexts
+// (e.g. back in E1 / Quem Somos, or another org in the same tab), since the key
+// was neither phase- nor token-scoped.
 
 // ============================================================================
 // MAIN PAGE
@@ -230,10 +232,10 @@ export default function CboProfilePage() {
   // "sending" indicator. Extraction now includes vision, so this can take a few
   // seconds; the user needs feedback that it's working.
   const [uploadingName, setUploadingName] = useState<string | null>(null);
-  const [rightTab, setRightTab] = useState<'document' | 'map' | 'scorecard' | 'interventions'>(getSavedMapParams() ? 'map' : 'document');
+  const [rightTab, setRightTab] = useState<'document' | 'map' | 'scorecard' | 'interventions'>('document');
   // Mobile-only: which top-level pane is visible. On `md+` both panels render
   // side-by-side and this state is ignored.
-  const [mobileActiveTab, setMobileActiveTab] = useState<'chat' | 'panel'>(getSavedMapParams() ? 'panel' : 'chat');
+  const [mobileActiveTab, setMobileActiveTab] = useState<'chat' | 'panel'>('chat');
   // Unread indicator on the Chat tab when the agent posts while the user is on
   // another mobile tab. Cleared on switch-to-chat.
   const [mobileChatUnread, setMobileChatUnread] = useState(false);
@@ -252,10 +254,9 @@ export default function CboProfilePage() {
       .catch(() => {});
   }, [cboId]);
   useEffect(() => { refreshFileCount(); }, [refreshFileCount]);
-  const [mapRelevant, setMapRelevant] = useState(!!getSavedMapParams());
-  const [openMapParams, _setOpenMapParams] = useState<OpenMapParams | null>(getSavedMapParams);
+  const [mapRelevant, setMapRelevant] = useState(false);
+  const [openMapParams, setOpenMapParams] = useState<OpenMapParams | null>(null);
   const [interventionSelectorParams, setInterventionSelectorParams] = useState<OpenInterventionSelectorParams | null>(null);
-  const setOpenMapParams = useCallback((p: OpenMapParams | null) => { _setOpenMapParams(p); saveMapParams(p); }, []);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -861,7 +862,7 @@ export default function CboProfilePage() {
 
   const handleRestart = useCallback(async () => {
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
-    clearId(); saveMapParams(null); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+    clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -730,8 +730,12 @@ export default function CboProfilePage() {
         }
         break;
       case 'ask_user': {
-        const spatialKeywords = /\b(zone|zona|area|área|site|sítio|where|onde|map|mapa|location|local|bairro)\b/i;
-        const hasMap = !!(event as any).showMap || spatialKeywords.test(event.question);
+        // Open the map only when the agent explicitly signals it via `showMap`
+        // on the question (or the `open_map` tool). A keyword regex on the
+        // question text used to also auto-open it — but that fired for any
+        // mention of "área/onde/local/bairro/…", popping the map open in E1
+        // (Quem Somos) and other non-spatial turns the agent never intended.
+        const hasMap = !!(event as any).showMap;
         setActiveQuestions(prev => {
           if (prev.length === 0) { setCurrentQuestionIdx(0); setQuestionAnswers({}); }
           return [...prev, { id: `q_${Date.now()}`, question: event.question, options: event.options, multiSelect: (event as any).multiSelect, relatedSections: (event as any).relatedSections }];


### PR DESCRIPTION
The map kept opening when it shouldn't — in **E1 (Quem Somos)** and on reloads — even though the agent never opened it. Two independent causes, both "the map auto-opens from something other than the tool":

## 1. Keyword regex on every question
`ask_user` ran each question through a spatial-keyword regex (`zona|área|onde|local|bairro|site|...`) and force-switched the panel to the map on any match. So an innocuous E1 question mentioning "área" or "onde" popped the map open. **Fix:** drop the regex; rely on the agent's explicit `showMap` flag (and the `open_map` tool) — the intentional signal the agent already sets only for genuinely spatial questions.

## 2. sessionStorage restore (didn't make the #297 merge)
`open_map` cached its params under a global, non-token/non-phase-scoped `sessionStorage` key (`cbo-map-params`) that four initial-state values read back on every load — so a map opened once (in E2, or for another org in the same tab) leaked into unrelated contexts. **Fix:** map visibility is live-session only. The Mapa tab stays available for manual viewing.

Net effect: the map opens **only** when the agent signals it (`open_map` tool, or `showMap: true` on a question). Tradeoff: reloading mid-E2 with the map open closes it until reopened.

Typechecks clean (`tsc --noEmit`).

**Note:** the city-facing `concept-note.tsx` has the same keyword-regex pattern (line ~457) — left untouched here to keep this scoped to the CBO flow; can do a matching fix if you want it.

**Deploy:** rebuild + republish the Repl after merge (serves compiled `build/`).