### PR TITLE
fix(cbo): Encontro 2 no longer dead-ends — shared phaseComplete() predicate

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -12,7 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/core/components/ui/to
 import { useFileDrop } from '@/core/hooks/useFileDrop';
 import {
   CBO_SECTIONS,
-  PHASE_COMPLETION_METRICS,
+  phaseComplete,
   type CboState,
   type CboEvent,
   type CboChatMessage,
@@ -1431,21 +1431,15 @@ export default function CboProfilePage() {
                    scoring instructions in the skill markdown +
                    buildPhaseInstructions fallback. */}
             {(() => {
-              if (isStreaming || messages.length === 0 || state.phase === 0) return null;
+              if (isStreaming || !stableStreamEnded || messages.length === 0 || state.phase === 0) return null;
               if (currentQuestion) return null;
 
-              // Phase → required maturity metrics. Single source of truth:
-              // PHASE_COMPLETION_METRICS in shared/cbo-schema.ts, derived from
-              // CBO_SECTIONS[].maturityMetrics. The server validates scores
-              // against the same metric ids, so the banner can no longer be
-              // held back by a misspelled metric, and this map can't drift
-              // from the schema.
-              const required = PHASE_COMPLETION_METRICS[state.phase] ?? [];
-              if (required.length > 0) {
-                const scored = new Set((state.maturityScores ?? []).map(s => s.metric));
-                const allScored = required.every(m => scored.has(m));
-                if (!allScored) return null;
-              }
+              // Forward-progress gate — the phase must be complete before we
+              // offer the next workshop. Uses the shared phaseComplete() predicate
+              // (scored metrics OR section-fill), so Encontro 2 — whose maturity
+              // scores are intentionally deferred (site_control / community_
+              // anchoring) — advances instead of dead-ending with no way forward.
+              if (!phaseComplete(state, state.phase)) return null;
 
               const nextUnlockedPhase = unlockedPhases.find(p => p > state.phase);
               if (nextUnlockedPhase == null) return null;

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -34,6 +34,46 @@ export const PHASE_COMPLETION_METRICS: Record<number, string[]> = (() => {
   return map;
 })();
 
+/** A field counts as "filled" when it holds a real value (non-null, non-empty). */
+export function cboFieldIsFilled(f?: CboFieldState): boolean {
+  if (!f) return false;
+  const v = f.value;
+  if (v == null) return false;
+  return typeof v === 'string' ? v.trim().length > 0 : true;
+}
+
+/**
+ * Whether a phase's work is done — the single forward-progress predicate used by
+ * the next-workshop advance banner (and available to the server phase gate).
+ * A phase is complete when EITHER signal holds:
+ *   (a) every maturity metric for the phase is scored (the legacy signal — still
+ *       true for phases that DO score), OR
+ *   (b) every section belonging to the phase has at least one filled field.
+ * (b) is what unblocks Encontro 2, whose skill intentionally DEFERS its two
+ * maturity scores (site_control / community_anchoring) — so (a) is never
+ * satisfiable there and the advance banner used to dead-end with no way forward.
+ * Being an OR of the two, this is strictly more permissive than the old
+ * metrics-only gate: it can never hide a banner that previously showed.
+ */
+export function phaseComplete(
+  state: Pick<CboState, 'sections' | 'maturityScores'>,
+  phase: number,
+): boolean {
+  const sections = CBO_SECTIONS.filter(s => s.phase === phase);
+  if (sections.length === 0) return true;
+
+  const required = PHASE_COMPLETION_METRICS[phase] ?? [];
+  if (required.length > 0) {
+    const scored = new Set((state.maturityScores ?? []).map(s => s.metric));
+    if (required.every(m => scored.has(m))) return true;
+  }
+
+  return sections.every(sec => {
+    const fields = state.sections?.[sec.id]?.fields ?? {};
+    return Object.values(fields).some(cboFieldIsFilled);
+  });
+}
+
 // Maturity scores (0-3 per COUGAR NBS Mapping Criteria)
 export interface MaturityScore {
   metric: string;


### PR DESCRIPTION
**Demo-blocker #3** (P0). An org that finishes Encontro 2 was stranded — the "Começar Encontro 3" banner never appeared even with WS3 opened.

**Root cause:** the banner gated on `PHASE_COMPLETION_METRICS[phase]` all being scored, but phase 2's metrics (`site_control`, `community_anchoring`) are **intentionally deferred** by `encontro-2.md` — so `allScored` was never true and the sole forward affordance never rendered. The skill's "done" contract and the client's advance gate used two different definitions of "phase complete."

**Fix:** one shared `phaseComplete(state, phase)` predicate (in `shared/cbo-schema.ts`), complete when **either** every phase metric is scored (legacy) **or** every section for the phase has ≥1 filled field. Being an OR it's strictly more permissive than before — can't regress any phase — and unblocks E2 via section-fill. Banner now calls it.

Also folds in **`CBO-BANNER-FLICKER`**: the banner now waits on the debounced `!stableStreamEnded` like the resume block, so it can't flash mid-turn.

`phaseComplete()` is pure + shared, ready to also back the server `set_phase` gate (`CBO-PHASE-JUMP`) in a follow-up. TS clean; golden-path + map/site e2e (7 specs) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)