### PR TITLE
fix(cbo): correct welcome phase + stop next-workshop banner flicker

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -765,14 +765,19 @@ export default function CboProfilePage() {
       case 'show_types':
         // Educational NBS type strip (E2 Beat 1) — inline, read-only. Shown
         // before the real examples; no tab switch.
+        // Do NOT end streaming here: this strip is a mid-turn composer always
+        // followed by an `ask_user` in the SAME turn. Setting isStreaming=false
+        // early opens a window (strip rendered, no question yet) where the
+        // "Começar Encontro N" banner flashes. isStreaming resets on `done` /
+        // stream close.
         setTypesShowcase({ typeIds: (event as any).typeIds, intro: (event as any).intro });
-        setIsStreaming(false);
         break;
       case 'show_examples':
         // Inline strip in chat — no tab switch. Replace any existing strip so
-        // the agent can refine the example set within a turn.
+        // the agent can refine the example set within a turn. Like show_types,
+        // this is mid-turn (paired with a following ask_user) — don't end
+        // streaming here or the next-workshop banner flickers in between.
         setShowcase({ cardIds: event.cardIds, mode: event.mode, intro: event.intro });
-        setIsStreaming(false);
         break;
       case 'ask_priority_rank':
         setPriorityRankPrompt({ prompt: event.prompt, minRanked: event.minRanked });

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -139,12 +139,26 @@ async function buildMemberPayload(member: typeof cohortMembers.$inferSelect) {
   const nextPhase = maxUnlocked + 1;
   const nextWorkshop = workshops.find(w => w.unlocksPhase === nextPhase) ?? null;
 
-  const memberPhase = typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0
-    ? member.snapshotPhase
-    : 1;
+  // The cbo_state is the source of truth for the working phase. member.snapshotPhase
+  // is a denormalized cache that can lag — it's only refreshed on a `phase_change`
+  // SSE event during a live session, so a phase advanced via /advance-phase or
+  // during a cross-device session swap leaves it stale (the welcome screen then
+  // shows the wrong encontro). Prefer the live state, and self-heal the cache so
+  // the coordinator roster (which reads snapshotPhase directly) stays correct too.
+  let statePhase = 0;
+  if (member.cboStateId) {
+    const live = getCboState(member.cboStateId) ?? (await loadCboFromDb(member.cboStateId))?.state;
+    if (live && typeof live.phase === 'number') statePhase = live.phase;
+  }
+  const snapPhase = typeof member.snapshotPhase === 'number' ? member.snapshotPhase : 0;
+  const effectivePhase = Math.max(statePhase, snapPhase);
+  if (statePhase > snapPhase) {
+    await db.update(cohortMembers).set({ snapshotPhase: statePhase }).where(eq(cohortMembers.id, member.id)).catch(() => {});
+  }
+
+  const memberPhase = effectivePhase > 0 ? effectivePhase : 1;
   const focusWorkshop = workshops.find(w => w.unlocksPhase === memberPhase) ?? workshops[0] ?? null;
-  const focusWorkshopIsCurrent =
-    !!focusWorkshop?.openedAt && typeof member.snapshotPhase === 'number' && member.snapshotPhase > 0;
+  const focusWorkshopIsCurrent = !!focusWorkshop?.openedAt && effectivePhase > 0;
 
   const supportRequests = Array.isArray(member.supportRequests) ? (member.supportRequests as SupportRequest[]) : [];
   const supportPending = supportRequests.filter(r => !r.resolvedAt);


### PR DESCRIPTION
Full audit of two issues seen while testing Encontro 2. Diagnosed against live dev data (member `test-file-upload`): bound `cbo_state.phase = 2`, 17 messages, `unlockedPhases = [1,2]` — the **state is correct**; both bugs were display/sync.

## 1. Welcome screen showed the wrong encontro
"Próximo encontro: Encontro 1 — Quem somos" while the conversation was actually at **phase 2**.

**Root cause:** `buildMemberPayload` derives the focus/next workshop from `member.snapshotPhase` — a denormalized **cache** that's only refreshed on a live `phase_change` SSE event (`cbo-profile.tsx` PATCHes `/snapshot` there). A phase advanced via `/advance-phase` (the "Começar Encontro N" CTA) or during the earlier cross-device session swap never updated it, so it stayed at 1. The live payload confirmed `focusWorkshop.unlocksPhase = 1`, `focusWorkshopIsCurrent = false`. The **authoritative** phase is on `cbo_state` (=2). Same stale value is why the coordinator card showed "FASE 1."

**Fix:** `buildMemberPayload` now reads the live `cbo_state` phase, uses `max(state, snapshot)` for the labels, and **self-heals** `snapshotPhase` when it's behind — so the coordinator roster (which reads `snapshotPhase` directly) corrects itself on the next read too. (The conversation resume was already correct — it loads `cbo_state` via the server binding; only the pre-resume label was wrong.)

## 2. "Começar Encontro N" banner flashed on/off
As the NBS **type** strip and then the **examples** strip appeared, a next-workshop banner flickered.

**Root cause:** the `show_types` / `show_examples` handlers called `setIsStreaming(false)`. But (since #300) those strips are **mid-turn composers always paired with an `ask_user` in the same turn**. Ending streaming early opened a window — strip rendered, `currentQuestion` not set yet — where the banner's gate (`!isStreaming && !currentQuestion && nextUnlockedPhase > state.phase`) briefly passed, until the `ask_user` event arrived and hid it again.

**Fix:** the two strip handlers no longer end streaming. `isStreaming` resets on the `done` event / stream close (after `ask_user` has set `currentQuestion`), so the banner stays hidden through the whole turn.

## Audit note (not a bug, by design)
With E2 scoring **deferred** (map step), `PHASE_COMPLETION_METRICS[2]` is never satisfied, so the "phase complete → next workshop" banner won't offer E2→E3 on its own. That's consistent with the deferred map step; progression returns when the map/scoring step is built.

`tsc --noEmit` clean. **Deploy:** rebuild + republish after merge.