### PR TITLE
feat(cbo): persist every prompt — reload lands back on the exact question

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -367,6 +367,27 @@ export default function CboProfilePage() {
   const handleSelectRef = useRef<(label: string) => void>(() => {});
 
   const currentQuestion = activeQuestions[currentQuestionIdx] || null;
+
+  // Restore a pending prompt from the transcript (PERSIST-PROMPTS). The server
+  // persists every user-prompting tool as a `composer` message; if the LAST
+  // transcript message is one of those — i.e. the user never answered — rebuild
+  // the live prompt state the SSE event would have set, so a reload lands the
+  // user back on the exact question instead of a dead transcript.
+  const hydrateMessages = useCallback((msgs: CboChatMessage[]) => {
+    setMessages(msgs);
+    const last = msgs[msgs.length - 1];
+    if (!last || last.role !== 'assistant' || last.messageType !== 'composer') return;
+    let parsed: any = null;
+    try { parsed = JSON.parse(last.content); } catch { return; }
+    if (parsed?.kind === 'ask_user' && parsed.question) {
+      setActiveQuestions([{ id: 'q_restored', question: parsed.question, options: parsed.options ?? [], multiSelect: parsed.multiSelect, relatedSections: parsed.relatedSections } as any]);
+      setCurrentQuestionIdx(0); setQuestionAnswers({}); setSelectedOptionIdx(0);
+    } else if (parsed?.kind === 'priority' && parsed.prompt) {
+      setPriorityRankPrompt({ prompt: parsed.prompt, minRanked: parsed.minRanked ?? 2 });
+    } else if (parsed?.kind === 'anchoring' && parsed.prompt) {
+      setAnchoringPrompt({ prompt: parsed.prompt });
+    }
+  }, []);
   const totalQuestions = activeQuestions.length;
   const [highlightedSections, setHighlightedSections] = useState<string[]>([]);
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -454,7 +475,7 @@ export default function CboProfilePage() {
           setCboId(candidate);
           setState(migrateCboState(data.state));
           const msgRes = await fetch(`/api/cbo/${candidate}/messages`);
-          if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) setMessages(msgs); }
+          if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) hydrateMessages(msgs); }
           saveId(candidate); // converge the same-device cache onto the server id
           return;
         }
@@ -694,7 +715,7 @@ export default function CboProfilePage() {
             setCboId(saved);
             setState(migrateCboState(data.state));
             const msgRes = await fetch(`/api/cbo/${saved}/messages`);
-            if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) setMessages(msgs); }
+            if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) hydrateMessages(msgs); }
             return;
           }
           // 404 means the cached id points at a CBO that no longer exists on the
@@ -1334,6 +1355,22 @@ export default function CboProfilePage() {
                     </div>
                   );
                 }
+                if (parsed.kind === 'ask_user' && parsed.question) {
+                  // A persisted question. While it's PENDING (trailing message,
+                  // live card showing) render nothing — the interactive card is
+                  // the surface. Once ANSWERED (a later message follows), render
+                  // the question as a plain agent bubble so the transcript reads
+                  // as Q→A instead of an answer to nothing (chip turns have no
+                  // other agent text by design).
+                  if (i === messages.length - 1 && currentQuestion) return null;
+                  return (
+                    <div key={i} className="flex justify-start">
+                      <div className="max-w-[90%] rounded-lg px-4 py-2.5 bg-muted">
+                        <p className="text-sm">{parsed.question}</p>
+                      </div>
+                    </div>
+                  );
+                }
                 return null;
               }
               const uploadName = msg.role === 'user' ? parseUploadFilename(msg.content) : null;
@@ -1473,7 +1510,9 @@ export default function CboProfilePage() {
                    buildPhaseInstructions fallback. */}
             {(() => {
               if (isStreaming || !stableStreamEnded || messages.length === 0 || state.phase === 0) return null;
-              if (currentQuestion) return null;
+              // ANY live affordance suppresses the banner — not just ask_user.
+              // Rank/anchoring/map composers previously co-rendered with it.
+              if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
 
               // Forward-progress gate — the phase must be complete before we
               // offer the next workshop. Uses the shared phaseComplete() predicate
@@ -1550,7 +1589,11 @@ export default function CboProfilePage() {
               // `stableStreamEnded` guards against the SSE-batch race where
               // `done` arrives before `ask_user` and the gate briefly thinks
               // the agent is finished but stranded. See state declaration.
-              if (isStreaming || !stableStreamEnded || state.phase === 0 || currentQuestion || messages.length === 0) return null;
+              // ANY pending affordance suppresses the resume block — the old
+              // currentQuestion-only check let "Continuar da Fase X" render
+              // UNDER a live rank/anchoring/map composer (tapping it derails).
+              if (isStreaming || !stableStreamEnded || state.phase === 0 || messages.length === 0) return null;
+              if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
               const lastContent = [...messages].reverse().find(m => m.messageType === 'content');
               const agentOwesResponse = !lastContent || lastContent.role === 'user';
               if (state.phase < 6 && !agentOwesResponse) return null;

--- a/docs/cbo-chat-composers.md
+++ b/docs/cbo-chat-composers.md
@@ -33,10 +33,17 @@ the widget it points at.
 - Keep composer messages **out of text-based message logic** — they're excluded by
   their `messageType` (the "last content message" finders filter on `'content'`).
 
-> ⚠️ **Known gap.** `RiskPriorityChips`, the community-anchoring composer, and the
-> map's `openMapParams` are **still ephemeral** — they will not survive a reload.
-> When you harden them, apply this pattern. (The map was deliberately made
-> session-live-only in PR #298; revisit if reload-resilience is wanted.)
+> ✅ **Hardened (PERSIST-PROMPTS).** `ask_user`, `ask_priority_rank`, and
+> `ask_community_anchoring` are now persisted as composer messages in `pushEvent`
+> (`{kind:'ask_user'|'priority'|'anchoring', ...}`) and **rehydrated on load** by
+> `hydrateMessages()` in `cbo-profile.tsx`: if the *trailing* transcript message
+> is one of these (the user never answered), the live prompt state is rebuilt so
+> a reload lands back on the exact question. Answered `ask_user` composers render
+> as a plain question bubble so the transcript reads Q→A. They also feed
+> `buildDecisionLog` as readable annotations ("You (agent) asked: …") — the agent
+> now *remembers* questions it asked, including ones synthesized by the
+> inline-options converter. The map is covered separately by the persisted
+> `state.activeTool` + right-panel-tool registry (Rule 6).
 
 ## Rule 2 — Only a **terminal** composer may `setIsStreaming(false)`
 

--- a/e2e/cbo-prompt-persist.spec.ts
+++ b/e2e/cbo-prompt-persist.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// PERSIST-PROMPTS: a pending ask_user must survive a reload. Before this, the
+// question was SSE-only — reloading mid-question dropped it, leaving a dead
+// transcript and only the derailing "Continuar" backstop (the top real-world
+// failure for a phone-first audience on flaky networks).
+
+test.describe('CBO — pending question survives reload', () => {
+  test('reload mid-question restores the exact card; answering still works', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Boa! Uma pergunta rápida.' },
+      { op: 'set_phase', phase: 1 },
+      { op: 'ask_user', question: 'Quantas pessoas participam do grupo?', options: [
+        { label: '1–5', description: 'Grupo pequeno' },
+        { label: '6–20', description: 'Grupo médio' },
+      ], multiSelect: false },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('oi');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible({ timeout: 20_000 });
+
+    // Reload mid-question — the card must come back with the same options.
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', cboId, { timeout: 30_000 });
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Quantas pessoas participam do grupo?').first()).toBeVisible();
+    await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', '1–5');
+    await expect(page.getByTestId('cbo-option-1')).toHaveAttribute('data-option-label', '6–20');
+
+    // Answering after the reload still works (fake model's default turn replies).
+    await page.getByTestId('cbo-option-0').click();
+    await expect(page.getByText('1–5', { exact: true }).first()).toBeVisible({ timeout: 20_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 20_000 });
+
+    // And once answered, a second reload shows the question as a transcript
+    // bubble (Q→A readable) with NO live card for it.
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', cboId, { timeout: 30_000 });
+    await expect(page.getByText('Quantas pessoas participam do grupo?').first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -881,6 +881,18 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'types', typeIds: event.typeIds, intro: event.intro }), messageType: 'composer', timestamp: new Date().toISOString() });
     } else if (event.type === 'show_examples') {
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'examples', cardIds: event.cardIds, mode: event.mode, intro: event.intro }), messageType: 'composer', timestamp: new Date().toISOString() });
+    } else if (event.type === 'ask_user') {
+      // Persist every user-prompting question (PERSIST-PROMPTS). Before this,
+      // ask_user was SSE-only: a reload mid-question dropped the prompt and the
+      // user faced a dead transcript with only the derailing "Continuar" chip.
+      // Persisting also puts the question into buildDecisionLog, so the agent
+      // remembers what it asked — including questions synthesized by the
+      // inline-options converter, which previously vanished from BOTH places.
+      addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'ask_user', question: event.question, options: event.options, multiSelect: event.multiSelect, showMap: event.showMap, relatedSections: event.relatedSections }), messageType: 'composer', timestamp: new Date().toISOString() });
+    } else if (event.type === 'ask_priority_rank') {
+      addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'priority', prompt: event.prompt, minRanked: event.minRanked }), messageType: 'composer', timestamp: new Date().toISOString() });
+    } else if (event.type === 'ask_community_anchoring') {
+      addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'anchoring', prompt: event.prompt }), messageType: 'composer', timestamp: new Date().toISOString() });
     } else if (event.type === 'open_map') {
       // Persist that the map step is active so the right-panel tool stays
       // reachable across reloads (not gated behind a transient button).
@@ -1128,17 +1140,34 @@ function buildDecisionLog(cboId: string): string {
   // a reply to "what's your org name?" — and starts re-introducing itself
   // every turn. Interleave user + assistant messages so the agent sees the
   // recent conversation as a coherent thread.
+  // Include composer messages (persisted prompts/strips) as readable
+  // annotations — without them the agent has NO memory of questions it asked
+  // via ask_user (the user's "Sim" reads as a reply to nothing), and re-asks.
   const msgs = getCboMessages(cboId).filter(m =>
-    m.messageType === 'content' &&
+    (m.messageType === 'content' || m.messageType === 'composer') &&
     !!m.content?.trim()
   );
   if (msgs.length === 0) return 'No prior conversation. This is the first turn — introduce yourself and start the flow.';
-  // Last 8 messages (≈ 4 turns each direction). Truncate each to keep prompt small.
-  const recent = msgs.slice(-8);
+  // Last 10 messages (composers now occupy slots too). Truncate each to keep prompt small.
+  const recent = msgs.slice(-10);
   return recent.map(m => {
+    if (m.messageType === 'composer') {
+      try {
+        const p = JSON.parse(m.content);
+        if (p.kind === 'ask_user') {
+          const opts = (p.options ?? []).map((o: any) => o.label).join(' / ');
+          return `- You (agent) asked: ${String(p.question).slice(0, 200)}${opts ? ` [options: ${opts.slice(0, 150)}]` : ''}`;
+        }
+        if (p.kind === 'priority') return '- You (agent) asked the user to rank the hazards by priority.';
+        if (p.kind === 'anchoring') return '- You (agent) asked the community-anchoring questions.';
+        if (p.kind === 'types') return '- You (agent) showed the NBS types strip.';
+        if (p.kind === 'examples') return '- You (agent) showed real project examples.';
+      } catch {}
+      return null;
+    }
     const who = m.role === 'user' ? 'User' : 'You (agent)';
     return `- ${who}: ${m.content.slice(0, 300)}`;
-  }).join('\n');
+  }).filter(Boolean).join('\n');
 }
 
 // Knowledge cache (cleared on server restart)


### PR DESCRIPTION
**The #1 structural gap** from the integration review — the single seam covering most of the remaining "foolproof" distance. Closes four findings at once:

1. **Reload drops the pending question** — `ask_user`/`ask_priority_rank`/`ask_community_anchoring` were SSE-only. Now persisted as `composer` transcript messages and **rehydrated on load**: if the trailing message is an unanswered prompt, the exact question card / rank chips / anchoring composer is rebuilt.
2. **Converted-question amnesia (#316 regression)** — a question synthesized by the inline-options converter existed nowhere. Now it flows through the same persistence, and…
3. **The agent remembers its own questions** — `buildDecisionLog` now renders composer messages as annotations ("You (agent) asked: … [options: …]"), so the user's "Sim" no longer reads as a reply to nothing (this was driving re-asks/derails).
4. **Resume-overlap** — the "Continuar da Fase X" backstop AND the advance banner now suppress on **any** pending affordance (question ‖ rank ‖ anchoring ‖ map ‖ selector), not just `ask_user` — they can no longer render under a live composer.

Also: answered questions render as plain Q-bubbles in the transcript (chip turns finally read Q→A on reload), and `docs/cbo-chat-composers.md` Rule-1's "known gap" note is updated to the hardened pattern.

New e2e `cbo-prompt-persist` (reload → exact card + options → answer works → second reload shows Q→A). **Full suite: 40 passed / 3 @live skipped**; the single failure (`cougar-invite-session`) is the known parallelism flake — passes isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY