### PR TITLE
feat(cbo): E2 map step — guided hazard tour + neighborhood/site (stage 1 of 2)

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -52,6 +52,16 @@ const HAZARD_LEGEND: Record<HazardFamily, { color: string; labelKey: string; def
   landslide: { color: TYPOLOGY_COLORS.LANDSLIDE, labelKey: 'mapMicroapp.hazardLandslide', defaultLabel: 'Landslide' },
 };
 
+// E2 guided hazard tour: the order to walk through, and the per-hazard caption
+// shown while that single layer is visible. Defaults are Portuguese (the CBO
+// cohort is pt-forced); en keys live in the locale files.
+const HAZARD_ORDER: HazardFamily[] = ['flood', 'heat', 'landslide'];
+const TOUR_COPY: Record<HazardFamily, { emoji: string; titleKey: string; title: string; bodyKey: string; body: string }> = {
+  flood:     { emoji: '🌊', titleKey: 'mapMicroapp.tourFloodTitle',     title: 'Enchente',     bodyKey: 'mapMicroapp.tourFloodBody',     body: 'As áreas em azul são as que mais alagam quando chove forte.' },
+  heat:      { emoji: '🔥', titleKey: 'mapMicroapp.tourHeatTitle',      title: 'Calor',        bodyKey: 'mapMicroapp.tourHeatBody',      body: 'As áreas em vermelho e laranja esquentam mais — o efeito ilha de calor.' },
+  landslide: { emoji: '⛰️', titleKey: 'mapMicroapp.tourLandslideTitle', title: 'Deslizamento', bodyKey: 'mapMicroapp.tourLandslideBody', body: 'As áreas em marrom têm encostas com risco de deslizar.' },
+};
+
 export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const { t } = useTranslation();
   const mapRef = useRef<L.Map | null>(null);
@@ -89,18 +99,45 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const selectionMode = params.selectionMode;
   const isComposite = selectionMode === 'composite';
   const isBrowseOnly = selectionMode === 'browse-only';
-  const showZones = !isComposite || compositeStep === 'zone';
-  const showAssets = !isComposite || compositeStep === 'assets';
+
+  // E2 guided hazard tour. tourLayers = the hazard tiles present, in flood→heat
+  // →landslide order. tourIdx: 0..n-1 = touring that hazard (only it visible);
+  // n = done (all visible, selection unlocked); -1 = tour off.
+  const tourLayers = HAZARD_ORDER
+    .map(fam => (params.tileLayers || []).find(id => hazardFamilyOf(id) === fam))
+    .filter(Boolean) as string[];
+  const [tourIdx, setTourIdx] = useState(params.hazardTour && tourLayers.length > 0 ? 0 : -1);
+  const tourActive = tourIdx >= 0 && tourIdx < tourLayers.length;
+
+  // During the tour, suppress zone/asset selection — it's hazard education only.
+  const showZones = !tourActive && (!isComposite || compositeStep === 'zone');
+  const showAssets = !tourActive && (!isComposite || compositeStep === 'assets');
   const polygonHelp = drawMode === 'polygon' ? t('mapMicroapp.polygonHelp') : '';
+  const tourFamily = tourActive ? hazardFamilyOf(tourLayers[tourIdx]) : null;
+  const advanceTour = useCallback(() => setTourIdx(i => i + 1), []);
 
   // E2: auto-enable requested tile layers on mount so the user immediately sees
   // the hazard colors (browse-only exploration, and any flow asking for the
   // simplified hazard legend). They can still toggle them off.
   useEffect(() => {
+    if (params.hazardTour) return; // the tour effect below owns tile visibility
     if (!isBrowseOnly && !params.showLegendSimple) return;
     if (!params.tileLayers || params.tileLayers.length === 0) return;
     setEnabledTiles(new Set(params.tileLayers));
-  }, [isBrowseOnly, params.showLegendSimple, params.tileLayers]);
+  }, [isBrowseOnly, params.showLegendSimple, params.tileLayers, params.hazardTour]);
+
+  // Hazard tour: while touring, show ONLY the active hazard; once done, show all
+  // three so the user sees combined risk while picking a neighborhood.
+  useEffect(() => {
+    if (!params.hazardTour || tourLayers.length === 0) return;
+    if (tourIdx >= 0 && tourIdx < tourLayers.length) {
+      setEnabledTiles(new Set([tourLayers[tourIdx]]));
+    } else if (tourIdx >= tourLayers.length) {
+      setEnabledTiles(new Set(tourLayers));
+    }
+    // tourLayers is derived from the stable params.tileLayers for this open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tourIdx, params.hazardTour]);
 
   const enabledTileLayerDefs = Array.from(enabledTiles)
     .map(id => ALL_TILE_LAYERS.find(l => l.id === id))
@@ -642,14 +679,30 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   }, [coordInput, addCustomSite]);
 
   // ── Confirm ─────────────────────────────────────────────────────────────────
+  // A real site = any non-zone asset (OSM/custom) or a sampled point. The zone
+  // alone is not a site (it's the neighborhood).
+  const hasSite = selectedAssets.some(a => a.type !== 'zone') || sampledPoints.length > 0;
   const handleConfirm = useCallback(() => {
     onConfirm({
       selectionMode,
       selectedAssets,
       sampledPoints,
       enabledLayers: [...(params.layers || []), ...Array.from(enabledTiles), ...(params.spatialQueries || [])],
+      siteSource: 'user',
     });
   }, [selectedAssets, sampledPoints, selectionMode, params, onConfirm, enabledTiles]);
+  // No-site path (E2 "usar o bairro todo"): commit the neighborhood, mark the
+  // site deferred. Keeps the zone, drops any site assets.
+  const confirmDeferred = useCallback(() => {
+    onConfirm({
+      selectionMode,
+      selectedAssets: selectedAssets.filter(a => a.type === 'zone'),
+      sampledPoints: [],
+      enabledLayers: [...(params.layers || []), ...Array.from(enabledTiles), ...(params.spatialQueries || [])],
+      siteDeferred: true,
+      siteSource: 'user',
+    });
+  }, [selectedAssets, selectionMode, params, onConfirm, enabledTiles]);
 
   const removeAsset = (index: number) => setSelectedAssets(prev => prev.filter((_, i) => i !== index));
   const clearAll = () => {
@@ -692,8 +745,8 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         </p>
       </div>
 
-      {/* Stepper bar (composite mode) */}
-      {isComposite && (
+      {/* Stepper bar (composite mode) — hidden during the hazard tour */}
+      {!tourActive && isComposite && (
         <div className="flex items-center gap-2 px-3 py-1.5 border-b bg-muted/20 shrink-0">
           <button
             onClick={compositeStep === 'assets' ? backToZones : undefined}
@@ -719,7 +772,8 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         </div>
       )}
 
-      {/* Tools bar */}
+      {/* Tools bar — hidden during the hazard tour (legend is locked) */}
+      {!tourActive && (
       <div className="flex items-center gap-1.5 px-3 py-1 border-b bg-muted/10 shrink-0">
         {/* Simplified hazard legend (E2): ≤3 colored chips standing in for the
             full layer toolkit, so first-time CBO users see only flood / heat /
@@ -775,6 +829,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
           <Button variant="ghost" size="sm" className="h-5 px-1" onClick={clearAll}><Trash2 className="w-3 h-3" /></Button>
         )}
       </div>
+      )}
 
       {/* Add-your-own-site panel (assets step) — search by name or coordinate
           for sites the OSM suggestions miss. Mobile-friendly: collapsed to a
@@ -854,10 +909,26 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         {/* Narration overlay (E2 needs-help). Translucent banner pinned to
             the top of the map so the agent can explain colors as the user
             scrolls. Pointer-events disabled so it doesn't block the map. */}
-        {params.narrationOverlay && (
+        {params.narrationOverlay && !tourActive && (
           <div className="absolute top-2 left-2 right-2 z-[900] pointer-events-none">
             <div className="bg-background/85 backdrop-blur-sm border border-foreground/10 rounded-lg px-3 py-2 shadow-sm">
               <p className="text-[11px] text-foreground/85 leading-snug">{params.narrationOverlay}</p>
+            </div>
+          </div>
+        )}
+        {/* Hazard-tour caption — pinned over the map while a single hazard is
+            shown. Pointer-events disabled so the user can still pan underneath. */}
+        {tourActive && tourFamily && (
+          <div className="absolute top-2 left-2 right-2 z-[900] pointer-events-none">
+            <div className="bg-background/90 backdrop-blur-sm border-2 rounded-lg px-3 py-2 shadow-md" style={{ borderColor: HAZARD_LEGEND[tourFamily].color }}>
+              <p className="text-xs font-semibold flex items-center gap-1.5" style={{ color: HAZARD_LEGEND[tourFamily].color }}>
+                <span>{TOUR_COPY[tourFamily].emoji}</span>
+                {t(TOUR_COPY[tourFamily].titleKey, { defaultValue: TOUR_COPY[tourFamily].title })}
+                <span className="ml-auto text-[10px] font-medium text-muted-foreground">{tourIdx + 1}/{tourLayers.length}</span>
+              </p>
+              <p className="text-[11px] text-foreground/85 leading-snug mt-0.5">
+                {t(TOUR_COPY[tourFamily].bodyKey, { defaultValue: TOUR_COPY[tourFamily].body })}
+              </p>
             </div>
           </div>
         )}
@@ -893,9 +964,17 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
 
       {/* Action bar */}
       <div className="flex items-center gap-2 px-3 py-2 border-t bg-background shrink-0">
-        {/* Browse-only mode (E2 needs-help): single CTA back to chat. No
-            confirm because the user isn't committing to anything. */}
-        {isBrowseOnly ? (
+        {tourActive ? (
+          /* Hazard tour: one CTA that advances flood→heat→landslide, then hands
+             off to neighborhood selection. The only control while touring. */
+          <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={advanceTour} data-testid="map-tour-next">
+            {tourIdx < tourLayers.length - 1
+              ? <>{t('mapMicroapp.tourNext', { defaultValue: 'Próximo risco' })} <ChevronRight className="w-3 h-3" /></>
+              : <>{t('mapMicroapp.tourToZone', { defaultValue: 'Escolher meu bairro' })} <ChevronRight className="w-3 h-3" /></>}
+          </Button>
+        ) : isBrowseOnly ? (
+          /* Browse-only mode (E2 needs-help): single CTA back to chat. No
+             confirm because the user isn't committing to anything. */
           <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={onCancel} data-testid="map-back-to-chat">
             ← {t('mapMicroapp.backToChat', { defaultValue: 'Voltar ao chat' })}
           </Button>
@@ -908,6 +987,19 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
           <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={advanceToAssets} disabled={!selectedAssets.some(a => a.type === 'zone')}>
             {t('mapMicroapp.nextSites')} <ChevronRight className="w-3 h-3" />
           </Button>
+        ) : isComposite && compositeStep === 'assets' && params.allowDeferSite ? (
+          /* E2 site step: a real site → Confirm; no site yet → "usar o bairro
+             todo" (commit the neighborhood, defer the site). Gated to the CBO
+             map step so the city/concept-note composite flow is unaffected. */
+          hasSite ? (
+            <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={handleConfirm} data-testid="map-confirm-site">
+              <Check className="w-3 h-3" /> {t('mapMicroapp.confirm', { count: totalSelections })}
+            </Button>
+          ) : (
+            <Button size="sm" variant="outline" className="h-7 text-xs gap-1 flex-1" onClick={confirmDeferred} data-testid="map-use-whole-bairro">
+              {t('mapMicroapp.useWholeBairro', { defaultValue: 'Usar o bairro todo' })}
+            </Button>
+          )
         ) : (
           <Button size="sm" className="h-7 text-xs gap-1 flex-1" onClick={handleConfirm} disabled={totalSelections === 0}>
             <Check className="w-3 h-3" /> {t('mapMicroapp.confirm', { count: totalSelections })}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -80,6 +80,9 @@ function formatMapResult(result: MapSelectionResult): string {
     const vals = Object.entries(pt.values).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ');
     lines.push(`- [sample] (${pt.lat.toFixed(4)}, ${pt.lng.toFixed(4)}) | ${vals}`);
   }
+  if (result.siteDeferred) {
+    lines.push(`- [site] DEFERRED — the user has no specific site yet; working with the whole neighborhood for now. Don't push for an exact site; you can revisit it later.`);
+  }
   lines.push(`Total: ${result.selectedAssets.length} assets, ${result.sampledPoints.length} sampled points`);
   return lines.join('\n');
 }
@@ -1704,7 +1707,6 @@ export default function CboProfilePage() {
                       const siteAsset = [...result.selectedAssets].reverse().find(a => a.type !== 'zone');
                       const zoneAsset = result.selectedAssets.find(a => a.type === 'zone');
                       if (siteAsset && memberSlug) {
-                        const poly = siteAsset.geometry?.type === 'Polygon' ? siteAsset.geometry : null;
                         fetch(`/api/cbo-member/${memberSlug}/site`, {
                           method: 'PUT',
                           headers: { 'Content-Type': 'application/json' },
@@ -1715,6 +1717,23 @@ export default function CboProfilePage() {
                             geometry: siteAsset.geometry ?? null,
                             source: (siteAsset.properties as any)?.source ?? siteAsset.source ?? null,
                             neighborhood: zoneAsset?.name ?? null,
+                          }),
+                        }).catch(() => {});
+                      } else if (result.siteDeferred && zoneAsset && memberSlug) {
+                        // "Usar o bairro todo" — persist the neighborhood as the
+                        // (deferred) site so the org leaves the map with at least
+                        // a bairro; the exact site stays TBD.
+                        fetch(`/api/cbo-member/${memberSlug}/site`, {
+                          method: 'PUT',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({
+                            name: zoneAsset.name,
+                            kind: 'zone',
+                            coordinates: zoneAsset.coordinates,
+                            geometry: null,
+                            source: 'whole-neighborhood',
+                            neighborhood: zoneAsset.name,
+                            deferred: true,
                           }),
                         }).catch(() => {});
                       }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1875,6 +1875,15 @@
     "phaseLocked": "Your coordinator will unlock this after the next workshop."
   },
   "mapMicroapp": {
+    "tourNext": "Next risk",
+    "tourToZone": "Choose my neighborhood",
+    "useWholeBairro": "Use the whole neighborhood",
+    "tourFloodTitle": "Flood",
+    "tourFloodBody": "The areas in blue are the ones that flood most when it rains hard.",
+    "tourHeatTitle": "Heat",
+    "tourHeatBody": "The areas in red and orange get hotter — the urban heat-island effect.",
+    "tourLandslideTitle": "Landslide",
+    "tourLandslideBody": "The areas in brown have slopes at risk of sliding.",
     "addSite": "Add a site by name or coordinate",
     "searchPlaceholder": "Search a place name…",
     "search": "Search",

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -66,9 +66,13 @@ Use `search_org_documents(query)` — it returns the relevant passage from anywh
 
 These searches are **extra tool calls in the same turn** — the turn still ends with the prescribed composer/`ask_user`, so you never strand the user (they attach to their beat, not to the entry turn whose first call must be `show_examples`). Confirm-don't-assert always: a doc hit is *"Vi na proposta que… certo?"*, riding on the next prescribed tool call — never a silent fill.
 
-## ⚠️ SCOPE OF E2 RIGHT NOW — educational only; the map is a separate later step
+## ⚠️ SCOPE OF E2 RIGHT NOW — educational module → map step
 
-E2 is currently the **educational module**: teach the kinds of nature-based solutions, show real Porto Alegre / Brazil examples tied to those kinds, and confirm the org understood. It **ends with a handoff** — *"a seguir: o mapa"*. **You do NOT open the map in this encontro.** The map + site selection + priority/tenure/anchoring + maturity scoring are a **separate later step** (kept below under "DEFERRED — MAP STEP" for reference). Until that step is wired, do **not** call `open_map`, `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`, and do **not** `set_phase(3)`.
+E2 has two active parts, in order:
+1. **Educational** (Turns 1–2): teach the kinds of SbN, show real Porto Alegre / Brazil examples tied to them, confirm the org understood.
+2. **Map step** (Turn 3 → the map): walk the user through the 3 hazards (the map runs a guided tour), then they pick their **neighborhood** and a **site** (or "usar o bairro todo").
+
+Still **deferred** (do NOT run): risk-priority ranking, land tenure, community anchoring, and maturity scoring — so do not call `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`, and do not `set_phase(3)`.
 
 ## ⚠️ First action on entering E2 — non-negotiable
 
@@ -76,10 +80,10 @@ When you see a user message like *"Vamos começar o Encontro 2"* or *"Let's star
 
 ⚠️ **The strips have NO buttons.** `show_intervention_types` and `show_examples` only render read-only cards — they give the user no way to move forward. So **every turn that shows a strip MUST also call `ask_user` in the same turn**; those chips are the only continue/skip affordance. Never end a turn on a strip alone, or the user is stranded with nothing to tap.
 
-Two turns, each = strip + `ask_user`:
+Educational = two turns, each = strip + `ask_user`:
 - **Turn 1:** `show_intervention_types({})` → short message → `ask_user` with options `[ "Ver exemplos" , "Já conheço SbN — pular" ]`
 - **Turn 2** (on "Ver exemplos"): `show_examples({ typeRefs: [...] })` → short message → `ask_user` with options `[ "✓ Entendi" , "Tenho uma dúvida" ]`
-- On **"pular"** (Turn 1) or **"✓ Entendi"** (Turn 2): send the short handoff (*"a seguir, o mapa"*) and STOP — do not advance phase, do not open the map.
+- On **"pular"** (Turn 1) or **"✓ Entendi"** (Turn 2) → go to **Turn 3 (the map step)** below.
 
 Do NOT generate free-text intro paragraphs like *"This phase is about understanding where you operate..."* — the user already saw the E2 preamble screen. Skip straight to the type strip.
 
@@ -139,19 +143,71 @@ ask_user({
 
 - **`needs-help`:** before the confirm, invite them to save 1–2 (*"Salva 1 ou 2 que fazem você pensar 'isso podia funcionar aqui'"*). If they save nothing after a turn, nudge once, then still show the confirm.
 - **Tenho uma dúvida** → answer warmly (use `read_knowledge` / `search_knowledge` if needed), then re-show the same confirm `ask_user`.
-- **✓ Entendi** → send the closing handoff (see Closing) and **STOP**. Do not open the map, do not advance phase.
+- **✓ Entendi** → go to **Turn 3 (the map step)**.
 
 ---
 
-## DEFERRED — MAP STEP (not active yet; do NOT run)
+## Turn 3 — Into the map (the risks, then your place)
 
-> ⚠️ Everything below (map, site, current use, priority, tenure, anchoring, scoring, `set_phase(3)`) is the **next step**, designed separately. The agent must **not** reach it from the educational module above. Kept here as the spec for when the map step is wired. Until then: never call `open_map`, `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`.
+Same E2 session. First, **silently** check the org's docs for a place they already named: `search_org_documents("endereço localização terreno área lote rua bairro")`. If it names somewhere, mention it naturally in your intro (*"vi que vocês falam da {local} na proposta"*). *(Pre-placing it on the map for one-tap validation is coming next; for now just mention it.)*
 
-### Map + site (deferred)
+Then one short message + an `ask_user` (no strip — this turn is fine ending on the question):
 
-Path-aware. `has-idea` goes straight to site selection (composite mode). `needs-help` first explores without commitment (browse-only mode), then transitions to site selection when ready.
+> Show, {nome}! Agora vou te mostrar os **riscos** — enchente, calor e deslizamento — nos bairros de Porto Alegre, e aí a gente marca onde vocês atuam.
 
-### `has-idea` flow
+```
+ask_user({
+  question: 'Pronta pra abrir o mapa?',
+  options: [
+    { label: 'Abrir o mapa', description: 'Ver os riscos e marcar o bairro' },
+    { label: 'Já conheço os riscos', description: 'Ir direto pra escolher o bairro' }
+  ]
+})
+```
+
+### The map — ONE call runs the whole step
+
+On **"Abrir o mapa"** open with the guided tour ON; on **"Já conheço os riscos"** the same call with `hazardTour: false` (skips the tour, straight to neighborhood selection):
+
+```
+open_map({
+  selectionMode: 'composite',
+  zoneSource: 'neighborhoods',
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+  showLegendSimple: true,
+  hazardTour: true,        // false if they tapped "Já conheço os riscos"
+  allowDeferSite: true,    // lets them tap "Usar o bairro todo" if no site yet
+  prompt: 'Conheça os riscos e marque onde vocês atuam.'
+})
+```
+
+The map runs the **whole step itself** — you make ONE call, then wait for ONE result:
+1. **Hazard tour** (if on): 🌊 flood → 🔥 heat → ⛰️ landslide, one at a time with captions; the user taps "Próximo risco", then "Escolher meu bairro".
+2. **Neighborhood** (required): they pick their bairro.
+3. **Site** (optional): they mark a specific lugar, OR tap **"Usar o bairro todo"** if they don't have one yet.
+
+You then receive a `Map selection (composite mode):` message. Parse it:
+- `[zone] {bairro}` → the **neighborhood**.
+- `[osm]` / `[custom]` line → `site_name`, `site_lat`, `site_lng`, `site_geometry` (if a drawn polygon).
+- a `- [site] DEFERRED …` line → they used the whole bairro; **don't push for an exact site**, just note it for later.
+
+Capture and close (do NOT `set_phase(3)`):
+
+```
+update_section('intervention_site', { bairro, site_name?, site_lat?, site_lng?, site_deferred? })
+```
+
+> ✓ **Pronto, {nome}!** Marcamos **{site_name ?? bairro}**.
+>
+> No próximo encontro a gente escolhe juntas o tipo de SbN que mais combina com esse lugar. Até lá! 🌱
+
+---
+
+## DEFERRED — priority / tenure / anchoring / scoring (do NOT run yet)
+
+> ⚠️ Beat 3 (risk priority, land tenure, community anchoring) and the maturity scoring below are the **next** refinement — not wired yet. Don't call `ask_priority_rank`, `ask_community_anchoring`, or `score_maturity`. The recipes are kept here for when that step lands.
+
+### Old map recipe (reference)
 
 ```
 open_map({
@@ -292,17 +348,11 @@ COMMUNITY_ANCHORING (0-3)
 
 Call `score_maturity` for both metrics with 1-sentence Portuguese justifications.
 
-## Closing — educational module (active)
+## Closing
 
-This is how you end the encontro **now**, right after the user taps **✓ Entendi** (or skips). One short content message, then STOP — no tool calls, no phase change, no map:
+The encontro ends in **Turn 3** after the map returns a selection — see the closing message there ("Pronto, {nome}! Marcamos {site}…"). Do not `set_phase(3)` (the coordinator gates it) and do not run the deferred scoring/priority/tenure/anchoring tools.
 
-> ✓ **Boa, {nome}!** Você já tem a base das Soluções baseadas na Natureza.
->
-> No próximo passo a gente vai abrir o **mapa** do seu território e ver isso no lugar de vocês.
->
-> Até já! 🌱
-
-Do not call `set_phase`, `open_map`, or any scoring tool. The map step takes over from here when it's wired.
+(If the user skipped straight from the educational confirm and you somehow have no map result — e.g. they closed the map — a graceful fallback is a short "a gente retoma o mapa quando você puder" and stop; don't fabricate a site.)
 
 ---
 

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -763,6 +763,7 @@ export function registerCohortRoutes(app: Express): void {
       source: typeof b.source === 'string' ? b.source : null,
       areaM2: typeof b.areaM2 === 'number' ? b.areaM2 : null,
       neighborhood: typeof b.neighborhood === 'string' ? b.neighborhood : (member.neighborhood ?? null),
+      deferred: b.deferred === true ? true : undefined,
       photos: prev?.photos ?? [], // keep photos attached before the site was (re)saved
       savedAt: new Date().toISOString(),
     };

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -474,6 +474,15 @@ STOP and wait for the user's map selection after calling this tool.`,
       zoneSource: z.enum(["neighborhood_zones", "intervention_zones", "neighborhoods"]).optional().describe("For composite mode step 1: 'neighborhood_zones' (default) shows bairros with risk scores + vulnerability-weighted priority. 'neighborhoods' shows raw IBGE census data. 'intervention_zones' uses legacy synthetic zones."),
       narrationOverlay: z.string().optional().describe("Translucent banner over the map for browse-only mode — agent narrates what colors mean. ~80 chars ideal."),
       showLegendSimple: z.boolean().optional().describe("Collapse the full toolkit into a simple 3-chip hazard legend. Useful for first-time CBO users."),
+      hazardTour: z.boolean().optional().describe("E2 map step: open into a guided tour that walks the user through flood → heat → landslide ONE at a time before unlocking neighborhood/site selection. Use selectionMode:'composite' with this. Pass the 3 poa_*_hazard tileLayers."),
+      allowDeferSite: z.boolean().optional().describe("E2 map step: let the user commit a neighborhood with no specific site yet ('usar o bairro todo'). Pass true for the CBO map step."),
+      suggestedSite: z.object({
+        quote: z.string().optional().describe("The literal passage from the org's document that names the place (shown to the user as 'na proposta: …')"),
+        name: z.string().optional().describe("Place/address to geocode (e.g. 'Rua Voluntários da Pátria 123, Porto Alegre') when you don't have coordinates"),
+        lat: z.number().optional(),
+        lng: z.number().optional(),
+        neighborhood: z.string().optional().describe("Bairro-only hint when the doc names a neighborhood but no precise site"),
+      }).optional().describe("E2 map step: a site candidate found via search_org_documents, to pre-place for the user to VALIDATE ('é aqui?') instead of picking blind. Only pass what the doc actually says — the quote is the basis the user sees."),
     },
     async (args: any) => {
       pushEvent({
@@ -488,6 +497,9 @@ STOP and wait for the user's map selection after calling this tool.`,
           zoneSource: args.zoneSource,
           narrationOverlay: args.narrationOverlay,
           showLegendSimple: args.showLegendSimple,
+          hazardTour: args.hazardTour,
+          allowDeferSite: args.allowDeferSite,
+          suggestedSite: args.suggestedSite,
         },
       });
       return { content: [{ type: "text" as const, text: `Map opened in "${args.selectionMode}" mode. STOP and wait for selection.` }] };

--- a/shared/cohort-schema.ts
+++ b/shared/cohort-schema.ts
@@ -62,6 +62,10 @@ export type MemberSite = {
   source?: string | null;                    // e.g. 'osm_parks', 'user-added'
   areaM2?: number | null;                    // for drawn polygons
   neighborhood?: string | null;
+  // E2 "usar o bairro todo": the org committed a neighborhood but no specific
+  // site yet. When true, kind is 'zone' and coordinates are the bairro centroid;
+  // site-specific UI should treat the exact site as TBD.
+  deferred?: boolean;
   photos: string[];                          // uploaded site-photo file paths
   savedAt: string;                           // ISO timestamp
 };

--- a/shared/concept-note-schema.ts
+++ b/shared/concept-note-schema.ts
@@ -179,6 +179,26 @@ export interface OpenMapParams {
   // hazard legend (flood/heat/landslide) when only those hazards are active.
   // Used by E2 to reduce visual noise for first-time CBO users.
   showLegendSimple?: boolean;
+  // E2 map step — allow committing a neighborhood with NO specific site ("usar
+  // o bairro todo"). Gates the site-optional UI so the city/concept-note flow
+  // (which requires a real site in composite mode) is unaffected.
+  allowDeferSite?: boolean;
+  // E2 map step — guided hazard tour. When true, the map opens in a tour that
+  // walks the user through flood → heat → landslide ONE at a time (locked
+  // legend, per-hazard caption + counter) before unlocking neighborhood/site
+  // selection. Opt-in; the city/concept-note flow leaves it off.
+  hazardTour?: boolean;
+  // E2 map step — a site candidate extracted from the org's uploaded docs, to
+  // pre-place for the user to validate ("é aqui?") instead of picking blind.
+  // Tiered: a precise place geocodes to a pin; a bairro-only hint pre-selects
+  // the neighborhood. `quote` is the literal doc excerpt shown as the basis.
+  suggestedSite?: {
+    quote?: string;        // literal passage from the doc (shown to the user)
+    name?: string;         // place/address to geocode (Nominatim) if no coords
+    lat?: number;
+    lng?: number;
+    neighborhood?: string; // bairro-only hint (pre-select the zone)
+  };
 }
 
 export interface SelectedAsset {
@@ -202,6 +222,12 @@ export interface MapSelectionResult {
   selectedAssets: SelectedAsset[];
   sampledPoints: SampledPoint[];
   enabledLayers: string[];
+  // E2: the user committed a neighborhood but no specific site ("usar o bairro
+  // todo"). Consumers should keep the neighborhood and treat the site as TBD.
+  siteDeferred?: boolean;
+  // E2: how the site was arrived at — 'doc' (validated a doc-extracted
+  // candidate) vs 'user' (picked/drew it). Omitted outside the CBO map step.
+  siteSource?: 'doc' | 'user';
 }
 
 // SSE event types pushed to the browser


### PR DESCRIPTION
Un-defers the **Encontro 2 map step**. After the educational confirm, the agent explains and offers **"Abrir o mapa"**; the map opens into a guided tour, then neighborhood → site.

## Flow
```
Turn 2 ✓ Entendi →
Turn 3: agent explains "agora os riscos nos bairros…"  ask_user [ Abrir o mapa ] / [ Já conheço os riscos ]
open_map({ selectionMode:'composite', hazardTour:true*, allowDeferSite:true, tileLayers:[3 hazards], showLegendSimple:true })
Map (ONE call, runs the whole step):
  1. 🌊 flood → 🔥 heat → ⛰️ landslide, one at a time (caption + 1/3 counter, "Próximo risco" → "Escolher meu bairro")   *false on "Já conheço"
  2. Neighborhood (required)
  3. Site (optional) — mark a lugar, OR "Usar o bairro todo" → site deferred
→ one result; agent captures intervention_site + closes
```
Priority / tenure / anchoring / scoring stay **deferred** (next refinement).

## What's in `MapMicroapp` (shared with the city flow)
- **Tour state machine**: shows only the active hazard, locks the legend, per-hazard caption + counter, advance CTA; on completion enables all three and enters the existing composite zone step. Zone/asset selection is suppressed during the tour.
- **No-site path**: "Usar o bairro todo" → commits the neighborhood with `siteDeferred`. **Gated behind `allowDeferSite`** so the city/concept-note composite flow is unaffected (verified: only the CBO map step passes it; the tour only activates when `hazardTour` is passed, which the city never does).

## Persistence
`MemberSite.deferred`; the deferred case persists the bairro as the site (centroid + `kind:'zone'` + `deferred:true`) so the org always leaves the map with at least a neighborhood. The map-result message gets a `- [site] DEFERRED …` line so the agent doesn't push for an exact site.

## Stage 1 of 2
This is the tour + no-site. **Stage 2** = the doc-extracted **site prefill** ("é aqui?" validate) — its `suggestedSite` schema/tool plumbing is included here but **inert** until stage 2 wires the map consumption + the agent's `search_org_documents` → `suggestedSite` step.

`tsc --noEmit` clean; en.json valid (PT via `defaultValue`). Not run in-app (no local DB; e2e suite disabled). **Deploy:** rebuild + republish after merge.

### Worth a careful look on dev
The tour is untested live (I can't run it here). Key things to eyeball: the tour advancing through all 3 hazards then unlocking neighborhood selection without a remount, and the city concept-note map still behaving exactly as before.