### PR TITLE
fix(cbo): NBS strips no longer drag the whole page sideways on phones

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1188,7 +1188,7 @@ export default function CboProfilePage() {
       <div className="flex flex-1 min-h-0">
         {/* LEFT: Chat — full width on mobile (when Chat tab active), half on md+ */}
         <div
-          className={`w-full md:w-1/2 md:border-r md:flex flex-col relative ${
+          className={`w-full md:w-1/2 min-w-0 md:border-r md:flex flex-col relative ${
             mobileActiveTab === 'chat' ? 'flex' : 'hidden'
           }`}
           {...dragHandlers}
@@ -1288,7 +1288,11 @@ export default function CboProfilePage() {
             />
           </div>
 
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {/* overflow-x-hidden + the column's min-w-0: without them the NBS
+              type/example strips' min-content width escapes the flex chain and
+              drags the WHOLE page sideways on a phone (header cut off, question
+              card clipped) — the strips scroll internally (overflow-x-auto). */}
+          <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-3">
             {messages.length === 0 && state.phase === 0 && (
               <div className="text-center text-muted-foreground py-8 sm:py-10 max-w-xs sm:max-w-sm mx-auto px-2">
                 <div className="inline-flex w-12 h-12 sm:w-14 sm:h-14 rounded-full bg-emerald-50 dark:bg-emerald-950/40 items-center justify-center mb-3 sm:mb-4">

--- a/e2e/cbo-mobile-no-hscroll.spec.ts
+++ b/e2e/cbo-mobile-no-hscroll.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The NBS type/example strips must scroll INTERNALLY — not drag the whole page
+// sideways at phone width (documented walkthrough: header cut off, question
+// card clipped). Regression: after rendering the widest composer, the document
+// must have zero horizontal overflow at 390px.
+
+test.describe('CBO — no page-level horizontal scroll on a phone', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('types strip renders without widening the page', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Dois minutos sobre os tipos de SbN.' },
+      { op: 'show_types' },
+      { op: 'ask_user', question: 'Seguimos pros exemplos?', options: [{ label: 'Ver exemplos' }, { label: 'Pular' }] },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('vamos');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 20_000 });
+    await expect(page.getByText('Bioswales', { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+
+    // The page itself must not overflow horizontally (the strip scrolls inside).
+    const overflow = await page.evaluate(() => {
+      const el = document.documentElement;
+      return Math.max(el.scrollWidth - el.clientWidth, document.body.scrollWidth - document.body.clientWidth);
+    });
+    expect(overflow).toBe(0);
+  });
+});


### PR DESCRIPTION
Documented-walkthrough beats 3/7: at 390px the NBS type/example strips pushed the **whole page** into horizontal scroll — header cut off, the question card clipped mid-word ("…seguimos pros exem").

Classic flex `min-width:auto` escape: the strips scroll internally (`overflow-x-auto`), but their min-content width still propagated up the flex chain and widened the page. Fix: `min-w-0` on the chat column + `overflow-x-hidden` on the message list.

New e2e `cbo-mobile-no-hscroll` asserts **zero document-level horizontal overflow at 390×844** with the types strip rendered. TS clean; golden-path green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY