### PR TITLE
feat(maps): data-literacy + provenance dialog for both views

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -9,6 +9,8 @@ import { Input } from '@/core/components/ui/input';
 import { TILE_LAYERS, ALL_TILE_LAYERS, tileVisualUrl, OSM_LAYERS, SPATIAL_QUERIES } from '@shared/geospatial-layers';
 import { riskBand, hazardPercentile, TYPOLOGY_COLORS, zoneRiskOpacity, type HazardKey } from '@shared/risk-display';
 import type { LegendSpec } from '@shared/legend-types';
+import { DataProvenanceDialog } from '@/core/components/maps/DataProvenanceDialog';
+import type { ProvenanceKey } from '@shared/data-provenance';
 import type { OpenMapParams, SelectedAsset, SampledPoint, MapSelectionResult } from '@shared/concept-note-schema';
 import { sampleRasterAtPoint, geometryCentroid } from '@/lib/valueTileUtils';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
@@ -79,7 +81,8 @@ function legendGradientCss(spec: LegendSpec | undefined): string | null {
 }
 
 export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const provLang: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
   const mapRef = useRef<L.Map | null>(null);
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const tileLayerRefs = useRef<Record<string, L.TileLayer>>({});
@@ -819,11 +822,24 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
       {/* Header */}
-      <div className="px-3 py-2 border-b bg-muted/30 shrink-0">
-        <p className="text-xs font-medium leading-tight">{params.prompt}</p>
-        <p className="text-[10px] text-muted-foreground mt-0.5">
-          {polygonHelp || stepInstruction}
-        </p>
+      <div className="px-3 py-2 border-b bg-muted/30 shrink-0 flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium leading-tight">{params.prompt}</p>
+          <p className="text-[10px] text-muted-foreground mt-0.5">
+            {polygonHelp || stepInstruction}
+          </p>
+        </div>
+        {/* "Where this data comes from" — data-literacy for the hazard/zone layers. */}
+        {(isComposite || simpleLegend.length > 0) && (
+          <DataProvenanceDialog
+            lang={provLang}
+            compact
+            className="shrink-0"
+            entries={(compositeStep === 'assets'
+              ? ['flood', 'heat', 'landslide', 'neighborhoods', 'sites']
+              : ['flood', 'heat', 'landslide', 'neighborhoods']) as ProvenanceKey[]}
+          />
+        )}
       </div>
 
       {/* Prominent point-vs-area control — CBO site step. Replaces the tiny draw

--- a/client/src/core/components/maps/DataProvenanceDialog.tsx
+++ b/client/src/core/components/maps/DataProvenanceDialog.tsx
@@ -1,0 +1,81 @@
+// "Where this data comes from" — a shared data-literacy dialog for BOTH the
+// orchestrator Community-projects map and the CBO map (Ana's #1 ask). One
+// component, parameterized by which layers are on screen, so the two views stay
+// in sync. Content + vintages come from shared/data-provenance.ts (sourced from
+// the OEF geospatial catalog, not invented).
+
+import { Info } from 'lucide-react';
+import { Button } from '@/core/components/ui/button';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger,
+} from '@/core/components/ui/dialog';
+import {
+  DATA_PROVENANCE, PROVENANCE_UI, RISK_METHODOLOGY, type ProvenanceKey,
+} from '@shared/data-provenance';
+
+interface Props {
+  lang: 'en' | 'pt';
+  /** Which layers are currently on the map — only these are documented. */
+  entries: ProvenanceKey[];
+  /** Optional extra classes for the trigger button. */
+  className?: string;
+  /** Compact trigger (icon only) for tight map corners. */
+  compact?: boolean;
+}
+
+export function DataProvenanceDialog({ lang, entries, className, compact }: Props) {
+  const ui = PROVENANCE_UI[lang];
+  const keys = entries.filter((k, i) => entries.indexOf(k) === i && DATA_PROVENANCE[k]);
+  if (keys.length === 0) return null;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={`gap-1.5 h-7 text-[11px] bg-white/90 backdrop-blur ${className ?? ''}`}
+          data-testid="data-provenance-trigger"
+          aria-label={ui.button}
+        >
+          <Info className="w-3.5 h-3.5" />
+          {!compact && <span>{ui.button}</span>}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto" data-testid="data-provenance-dialog">
+        <DialogHeader>
+          <DialogTitle>{ui.title}</DialogTitle>
+          <DialogDescription>{ui.subtitle}</DialogDescription>
+        </DialogHeader>
+
+        {/* Data-literacy: what "risk" means here (H×E×V). */}
+        {keys.some(k => k === 'flood' || k === 'heat' || k === 'landslide' || k === 'neighborhoods') && (
+          <div className="rounded-md bg-muted/60 p-3 text-xs leading-relaxed text-muted-foreground">
+            <div className="font-medium text-foreground mb-1">{ui.methodologyTitle}</div>
+            {RISK_METHODOLOGY[lang]}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {keys.map(key => {
+            const e = DATA_PROVENANCE[key][lang];
+            return (
+              <div key={key} className="rounded-md border p-3 text-xs" data-testid={`provenance-entry-${key}`}>
+                <div className="font-semibold text-sm text-foreground">{e.title}</div>
+                <p className="text-muted-foreground mt-0.5 leading-relaxed">{e.whatItShows}</p>
+                <p className="text-muted-foreground mt-1"><span className="font-medium text-foreground/80">{ui.colors}:</span> {e.colorMeaning}</p>
+                <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 text-muted-foreground">
+                  <dt className="font-medium text-foreground/80">{ui.source}</dt><dd>{e.source}</dd>
+                  <dt className="font-medium text-foreground/80">{ui.updated}</dt><dd>{e.vintage}</dd>
+                  <dt className="font-medium text-foreground/80">{ui.resolution}</dt><dd>{e.resolution}</dd>
+                </dl>
+                <p className="mt-2 text-amber-700 dark:text-amber-500"><span className="font-medium">{ui.note}:</span> {e.caveat}</p>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -46,6 +46,8 @@ import {
 import { WorkshopCadence } from '@/core/components/orchestrator/WorkshopCadence';
 import { SupportInbox } from '@/core/components/orchestrator/SupportInbox';
 import { LanguageSwitcher } from '@/core/components/i18n/language-switcher';
+import { DataProvenanceDialog } from '@/core/components/maps/DataProvenanceDialog';
+import type { ProvenanceKey } from '@shared/data-provenance';
 import { CboFilesDrawer, type FilesDrawerMember, type CboDrawerTab } from '@/core/components/orchestrator/CboFilesDrawer';
 
 // ---------------------------------------------------------------------------
@@ -453,7 +455,8 @@ function MapLayerControls({
   active: RiskView | null;
   onChange: (next: RiskView | null) => void;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const provLang: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
   const VIEWS: Array<{ id: RiskView; label: string; dot: string }> = [
     { id: 'flood',     label: t('orchestrator.map.flood', { defaultValue: 'Flood hazard' }),         dot: '#2563eb' },
     { id: 'heat',      label: t('orchestrator.map.heat', { defaultValue: 'Heat hazard' }),           dot: '#dc2626' },
@@ -538,6 +541,14 @@ function MapLayerControls({
           </div>
         </div>
       )}
+      {/* "Where this data comes from" — same shared dialog as the CBO map. */}
+      <div className="pt-1.5 mt-1.5 border-t border-foreground/5">
+        <DataProvenanceDialog
+          lang={provLang}
+          className="w-full justify-center"
+          entries={['flood', 'heat', 'landslide', 'neighborhoods'] as ProvenanceKey[]}
+        />
+      </div>
     </div>
   );
 }

--- a/e2e/cougar-data-provenance.spec.ts
+++ b/e2e/cougar-data-provenance.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Data-literacy: the "Where this data comes from" dialog on the CBO map. Opens
+// from the map header, lists each layer with a plain-language description +
+// real vintage (Ana's ask). The same shared dialog also renders on the
+// orchestrator map (not reachable in this deterministic harness without the
+// demo cohort, so it's covered by the shared component + TS types).
+
+test.describe('COUGAR — data provenance dialog (CBO map)', () => {
+  test('the map header exposes "About this data" with sourced vintages', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Vamos ao mapa.' },
+      {
+        op: 'open_map',
+        params: {
+          selectionMode: 'composite',
+          zoneSource: 'neighborhood_zones',
+          tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+          showLegendSimple: true,
+          hazardTour: false,
+          allowDeferSite: true,
+          prompt: 'Marque o bairro e o lugar onde vocês atuam.',
+        },
+      },
+    ]]);
+
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    // The map mounted → its header carries the provenance trigger.
+    const trigger = page.getByTestId('data-provenance-trigger');
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+    await trigger.click();
+
+    // Dialog lists layers with real sources + vintages (en for a standalone session).
+    const dialog = page.getByTestId('data-provenance-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Where this data comes from')).toBeVisible();
+    await expect(page.getByTestId('provenance-entry-flood')).toBeVisible();
+    await expect(page.getByTestId('provenance-entry-landslide')).toBeVisible();
+    // The landslide caveat closes the "it's just old 2016 data" gap.
+    await expect(dialog.getByText(/susceptibility index/i)).toBeVisible();
+    // A real vintage is shown (2022 Census feeds every risk layer).
+    await expect(dialog.getByText(/2022 Census/i).first()).toBeVisible();
+  });
+});

--- a/shared/data-provenance.ts
+++ b/shared/data-provenance.ts
@@ -1,0 +1,176 @@
+// Data provenance / "where this data comes from" catalog (data-literacy).
+//
+// Ana's #1 critique of the maps: people "see colors but don't understand what
+// the data means or where it's from" (and Julia repeatedly asked to show the
+// vintage). This is the authoritative, plain-language provenance for the layers
+// the CBO + orchestrator maps actually display. Sourced from the OEF
+// geospatial-data catalog (Open-Earth-Foundation/geospatial-data,
+// catalog/datasets.yaml) — NOT invented — so the dates and sources are real.
+//
+// Shared (client imports it) so the same one dialog serves both views.
+
+export type ProvenanceKey = 'flood' | 'heat' | 'landslide' | 'neighborhoods' | 'sites';
+
+export interface ProvenanceText {
+  title: string;
+  /** Plain-language: what this layer actually shows. */
+  whatItShows: string;
+  /** What the colors on the map mean. */
+  colorMeaning: string;
+  /** Who produced it. */
+  source: string;
+  /** When it's from — the vintage Julia kept asking for. */
+  vintage: string;
+  /** Spatial resolution, in words a non-GIS user gets. */
+  resolution: string;
+  /** An honest limitation — the part that builds trust. */
+  caveat: string;
+}
+
+export interface ProvenanceEntry {
+  key: ProvenanceKey;
+  en: ProvenanceText;
+  pt: ProvenanceText;
+}
+
+export const DATA_PROVENANCE: Record<ProvenanceKey, ProvenanceEntry> = {
+  flood: {
+    key: 'flood',
+    en: {
+      title: 'Flood risk',
+      whatItShows: 'Where flooding is most likely to cause harm — combining how flood-prone an area is with how many people live there and how vulnerable they are.',
+      colorMeaning: 'Green = lower risk, orange/red = higher risk.',
+      source: 'Open Earth Foundation, built from Copernicus Emergency Mapping (May 2024 flood), MERIT Hydro terrain, JRC surface water, and the IBGE 2022 Census.',
+      vintage: 'Flood hazard: current terrain + the May 2024 event. People & vulnerability: 2022 Census.',
+      resolution: '~250 m grid',
+      caveat: 'A screening estimate to compare areas — not a street-level flood forecast.',
+    },
+    pt: {
+      title: 'Risco de inundação',
+      whatItShows: 'Onde as inundações têm mais chance de causar dano — combinando o quanto uma área alaga com quantas pessoas vivem ali e quão vulneráveis são.',
+      colorMeaning: 'Verde = menor risco, laranja/vermelho = maior risco.',
+      source: 'Open Earth Foundation, a partir do Mapeamento de Emergência Copernicus (enchente de maio de 2024), terreno MERIT Hydro, água superficial do JRC e o Censo IBGE 2022.',
+      vintage: 'Ameaça de inundação: terreno atual + o evento de maio de 2024. Pessoas e vulnerabilidade: Censo 2022.',
+      resolution: 'grade de ~250 m',
+      caveat: 'Uma estimativa para comparar áreas — não é uma previsão de inundação rua a rua.',
+    },
+  },
+  heat: {
+    key: 'heat',
+    en: {
+      title: 'Heat risk',
+      whatItShows: 'Where extreme heat is most likely to harm people — the hottest areas combined with who lives there and how vulnerable they are.',
+      colorMeaning: 'Green = lower risk, orange/red = higher risk.',
+      source: 'Open Earth Foundation, built from summer land-surface temperature 2015–2024 (Landsat 8, NASA MODIS), ERA5-Land climate data, and the IBGE 2022 Census.',
+      vintage: 'Heat: summers 2015–2024. People & vulnerability: 2022 Census.',
+      resolution: '~250 m grid',
+      caveat: 'Based on satellite surface temperature — a close proxy for the heat people actually feel.',
+    },
+    pt: {
+      title: 'Risco de calor',
+      whatItShows: 'Onde o calor extremo tem mais chance de prejudicar as pessoas — as áreas mais quentes combinadas com quem vive ali e quão vulnerável é.',
+      colorMeaning: 'Verde = menor risco, laranja/vermelho = maior risco.',
+      source: 'Open Earth Foundation, a partir da temperatura de superfície dos verões de 2015–2024 (Landsat 8, NASA MODIS), dados climáticos ERA5-Land e o Censo IBGE 2022.',
+      vintage: 'Calor: verões de 2015–2024. Pessoas e vulnerabilidade: Censo 2022.',
+      resolution: 'grade de ~250 m',
+      caveat: 'Baseado na temperatura de superfície por satélite — um bom indicador do calor que as pessoas sentem.',
+    },
+  },
+  landslide: {
+    key: 'landslide',
+    en: {
+      title: 'Landslide risk',
+      whatItShows: 'Where steep, unstable ground could slide and harm people nearby.',
+      colorMeaning: 'Green = lower risk, brown/red = higher risk.',
+      source: 'Open Earth Foundation, built from Copernicus 30 m terrain slope, MERIT Hydro, SoilGrids soil, CHIRPS rainfall, and vegetation 2015–2024 (MODIS, Dynamic World 2023).',
+      vintage: 'Terrain: current. Rainfall & vegetation: through 2024.',
+      resolution: '~90 m grid',
+      caveat: 'A susceptibility index — where slides are physically possible, not how likely one is — and not yet checked against Porto Alegre’s historical landslide records.',
+    },
+    pt: {
+      title: 'Risco de deslizamento',
+      whatItShows: 'Onde o terreno íngreme e instável pode deslizar e atingir quem está por perto.',
+      colorMeaning: 'Verde = menor risco, marrom/vermelho = maior risco.',
+      source: 'Open Earth Foundation, a partir da declividade do terreno Copernicus 30 m, MERIT Hydro, solos SoilGrids, chuva CHIRPS e vegetação 2015–2024 (MODIS, Dynamic World 2023).',
+      vintage: 'Terreno: atual. Chuva e vegetação: até 2024.',
+      resolution: 'grade de ~90 m',
+      caveat: 'Um índice de suscetibilidade — onde deslizamentos são fisicamente possíveis, não a probabilidade de ocorrerem — e ainda não comparado ao histórico de deslizamentos de Porto Alegre.',
+    },
+  },
+  neighborhoods: {
+    key: 'neighborhoods',
+    en: {
+      title: 'Neighborhoods (bairros)',
+      whatItShows: 'Official bairro boundaries, shaded by their main risk and by how many people live there.',
+      colorMeaning: 'Each bairro is shaded by its dominant hazard; a stronger color means higher risk.',
+      source: 'Boundaries and population from IBGE (the Brazilian census bureau); risk coloring from Open Earth Foundation.',
+      vintage: 'Population & vulnerability: 2022 Census. Some indicators: 2010 Census.',
+      resolution: 'Per bairro',
+      caveat: 'Risk is averaged across the whole bairro — conditions still vary block to block.',
+    },
+    pt: {
+      title: 'Bairros',
+      whatItShows: 'Limites oficiais dos bairros, coloridos pelo seu principal risco e por quantas pessoas vivem ali.',
+      colorMeaning: 'Cada bairro é colorido pela sua ameaça dominante; cor mais forte significa maior risco.',
+      source: 'Limites e população do IBGE; coloração de risco pela Open Earth Foundation.',
+      vintage: 'População e vulnerabilidade: Censo 2022. Alguns indicadores: Censo 2010.',
+      resolution: 'Por bairro',
+      caveat: 'O risco é uma média de todo o bairro — as condições ainda variam de quadra em quadra.',
+    },
+  },
+  sites: {
+    key: 'sites',
+    en: {
+      title: 'Parks, schools & hospitals',
+      whatItShows: 'Points of interest near your area, to help you place a project.',
+      colorMeaning: 'Pins mark each type of place (parks, schools, hospitals, wetlands).',
+      source: 'OpenStreetMap — a free, community-maintained map.',
+      vintage: 'Continuously updated by contributors.',
+      resolution: 'Individual places',
+      caveat: 'Community-contributed, so coverage can be incomplete or slightly out of date.',
+    },
+    pt: {
+      title: 'Parques, escolas e hospitais',
+      whatItShows: 'Pontos de interesse perto da sua área, para ajudar a posicionar um projeto.',
+      colorMeaning: 'Os marcadores indicam cada tipo de lugar (parques, escolas, hospitais, áreas úmidas).',
+      source: 'OpenStreetMap — um mapa livre, mantido pela comunidade.',
+      vintage: 'Atualizado continuamente pelos colaboradores.',
+      resolution: 'Lugares individuais',
+      caveat: 'Feito pela comunidade, então a cobertura pode estar incompleta ou um pouco desatualizada.',
+    },
+  },
+};
+
+/** The Hazard × Exposure × Vulnerability explainer — the core data-literacy idea. */
+export const RISK_METHODOLOGY: Record<'en' | 'pt', string> = {
+  en: 'On these maps, risk = Hazard × Exposure × Vulnerability: how strong the threat is, how many people and assets are in its path, and how vulnerable they are. A strong hazard in an empty area is lower risk than a moderate hazard where many vulnerable people live.',
+  pt: 'Nestes mapas, risco = Ameaça × Exposição × Vulnerabilidade: quão forte é a ameaça, quantas pessoas e bens estão no caminho e quão vulneráveis são. Uma ameaça forte numa área vazia representa menos risco do que uma ameaça média onde vivem muitas pessoas vulneráveis.',
+};
+
+/** UI chrome strings, kept here so the shared dialog needs no i18n wiring. */
+export const PROVENANCE_UI: Record<'en' | 'pt', {
+  button: string; title: string; subtitle: string; methodologyTitle: string;
+  source: string; updated: string; resolution: string; note: string; colors: string;
+}> = {
+  en: {
+    button: 'About this data',
+    title: 'Where this data comes from',
+    subtitle: 'What these layers show, and how current they are.',
+    methodologyTitle: 'How we measure risk',
+    source: 'Source', updated: 'Updated', resolution: 'Resolution',
+    note: 'Good to know', colors: 'Colors',
+  },
+  pt: {
+    button: 'Sobre estes dados',
+    title: 'De onde vêm estes dados',
+    subtitle: 'O que cada camada mostra e o quão atualizada está.',
+    methodologyTitle: 'Como medimos o risco',
+    source: 'Fonte', updated: 'Atualização', resolution: 'Resolução',
+    note: 'Bom saber', colors: 'Cores',
+  },
+};
+
+export function provenanceText(key: ProvenanceKey, lang: 'en' | 'pt'): ProvenanceText {
+  const entry = DATA_PROVENANCE[key];
+  return lang === 'pt' ? entry.pt : entry.en;
+}


### PR DESCRIPTION
**Ana's #1 strategic ask** (data-source/lineage button, both views, due 07-15): people "see colors but don't understand what the data means or where it's from," and Julia repeatedly asked to show the **vintage**.

Adds an **"About this data"** button to **both** the orchestrator Community-projects map (in the RISK VIEW panel) and the **CBO map** (in the header). One shared dialog.

- **`shared/data-provenance.ts`** — bilingual (pt/en), plain-language provenance for each displayed layer (flood / heat / landslide risk, neighborhoods, sites): *what it shows, what the colors mean, source, vintage, resolution,* and an honest caveat. **Sourced from the OEF geospatial catalog (`datasets.yaml`), not invented.** It also corrects a real misconception: the **landslide** layer is a *static susceptibility index* (Copernicus 30 m slope + MERIT Hydro + SoilGrids + CHIRPS + 2015–2024 vegetation), explicitly **not validated against historical records** — not the "old 2016 data" it was assumed to be. Includes the Hazard × Exposure × Vulnerability explainer.
- **`DataProvenanceDialog`** — shared component, wired into both views per `docs/ROLE-ARCHITECTURE.md` (no per-view fork).

New e2e `cougar-data-provenance` (asserts the landslide caveat + 2022 Census vintage render). TS clean; 4 specs green.

Follow-up (Ana, due 07-22): risk-summary-in-chat with the actual neighborhood stats after selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)