### PR TITLE
fix(cbo map): parse Brazilian decimal-comma coordinates; reject out-of-region points

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -125,7 +125,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const [siteSearching, setSiteSearching] = useState(false);
   const [siteResults, setSiteResults] = useState<Array<{ name: string; centroid: [number, number] }>>([]);
   const [coordInput, setCoordInput] = useState('');
-  const [coordError, setCoordError] = useState(false);
+  const [coordError, setCoordError] = useState<false | 'format' | 'outside'>(false);
 
   const selectionMode = params.selectionMode;
   const isComposite = selectionMode === 'composite';
@@ -763,10 +763,28 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   }, [siteQuery, zoneBbox]);
 
   const addByCoordinate = useCallback(async () => {
-    const parts = coordInput.trim().split(/[,\s]+/).filter(Boolean);
-    const lat = parseFloat(parts[0]); const lng = parseFloat(parts[1]);
-    if (parts.length < 2 || isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
-      setCoordError(true);
+    // Accept Brazilian decimal-comma input — the PT placeholder itself teaches
+    // "-30,03, -51,22", which the old split-on-comma parser mangled into
+    // lat -30 / lng 3 (a point in the ocean, silently accepted). Extract signed
+    // numeric tokens where ",digits" binds as a decimal separator, and
+    // recombine the space-split "lat, frac, lng, frac" shape.
+    const tokens = coordInput.match(/-?\d+(?:[.,]\d+)?/g) ?? [];
+    const num = (s: string) => parseFloat(s.replace(',', '.'));
+    let lat = NaN, lng = NaN;
+    if (tokens.length === 2) {
+      lat = num(tokens[0]); lng = num(tokens[1]);
+    } else if (tokens.length === 4 && /^\d+$/.test(tokens[1]) && /^\d+$/.test(tokens[3])) {
+      lat = num(`${tokens[0]}.${tokens[1]}`); lng = num(`${tokens[2]}.${tokens[3]}`);
+    }
+    if (isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      setCoordError('format');
+      return;
+    }
+    // Sanity net: this map is Porto Alegre — a coordinate outside the metro
+    // region is almost certainly a typo/mis-paste, and would otherwise be
+    // persisted as the org's site with no visible feedback.
+    if (lat < -31.5 || lat > -29.2 || lng < -52.5 || lng > -50.2) {
+      setCoordError('outside');
       return;
     }
     setCoordError(false);
@@ -1026,7 +1044,11 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
                 </Button>
               </div>
               {coordError && (
-                <p className="text-[10px] text-red-500">{t('mapMicroapp.coordInvalid', { defaultValue: 'Enter as: latitude, longitude' })}</p>
+                <p className="text-[10px] text-red-500" data-testid="map-coord-error">
+                  {coordError === 'outside'
+                    ? t('mapMicroapp.coordOutside', { defaultValue: 'That point is outside the Porto Alegre region — double-check the numbers.' })
+                    : t('mapMicroapp.coordInvalid', { defaultValue: 'Enter as: latitude, longitude' })}
+                </p>
               )}
             </div>
           )}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -2058,6 +2058,7 @@
     "coordPlaceholder": "lat, lng (ex.: -30,03, -51,22)",
     "addPin": "Adicionar",
     "coordInvalid": "Informe assim: latitude, longitude",
+    "coordOutside": "Esse ponto fica fora da região de Porto Alegre — confira os números.",
     "risks": "Riscos",
     "hazardFlood": "Enchente",
     "hazardHeat": "Calor",

--- a/e2e/cougar-coord-decimal-comma.spec.ts
+++ b/e2e/cougar-coord-decimal-comma.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Brazilian decimal-comma coordinates. The PT placeholder itself teaches
+// "-30,03, -51,22" — the old parser split on commas and turned that into
+// lat -30 / lng 3: a point in the South Atlantic, silently persisted as the
+// org's site. Now the Brazilian format parses correctly, and any point outside
+// the Porto Alegre region is rejected with a distinct message.
+
+async function openSitesMap(page: Page, request: APIRequestContext) {
+  const api = new TestApi(request);
+  test.skip(!(await api.ping()).fakeModel, 'needs fake model');
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+  await api.scriptCbo(cboId, [[
+    { op: 'open_map', params: { selectionMode: 'assets', layers: ['osm_parks'], tileLayers: ['poa_heat_hazard'], prompt: 'Adicione o local.' } },
+  ]]);
+  await page.getByTestId('cbo-chat-input').fill('mapa');
+  await page.getByTestId('cbo-chat-input').press('Enter');
+  await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId('map-add-site-toggle').click();
+}
+
+test.describe('COUGAR — coordinate input accepts Brazilian decimal commas', () => {
+  test('the PT placeholder example "-30,03, -51,22" adds the right site', async ({ page, request }) => {
+    await openSitesMap(page, request);
+    await page.getByTestId('map-site-coord-input').fill('-30,03, -51,22');
+    await page.getByTestId('map-site-coord-btn').click();
+    // Parsed as -30.03 / -51.22 (Porto Alegre), NOT -30 / 3 (the ocean).
+    await expect(page.getByText('Site (-30.0300', { exact: false })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('map-coord-error')).toHaveCount(0);
+  });
+
+  test('a point outside the Porto Alegre region is rejected with a clear message', async ({ page, request }) => {
+    await openSitesMap(page, request);
+    await page.getByTestId('map-site-coord-input').fill('-23.55, -46.63'); // São Paulo
+    await page.getByTestId('map-site-coord-btn').click();
+    await expect(page.getByTestId('map-coord-error')).toBeVisible();
+    await expect(page.getByTestId('map-coord-error')).toContainText(/Porto Alegre/);
+    await expect(page.getByText('Site (-23.55', { exact: false })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
**Field-safety pack 3/6** (P1). The PT coordinate placeholder itself teaches `-30,03, -51,22` — and the parser split on commas, turning exactly that input into **lat -30 / lng 3: a point in the South Atlantic**, silently accepted, pinned, and persisted as the org's intervention site.

- Numeric tokenizer where `,digits` binds as a decimal separator (plus the space-split `lat, frac, lng, frac` shape); dot-decimal input unchanged.
- **Region sanity net**: points outside the Porto Alegre metro are rejected with a distinct message ("Esse ponto fica fora da região de Porto Alegre — confira os números") instead of being silently persisted.

New e2e `cougar-coord-decimal-comma` (placeholder example → correct site; São Paulo coords → rejected). Existing add-site specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY