### PR TITLE
fix(cbo): SSE watchdog + localized retry — a dropped stream is self-service now

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -374,6 +374,9 @@ export default function CboProfilePage() {
   // Cohort membership: if `?cbo=<memberSlug>` is in the URL, this CBO is part
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
+  // A turn whose SSE stream dropped/stalled — holds the original message text
+  // so a "Tentar de novo" tap can resend it (hidden — no duplicate user bubble).
+  const [streamRetry, setStreamRetry] = useState<string | null>(null);
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
   // Project-readiness triage from E1: 'has-project' | 'has-idea' | 'needs-help'
   // | null (until triaged). has-project + has-idea are project-forward.
@@ -935,12 +938,25 @@ export default function CboProfilePage() {
     if (!cboId || !text.trim() || isStreaming) return;
     setInput('');
     setActiveQuestions([]);
+    setStreamRetry(null);
     // displayText lets the chat bubble show a clean summary while the agent
     // still receives the full technical `text` (map selection risk summary).
     if (!hidden) setMessages(prev => [...prev, { role: 'user', content: displayText ?? text, messageType: 'content', timestamp: new Date().toISOString(), viaVoice }]);
     setIsStreaming(true);
+    // Inactivity watchdog. On patchy mobile data the SSE socket can stall
+    // silently — reader.read() then hangs forever, isStreaming stays true, and
+    // the user faces a frozen "Processando…" with no way out. If no chunk
+    // arrives for 60s (well beyond the slowest tool roundtrip), abort and offer
+    // a retry instead.
+    const ctrl = new AbortController();
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const armWatchdog = () => {
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => ctrl.abort(), 60_000);
+    };
     try {
-      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang }) });
+      armWatchdog();
+      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang }), signal: ctrl.signal });
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
@@ -948,16 +964,30 @@ export default function CboProfilePage() {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
+          armWatchdog();
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n');
           buffer = lines.pop() || '';
           for (const line of lines) { if (line.startsWith('data: ')) { try { processEvent(JSON.parse(line.slice(6))); } catch {} } }
         }
       }
-    } catch (e: any) { setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${e.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); }
+    } catch {
+      // Dropped/stalled stream — a human, localized message + a self-service
+      // retry (resends the same message hidden, so no duplicate user bubble).
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: lang === 'pt'
+          ? 'A conexão caiu no meio da resposta. Toque em "Tentar de novo" que eu retomo daqui.'
+          : 'The connection dropped mid-response. Tap "Try again" and I\'ll pick it up.',
+        messageType: 'content', timestamp: new Date().toISOString(),
+      }]);
+      setStreamRetry(text);
+    } finally {
+      clearTimeout(watchdog);
+    }
     setIsStreaming(false);
     setCompletedTurns(n => n + 1);
-  }, [cboId, isStreaming, processEvent]);
+  }, [cboId, isStreaming, processEvent, lang]);
 
   // MC selection
   const handleSelectOption = useCallback((label: string) => {
@@ -1629,6 +1659,19 @@ export default function CboProfilePage() {
               <div className="flex items-start gap-1.5 mb-1.5 text-[11px] text-amber-700">
                 <AlertCircle className="w-3 h-3 mt-0.5 shrink-0" />
                 <span>{voiceError}</span>
+              </div>
+            )}
+            {streamRetry && !isStreaming && (
+              <div className="mb-1.5">
+                <Button
+                  size="sm"
+                  className="w-full h-9 bg-emerald-600 hover:bg-emerald-700 gap-1.5"
+                  data-testid="cbo-stream-retry"
+                  onClick={() => { const msg = streamRetry; setStreamRetry(null); sendMessage(msg, true); }}
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                  {lang === 'pt' ? 'Tentar de novo' : 'Try again'}
+                </Button>
               </div>
             )}
             <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input); }} className="flex gap-2">

--- a/e2e/cbo-stream-retry.spec.ts
+++ b/e2e/cbo-stream-retry.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// When the chat stream drops (patchy mobile data), the user must get a human,
+// localized message + a self-service "Try again" — not a frozen "Processando…"
+// or a raw "Error: Failed to fetch". Simulated by aborting the /chat request.
+
+test.describe('CBO chat stream drop → retry', () => {
+  test('a dropped stream shows the retry chip; tapping it completes the turn', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Script the NEXT fake-model turn (it will only be consumed by the retry,
+    // since the first attempt is aborted at the network layer).
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Retomando daqui — anotado!' },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
+    ]]);
+
+    // Kill the first /chat request mid-flight.
+    let aborted = 0;
+    await page.route('**/api/cbo/*/chat', route => { aborted += 1; return route.abort('connectionreset'); });
+    await page.getByTestId('cbo-chat-input').fill('oi, tudo bem?');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    // Human message + retry chip, no raw "Error:" text, input re-enabled.
+    await expect(page.getByText(/conexão caiu|connection dropped/i)).toBeVisible({ timeout: 15_000 });
+    const retry = page.getByTestId('cbo-stream-retry');
+    await expect(retry).toBeVisible();
+    await expect(page.getByText(/^Error:/)).toHaveCount(0);
+    expect(aborted).toBeGreaterThan(0);
+
+    // Restore the network and retry → the scripted turn completes normally,
+    // with NO duplicate user bubble (retry resends hidden).
+    await page.unroute('**/api/cbo/*/chat');
+    await retry.click();
+    await expect(page.getByText('Retomando daqui', { exact: false })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('cbo-stream-retry')).toHaveCount(0);
+    await expect(page.getByText('oi, tudo bem?', { exact: true })).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
**Field-safety pack 6/6** (P1). On patchy data / venue wifi the chat stream can (a) **stall silently** — `reader.read()` hangs forever, `isStreaming` stays true, the input is locked on "Processando…" with no way out but a reload the user doesn't know to do; or (b) **error** — which appended a raw English `Error: Failed to fetch` bubble with no retry.

- **60s inactivity watchdog** (re-armed on every received chunk) aborts a stalled stream.
- Both paths now show a **human PT/EN message** + a full-width **"Tentar de novo"** chip that resends the same message hidden (no duplicate user bubble). A facilitator interrupt becomes a self-service tap.

New e2e `cbo-stream-retry` — aborts `/chat` at the network layer, asserts message + chip + no raw `Error:`, restores the network, taps retry, and the turn completes without doubling the user bubble. Golden-path + voice regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY