### PR TITLE
fix(cbo): give E2 educational strips a continue/skip affordance

### DIFF
--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -74,23 +74,22 @@ E2 is currently the **educational module**: teach the kinds of nature-based solu
 
 When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's start Encontro 2"* and state.phase = 2 (already advanced server-side), your **FIRST tool call MUST be `show_intervention_types`**. Do NOT ask free-text intro questions first.
 
-Order of tool calls when entering E2 (educational module):
-1. `show_intervention_types({})` — the read-only NBS **type** strip (teach the categories)
-2. Short content message; invite them to tap **"Saber mais"**
-3. `show_examples({ typeRefs: [...] })` — **real cases** tied to those types (path-aware mode)
-4. Short content message
-5. `ask_user` confirm-understood — `[✓ Entendi]` / `[Tenho uma dúvida]`
-6. On **Entendi**: a short handoff — *"a seguir, o mapa"* — then STOP. (Do not advance phase, do not open the map.)
+⚠️ **The strips have NO buttons.** `show_intervention_types` and `show_examples` only render read-only cards — they give the user no way to move forward. So **every turn that shows a strip MUST also call `ask_user` in the same turn**; those chips are the only continue/skip affordance. Never end a turn on a strip alone, or the user is stranded with nothing to tap.
+
+Two turns, each = strip + `ask_user`:
+- **Turn 1:** `show_intervention_types({})` → short message → `ask_user` with options `[ "Ver exemplos" , "Já conheço SbN — pular" ]`
+- **Turn 2** (on "Ver exemplos"): `show_examples({ typeRefs: [...] })` → short message → `ask_user` with options `[ "✓ Entendi" , "Tenho uma dúvida" ]`
+- On **"pular"** (Turn 1) or **"✓ Entendi"** (Turn 2): send the short handoff (*"a seguir, o mapa"*) and STOP — do not advance phase, do not open the map.
 
 Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen. Skip straight to the type strip.
 
 ## Beat 1 — Educational sequence (types → examples → confirm)
 
-This is the whole active encontro right now. Three steps, each ending in a tool call. **Easy to skip for project-forward orgs** (see the skip note).
+This is the whole active encontro right now. **Two turns, each = a strip + an `ask_user`** (the chips are the only buttons the user gets). **Easy to skip for project-forward orgs** via the Turn-1 chip.
 
-### Step 1 · The NBS types (teach the categories)
+### Turn 1 · The NBS types (teach the categories)
 
-First tool call on entering E2. Open with one short line, then the type strip:
+First tool calls on entering E2 — all in ONE turn: a short line, the type strip, a short message, then the `ask_user`.
 
 ```
 Oi, {nome}. Antes de falar do seu território, dois minutos sobre os tipos de Solução baseada na Natureza — pra gente falar a mesma língua.
@@ -98,15 +97,25 @@ Oi, {nome}. Antes de falar do seu território, dois minutos sobre os tipos de So
 show_intervention_types({ intro: 'Toca em "Saber mais" em qualquer um pra entender melhor.' })
 ```
 
-After it renders, a short content message:
+> Esses são os grandes tipos de SbN. Não precisa decorar — é só pra você reconhecer quando aparecerem. Dá uma olhada nos que te chamam atenção e, quando terminar, é só tocar abaixo.
 
-> Esses são os grandes tipos de SbN. Não precisa decorar — é só pra você reconhecer quando aparecerem. Dá uma olhada nos que te chamam atenção.
+```
+ask_user({
+  question: 'Quando terminar de ver os tipos, seguimos pros exemplos reais?',
+  options: [
+    { label: 'Ver exemplos', description: 'Casos reais desses tipos' },
+    { label: 'Já conheço SbN — pular', description: 'Ir direto pro final' }
+  ]
+})
+```
 
-**Skip (project-forward orgs).** For `has-idea` / `has-project`, after the strip add a one-line out: *"Se você já manja de SbN, pode pular essa parte — é só me dizer 'pular'."* If they say *pular / já conheço / skip*, jump straight to Step 3 (confirm) and the handoff. `needs-help` gets no skip — they need this.
+- **`needs-help`:** drop the "Já conheço — pular" option (give only "Ver exemplos") — they need the grounding.
+- **"Já conheço SbN — pular"** → skip Turn 2 entirely; go straight to the handoff (see Closing).
+- **"Ver exemplos"** → Turn 2.
 
-### Step 2 · Real examples (tied to the types)
+### Turn 2 · Real examples (tied to the types) + confirm
 
-Now ground the types in real cases. Pass `typeRefs` so the examples match what you just taught (e.g. the hazards their bairro lives with, from E1/docs). `has-idea`/`has-project` → `browse`; `needs-help` → `favorites` (saveable).
+One turn: the examples strip + a short message + the confirm `ask_user`. Pass `typeRefs` so the cases match what you just taught (use the hazards their bairro lives with, from E1/docs). `has-idea`/`has-project` → `browse`; `needs-help` → `favorites` (saveable).
 
 ```
 show_examples({
@@ -116,15 +125,7 @@ show_examples({
 })
 ```
 
-Short content message after the strip:
-
 > Esses são exemplos reais — em Porto Alegre e no Brasil — desses tipos de solução. A gente não precisa copiar nenhum; é só pra ver o que já deu certo perto da gente.
-
-For `needs-help`, dwell: invite them to save 1–2 (*"Salva 1 ou 2 que fazem você pensar 'isso podia funcionar aqui'"*). If they save nothing after a turn, nudge gently once.
-
-### Step 3 · Confirm understood → handoff
-
-Close the educational module with a single confirm. Use `ask_user` (no map flag):
 
 ```
 ask_user({
@@ -136,8 +137,9 @@ ask_user({
 })
 ```
 
-- **Tenho uma dúvida** → answer it warmly (use `read_knowledge` / `search_knowledge` if needed), then ask the confirm again.
-- **✓ Entendi** (or a skip) → send the closing handoff (see Closing) and **STOP**. Do not open the map, do not advance phase.
+- **`needs-help`:** before the confirm, invite them to save 1–2 (*"Salva 1 ou 2 que fazem você pensar 'isso podia funcionar aqui'"*). If they save nothing after a turn, nudge once, then still show the confirm.
+- **Tenho uma dúvida** → answer warmly (use `read_knowledge` / `search_knowledge` if needed), then re-show the same confirm `ask_user`.
+- **✓ Entendi** → send the closing handoff (see Closing) and **STOP**. Do not open the map, do not advance phase.
 
 ---
 
@@ -342,9 +344,9 @@ You may reference the showcase card photos in conversation, but never describe p
 ## Tool calls available
 
 Active in this educational module:
-- `show_intervention_types({typeIds?, intro?})` — E2 Step 1, the read-only NBS TYPE strip
-- `show_examples({mode, typeRefs?, hazardFilter?, intro?, cardIds?})` — E2 Step 2, real cases (pass `typeRefs` to tie them to the types shown)
-- `ask_user(...)` — E2 Step 3 confirm-understood
+- `show_intervention_types({typeIds?, intro?})` — Turn 1, the read-only NBS TYPE strip (pair with `ask_user`)
+- `show_examples({mode, typeRefs?, hazardFilter?, intro?, cardIds?})` — Turn 2, real cases (pass `typeRefs`; pair with `ask_user`)
+- `ask_user(...)` — the continue/skip + confirm chips (one per strip turn; the ONLY forward affordance)
 - `read_knowledge` / `search_knowledge`, `search_org_documents` / `list_org_documents` / `read_org_document` — to answer questions
 
 Wired but DEFERRED to the map step (do NOT call here):

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -352,7 +352,7 @@ function createCboMcpTools(cboId: string) {
       }
       const ids = cards.map(c => c.id);
       pushEvent({ type: 'show_examples', cardIds: ids, mode: args.mode ?? 'browse', intro: args.intro });
-      return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode. STOP and wait for the user's reaction.` }] };
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode. The strip has NO continue button. In browse mode, follow IN THE SAME TURN with a short message and an \`ask_user\` (e.g. "✓ Entendi" / "Tenho uma dúvida") so the user can continue. In favorites mode, let them save first — your next turn ends with that \`ask_user\`. Never leave the strip as the last thing in a turn.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -376,7 +376,7 @@ function createCboMcpTools(cboId: string) {
         ? args.typeIds.filter((id: string) => all.includes(id))
         : all;
       pushEvent({ type: 'show_types', typeIds: ids, intro: args.intro });
-      return { content: [{ type: "text" as const, text: `Showed ${ids.length} NBS type(s). STOP and wait for the user to read/react.` }] };
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} NBS type(s). The strip is read-only and has NO buttons — in this SAME turn you MUST follow with a short message and an \`ask_user\` (e.g. options "Ver exemplos" / "Já conheço, pular") so the user has a way to continue. Do not end the turn on the strip alone.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );


### PR DESCRIPTION
Follow-up to #299. The new NBS **type/example strips are read-only cards with no buttons**, so after the type strip the agent's turn ended and the user was stranded — nothing to tap, had to guess and type a reply. (The map composer used to be the "next" affordance before it was deferred.)

## Fix
Every turn that shows a strip now also calls `ask_user` in the **same turn** — the chips are the continue/skip buttons. Two turns:

1. `show_intervention_types` + `ask_user[ Ver exemplos / Já conheço — pular ]`
2. `show_examples` + `ask_user[ ✓ Entendi / Tenho uma dúvida ]` → handoff

Skip (Turn 1) and confirm (Turn 2) both route to the handoff — no map, no phase change. `needs-help` drops the skip option.

- `encontro-2.md` — Beat 1 rewritten as two `strip + ask_user` turns; entry note now states strips have no buttons and must be paired.
- `cboAgent.ts` — `show_intervention_types` / `show_examples` return text instructs the model to pair the strip with `ask_user` and never end a turn on a strip alone (replaces the old "STOP and wait" text that caused the dead end).

`tsc --noEmit` clean. **Deploy:** rebuild + republish after merge.