### PR TITLE
perf(cbo): strip generic file tools from the agent + cap turns at 12

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -985,8 +985,16 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
         cwd: process.cwd(),
         model,
         systemPrompt,
+        // Turn cap — a runaway tool loop otherwise burns the full ~10K-token
+        // prompt once per roundtrip while the user watches "Processando…".
+        // Normal turns use 2-5 tool calls; 12 is generous headroom.
+        maxTurns: 12,
+        // NOTE: no generic Read/Glob/Grep here. All knowledge + org-document
+        // access goes through the purpose-built MCP tools below; the generic
+        // file tools only invited stray repo exploration — each stray call is
+        // a whole extra model roundtrip on the slowest path (Ana's "agent too
+        // slow on basic questions").
         allowedTools: [
-          "Read", "Glob", "Grep",
           "mcp__cbo__update_section",
           "mcp__cbo__flag_gap",
           "mcp__cbo__set_phase",


### PR DESCRIPTION
**Latency quick wins** (Ana's "agent too slow on basic questions" — the structural findings from the integration review).

- **Remove `Read`/`Glob`/`Grep`** from `allowedTools`: all knowledge + org-document access already goes through the purpose-built MCP tools; the generic file tools (with `cwd` = repo root) only invited stray repo exploration — and every stray call is a **full extra model roundtrip over the ~10K-token system prompt**, on the slowest path.
- **`maxTurns: 12`**: a runaway tool loop can no longer burn roundtrips indefinitely behind "Processando…" (normal turns use 2–5 tool calls).

Verified no skill/prompt instructs direct file reads (all references are `read_knowledge`/`read_org_document`). Live-SDK path only — fake-model e2e unaffected (golden-path green; TS clean).

Remaining latency levers stay in the backlog as separate, judgment-heavier changes: slim the 29KB `encontro-1.md` (~60% is worked examples), and per-phase `model:` overrides for chip-only E1 turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY