### PR TITLE
fix(cbo): Restart requires confirmation — no more one-tap total data loss

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -9,6 +9,10 @@ import { Badge } from '@/core/components/ui/badge';
 import { Textarea } from '@/core/components/ui/textarea';
 import { Input } from '@/core/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/core/components/ui/tooltip';
+import {
+  AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogFooter,
+  AlertDialogTitle, AlertDialogDescription, AlertDialogAction, AlertDialogCancel,
+} from '@/core/components/ui/alert-dialog';
 import { useFileDrop } from '@/core/hooks/useFileDrop';
 import {
   CBO_SECTIONS,
@@ -1266,14 +1270,45 @@ export default function CboProfilePage() {
                   </TooltipTrigger>
                   <TooltipContent>{t('cbo.export')}</TooltipContent>
                 </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button variant="outline" size="sm" className="h-8 w-8 p-0" onClick={handleRestart}>
-                      <RotateCcw className="w-4 h-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('cbo.startOver')}</TooltipContent>
-                </Tooltip>
+                {/* Restart is IRREVERSIBLE (deletes the whole session server-side).
+                    It sits one thumb-width from Export on mobile, and the tooltip
+                    label never shows on touch — so it MUST confirm before firing. */}
+                <AlertDialog>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="outline" size="sm" className="h-8 w-8 p-0" data-testid="cbo-restart-trigger">
+                          <RotateCcw className="w-4 h-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>{t('cbo.startOver')}</TooltipContent>
+                  </Tooltip>
+                  <AlertDialogContent data-testid="cbo-restart-dialog">
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {lang === 'pt' ? 'Recomeçar do zero?' : 'Start over from scratch?'}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {lang === 'pt'
+                          ? 'Isso apaga TODAS as respostas desta organização — o perfil, o placar e a conversa. Não dá pra desfazer.'
+                          : 'This erases ALL of this organization’s answers — the profile, the scorecard, and the conversation. It cannot be undone.'}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel data-testid="cbo-restart-cancel">
+                        {lang === 'pt' ? 'Cancelar' : 'Cancel'}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleRestart}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        data-testid="cbo-restart-confirm"
+                      >
+                        {lang === 'pt' ? 'Apagar e recomeçar' : 'Erase and start over'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </div>
             </div>
             <CboProgress

--- a/e2e/cbo-restart-confirm.spec.ts
+++ b/e2e/cbo-restart-confirm.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Restart is irreversible (DELETE /api/cbo/:id). It must never fire from a
+// single (mis)tap — a confirmation dialog guards it, Cancel is harmless, and
+// only the explicit destructive action resets the session.
+
+test.describe('CBO restart requires confirmation', () => {
+  test('cancel keeps everything; confirm resets to a fresh session', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Put real data into the session so loss would matter.
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Anotado!' },
+      { op: 'update_section', sectionId: 'org_profile', field: 'org_name', value: 'Horta do Beco' },
+      { op: 'set_phase', phase: 1 },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('oi');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(marker).toHaveAttribute('data-org-name', 'Horta do Beco');
+
+    // Tap restart → the dialog appears; NOTHING was deleted yet.
+    await page.getByTestId('cbo-restart-trigger').click();
+    await expect(page.getByTestId('cbo-restart-dialog')).toBeVisible();
+
+    // Cancel → dialog closes, session + data intact.
+    await page.getByTestId('cbo-restart-cancel').click();
+    await expect(page.getByTestId('cbo-restart-dialog')).toHaveCount(0);
+    await expect(marker).toHaveAttribute('data-org-name', 'Horta do Beco');
+    await expect(marker).toHaveAttribute('data-cbo-id', cboId);
+
+    // Restart again and CONFIRM → a fresh, empty session with a new id.
+    await page.getByTestId('cbo-restart-trigger').click();
+    await page.getByTestId('cbo-restart-confirm').click();
+    await expect(marker).not.toHaveAttribute('data-cbo-id', cboId, { timeout: 15_000 });
+    await expect(marker).not.toHaveAttribute('data-org-name', 'Horta do Beco');
+  });
+});


### PR DESCRIPTION
**Field-safety pack 1/6** (P0 from the phone-first deep review + documented walkthrough).

The Restart button — a 32px icon **right next to Export** in the mobile header — fired `DELETE /api/cbo/:id` on a single tap: the org's entire profile, scorecard and conversation gone irreversibly, and for cohort members the snapshot effect rebinds the coordinator's roster entry to the now-empty session. Its only label is a hover tooltip that never shows on touch. One thumb-slip in a workshop room = weeks of answers lost.

Now wrapped in an `AlertDialog`: explicit PT/EN warning ("Isso apaga TODAS as respostas… Não dá pra desfazer"), destructive-styled confirm, Cancel as the default action.

New e2e `cbo-restart-confirm`: cancel keeps the session id + data intact; confirm produces a fresh empty session. TS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY