### PR TITLE
fix(cbo): inline option lists become real buttons + stop fusing sentences

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -763,7 +763,12 @@ export default function CboProfilePage() {
           // (the SSE stream emits the response in pieces as the model
           // generates it).
           if (last?.role === 'assistant' && last.messageType === 'content') {
-            return [...prev.slice(0, -1), { ...last, content: last.content + event.content }];
+            // Join consecutive whole-block chat chunks with a paragraph break ONLY
+            // at a sentence boundary (prev ends with . ! ? : ; and next starts
+            // non-space), so two distinct sentences can't fuse ("profile:A few…")
+            // while a sub-block token split (mid-word) is never separated.
+            const sep = /[.!?:;]$/.test(last.content) && !/^\s/.test(event.content) ? '\n\n' : '';
+            return [...prev.slice(0, -1), { ...last, content: last.content + sep + event.content }];
           }
           return [...prev, { role: 'assistant' as const, content: event.content, messageType: 'content', timestamp: new Date().toISOString() }];
         });

--- a/e2e/cougar-inline-options.spec.ts
+++ b/e2e/cougar-inline-options.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// CBO-INLINE-OPTIONS (safe subset): when the agent writes a selectable question
+// as a trailing markdown list instead of calling ask_user, the server converts
+// it to a real ask_user event (buttons) before it reaches the client. Guarded by
+// a select/choose cue so it never hijacks a plain bulleted prose block.
+// Both paths (live SDK + fake model) share emitAssistantText, so the fake model
+// exercises the exact same conversion.
+
+test.describe('COUGAR — inline options become buttons', () => {
+  test('a trailing option list with a cue renders as a question card, not inert bullets', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // The agent inlines a multi-option question as a markdown list (the bug).
+    await api.scriptCbo(cboId, [
+      [
+        {
+          op: 'say',
+          text: 'Qual é o foco principal de vocês? Selecione uma:\n- Segurança alimentar\n- Resiliência climática\n- Educação ambiental',
+        },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // Converted: the preamble is the card question, the bullets are real options.
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible();
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', 'Segurança alimentar');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', 'Resiliência climática');
+    await expect(page.getByTestId('cbo-option-2')).toHaveAttribute('data-option-label', 'Educação ambiental');
+  });
+
+  test('a bulleted prose block WITHOUT a choose-cue stays chat; a real ask_user wins the card', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Bullets but no select/choose cue → must NOT convert; the real ask_user that
+    // follows is the one that becomes the question card.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Beleza. Vou anotar isso:\n- primeiro ponto\n- segundo ponto' },
+        { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }, { label: 'Não' }] },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The bulleted block rendered as chat text (not hijacked into options).
+    await expect(page.getByText('primeiro ponto', { exact: false })).toBeVisible();
+    // The real ask_user is the card — options are Sim/Não, not the bullets.
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', 'Sim');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', 'Não');
+  });
+});

--- a/server/services/agentOutput.ts
+++ b/server/services/agentOutput.ts
@@ -1,0 +1,74 @@
+// Agent output normalization (safe subset of the foolproof turn contract).
+//
+// One place that turns a raw assistant text block into the SSE event(s) the
+// client renders. Today it does one job — the CBO-INLINE-OPTIONS fix — but it's
+// the seam the full per-turn normalization layer will grow into. Shared by the
+// live SDK path (cboAgent.ts) and the fake model (fakeCboModel.ts) so both
+// behave identically and the conversion is deterministically e2e-testable.
+
+import type { CboEvent } from "@shared/cbo-schema";
+
+// A markdown-ish option line: a bullet (-, *, •, ·), a single-letter marker
+// (A) / a.) or a numeric marker (1. / 1)), then whitespace and a non-empty label.
+const OPTION_LINE_RE = /^\s*(?:[-*•·]|[A-Za-z][.)]|\d+[.)])\s+(\S.*?)\s*$/;
+// The preamble must actually invite a choice — this is what keeps us from
+// rewriting explanatory prose that merely happens to contain a bulleted list.
+const SELECT_CUE_RE = /(select|choose|pick one|which|selecione|escolh|marque|qual\b|quais\b)/i;
+const MULTI_CUE_RE = /(select multiple|more than one|all that apply|multiple|múltipl|mais de uma|v[áa]rias?|quantas quiser|selecione as|todas que)/i;
+
+export type InlineOptions = {
+  question: string;
+  options: Array<{ label: string; description: string }>;
+  multiSelect: boolean;
+};
+
+/**
+ * Detect the exact "options written as a trailing markdown list instead of an
+ * ask_user call" shape (CBO-INLINE-OPTIONS). Returns a structured question only
+ * when the block is: [preamble containing a select/choose cue] followed by [a
+ * contiguous list of 2–8 option lines at the END of the block, nothing but
+ * blank lines after]. Deliberately strict so it never rewrites legitimate prose.
+ */
+export function detectInlineOptionList(text: string): InlineOptions | null {
+  const lines = text.split(/\r?\n/);
+  const optionIdx: number[] = [];
+  const labels: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(OPTION_LINE_RE);
+    if (m && m[1].trim()) { optionIdx.push(i); labels.push(m[1].trim()); }
+  }
+  if (labels.length < 2 || labels.length > 8) return null;
+
+  const first = optionIdx[0];
+  const last = optionIdx[optionIdx.length - 1];
+  // The option lines must be contiguous (blank lines between them are allowed).
+  for (let k = first; k <= last; k++) {
+    if (optionIdx.includes(k) || lines[k].trim() === '') continue;
+    return null;
+  }
+  // The list must be the tail of the block — nothing but blanks after it.
+  if (lines.slice(last + 1).some(l => l.trim() !== '')) return null;
+
+  const preamble = lines.slice(0, first).join('\n').trim();
+  if (!preamble || !SELECT_CUE_RE.test(preamble)) return null;
+
+  return {
+    question: preamble,
+    options: labels.map(label => ({ label, description: '' })),
+    multiSelect: MULTI_CUE_RE.test(preamble),
+  };
+}
+
+/**
+ * Emit one assistant text block. If it's really an inline option list, send a
+ * structured ask_user event (real buttons) instead of inert markdown bullets;
+ * otherwise send it as a normal chat bubble.
+ */
+export function emitAssistantText(text: string, pushEvent: (event: CboEvent) => void): void {
+  const inline = detectInlineOptionList(text);
+  if (inline) {
+    pushEvent({ type: 'ask_user', question: inline.question, options: inline.options, multiSelect: inline.multiSelect });
+  } else {
+    pushEvent({ type: 'chat', content: text, role: 'assistant' });
+  }
+}

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -28,6 +28,7 @@ import { eq } from "drizzle-orm";
 import { getOrgIdForCboState, listDocumentsByOrg, getDocumentForOrg } from "./documentPersistence";
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
+import { emitAssistantText } from "./agentOutput";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -1012,7 +1013,9 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
         for (const block of message.message.content) {
           if (block.type === "text" && block.text) {
             emittedText = true;
-            pushEvent({ type: 'chat', content: block.text, role: 'assistant' });
+            // Normalize before flushing: an inline option list becomes a real
+            // ask_user (buttons) instead of inert markdown bullets (CBO-INLINE-OPTIONS).
+            emitAssistantText(block.text, pushEvent);
           } else if (block.type === "tool_use" && block.name) {
             // MCP tools come through namespaced as "mcp__cbo__<name>"; strip
             // the prefix so the guard below can match against canonical names.

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -33,6 +33,7 @@ import {
   isValidSectionId,
 } from '@shared/cbo-schema';
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
+import { emitAssistantText } from './agentOutput';
 
 export function isFakeModelEnabled(): boolean {
   return process.env.CBO_FAKE_MODEL === '1';
@@ -100,7 +101,7 @@ export async function streamWithFakeModel(
 function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent, deps: FakeDeps): void {
   switch (op.op) {
     case 'say': {
-      pushEvent({ type: 'chat', content: op.text, role: 'assistant' });
+      emitAssistantText(op.text, pushEvent);
       break;
     }
     case 'update_section': {


### PR DESCRIPTION
**Demo-blocker #4 (safe subset)** — your #1 complaint: options showing as inline text instead of buttons, plus the duplicated/fused text.

Per our call, this is the low-risk subset; the full per-turn buffering normalization layer (which also dedupes a restated question) is a focused follow-up.

- **`server/services/agentOutput.ts` (new)** — `emitAssistantText()` detects the exact "options written as a trailing markdown list instead of `ask_user`" shape (preamble with a select/choose cue + a contiguous list of 2–8 option lines at the end, nothing after) and emits a real `ask_user` (buttons) instead of inert markdown. Strictly guarded by the cue so it never rewrites legit prose. **Shared by the live SDK path and the fake model**, so both behave identically and it's deterministically testable.
- **Client sentence-fusing fix** — consecutive whole-block chat chunks now join with a paragraph break only at a sentence boundary, so `profile:` + `A few…` can't fuse, while a sub-block token split is never separated.

**New e2e** `cougar-inline-options`: an inline list → question card with the 3 parsed options; a cue-less bulleted block stays chat while a real `ask_user` wins the card. TS clean; 10 specs green (inline-options + golden-path + map/site/cohort).

Follow-up (deferred): the full buffering layer to also dedupe a question restated as prose + `ask_user`, and persist prompts across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)