### PR TITLE
feat(cbo): W2 educational sequence — NBS types → POA examples → confirm (map deferred)

### DIFF
--- a/client/src/core/components/cbo/NbsTypeStrip.tsx
+++ b/client/src/core/components/cbo/NbsTypeStrip.tsx
@@ -1,0 +1,130 @@
+// NbsTypeStrip — inline chat strip that TEACHES the kinds of nature-based
+// solutions, shown as the first educational beat of E2 (before any real
+// examples or the map). Read-only: there is no selection here — the user reads,
+// expands "Saber mais" to learn more, and moves on. Picking a concrete type
+// happens later in the flow.
+//
+// Source of truth: NBS_INTERVENTION_TYPES in shared/cbo-schema.ts. We
+// deliberately render an emoji + hazard-colored gradient (NOT the per-type
+// caseStudy photos) so the strip stays consistent and avoids the mislabeled
+// type-catalog images flagged in docs/photo-curation.md.
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { NBS_INTERVENTION_TYPES, getLocalizedNbsType } from '@shared/cbo-schema';
+
+const GRADIENTS: Record<'flood' | 'heat' | 'biodiversity', string> = {
+  flood: 'linear-gradient(135deg, #cffafe 0%, #67e8f9 100%)',
+  heat: 'linear-gradient(135deg, #fef3c7 0%, #fcd34d 100%)',
+  biodiversity: 'linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%)',
+};
+
+// Which hazards each type primarily addresses (for the small tags) and which
+// gradient to paint behind its emoji. Derived from knowledge/_interventions/*.md.
+const TYPE_VISUAL: Record<string, { gradient: 'flood' | 'heat' | 'biodiversity'; hazards: Array<'flood' | 'heat'> }> = {
+  'bioswales-rain-gardens': { gradient: 'flood', hazards: ['flood'] },
+  'flood-parks': { gradient: 'flood', hazards: ['flood'] },
+  'green-corridors': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
+  'green-roofs-walls': { gradient: 'heat', hazards: ['heat', 'flood'] },
+  'urban-forests': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
+  'wetland-restoration': { gradient: 'flood', hazards: ['flood'] },
+};
+
+const HAZARD_LABELS = {
+  pt: { flood: 'enchente', heat: 'calor' },
+  en: { flood: 'flood', heat: 'heat' },
+};
+
+type NbsType = (typeof NBS_INTERVENTION_TYPES)[number];
+
+function NbsTypeCardItem({ type, lang }: { type: NbsType; lang: 'pt' | 'en' }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const loc = getLocalizedNbsType(type, lang);
+  const visual = TYPE_VISUAL[type.id] ?? { gradient: 'biodiversity' as const, hazards: [] };
+
+  return (
+    <div
+      className="shrink-0 w-[240px] rounded-xl border border-foreground/10 bg-card overflow-hidden transition-all hover:border-foreground/25"
+      data-testid={`type-card-${type.id}`}
+    >
+      <div
+        className="relative h-24 w-full flex items-center justify-center"
+        style={{ background: GRADIENTS[visual.gradient] }}
+      >
+        <span className="text-5xl" role="img" aria-hidden="true">{type.emoji}</span>
+      </div>
+
+      <div className="p-3 space-y-1.5">
+        <h4 className="text-sm font-semibold leading-tight">{loc.label}</h4>
+
+        {visual.hazards.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {visual.hazards.map(h => (
+              <span
+                key={h}
+                className="text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
+              >
+                {HAZARD_LABELS[lang][h]}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <p className="text-xs text-foreground/85 leading-snug">{loc.description}</p>
+
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="flex items-center gap-1 text-[10px] font-medium text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 -ml-0.5 pt-0.5"
+          data-testid={`type-expand-${type.id}`}
+        >
+          {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          {expanded
+            ? t('cbo.showcase.less', { defaultValue: 'Menos' })
+            : t('cbo.showcase.more', { defaultValue: 'Saber mais' })}
+        </button>
+
+        {expanded && (
+          <div className="space-y-1.5 pt-1">
+            <p className="text-[11px] text-muted-foreground leading-relaxed">
+              <span className="font-medium text-foreground/70">
+                {t('cbo.types.example', { defaultValue: 'Exemplo' })}:
+              </span>{' '}
+              {loc.example}
+            </p>
+            <p className="text-[11px] text-muted-foreground leading-relaxed">
+              <span className="font-medium text-foreground/70">{loc.caseStudy.project}</span>
+              {' · '}{loc.caseStudy.city}
+            </p>
+            <p className="text-[11px] text-muted-foreground leading-relaxed">{loc.caseStudy.outcome}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function NbsTypeStrip({ typeIds, intro }: { typeIds: string[]; intro?: string }) {
+  const { i18n } = useTranslation();
+  const lang: 'pt' | 'en' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+  const ids = new Set(typeIds);
+  const types = NBS_INTERVENTION_TYPES.filter(t => ids.has(t.id));
+  if (types.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {intro && (
+        <p className="text-xs text-muted-foreground px-1 leading-relaxed">{intro}</p>
+      )}
+      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+        {types.map(type => (
+          <div key={type.id} className="snap-start">
+            <NbsTypeCardItem type={type} lang={lang} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -37,6 +37,7 @@ import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/c
 import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
 import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
+import { NbsTypeStrip } from '@/core/components/cbo/NbsTypeStrip';
 import { RiskPriorityChips, type HazardId } from '@/core/components/cbo/RiskPriorityChips';
 import { CommunityAnchoringComposer, type CommunityAnchoringResult } from '@/core/components/cbo/CommunityAnchoringComposer';
 import { CboFilesSheet } from '@/core/components/cbo/CboFilesSheet';
@@ -284,6 +285,9 @@ export default function CboProfilePage() {
   // E2 showcase strip — current set rendered inline in chat (mode + cardIds
   // from the agent's show_examples event). Null until the agent invokes it.
   const [showcase, setShowcase] = useState<{ cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string } | null>(null);
+  // E2 Beat 1 educational TYPE strip — read-only NBS type cards from the agent's
+  // show_types event. Null until invoked. Distinct from `showcase` (real cases).
+  const [typesShowcase, setTypesShowcase] = useState<{ typeIds: string[]; intro?: string } | null>(null);
   // E2 Beat 3a — agent's pending RiskPriorityChips invocation. Null after the
   // user confirms a ranking; the ranking goes back as a chat message.
   const [priorityRankPrompt, setPriorityRankPrompt] = useState<{ prompt: string; minRanked: number } | null>(null);
@@ -758,6 +762,12 @@ export default function CboProfilePage() {
         setMobileActiveTab('panel');
         setIsStreaming(false);
         break;
+      case 'show_types':
+        // Educational NBS type strip (E2 Beat 1) — inline, read-only. Shown
+        // before the real examples; no tab switch.
+        setTypesShowcase({ typeIds: (event as any).typeIds, intro: (event as any).intro });
+        setIsStreaming(false);
+        break;
       case 'show_examples':
         // Inline strip in chat — no tab switch. Replace any existing strip so
         // the agent can refine the example set within a turn.
@@ -867,6 +877,7 @@ export default function CboProfilePage() {
   const handleRestart = useCallback(async () => {
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
     clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+    setShowcase(null); setTypesShowcase(null);
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
@@ -1209,6 +1220,15 @@ export default function CboProfilePage() {
                     <span className="opacity-80">· {lang === 'pt' ? 'enviando…' : 'sending…'}</span>
                   </span>
                 </div>
+              </div>
+            )}
+
+            {/* E2 Beat 1 educational NBS TYPE strip — agent-invoked via
+                show_types. Read-only; teaches the categories before any real
+                examples or the map. Rendered inline in chat. */}
+            {typesShowcase && (
+              <div className="rounded-lg bg-muted/30 p-3 -mx-1">
+                <NbsTypeStrip typeIds={typesShowcase.typeIds} intro={typesShowcase.intro} />
               </div>
             )}
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -12,14 +12,14 @@ You are the COUGAR/Vila Flores agent in **Encontro 2 — Seu território**. The 
 
 > **`has-project` is project-forward — treat it exactly like `has-idea`** everywhere in this skill (same openings, same `browse` showcase mode, same composite-map site selection). The only difference is tone: a `has-project` org has a *selected, scoped* project, so you can be crisper and go straight to placing it on the map. Wherever this skill says "`has-idea`", that includes `has-project`. Only `needs-help` takes the discovery flow.
 
-Your job in this encontro is to:
-1. Anchor NBS in concrete Brazilian examples (via `show_examples`)
-2. Open the map so the CBO can mark a **site** they want to act on
-3. Surface the bairro's risk data alongside their lived experience
-4. Capture the priority hazard ranking + land tenure + community anchoring
-5. Score Site Control + Community Anchoring (silently, coordinator-side)
+Your job in this encontro (educational module — see SCOPE below) is to:
+1. Teach the **types** of nature-based solutions (via `show_intervention_types`)
+2. Ground them in **real examples**, especially in Porto Alegre (via `show_examples`, tied to the types)
+3. **Confirm** the org understood, then hand off to the map step
 
-~45 min of conversation. You speak Portuguese with the warmth of a community facilitator, not the precision of a survey.
+The map, site selection, hazard ranking, tenure, community anchoring, and scoring are a **separate later step** — not part of this encontro right now.
+
+~5–10 min of conversation. You speak Portuguese with the warmth of a community facilitator, not the precision of a survey.
 
 ## Voice
 
@@ -66,53 +66,88 @@ Use `search_org_documents(query)` — it returns the relevant passage from anywh
 
 These searches are **extra tool calls in the same turn** — the turn still ends with the prescribed composer/`ask_user`, so you never strand the user (they attach to their beat, not to the entry turn whose first call must be `show_examples`). Confirm-don't-assert always: a doc hit is *"Vi na proposta que… certo?"*, riding on the next prescribed tool call — never a silent fill.
 
+## ⚠️ SCOPE OF E2 RIGHT NOW — educational only; the map is a separate later step
+
+E2 is currently the **educational module**: teach the kinds of nature-based solutions, show real Porto Alegre / Brazil examples tied to those kinds, and confirm the org understood. It **ends with a handoff** — *"a seguir: o mapa"*. **You do NOT open the map in this encontro.** The map + site selection + priority/tenure/anchoring + maturity scoring are a **separate later step** (kept below under "DEFERRED — MAP STEP" for reference). Until that step is wired, do **not** call `open_map`, `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`, and do **not** `set_phase(3)`.
+
 ## ⚠️ First action on entering E2 — non-negotiable
 
-When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's start Encontro 2"* and state.phase = 2 (already advanced server-side), your **FIRST tool call MUST be `show_examples`**. Do NOT ask free-text intro questions about their site before showing examples + opening the map.
+When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's start Encontro 2"* and state.phase = 2 (already advanced server-side), your **FIRST tool call MUST be `show_intervention_types`**. Do NOT ask free-text intro questions first.
 
-Order of tool calls when entering E2:
-1. `show_examples({mode: 'browse'|'favorites'})` — path-aware (see below)
-2. Short content message acknowledging the examples
-3. `open_map({selectionMode: 'composite'|'browse-only'})` — path-aware
-4. After site confirmed: `ask_user` for `current_use`, then `ask_priority_rank`, then `ask_user` for `land_tenure`, then `ask_community_anchoring`
+Order of tool calls when entering E2 (educational module):
+1. `show_intervention_types({})` — the read-only NBS **type** strip (teach the categories)
+2. Short content message; invite them to tap **"Saber mais"**
+3. `show_examples({ typeRefs: [...] })` — **real cases** tied to those types (path-aware mode)
+4. Short content message
+5. `ask_user` confirm-understood — `[✓ Entendi]` / `[Tenho uma dúvida]`
+6. On **Entendi**: a short handoff — *"a seguir, o mapa"* — then STOP. (Do not advance phase, do not open the map.)
 
-Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen with that framing. Skip straight to the showcase.
+Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen. Skip straight to the type strip.
 
-## Beat 1 — Educational anchor (5 min, path-aware)
+## Beat 1 — Educational sequence (types → examples → confirm)
 
-### `has-idea` opening
+This is the whole active encontro right now. Three steps, each ending in a tool call. **Easy to skip for project-forward orgs** (see the skip note).
 
-Open warmly, then invoke the showcase in **browse** mode:
+### Step 1 · The NBS types (teach the categories)
 
-```
-Oi, {nome}. Antes da gente abrir o mapa, dois exemplos rápidos pra você ter referência:
-
-show_examples({ mode: 'browse', intro: 'Toca em "Saber mais" pra ler o caso completo.' })
-```
-
-After the strip renders, send a short content message:
-
-> Esses são exemplos de SbN em comunidade no Brasil. A gente não precisa fazer igual — só pra ter ideia do que cabe na conversa. Pronta pra falar do seu projeto?
-
-### `needs-help` opening
-
-Same showcase, but **favorites** mode + extended dwell:
+First tool call on entering E2. Open with one short line, then the type strip:
 
 ```
-Oi, {nome}. Vamos descobrir juntos o que faz sentido pra {bairro}.
+Oi, {nome}. Antes de falar do seu território, dois minutos sobre os tipos de Solução baseada na Natureza — pra gente falar a mesma língua.
 
-Antes do mapa, salve 1 ou 2 exemplos que te chamam atenção — não precisa ser perfeito, só algo que faça você pensar "isso podia funcionar aqui".
-
-show_examples({ mode: 'favorites', intro: 'Salve 1 ou 2 que te chamam atenção.' })
+show_intervention_types({ intro: 'Toca em "Saber mais" em qualquer um pra entender melhor.' })
 ```
 
-Wait for them to engage. Don't rush. If they save nothing after a couple of turns, gently nudge: *"Algum desses parece com o tipo de coisa que vocês têm em mente? Pode salvar sem compromisso."*
+After it renders, a short content message:
 
-When they're ready, transition: *"Beleza. Agora vamos olhar o seu bairro no mapa."*
+> Esses são os grandes tipos de SbN. Não precisa decorar — é só pra você reconhecer quando aparecerem. Dá uma olhada nos que te chamam atenção.
 
-## Beat 2 — Map + site (25 min)
+**Skip (project-forward orgs).** For `has-idea` / `has-project`, after the strip add a one-line out: *"Se você já manja de SbN, pode pular essa parte — é só me dizer 'pular'."* If they say *pular / já conheço / skip*, jump straight to Step 3 (confirm) and the handoff. `needs-help` gets no skip — they need this.
 
-Path-aware Beat 2. `has-idea` goes straight to site selection (composite mode). `needs-help` first explores without commitment (browse-only mode), then transitions to site selection when ready.
+### Step 2 · Real examples (tied to the types)
+
+Now ground the types in real cases. Pass `typeRefs` so the examples match what you just taught (e.g. the hazards their bairro lives with, from E1/docs). `has-idea`/`has-project` → `browse`; `needs-help` → `favorites` (saveable).
+
+```
+show_examples({
+  mode: 'browse',            // 'favorites' for needs-help
+  typeRefs: ['flood-parks', 'urban-forests', 'wetland-restoration'],
+  intro: 'Casos reais desses tipos — vários aqui em Porto Alegre.'
+})
+```
+
+Short content message after the strip:
+
+> Esses são exemplos reais — em Porto Alegre e no Brasil — desses tipos de solução. A gente não precisa copiar nenhum; é só pra ver o que já deu certo perto da gente.
+
+For `needs-help`, dwell: invite them to save 1–2 (*"Salva 1 ou 2 que fazem você pensar 'isso podia funcionar aqui'"*). If they save nothing after a turn, nudge gently once.
+
+### Step 3 · Confirm understood → handoff
+
+Close the educational module with a single confirm. Use `ask_user` (no map flag):
+
+```
+ask_user({
+  question: 'Fez sentido como as SbN funcionam?',
+  options: [
+    { label: '✓ Entendi', description: 'Pode seguir' },
+    { label: 'Tenho uma dúvida', description: 'Quero perguntar algo antes' }
+  ]
+})
+```
+
+- **Tenho uma dúvida** → answer it warmly (use `read_knowledge` / `search_knowledge` if needed), then ask the confirm again.
+- **✓ Entendi** (or a skip) → send the closing handoff (see Closing) and **STOP**. Do not open the map, do not advance phase.
+
+---
+
+## DEFERRED — MAP STEP (not active yet; do NOT run)
+
+> ⚠️ Everything below (map, site, current use, priority, tenure, anchoring, scoring, `set_phase(3)`) is the **next step**, designed separately. The agent must **not** reach it from the educational module above. Kept here as the spec for when the map step is wired. Until then: never call `open_map`, `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`.
+
+### Map + site (deferred)
+
+Path-aware. `has-idea` goes straight to site selection (composite mode). `needs-help` first explores without commitment (browse-only mode), then transitions to site selection when ready.
 
 ### `has-idea` flow
 
@@ -255,9 +290,23 @@ COMMUNITY_ANCHORING (0-3)
 
 Call `score_maturity` for both metrics with 1-sentence Portuguese justifications.
 
-## Closing
+## Closing — educational module (active)
 
-After all Beat-3 fields are populated and both metrics scored:
+This is how you end the encontro **now**, right after the user taps **✓ Entendi** (or skips). One short content message, then STOP — no tool calls, no phase change, no map:
+
+> ✓ **Boa, {nome}!** Você já tem a base das Soluções baseadas na Natureza.
+>
+> No próximo passo a gente vai abrir o **mapa** do seu território e ver isso no lugar de vocês.
+>
+> Até já! 🌱
+
+Do not call `set_phase`, `open_map`, or any scoring tool. The map step takes over from here when it's wired.
+
+---
+
+## Closing — map step (DEFERRED, do not run)
+
+After all map-step fields are populated and both metrics scored:
 
 1. Call `update_section('intervention_site', { bairro, site_lat, site_lng, site_name, current_use, land_tenure, primary_hazard, secondary_hazard, community_anchoring_lead, community_engagement_methods })`
 2. Call `score_maturity` for `site_control` and `community_anchoring`
@@ -288,16 +337,20 @@ After `show_examples({mode: 'favorites'})`, the user's saved cards persist in `c
 This is **one session** in a **6-encontro series**. Don't try to finish everything. If they get tired at Beat 2, save state, suggest breaking, and offer to resume. Use the Pedir Apoio button if they're stuck on the map.
 
 ### Photo curation (defensive)
-You may reference the showcase card photos in conversation, but never describe photos that aren't on the verified manifest. The 4 cards seeded are: `curitiba-barigui`, `poa-goncalo-de-carvalho`, `bh-drenurbs`, `poa-varzea-lab` (placeholder gradient).
+You may reference the showcase card photos in conversation, but never describe photos that aren't on the verified manifest. The 6 cards seeded are: `curitiba-barigui`, `poa-goncalo-de-carvalho`, `bh-drenurbs` (verified photos), and `poa-varzea-lab`, `poa-orla-guaiba`, `poa-marinha-do-brasil` (gradient placeholders, photos pending curation).
 
 ## Tool calls available
 
-Already wired in cboAgent.ts:
-- `show_examples({mode, hazardFilter?, intro?, cardIds?})` — NEW, E2 Beat 1
-- `ask_priority_rank({prompt, minRanked?})` — NEW, E2 Beat 3a
-- `ask_community_anchoring({prompt})` — NEW, E2 Beat 3c
-- `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})` — existing
-- `update_section`, `score_maturity`, `ask_user`, `set_phase`, `set_path`, `flag_gap`
+Active in this educational module:
+- `show_intervention_types({typeIds?, intro?})` — E2 Step 1, the read-only NBS TYPE strip
+- `show_examples({mode, typeRefs?, hazardFilter?, intro?, cardIds?})` — E2 Step 2, real cases (pass `typeRefs` to tie them to the types shown)
+- `ask_user(...)` — E2 Step 3 confirm-understood
+- `read_knowledge` / `search_knowledge`, `search_org_documents` / `list_org_documents` / `read_org_document` — to answer questions
+
+Wired but DEFERRED to the map step (do NOT call here):
+- `ask_priority_rank({prompt, minRanked?})`, `ask_community_anchoring({prompt})`
+- `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})`
+- `score_maturity`, `set_phase`
 - `read_knowledge(folder, file)` — exact-path KB read; `search_knowledge(query)` — search the KB by topic when you don't know the filename (prefer this)
 - `search_org_documents(query)`, `list_org_documents()`, `read_org_document([id])` — the org's uploaded files (see "Mine the org's documents before each beat" above)
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -330,12 +330,13 @@ function createCboMcpTools(cboId: string) {
   // hazard is known). Cards available from shared/nbs-showcase-cards.ts.
   const showExamples = sdkTool(
     "show_examples",
-    "Render the NbsShowcaseCard strip inline in chat. Use at the start of E2 to build NBS vocabulary. mode='favorites' for needs-help path. Optional hazardFilter to narrow the cards.",
+    "Render the NbsShowcaseCard strip inline in chat. Use in E2 Beat 1, AFTER show_intervention_types, to show REAL Brazilian/Porto Alegre cases of the NBS types. Pass typeRefs to tie the examples to the types just shown. mode='favorites' for needs-help path. Optional hazardFilter to narrow.",
     {
       mode: z.enum(["browse", "favorites"]).default("browse"),
       hazardFilter: z.enum(["flood", "heat", "biodiversity"]).optional(),
+      typeRefs: z.array(z.string()).optional().describe("NBS type ids (e.g. ['flood-parks','urban-forests']) — show only examples that represent these types"),
       intro: z.string().optional().describe("Optional 1-line lead text rendered above the strip"),
-      cardIds: z.array(z.string()).optional().describe("Explicit card IDs to show (overrides hazardFilter)"),
+      cardIds: z.array(z.string()).optional().describe("Explicit card IDs to show (overrides hazardFilter/typeRefs)"),
     },
     async (args: any) => {
       const showcase = await import("@shared/nbs-showcase-cards");
@@ -344,12 +345,38 @@ function createCboMcpTools(cboId: string) {
         cards = args.cardIds
           .map((id: string) => showcase.getShowcaseCard(id))
           .filter(Boolean) as { id: string }[];
+      } else if (args.hazardFilter || (Array.isArray(args.typeRefs) && args.typeRefs.length > 0)) {
+        cards = showcase.filterShowcaseCards({ hazard: args.hazardFilter, typeRefs: args.typeRefs });
       } else {
-        cards = showcase.filterShowcaseCards(args.hazardFilter ? { hazard: args.hazardFilter } : undefined);
+        cards = showcase.filterShowcaseCards();
       }
       const ids = cards.map(c => c.id);
       pushEvent({ type: 'show_examples', cardIds: ids, mode: args.mode ?? 'browse', intro: args.intro });
       return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode. STOP and wait for the user's reaction.` }] };
+    },
+    { annotations: { readOnlyHint: true } }
+  );
+
+  // E2 Beat 1 (educational): render the read-only NBS TYPE strip inline. This is
+  // the FIRST thing in E2 — teach the categories of nature-based solutions
+  // before showing real examples. Each card expands ("Saber mais") to the type's
+  // description, example, and a case study. No selection here — purely to learn;
+  // picking a type happens later. Types come from shared/cbo-schema NBS_INTERVENTION_TYPES.
+  const showInterventionTypes = sdkTool(
+    "show_intervention_types",
+    "Render the educational NBS TYPE strip inline in chat. Use as the FIRST action in E2 to teach the kinds of nature-based solutions (read-only, expandable). Optionally pass typeIds to show a subset; omit to show all 6. STOP and wait for the user to read/react.",
+    {
+      typeIds: z.array(z.string()).optional().describe("Subset of NBS type ids to show (e.g. ['flood-parks','wetland-restoration']); omit for all 6"),
+      intro: z.string().optional().describe("Optional 1-line lead text rendered above the strip"),
+    },
+    async (args: any) => {
+      const schema = await import("@shared/cbo-schema");
+      const all = schema.NBS_INTERVENTION_TYPES.map((t: any) => t.id);
+      const ids = Array.isArray(args.typeIds) && args.typeIds.length > 0
+        ? args.typeIds.filter((id: string) => all.includes(id))
+        : all;
+      pushEvent({ type: 'show_types', typeIds: ids, intro: args.intro });
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} NBS type(s). STOP and wait for the user to read/react.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -690,7 +717,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, searchKnowledge, listOrgDocuments, readOrgDocument, searchOrgDocuments, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, showInterventionTypes, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, searchKnowledge, listOrgDocuments, readOrgDocument, searchOrgDocuments, openInterventionSelector],
   });
 }
 

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -28,9 +28,11 @@ import {
   type CboEvent,
   type Confidence,
   MATURITY_METRICS,
+  NBS_INTERVENTION_TYPES,
   isValidMaturityMetric,
   isValidSectionId,
 } from '@shared/cbo-schema';
+import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 
 export function isFakeModelEnabled(): boolean {
   return process.env.CBO_FAKE_MODEL === '1';
@@ -46,7 +48,9 @@ export type FakeOp =
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
   | { op: 'set_phase'; phase: number }
   | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
-  | { op: 'open_map'; params?: Record<string, unknown> };
+  | { op: 'open_map'; params?: Record<string, unknown> }
+  | { op: 'show_types'; typeIds?: string[]; intro?: string }
+  | { op: 'show_examples'; cardIds?: string[]; mode?: 'browse' | 'favorites'; intro?: string };
 
 export type FakeTurn = FakeOp[];
 
@@ -149,6 +153,20 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
     }
     case 'open_map': {
       pushEvent({ type: 'open_map', params: (op.params ?? {}) as any });
+      break;
+    }
+    case 'show_types': {
+      const ids = op.typeIds && op.typeIds.length > 0
+        ? op.typeIds
+        : NBS_INTERVENTION_TYPES.map(t => t.id);
+      pushEvent({ type: 'show_types', typeIds: ids, intro: op.intro });
+      break;
+    }
+    case 'show_examples': {
+      const ids = op.cardIds && op.cardIds.length > 0
+        ? op.cardIds
+        : NBS_SHOWCASE_CARDS.map(c => c.id);
+      pushEvent({ type: 'show_examples', cardIds: ids, mode: op.mode ?? 'browse', intro: op.intro });
       break;
     }
   }

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -222,6 +222,7 @@ export type CboEvent =
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }
+  | { type: 'show_types'; typeIds: string[]; intro?: string }
   | { type: 'ask_priority_rank'; prompt: string; minRanked: number }
   | { type: 'ask_community_anchoring'; prompt: string }
   | { type: 'done'; summary: string }

--- a/shared/nbs-showcase-cards.ts
+++ b/shared/nbs-showcase-cards.ts
@@ -130,17 +130,62 @@ export const NBS_SHOWCASE_CARDS: NbsShowcaseCard[] = [
       emoji: '🌱',
     },
   },
+  {
+    id: 'poa-orla-guaiba',
+    org: 'Orla do Guaíba (Trecho 1)',
+    city: 'Porto Alegre, RS',
+    year: 2018,
+    hazard: 'heat',
+    typeRefs: ['urban-forests', 'green-corridors'],
+    summaryPt: 'Orla revitalizada com espécies nativas à beira do Guaíba',
+    summaryEn: 'Revitalized waterfront with native species along the Guaíba',
+    detailPt:
+      '1,5 km de orla revitalizada (Trecho 1, aberto em 2018), projeto de Jaime Lerner, com 100% de espécies nativas e gestão por PPP. Virou modelo replicável de requalificação da beira-rio — sombra, lazer e biodiversidade reconectando a cidade à água.',
+    detailEn:
+      '1.5 km of revitalized waterfront (Trecho 1, opened 2018), a Jaime Lerner design with 100% native species and PPP management. A replicable model for riverfront requalification — shade, leisure, and biodiversity reconnecting the city to the water.',
+    // Photo pending curation (verified Wikimedia source + attribution) — gradient for now.
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '🌳',
+    },
+  },
+  {
+    id: 'poa-marinha-do-brasil',
+    org: 'Parque Marinha do Brasil',
+    city: 'Porto Alegre, RS',
+    year: 1978,
+    hazard: 'flood',
+    typeRefs: ['flood-parks', 'urban-forests'],
+    summaryPt: 'Parque de 67 ha que ajuda a absorver água e refrescar o centro',
+    summaryEn: '67 ha park that helps absorb water and cool the city center',
+    detailPt:
+      'Maior parque da área central (67 ha, aberto em 1978), com grande cobertura arbórea, lazer e drenagem natural junto ao Guaíba. Foi parcialmente inundado na cheia de maio de 2024 — hoje peça-chave no debate sobre recuperação verde e convivência com a água.',
+    detailEn:
+      "The central area's largest park (67 ha, opened 1978) — extensive canopy, recreation, and natural drainage along the Guaíba. Partially flooded in the May 2024 flood, it's now central to the conversation on green recovery and living with water.",
+    // Photo pending curation — gradient for now.
+    photo: null,
+    placeholder: {
+      gradient: 'flood',
+      emoji: '🌊',
+    },
+  },
 ];
 
 export function getShowcaseCard(id: string): NbsShowcaseCard | undefined {
   return NBS_SHOWCASE_CARDS.find(c => c.id === id);
 }
 
-/** Filter by tag — currently just hazard. Extend with more dimensions as we add cards. */
-export function filterShowcaseCards(opts?: { hazard?: ShowcaseHazard }): NbsShowcaseCard[] {
+/**
+ * Filter by tag — hazard and/or NBS type. `typeRefs` keeps cards that represent
+ * ANY of the requested types (used by E2 to show examples tied to the NBS types
+ * the user just learned about).
+ */
+export function filterShowcaseCards(opts?: { hazard?: ShowcaseHazard; typeRefs?: string[] }): NbsShowcaseCard[] {
   if (!opts) return NBS_SHOWCASE_CARDS;
   return NBS_SHOWCASE_CARDS.filter(c => {
     if (opts.hazard && c.hazard !== opts.hazard && c.hazard !== 'mixed') return false;
+    if (opts.typeRefs && opts.typeRefs.length > 0 && !c.typeRefs.some(t => opts.typeRefs!.includes(t))) return false;
     return true;
   });
 }


### PR DESCRIPTION
Reworks **Workshop 2 (Encontro 2) Beat 1** from "show examples + open the map at once" into a sequenced, read-only **educational module**, and defers the map to a separate later step.

## New flow
1. **NBS types** — `show_intervention_types` renders a new read-only strip (`NbsTypeStrip`) teaching the 6 NBS categories; each card expands ("Saber mais") to description / example / case study. Uses emoji + hazard gradient (deliberately **not** the mislabeled type-catalog photos the audit flagged).
2. **Real examples tied to types** — `show_examples` gains a `typeRefs` filter so the cases shown match the types just taught. Adds 2 Porto Alegre cards: **Orla do Guaíba** and **Parque Marinha do Brasil** (gradient placeholders — photos pending curation).
3. **Confirm understood** — `ask_user` → `[✓ Entendi]` / `[Tenho uma dúvida]`, then a handoff (*"a seguir: o mapa"*) and **stop**. The agent no longer opens the map in E2.

Fork kept: `has-project`/`has-idea` get a **skip** ("já conheço SbN — pular"); `needs-help` gets the full dwell + saveable favorites.

## Map deferred
`encontro-2.md` keeps the map / site / priority / tenure / anchoring / scoring beats but marks them **DEFERRED — MAP STEP (do not run)** so nothing is lost when that step is designed. Until then the agent won't call `open_map`, `ask_priority_rank`, `ask_community_anchoring`, `score_maturity`, or `set_phase(3)`.

### ⚠️ Intentional consequence
E2 stops producing **Site Control / Community Anchoring** maturity scores until the map step lands (those are computed off the map/site). Flagged so the coordinator scorecard going quiet for E2 isn't a surprise.

## Files
- `shared/cbo-schema.ts` — `show_types` event
- `shared/nbs-showcase-cards.ts` — 2 POA cards + `typeRefs` filter
- `server/services/cboAgent.ts` — `show_intervention_types` tool + `show_examples` `typeRefs`
- `server/services/fakeCboModel.ts` — `show_types` / `show_examples` ops (for e2e)
- `client/.../NbsTypeStrip.tsx` (new) + `cbo-profile.tsx` (handler + inline render)
- `knowledge/_skills/encontro-2.md` — Beat 1 rewrite + map deferral

`tsc --noEmit` clean. e2e not run locally (no DB in this checkout; suite is also disabled). **Photos** for the 2 new POA cards need verified Wikimedia sourcing — shipped as placeholders, flagged for curation.

**Deploy:** rebuild + republish the Repl after merge (serves compiled `build/`).