### PR TITLE
fix(cbo): live open_map renders the map (don't over-gate on stale activeTool)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -834,6 +834,10 @@ export default function CboProfilePage() {
       }
       case 'open_map':
         setOpenMapParams(event.params);
+        // Mirror the server-persisted activeTool locally so the chip/pulse/
+        // re-entry reflect it immediately (the client's loaded state predates
+        // this turn; without this they'd only update on reload).
+        setState(prev => prev ? { ...prev, activeTool: { kind: 'map' } } : prev);
         setRightTab('map');
         setMapRelevant(true);
         setMobileActiveTab('panel');
@@ -841,6 +845,7 @@ export default function CboProfilePage() {
         break;
       case 'open_intervention_selector':
         setInterventionSelectorParams((event as any).params);
+        setState(prev => prev ? { ...prev, activeTool: { kind: 'interventions' } } : prev);
         setRightTab('interventions');
         setMobileActiveTab('panel');
         setIsStreaming(false);
@@ -1783,7 +1788,7 @@ export default function CboProfilePage() {
           {rightTab === 'map' && (
             <div className="flex-1 min-h-0 relative">
               <Suspense fallback={<div className="flex items-center justify-center h-full"><Loader2 className="w-6 h-6 animate-spin" /></div>}>
-                {toolReached(state, 'map') && (openMapParams ?? (state && RIGHT_PANEL_TOOLS.map.defaultParams(state))) ? (
+                {(openMapParams ?? (toolReached(state, 'map') && state ? RIGHT_PANEL_TOOLS.map.defaultParams(state) : null)) ? (
                   <MapMicroapp
                     params={(openMapParams ?? RIGHT_PANEL_TOOLS.map.defaultParams(state!)) as OpenMapParams}
                     onConfirm={(result: MapSelectionResult) => {


### PR DESCRIPTION
Follow-up to #307. Testing showed the Mapa tab stuck on the "O mapa abre quando a gente chegar nessa parte" **placeholder** even though the agent had opened the map.

**Root cause** (verified against live state — `activeTool: {kind:'map'}` IS set server-side): #307 gated the tab render on `toolReached(state,'map') && (openMapParams ?? default)`. But the client's `state` is loaded at page-load and **predates** the agent's `open_map` turn (a `[SKIP]`/agent turn isn't a reload), so `state.activeTool` is stale (false) → placeholder, even though the live `openMapParams` was set.

**Fixes:**
1. Render `openMapParams` **unconditionally**; `toolReached` only gates the *re-entry default* config (reload with no live params).
2. The `open_map` / `open_intervention_selector` handlers now mirror the server-persisted `activeTool` into client state, so the chip / pulse / re-entry update **immediately**, not only on reload.

After this: a live agent open renders the map; clicking the Mapa tab / reloading mid-step resolves the persisted `activeTool` → live map + "Abrir o mapa" chip. `tsc` clean.