### PR TITLE
fix(cbo map): tooltips anchor to the feature and close on leave (no touch lingering)

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -330,13 +330,13 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
                 hazardLine + (riskLine ? riskLine + '<br/>' : '') + fhxv + priorityLine +
                 `${pop} hab. · ${(p.areaKm2 || p.area_km2)?.toFixed(1) || '?'} km²<br/>` +
                 `<span style="color:#888">Poverty: ${poverty}</span></div>`,
-                { sticky: true }
+                { direction: 'top' }
               );
             } else if (zoneSource === 'intervention_zones') {
               const hc = p.primaryHazard === 'FLOOD' ? '#3b82f6' : p.primaryHazard === 'HEAT' ? '#ef4444' : '#a16207';
               featureLayer.bindTooltip(
                 `<div style="font-size:11px"><strong>${p.zoneId}</strong><br/><span style="color:${hc}">${p.typologyLabel}</span> — ${(p.interventionType || '').replace(/_/g, ' ')}<br/>${p.areaKm2?.toFixed(1)} km² · ${p.populationSum?.toLocaleString() || '?'} people</div>`,
-                { sticky: true }
+                { direction: 'top' }
               );
             }
 
@@ -379,6 +379,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
               // touch, where tap fires mouseover→click→mouseout in a burst).
               const isSelected = selectedAssetsRef.current.some(a => a.type === 'zone' && a.name === zoneName);
               (featureLayer as any).setStyle(isSelected ? SELECTED_ZONE_STYLE : featureDefaultStyle);
+              (featureLayer as any).closeTooltip();
             });
           },
         });
@@ -429,7 +430,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
 
               featureLayer.bindTooltip(
                 `<div style="font-size:11px"><strong>${visual.emoji} ${name}</strong><br/><span style="color:#888">${visual.label} — click to select</span></div>`,
-                { sticky: true }
+                { direction: 'top' }
               );
 
               (featureLayer as any).on('click', async (e: any) => {
@@ -469,7 +470,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
               });
 
               (featureLayer as any).on('mouseover', () => { map.getContainer().style.cursor = 'pointer'; });
-              (featureLayer as any).on('mouseout', () => { map.getContainer().style.cursor = ''; });
+              (featureLayer as any).on('mouseout', () => { map.getContainer().style.cursor = ''; (featureLayer as any).closeTooltip(); });
             },
           });
           layer.addTo(map);


### PR DESCRIPTION
Same family as the orchestrator's #319, now on the **CBO map** (MapMicroapp). Zone + OSM tooltips were `sticky:true` — they follow the cursor, pile up when crossing shared borders, and on touch (no `mouseout`) a tapped tooltip **lingered half off-screen covering the map**. In the documented walkthrough this lingering tooltip is what made a lake-tap look like a zone-hit (beats 6/10).

Anchored (`direction:'top'`) + explicit `closeTooltip()` on mouseout for zones and OSM features. Map-step + add-site regressions green; TS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY