### PR TITLE
fix(cbo): invite-prefilled fields don't count as phase progress (premature banner)

### DIFF
--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -70,7 +70,11 @@ export function phaseComplete(
 
   return sections.every(sec => {
     const fields = state.sections?.[sec.id]?.fields ?? {};
-    return Object.values(fields).some(cboFieldIsFilled);
+    // Invite-prefilled values (org name / neighborhood the ORCHESTRATOR typed at
+    // invite time, source:'invite') are not work the org did — counting them
+    // made phase 1 "complete" at turn 0 for every invited org, so the green
+    // "Começar Encontro 2" banner appeared mid-interview once WS2 was unlocked.
+    return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
   });
 }
 


### PR DESCRIPTION
**Field-safety pack 4/6** (P1) — caught by the fresh-eyes integration review as an interaction between #315 (`phaseComplete` section-fill OR) and the invite prefill.

`/prefill` writes `org_name` (+ neighborhood) with `source:'invite'` for **every invited org**. The section-fill branch counted any filled field → phase 1 was "complete" at turn 0 → once the coordinator opened WS2, a lagging org saw the green **"Começar Encontro 2"** banner under every question mid-interview — one tap skips their own intake.

Fix: the fill test ignores `source:'invite'` fields. Progress = work the org actually did (agent/user-written fields or scored metrics). The E2 dead-end fix is unaffected (map/`update_section` writes carry their own sources).

TS clean; golden-path + map-step e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY