### PR TITLE
fix(cbo map): site step pans by default — arm-to-drop, tap-first-vertex closes areas

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -220,11 +220,10 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
     setBasemap(compositeStep === 'assets' ? 'satellite' : 'political');
   }, [compositeStep, params.allowDeferSite]);
 
-  // CBO site step: default to point-drop so a tap marks their spot (the
-  // prominent draw control lets them switch to drawing an area).
-  useEffect(() => {
-    if (params.allowDeferSite && isComposite && compositeStep === 'assets') setDrawMode('point');
-  }, [compositeStep, params.allowDeferSite, isComposite]);
+  // CBO site step: draw mode starts OFF — the user arms "Um ponto" / "Desenhar
+  // a área" explicitly. Auto-arming 'point' here meant the first thing every
+  // phone user did (pan the satellite map to find their building) dropped a
+  // wrong pin instead, which then flipped the confirm button (P0 mobile bug).
 
   // ── Load boundary ───────────────────────────────────────────────────────────
   useEffect(() => {
@@ -639,6 +638,16 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         setDrawMode('off');
       }
       if (drawMode === 'polygon') {
+        // Close by tapping the FIRST vertex again (what the PT help copy says:
+        // "feche no primeiro ponto") — double-tap still works as a fallback.
+        if (polygonPointsRef.current.length >= 3) {
+          const firstPt = map.latLngToContainerPoint(polygonPointsRef.current[0]);
+          const clickPt = map.latLngToContainerPoint(e.latlng);
+          if (firstPt.distanceTo(clickPt) < 24) {
+            await closePolygon();
+            return;
+          }
+        }
         polygonPointsRef.current.push(e.latlng);
         if (polygonPreviewRef.current) map.removeLayer(polygonPreviewRef.current);
         if (polygonPointsRef.current.length >= 2) {
@@ -653,9 +662,8 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
       }
     };
 
-    const handleDblClick = async (e: L.LeafletMouseEvent) => {
-      if (drawMode !== 'polygon' || polygonPointsRef.current.length < 3) return;
-      e.originalEvent.preventDefault();
+    const closePolygon = async () => {
+      if (polygonPointsRef.current.length < 3) return;
       const coords = polygonPointsRef.current.map(p => [p.lng, p.lat] as [number, number]);
       coords.push(coords[0]);
       const geometry = { type: 'Polygon' as const, coordinates: [coords] };
@@ -682,16 +690,25 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
       setDrawMode('off');
     };
 
+    const handleDblClick = async (e: L.LeafletMouseEvent) => {
+      if (drawMode !== 'polygon' || polygonPointsRef.current.length < 3) return;
+      e.originalEvent.preventDefault();
+      await closePolygon();
+    };
+
     map.on('click', handleClick);
     map.on('dblclick', handleDblClick);
     map.doubleClickZoom.disable();
-    map.dragging.disable(); // Disable drag so clicks register for drawing
+    // NOTE: map dragging stays ENABLED while drawing. Leaflet already tells a
+    // tap (click) apart from a drag, so vertex/pin placement works fine with
+    // panning on — and phone users MUST be able to pan the satellite view to
+    // find their building. The old dragging.disable() froze one-finger pan for
+    // the whole site step (P0 mobile bug).
     map.getContainer().style.cursor = 'crosshair';
     return () => {
       map.off('click', handleClick);
       map.off('dblclick', handleDblClick);
       map.doubleClickZoom.enable();
-      map.dragging.enable(); // Re-enable drag when draw mode exits
       map.getContainer().style.cursor = '';
       polygonPointsRef.current = [];
       if (polygonPreviewRef.current) { map.removeLayer(polygonPreviewRef.current); polygonPreviewRef.current = null; }
@@ -861,17 +878,23 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         <div className="px-3 py-2 border-b bg-muted/10 shrink-0">
           <p className="text-[10px] text-muted-foreground mb-1">{t('mapMicroapp.siteHowToMark', { defaultValue: 'Como marcar seu lugar?' })}</p>
           <div className="flex gap-1.5">
-            <Button variant={drawMode !== 'polygon' ? 'default' : 'outline'} size="sm" className="h-7 text-[11px] gap-1 flex-1" onClick={() => setDrawMode('point')} data-testid="map-draw-point">
+            {/* True three-state toggles: nothing is armed until the user picks a
+                mode (re-tapping disarms). The old default made "Um ponto" LOOK
+                active while drawMode was off — and pairing that with auto-arm
+                meant panning taps dropped pins. */}
+            <Button variant={drawMode === 'point' ? 'default' : 'outline'} size="sm" className="h-9 text-[11px] gap-1 flex-1" onClick={() => setDrawMode(drawMode === 'point' ? 'off' : 'point')} data-testid="map-draw-point">
               <MapPin className="w-3 h-3" /> {t('mapMicroapp.drawPoint', { defaultValue: 'Um ponto' })}
             </Button>
-            <Button variant={drawMode === 'polygon' ? 'default' : 'outline'} size="sm" className="h-7 text-[11px] gap-1 flex-1" onClick={() => setDrawMode('polygon')} data-testid="map-draw-area">
+            <Button variant={drawMode === 'polygon' ? 'default' : 'outline'} size="sm" className="h-9 text-[11px] gap-1 flex-1" onClick={() => setDrawMode(drawMode === 'polygon' ? 'off' : 'polygon')} data-testid="map-draw-area">
               <Pencil className="w-3 h-3" /> {t('mapMicroapp.drawArea', { defaultValue: 'Desenhar a área' })}
             </Button>
           </div>
-          <p className="text-[10px] text-muted-foreground mt-1">
+          <p className="text-[10px] text-muted-foreground mt-1" data-testid="map-draw-help">
             {drawMode === 'polygon'
               ? t('mapMicroapp.drawHelpArea', { defaultValue: 'Toque nos cantos do lugar; feche no primeiro ponto.' })
-              : t('mapMicroapp.drawHelpPoint', { defaultValue: 'Toque no mapa pra marcar o lugar.' })}
+              : drawMode === 'point'
+                ? t('mapMicroapp.drawHelpPoint', { defaultValue: 'Toque no mapa pra marcar o lugar.' })
+                : t('mapMicroapp.drawHelpOff', { defaultValue: 'Arraste pra navegar no mapa. Pra marcar, escolha uma opção acima.' })}
           </p>
         </div>
       )}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -2058,6 +2058,7 @@
     "coordPlaceholder": "lat, lng (ex.: -30,03, -51,22)",
     "addPin": "Adicionar",
     "coordInvalid": "Informe assim: latitude, longitude",
+    "drawHelpOff": "Arraste pra navegar no mapa. Pra marcar, escolha uma opção acima.",
     "risks": "Riscos",
     "hazardFlood": "Enchente",
     "hazardHeat": "Calor",

--- a/e2e/cougar-site-step-panning.spec.ts
+++ b/e2e/cougar-site-step-panning.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The CBO site step must never fight the thumb: draw mode starts OFF (panning
+// works, stray taps drop nothing), arming "Um ponto" is explicit, and re-tapping
+// disarms. Regression for the P0 where drawMode auto-armed to 'point' and
+// dragging was disabled — the first pan attempt dropped a wrong pin instead.
+
+test.describe('COUGAR — site step: pan by default, arm to drop', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('assets step starts disarmed; tap adds nothing; arm→tap adds; re-tap disarms', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'open_map', params: {
+        selectionMode: 'composite', zoneSource: 'neighborhood_zones',
+        tileLayers: ['risk_flood_250m'], showLegendSimple: true,
+        hazardTour: false, allowDeferSite: true, prompt: 'Marque onde vocês atuam.',
+      } },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // Select a zone (paths appear once the zones GeoJSON loads) and advance.
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect.poll(async () => paths.count(), { timeout: 30_000 }).toBeGreaterThan(10);
+    const box = (await paths.nth(45).boundingBox())!;
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await page.getByRole('button', { name: /next: select sites|próximo: selecionar/i }).first().click();
+    await page.waitForTimeout(2500); // satellite basemap + OSM load
+
+    // 1) Disarmed by default: navigate hint shows, neither arm button is active.
+    const help = page.getByTestId('map-draw-help');
+    await expect(help).toContainText(/arraste|drag|navegar|navigate|escolha|choose/i);
+
+    // 2) A stray tap on the map adds NO custom point.
+    const mapBox = (await page.locator('.leaflet-container').first().boundingBox())!;
+    await page.mouse.click(mapBox.x + mapBox.width / 2, mapBox.y + mapBox.height / 2);
+    await page.waitForTimeout(800);
+    await expect(page.getByText('Custom point', { exact: false })).toHaveCount(0);
+
+    // 3) Arm "Um ponto" → the tap now drops the pin.
+    await page.getByTestId('map-draw-point').click();
+    await expect(help).toContainText(/toque no mapa|tap the map|marcar o lugar/i);
+    await page.mouse.click(mapBox.x + mapBox.width / 2 + 20, mapBox.y + mapBox.height / 2 + 10);
+    await expect(page.getByText('Custom point', { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+
+    // 4) Point mode auto-disarms after the drop (back to pan).
+    await expect(help).toContainText(/arraste|escolha uma opção/i);
+
+    // 5) Arm then re-tap the same button → disarms without dropping anything.
+    await page.getByTestId('map-draw-area').click();
+    await page.getByTestId('map-draw-area').click();
+    await expect(help).toContainText(/arraste|escolha uma opção/i);
+  });
+});


### PR DESCRIPTION
**Field-safety pack 5/6** (P0 — Ana's "test/fix mobile-specific breakage", found by the phone-first deep review + documented walkthrough).

Entering the site step **auto-armed** `drawMode:'point'` **and disabled map dragging**. On a phone that means: the satellite view lands zoomed on the bairro, the user tries to pan to find their building — one-finger pan is dead, and the attempted pan-tap **drops a wrong pin**, which flips "Usar o bairro todo" into "Confirmar". The exact step every org must do on their phone, unusable.

- **Draw starts OFF**; "Um ponto" / "Desenhar a área" are real three-state toggles (re-tap disarms) with a disarmed hint: "Arraste pra navegar…".
- **Panning stays enabled while drawing** — Leaflet distinguishes tap from drag (Leaflet.draw keeps dragging on too), so removing `dragging.disable()` costs nothing and unfreezes the map.
- **Polygon close matches its own PT copy**: tap the first vertex to close (24px tolerance); double-tap still works. Previously the copy said "feche no primeiro ponto" but only double-click closed — instruction-followers got stuck in draw mode with panning frozen.
- Arm buttons h-7 → h-9 (touch targets).

New e2e `cougar-site-step-panning` at 390×844 — first spec to exercise the full zone-click → sites-step path (the coverage hole that let the auto-arm bug survive). add-site + map-step regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY