### PR TITLE
feat(cbo): structural always-on right-panel tools (registry + persisted activeTool)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -27,7 +27,8 @@ import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/c
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
   FileText, Files, Loader2, RotateCcw, Star, Leaf,
-  Check, Circle, AlertCircle, Pencil, Mic, Square,
+  Check, Circle, AlertCircle, Pencil, Mic, Square, Map as MapIcon, Layers,
+  type LucideIcon,
 } from 'lucide-react';
 import { useVoiceRecorder, type RecorderError } from '@/core/hooks/useVoiceRecorder';
 import { CboWelcome } from '@/core/components/cbo/CboWelcome';
@@ -55,7 +56,6 @@ import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards'
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { localizedWorkshopName } from '@/lib/workshopHelpers';
 
-const ConceptNoteMap = lazy(() => import('@/core/components/concept-note/ConceptNoteMap'));
 const MapMicroapp = lazy(() => import('@/core/components/concept-note/MapMicroapp'));
 const InterventionSelector = lazy(() => import('@/core/components/concept-note/InterventionSelector'));
 
@@ -90,6 +90,71 @@ function formatMapResult(result: MapSelectionResult): string {
 function fixMarkdownTables(text: string): string {
   if (!text.includes('|')) return text;
   return text.replace(/\|\s*\|/g, '|\n|').replace(/\|\s*\n\s*\|/g, '|\n|');
+}
+
+// ── Right-panel tool registry ────────────────────────────────────────────────
+// Agent-driven right-panel tools (the map, the NBS-type selector, future ones)
+// follow ONE structural pattern instead of ad-hoc per-tool conditionals:
+//   • the agent's open_* persists `state.activeTool = { kind }` (server-side), so
+//     the tool survives reload and is never gated behind a one-shot agent button;
+//   • each tool declares a re-entry config + a done-check + a nudge label here;
+//   • the always-on tab render, the chat nudge chip, and the tab pulse are all
+//     GENERIC over this registry (see pendingTool / toolReached below).
+// Adding a tool for a future phase = one declarative entry, not new plumbing.
+type ToolKind = 'map' | 'interventions';
+interface RightPanelToolDef {
+  tab: 'document' | 'map' | 'interventions' | 'scorecard';
+  icon: LucideIcon;
+  // Config to render the tool with no live agent params (reload / re-entry).
+  // null = no default for this phase (the tool only shows on a live agent open).
+  defaultParams: (state: CboState) => any | null;
+  // Task complete → the nudge clears; re-entry is just "revisit".
+  isDone: (state: CboState) => boolean;
+  nudge: { pt: string; en: string };
+}
+
+function fieldVal(state: CboState | null, section: string, ...fields: string[]): boolean {
+  const f = (state?.sections as any)?.[section]?.fields;
+  return !!f && fields.some(k => f?.[k]?.value);
+}
+
+const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
+  map: {
+    tab: 'map',
+    icon: MapIcon,
+    defaultParams: (s) => s.phase === 2 ? {
+      selectionMode: 'composite',
+      zoneSource: 'neighborhoods',
+      tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+      showLegendSimple: true,
+      hazardTour: false,        // re-entry skips the guided tour, straight to selection
+      allowDeferSite: true,
+      prompt: 'Marque o bairro e o lugar onde vocês atuam.',
+    } : null,
+    isDone: (s) => fieldVal(s, 'intervention_site', 'bairro', 'site_name'),
+    nudge: { pt: 'Abrir o mapa', en: 'Open the map' },
+  },
+  interventions: {
+    tab: 'interventions',
+    icon: Layers,
+    defaultParams: () => null,  // wired when E3 (NBS-type selection) lands
+    isDone: (s) => fieldVal(s, 'intervention_type', 'intervention_type', 'nbs_type'),
+    nudge: { pt: 'Escolher o tipo de SbN', en: 'Choose the NBS type' },
+  },
+};
+
+// The tool the agent has opened (persisted), if its task isn't done → drives the
+// chat nudge chip + the tab pulse.
+function pendingTool(state: CboState | null): { kind: ToolKind; def: RightPanelToolDef } | null {
+  const kind = (state as any)?.activeTool?.kind as ToolKind | undefined;
+  if (!kind || !RIGHT_PANEL_TOOLS[kind] || !state) return null;
+  const def = RIGHT_PANEL_TOOLS[kind];
+  return def.isDone(state) ? null : { kind, def };
+}
+// Has this tool's step been reached (active now, or already done)? → the tab
+// renders the live tool rather than the "not yet" placeholder.
+function toolReached(state: CboState | null, kind: ToolKind): boolean {
+  return (state as any)?.activeTool?.kind === kind || (!!state && RIGHT_PANEL_TOOLS[kind].isDone(state));
 }
 
 // ── Inline editable field ────────────────────────────────────────────────────
@@ -1480,6 +1545,28 @@ export default function CboProfilePage() {
               );
             })()}
 
+            {/* Persistent tool affordance — while ANY right-panel tool task is
+                pending (agent opened it, not yet done), this chip is always
+                available so the user can (re)enter it without relying on a
+                one-shot agent button. Generic over the tool registry. */}
+            {(() => {
+              const pend = !isStreaming ? pendingTool(state) : null;
+              if (!pend || rightTab === pend.def.tab) return null;
+              const Icon = pend.def.icon;
+              return (
+                <div className="flex justify-center py-2">
+                  <Button
+                    size="sm"
+                    className="h-8 text-xs gap-1.5 bg-emerald-600 hover:bg-emerald-700"
+                    onClick={() => { setRightTab(pend.def.tab); setMapRelevant(true); setMobileActiveTab('panel'); }}
+                    data-testid={`cbo-open-tool-${pend.kind}`}
+                  >
+                    <Icon className="w-3.5 h-3.5" /> {lang === 'pt' ? pend.def.nudge.pt : pend.def.nudge.en}
+                  </Button>
+                </div>
+              );
+            })()}
+
             <div ref={chatEndRef} />
           </div>
 
@@ -1603,7 +1690,7 @@ export default function CboProfilePage() {
                 <button key={tab} onClick={() => setRightTab(tab)}
                   className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${rightTab === tab ? 'border-green-600 text-green-700' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
                   {tab === 'interventions' ? (t('cbo.tabs.interventions', 'NBS Types')) : t(`cbo.tabs.${tab}`)}
-                  {tab === 'map' && mapRelevant && rightTab !== 'map' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
+                  {rightTab !== tab && ((tab === 'map' && mapRelevant) || pendingTool(state)?.def.tab === tab) && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
                   {tab === 'interventions' && interventionSelectorParams && rightTab !== 'interventions' && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse ml-1 inline-block" />}
                   {tab === 'scorecard' && state.totalMaturityScore > 0 && <span className="ml-1 text-xs text-muted-foreground">{state.totalMaturityScore}/27</span>}
                 </button>
@@ -1696,9 +1783,9 @@ export default function CboProfilePage() {
           {rightTab === 'map' && (
             <div className="flex-1 min-h-0 relative">
               <Suspense fallback={<div className="flex items-center justify-center h-full"><Loader2 className="w-6 h-6 animate-spin" /></div>}>
-                {openMapParams ? (
+                {toolReached(state, 'map') && (openMapParams ?? (state && RIGHT_PANEL_TOOLS.map.defaultParams(state))) ? (
                   <MapMicroapp
-                    params={openMapParams}
+                    params={(openMapParams ?? RIGHT_PANEL_TOOLS.map.defaultParams(state!)) as OpenMapParams}
                     onConfirm={(result: MapSelectionResult) => {
                       const message = formatMapResult(result);
                       // Gap 1 — persist the chosen site as STRUCTURED data, not just
@@ -1747,10 +1834,9 @@ export default function CboProfilePage() {
                     }}
                   />
                 ) : (
-                  <ConceptNoteMap isActive={rightTab === 'map'} onConfirm={(_summary, description) => {
-                    if (currentQuestion) handleSelectOption(description); else sendMessage(description);
-                    setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
-                  }} />
+                  <div className="flex items-center justify-center h-full p-6 text-center text-sm text-muted-foreground">
+                    {lang === 'pt' ? 'O mapa abre quando a gente chegar nessa parte do encontro.' : 'The map opens when we reach that part of the workshop.'}
+                  </div>
                 )}
               </Suspense>
             </div>

--- a/docs/cbo-chat-composers.md
+++ b/docs/cbo-chat-composers.md
@@ -72,6 +72,33 @@ A token link's working session is `member.cboStateId`, resolved server-side
 resumes the same conversation on **any** device; localStorage is only a same-device
 cache (PR #297). Don't key the session on the browser.
 
+## Rule 6 — Right-panel tools go through the registry, not ad-hoc gating
+
+The **right-panel** tools (the Mapa interactive map, the Tipos de SbN selector,
+future ones) are NOT the same as inline chat composers — they live in the panel
+tabs and must be **always reachable**, never gated behind a one-shot agent button
+(a reload would strand the user with no way back into a pending task).
+
+One structural pattern, in `cbo-profile.tsx`:
+
+- **Persist which tool is open.** When the agent calls `open_map` /
+  `open_intervention_selector`, the server sets `cbo_state.activeTool = { kind }`
+  (in `pushEvent`). It survives reload, so the panel is re-enterable. (Don't gate
+  on the ephemeral `openMapParams` event — that's lost on reload.)
+- **Declare each tool in `RIGHT_PANEL_TOOLS`.** Each entry gives its `tab`, a
+  `defaultParams(state)` (the re-entry config when there's no live agent params —
+  e.g. the map's composite/site config with the tour OFF), an `isDone(state)`
+  check (reads the captured section field), a `nudge` label, and an `icon`.
+- **The plumbing is generic over the registry.** `pendingTool(state)` (open +
+  not done) drives a persistent chat **nudge chip** and the **tab pulse**;
+  `toolReached(state, kind)` makes the tab render the live tool (`openMapParams ??
+  defaultParams(state)`) instead of the "not yet" placeholder. The agent's
+  `open_*` just sets the live params + focuses the tab — it never *gates* access.
+
+Adding a tool for a future phase = **one declarative entry** in the registry +
+wiring that tab's component render, not a new pile of conditionals. (PR for the
+map established this; `interventions` is registered as a stub for E3.)
+
 ---
 
 ### TL;DR for a new in-chat widget
@@ -80,3 +107,9 @@ cache (PR #297). Don't key the session on the browser.
 2. Don't end streaming if it's mid-turn. (R2)
 3. If it's read-only, pair it with an `ask_user`. (R3)
 4. Read phase/identity from the authoritative server state, not a cache. (R4, R5)
+
+### TL;DR for a new right-panel tool
+
+5. Persist `activeTool` server-side on `open_*`; add a `RIGHT_PANEL_TOOLS` entry
+   (`tab`, `defaultParams`, `isDone`, `nudge`, `icon`); the nudge/pulse/always-on
+   are generic. Never gate the tool behind a one-shot button. (R6)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -880,6 +880,14 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'types', typeIds: event.typeIds, intro: event.intro }), messageType: 'composer', timestamp: new Date().toISOString() });
     } else if (event.type === 'show_examples') {
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'examples', cardIds: event.cardIds, mode: event.mode, intro: event.intro }), messageType: 'composer', timestamp: new Date().toISOString() });
+    } else if (event.type === 'open_map') {
+      // Persist that the map step is active so the right-panel tool stays
+      // reachable across reloads (not gated behind a transient button).
+      state.activeTool = { kind: 'map' };
+      setCboState(cboId, state); debouncedPersist(cboId);
+    } else if (event.type === 'open_intervention_selector') {
+      state.activeTool = { kind: 'interventions' };
+      setCboState(cboId, state); debouncedPersist(cboId);
     }
   };
 

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -83,6 +83,10 @@ export interface CboState {
   maturityScores: MaturityScore[];
   priorityFlags: PriorityFlag[];
   totalMaturityScore: number; // out of 27
+  // The right-panel tool the agent has opened for this phase (map / type selector).
+  // Persisted so the tool stays reachable across reloads — the panel isn't gated
+  // behind a one-shot agent button. Cleared/superseded as the task completes.
+  activeTool?: { kind: 'map' | 'interventions' } | null;
   editLog: Array<{ timestamp: string; sectionId: string; field: string; oldValue: any; newValue: any; source: 'agent' | 'user' }>;
   uploadedFiles: Array<{ name: string; path: string; parsedAt: string; summary: string }>;
   metadata: {


### PR DESCRIPTION
Reloading mid-map-step stranded the user: the chat showed "Aguardando sua seleção no mapa" but the interactive map was gone with **no way back** — `openMapParams` is ephemeral and the map was gated behind a one-shot agent button.

Fixed **structurally** (your ask), so it repeats for every future phase tool instead of ad-hoc per-tool code.

## The pattern
- **Persist which tool is open**: the server sets `cbo_state.activeTool = { kind }` on `open_map` / `open_intervention_selector` (in `pushEvent`). Survives reload → the panel is re-enterable.
- **`RIGHT_PANEL_TOOLS` registry**: each tool declares its `tab`, a re-entry `defaultParams(state)` (map = composite/site config with the **tour off**), an `isDone(state)` check, a `nudge` label, and an `icon`.
- **Generic plumbing over the registry**:
  - `pendingTool(state)` (open + not done) → a **persistent chat nudge chip** + the **tab pulse**.
  - `toolReached(state, kind)` → the tab renders the **live tool** (`openMapParams ?? defaultParams(state)`) instead of a "not yet" placeholder.
  - The agent's `open_*` just sets live params + focuses the tab — it **never gates** access.

So: educational E2 (no `activeTool`) shows a gentle placeholder; the map part shows the live, always-reachable map that **survives reload**; once a site is captured, the nudge/pulse clear automatically.

Map is fully wired; **`interventions` is registered as a stub for E3** — adding a future tool is one registry entry + that tab's render.

Also dropped the wrong `ConceptNoteMap` fallback on the CBO path (that was the city map).

Documented as **Rule 6** in `docs/cbo-chat-composers.md` (+ a "new right-panel tool" TL;DR).

`tsc` clean. **Deploy:** rebuild + republish.

### Eyeball on dev
- Reload mid-site-step → Mapa tab is live + interactive, with the "Abrir o mapa" chip + pulse; no dead-end.
- During educational E2 → placeholder (no premature map nudge).
- Capture a site → chip/pulse clear.