### PR TITLE
fix(orchestrator): bairro hover tooltips no longer stack

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -378,10 +378,17 @@ function MapPanel({
             ? `<br/><span style="color:${TYPOLOGY_COLORS.LANDSLIDE}">▨ landslide-prone · slope stabilization</span>`
             : '';
           const tipHtml = `<b>${name}</b><br/>${hazard ? hazard.toLowerCase() + ' risk · ' : ''}${pop.toLocaleString()} people<br/>priority ${score.toFixed(2)}${proneHtml}`;
-          (lyr as L.Path).bindTooltip(tipHtml, { direction: 'top', className: 'orch-marker-tip', sticky: true });
+          // Anchored (not sticky): a sticky tooltip follows the pointer and its
+          // per-layer mouseout→close doesn't reliably fire when crossing a shared
+          // bairro border, so tooltips pile up unreadably (ORCH-1). Anchor it to
+          // the bairro and close it explicitly on mouseout.
+          (lyr as L.Path).bindTooltip(tipHtml, { direction: 'top', className: 'orch-marker-tip' });
           lyr.on('click', () => onBairroClickRef.current({ name, primaryHazard: hazard, population: pop, priorityScore: score }));
           lyr.on('mouseover', () => (lyr as L.Path).setStyle({ weight: 2.5, color: '#0f172a' }));
-          lyr.on('mouseout', () => (lyr as L.Path).setStyle(bairroStyle(feat, activeRiskRef.current, riskRangeRef.current)));
+          lyr.on('mouseout', () => {
+            (lyr as L.Path).setStyle(bairroStyle(feat, activeRiskRef.current, riskRangeRef.current));
+            (lyr as L.Path).closeTooltip();
+          });
         },
       });
       layer.addTo(mapInstanceRef.current);


### PR DESCRIPTION
**ORCH-1** — screenshot 1: hovering neighborhoods on the Community-projects map piled multiple tooltips on top of each other (Passo da Areia / Jardim Carvalho / Partenon), unreadable.

**Cause:** the bairro tooltip was bound `sticky: true`, which follows the pointer; Leaflet's per-layer `mouseout → closeTooltip` doesn't reliably fire when crossing a shared bairro border, so the previous tooltip never closed.

**Fix:** anchor the tooltip (`direction: 'top'`, no sticky) and close it explicitly on `mouseout`. One tooltip at a time.

Visual fix — verified by the coordinator-risk-map e2e regression + reasoning (tooltip stacking is pixel-level). TS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)