### PR TITLE
fix(cbo): E2 map — orchestrator colors, visible borders, OSM sites load

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -277,10 +277,12 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
           if (params.allowDeferSite) {
             const norm = (zoneRisk(p) - riskMin) / riskSpan;
             return {
-              color: '#ffffff',
-              weight: 1 + Math.max(0, Math.min(1, norm)) * 1.5,
+              // Dark border (the CBO zone step is on the LIGHT basemap — a white
+              // border like the orchestrator's dark-map view would be invisible).
+              color: '#334155',
+              weight: 0.8 + Math.max(0, Math.min(1, norm)) * 1.4,
               fillColor: TYPOLOGY_COLORS[p?.typologyLabel] || TYPOLOGY_COLORS.LOW,
-              fillOpacity: zoneRiskOpacity(norm),
+              fillOpacity: Math.max(0.35, zoneRiskOpacity(norm)),
               dashArray: undefined as string | undefined,
             };
           }

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -124,7 +124,8 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
     icon: MapIcon,
     defaultParams: (s) => s.phase === 2 ? {
       selectionMode: 'composite',
-      zoneSource: 'neighborhoods',
+      zoneSource: 'neighborhood_zones',  // risk-scored bairros (typologyLabel/meanFlood…) — same as the orchestrator
+      layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
       tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
       showLegendSimple: true,
       hazardTour: false,        // re-entry skips the guided tour, straight to selection

--- a/e2e/cougar-e2-map-step.spec.ts
+++ b/e2e/cougar-e2-map-step.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// E2 map step (the new flow): the agent opens the map with the guided hazard
+// tour + neighborhood/site selection, and the panel is "always-on" — persisted
+// in state.activeTool so it survives reload and is reachable via the chip, not
+// gated behind the one-shot agent button.
+
+test.describe('COUGAR — E2 map step (tour + always-on)', () => {
+  const E2_OPEN_MAP = {
+    op: 'open_map' as const,
+    params: {
+      selectionMode: 'composite',
+      zoneSource: 'neighborhood_zones',
+      layers: ['osm_parks', 'osm_schools'],
+      tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+      showLegendSimple: true,
+      hazardTour: true,
+      allowDeferSite: true,
+      prompt: 'Conheça os riscos e marque onde vocês atuam.',
+    },
+  };
+
+  test('hazard tour cycles 3 hazards, then unlocks the neighborhood step', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[{ op: 'say', text: 'Vamos pro mapa.' }, E2_OPEN_MAP]]);
+    await page.getByTestId('cbo-chat-input').fill('Abrir o mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // Tour: the "Próximo risco" CTA walks flood → heat → landslide, then becomes
+    // "Escolher meu bairro" and hands off to selection (the CTA disappears).
+    const tourNext = page.getByTestId('map-tour-next');
+    await expect(tourNext).toBeVisible({ timeout: 15_000 });
+    await tourNext.click(); // → heat
+    await tourNext.click(); // → landslide
+    await tourNext.click(); // → done (neighborhood step)
+    await expect(tourNext).toHaveCount(0, { timeout: 10_000 });
+
+    // Neighborhood step is composite/zone — the "1 Bairro → 2 Locais" stepper renders.
+    await expect(page.locator('.leaflet-container').first()).toBeVisible();
+  });
+
+  test('the map is always-on: survives reload + re-enterable via the chip', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[{ op: 'set_phase', phase: 2 }, { op: 'say', text: 'Mapa.' }, E2_OPEN_MAP]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // Leave the map (go to the document tab) → the persistent "open the map"
+    // chip is available (activeTool is pending, no site captured yet).
+    await page.getByRole('button', { name: /document/i }).first().click();
+    const chip = page.getByTestId('cbo-open-tool-map');
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    // Reload — the pending tool is persisted in state.activeTool, so the chip is
+    // still there (no dead-end), and tapping it re-enters the live map.
+    await page.reload();
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const chip2 = page.getByTestId('cbo-open-tool-map');
+    await expect(chip2).toBeVisible({ timeout: 15_000 });
+    await chip2.click();
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -172,7 +172,8 @@ On **"Abrir o mapa"** open with the guided tour ON; on **"Já conheço os riscos
 ```
 open_map({
   selectionMode: 'composite',
-  zoneSource: 'neighborhoods',
+  zoneSource: 'neighborhood_zones',  // risk-scored bairros (colored by risk like the orchestrator) — NOT 'neighborhoods' (raw IBGE, no risk colors)
+  layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
   tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],  // risk layers — all have legends; the tour shows them one at a time with the real color scale
   showLegendSimple: true,
   hazardTour: true,        // false if they tapped "Já conheço os riscos"


### PR DESCRIPTION
Audit + fix of the neighborhood/site step. Three bugs, all from the map config and a copied style:

1. **Washed-out colors.** Config used `zoneSource: 'neighborhoods'` → `porto-alegre-ibge-indicators.json` (**raw IBGE, no `typologyLabel`/`meanFlood`**), so every bairro fell back to `LOW` (pale green). The orchestrator loads `neighborhood_zones` (`porto-alegre-neighborhood-zones.json`, **risk-scored**). Switched to `'neighborhood_zones'` → the choropleth now matches the coordinator's map (hue = which risk, opacity = how risky).
2. **Invisible boundaries.** The CBO zone style used a **white** border (copied from the orchestrator's *dark*-basemap view) — invisible on the CBO **light** basemap. Now a dark border (`#334155`) + a fill-opacity floor so every bairro is legible.
3. **OSM sites didn't load in step 2.** The config omitted `layers`, so the OSM loader (which fires on reaching the assets step, `MapMicroapp:383`) had nothing to fetch. Added `osm_parks/schools/wetlands/hospitals` → they auto-load when you pick a neighborhood.

`tsc` clean. Builds on #304/#305/#307/#309. **Deploy:** rebuild + republish.