### PR TITLE
fix(cbo): silent state-only turns no longer strand the user

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1038,18 +1038,24 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // This guard logs the violation (for measurement) and, when the turn was
   // both tool-less AND text-less, emits a small recoverable message so the
   // user can re-prompt instead of facing a blank screen.
-  const TURN_ENDERS = new Set([
+  // Only USER-PROMPTING tools make a turn "safe" — ones that actually leave the
+  // user something to do. score_maturity and a mid-flow set_phase are SILENT
+  // (they mutate state but ask nothing); counting them as enders let a turn that
+  // only scored maturity or advanced a phase strand the user with a bare
+  // "Continue" and no question (CBO-TURNENDER-GUARD). set_phase to 6 is the one
+  // legitimate silent close (the flow is complete).
+  const USER_PROMPTING = new Set([
     'ask_user',
     'open_map',
     'open_intervention_selector',
     'ask_priority_rank',
     'ask_community_anchoring',
     'show_examples',
-    'score_maturity', // closing
-    'set_phase',      // closing / cross-phase advance
+    'show_types',
   ]);
-  const hadTurnEnder = Array.from(calledTools).some(name => TURN_ENDERS.has(name));
-  if (!hadTurnEnder && state.phase < 6) {
+  const hadPrompt = Array.from(calledTools).some(name => USER_PROMPTING.has(name));
+  const completedFlow = calledTools.has('set_phase') && state.phase >= 6;
+  if (!hadPrompt && !completedFlow && state.phase < 6) {
     const toolsList = Array.from(calledTools).join(',') || 'none';
     console.warn(`[cbo] silent_turn_fallback for ${cboId} phase=${state.phase} tools=${toolsList} text=${emittedText}`);
     // Recovery affordance ONLY when the agent emitted no text either — that's


### PR DESCRIPTION
**`CBO-TURNENDER-GUARD`** (P1) — screenshot 3: right after a name+role answer the user saw "Phase 1/5, 1 sections filled" with a lone **Continue** and no question; tapping it derails the agent.

**Cause:** the post-turn guard counted **any** tool as a valid "turn-ender", including `score_maturity` and `set_phase` — both **silent** (they change state but ask nothing). A turn that only scored maturity or advanced a phase therefore looked "safe" and skipped the recovery affordance, stranding the user.

**Fix:** only **user-prompting** tools make a turn safe (`ask_user` / `open_map` / `open_intervention_selector` / `ask_priority_rank` / `ask_community_anchoring` / `show_examples` / `show_types`). `score_maturity` and a mid-flow `set_phase` no longer count; `set_phase` to 6 is the one legitimate silent close. The emitted-text gate is unchanged, so the skill's imperative free-text questions ("me conta…", often no "?") are still left alone — no double-prompt.

Guard lives on the real SDK path (the fake model is scripted/deterministic, so it's verified by reasoning + regression). TS clean; golden-path + map-step green; the cohort-language failure was the known parallelism flake (passes isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)