### PR TITLE
fix(cbo): lock session language to the cohort, server-side (kills PT/EN drift)

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -22,7 +22,7 @@ Whoever it is, they:
 
 - Brazilian Portuguese, warm, second-person singular (tu/você as natural — match what they use)
 - Never use "preencha" or "responda" — use "conta", "me fala"
-- Switch to English **only if the user writes in English first**
+- **Always respond in the session language provided by the system** — never switch based on what the user types (an English word, an English-looking org name, or an English reply does NOT change your language)
 
 ## ⚠️ Acknowledgments — strict rule (READ THIS FIRST)
 
@@ -31,7 +31,7 @@ Warmth comes from speed, not from words. Long acks make the user wait. Default t
 **After a chip selection** (the user clicked a button): emit `update_section` + the next `ask_user` with **no chat text at all**. The chip click IS the user's answer — confirming it back wastes their time.
 
 **After a free-text answer** (org name, mission, year, story, proud-moment): a maximum of **3 words** of ack, then immediately the next question. Examples of acceptable acks:
-- "Anotado." / "Got it."
+- "Anotado."
 - "Show!"
 - "Faz sentido."
 - "Lindo."
@@ -341,7 +341,7 @@ Common stuck patterns + responses:
 | "Não sei se a gente conta como organização" | Informal group, hesitant about formality | "Conta sim. Vamos chamar assim por enquanto e refinar depois. Há quanto tempo vocês fazem esse trabalho?" |
 | "Não temos orçamento" | Score-0 fears the platform isn't for them | "Faz parte do diagnóstico saber disso. Muitos projetos importantes começam aí. Vamos seguir." |
 | "Já fiz isso pro Caixa, não quero repetir" | Done a similar form before, frustrated | "Você pode subir esse documento — eu leio e preencho tudo o que conseguir." |
-| Switches to English | First-language English speaker visiting | Switch immediately. |
+| Writes a word or two in English | Bilingual reply — not a language change | Keep responding in the session language; do NOT switch. |
 
 ## Tool calls
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -25,7 +25,7 @@ The map, site selection, hazard ranking, tenure, community anchoring, and scorin
 
 - Brazilian Portuguese, warm, second-person singular
 - Never use "preencha" or "responda" — use "conta", "me fala"
-- Switch to English only if the user writes in English first
+- **Always respond in the session language provided by the system** — never switch based on what the user types
 
 ## ⚠️ Acknowledgments — strict rule (READ THIS FIRST)
 

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -24,6 +24,7 @@ import {
   getOrgIdForCboState,
   toDocumentMeta,
 } from "../services/documentPersistence";
+import { getCohortLanguageForCbo } from "../services/cohortLanguage";
 
 // Shim — pre-DB code called this synchronous-style. Routes now await DB.
 async function loadPersistedCboState(id: string): Promise<{ state: CboState; messages: any[] } | null> {
@@ -122,13 +123,18 @@ export function registerCboRoutes(app: Express): void {
       }
     }
 
-    // Sticky session language — set ONCE, never auto-flipped mid-session. The
-    // old per-turn accent/keyword regex flipped EN↔PT on a short reply, which
-    // produced half-English/half-Portuguese documents. Now: an explicit UI pick
-    // (the language picker) always wins and updates the sticky value; otherwise
-    // use the stored language; otherwise detect once from this first message.
+    // Session language authority (CBO-LANG-AUTH). If this CBO belongs to a
+    // cohort with a coordinator-forced language, that ALWAYS wins — it overrides
+    // the client-sent lang and text detection, so an English-looking org name, a
+    // standalone/test fallback, or a pre-fetch race can't flip the agent to
+    // English mid-flow. Only truly standalone CBOs (no cohort) fall through to
+    // the legacy sticky behavior: an explicit UI pick, else the stored language,
+    // else detect once from this first message.
+    const cohortLang = await getCohortLanguageForCbo(req.params.id);
     let sessionLang: 'pt' | 'en';
-    if (lang === 'pt' || lang === 'en') {
+    if (cohortLang) {
+      sessionLang = cohortLang;
+    } else if (lang === 'pt' || lang === 'en') {
       sessionLang = lang;
     } else if (state.metadata.language) {
       sessionLang = state.metadata.language;

--- a/server/services/cohortLanguage.ts
+++ b/server/services/cohortLanguage.ts
@@ -1,0 +1,33 @@
+// Cohort language authority (CBO-LANG-AUTH).
+//
+// When a CBO belongs to a coordinator-managed cohort, the cohort's forced
+// language (cohort.settings.language) is the ONE authority for the whole
+// session — it overrides the client-sent lang and any text detection. This is
+// what stops the PT/EN drift the coordinator sees (an English-looking org name,
+// a standalone/test fallback, or a pre-fetch race would otherwise flip the agent
+// to English mid-flow). Standalone CBOs (no cohort) return null and keep the
+// legacy client/stored/detect behavior.
+
+import { db } from '../db';
+import { cohorts, cohortMembers, type CohortSettings } from '@shared/cohort-schema';
+import { eq } from 'drizzle-orm';
+
+export async function getCohortLanguageForCbo(cboStateId: string): Promise<'pt' | 'en' | null> {
+  if (!cboStateId) return null;
+  try {
+    const [member] = await db
+      .select({ cohortId: cohortMembers.cohortId })
+      .from(cohortMembers)
+      .where(eq(cohortMembers.cboStateId, cboStateId))
+      .limit(1);
+    if (!member?.cohortId) return null;
+    const [cohort] = await db
+      .select({ settings: cohorts.settings })
+      .from(cohorts)
+      .where(eq(cohorts.id, member.cohortId))
+      .limit(1);
+    return (cohort?.settings as CohortSettings | null)?.language ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
**Demo-blocker #2** (Ana: "language toggle inconsistency PT/EN"). The systemic fix — one authority for language, resolved server-side.

**Root cause:** three competing truths (client `i18n.language`, server `sessionLang` which trusted the client-sent `lang`/text-detected, and the skill telling the agent to switch on English input). None was anchored to the member's `cohort.language`, so any fallback to `en` flipped everything English.

**Fix:**
- `getCohortLanguageForCbo()` (new) resolves `cohort.settings.language` for the CBO.
- `/api/cbo/:id/chat` makes cohort language the **top authority** — overrides client `lang` + text detection. Standalone CBOs (no cohort) keep the legacy pick/stored/detect path.
- Skills: deleted the "switch to English if the user writes English first" rule from `encontro-1.md` (+ the table row) and `encontro-2.md` (it was overriding the `langDirective`), and dropped the bilingual `"Got it."` sample ack.

The real Rede cohort is PT-forced, so the agent is now reliably PT regardless of what the client sends. `CBO-I18N-SYNC` (client static-string pre-fetch race) ships separately.

TS clean; `cougar-cohort-language` + `cbo-golden-path` e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)