### PR TITLE
feat(cbo): adaptive turn routing — trivial turns run on the fast model

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -931,7 +931,7 @@ export default function CboProfilePage() {
   }, [isStreaming]);
 
   // Send message. `viaVoice` marks the optimistic user bubble as dictated (🎤).
-  const sendMessage = useCallback(async (text: string, hidden = false, viaVoice = false, displayText?: string) => {
+  const sendMessage = useCallback(async (text: string, hidden = false, viaVoice = false, displayText?: string, turnKind?: 'chip' | 'text' | 'upload' | 'map' | 'system') => {
     if (!cboId || !text.trim() || isStreaming) return;
     setInput('');
     setActiveQuestions([]);
@@ -940,7 +940,7 @@ export default function CboProfilePage() {
     if (!hidden) setMessages(prev => [...prev, { role: 'user', content: displayText ?? text, messageType: 'content', timestamp: new Date().toISOString(), viaVoice }]);
     setIsStreaming(true);
     try {
-      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang }) });
+      const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang, turnKind }) });
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
@@ -966,7 +966,7 @@ export default function CboProfilePage() {
       if (Object.keys(updated).length === totalQuestions) {
         const all = activeQuestions.map((_, i) => updated[i]).filter(Boolean);
         setActiveQuestions([]); setCurrentQuestionIdx(0); setSelectedOptionIdx(0);
-        sendMessage(all.join('; '));
+        sendMessage(all.join('; '), false, false, undefined, 'chip');
         return {};
       }
       return updated;
@@ -1029,7 +1029,7 @@ export default function CboProfilePage() {
     const text = lang === 'pt'
       ? "Vamos começar."
       : "Let's begin.";
-    sendMessage(text, true);
+    sendMessage(text, true, false, undefined, 'system');
   }, [lang, sendMessage]);
 
   // File drop handler
@@ -1071,7 +1071,7 @@ export default function CboProfilePage() {
     cboId,
     lang,
     // Send the transcript straight away, marked as a voice message.
-    onTranscript: (text) => { setVoiceError(null); sendMessage(text, false, true); },
+    onTranscript: (text) => { setVoiceError(null); sendMessage(text, false, true, undefined, 'text'); },
     onError: handleVoiceError,
   });
   // Clear a stale voice error once the user starts a new recording.
@@ -1283,7 +1283,7 @@ export default function CboProfilePage() {
               onJumpToPhase={(p) => {
                 if (isStreaming) return;
                 const skip = p === 3 ? '3a' : String(p);
-                sendMessage(`[SKIP TO phase:${skip}]`);
+                sendMessage(`[SKIP TO phase:${skip}]`, false, false, undefined, 'system');
               }}
             />
           </div>
@@ -1579,7 +1579,7 @@ export default function CboProfilePage() {
                 ) : (
                   <div className="inline-flex flex-col items-center gap-2 p-4 rounded-lg border border-dashed border-green-300 bg-green-50">
                     <p className="text-sm text-muted-foreground">{t('cbo.phase', { num: state.phase, count: filledCount })}</p>
-                    <Button variant="outline" onClick={() => sendMessage(lang === 'pt' ? `Continuar da Fase ${state.phase}.` : `Continue from Phase ${state.phase}.`)}>{t('cbo.continue')}</Button>
+                    <Button variant="outline" onClick={() => sendMessage(lang === 'pt' ? `Continuar da Fase ${state.phase}.` : `Continue from Phase ${state.phase}.`, false, false, undefined, 'system')}>{t('cbo.continue')}</Button>
                   </div>
                 )}
               </div>
@@ -1631,7 +1631,7 @@ export default function CboProfilePage() {
                 <span>{voiceError}</span>
               </div>
             )}
-            <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input); }} className="flex gap-2">
+            <form onSubmit={(e) => { e.preventDefault(); if (currentQuestion && input.trim()) { handleSelectOption(input.trim()); setInput(''); } else sendMessage(input, false, false, undefined, 'text'); }} className="flex gap-2">
               <input ref={fileInputRef} type="file" className="hidden" accept=".pdf,.pptx,.docx,.xlsx,.txt,.md,.csv,.tsv,.json,.png,.jpg,.jpeg,.gif,.webp,.heic,.heif,.mp3,.wav,.m4a,.webm,.ogg,.opus,.aac,.flac,audio/*,image/*"
                 onChange={(e) => {
                   const file = e.target.files?.[0];
@@ -1869,7 +1869,7 @@ export default function CboProfilePage() {
                       // to the agent as the message body (hidden context).
                       const summary = buildRiskSummary(result, lang);
                       if (currentQuestion) setActiveQuestions([]);
-                      sendMessage(message, false, false, summary);
+                      sendMessage(message, false, false, summary, 'map');
                       setOpenMapParams(null);
                       setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
                     }}

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -154,8 +154,12 @@ export function registerCboRoutes(app: Express): void {
       : '\n[LANGUAGE: Respond ONLY in English — every single word, including ask_user option labels and update_section content. Do NOT mix in any Portuguese words or phrases, even if the user writes some Portuguese back. One language, English, with no exceptions.]';
 
     const resolvedLang = sessionLang;
+    // Client-declared turn kind ('chip' | 'text' | 'upload' | 'map' | 'system') —
+    // a HINT for adaptive model routing. The server only ever *downgrades* to the
+    // fast model when its own checks agree; a missing/bogus value routes heavy.
+    const turnKind = typeof req.body.turnKind === 'string' ? req.body.turnKind : undefined;
     addCboMessage(req.params.id, { role: 'user', content: message, messageType: 'content', timestamp: new Date().toISOString() });
-    await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang);
+    await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang, turnKind);
     debouncedPersist(req.params.id);
   });
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -841,7 +841,7 @@ function applySkipData(state: CboState, targetPhase: string): { phase: number; a
   };
 }
 
-export async function streamCboChat(cboId: string, userMessage: string, res: Response, state: CboState, lang: string = 'en') {
+export async function streamCboChat(cboId: string, userMessage: string, res: Response, state: CboState, lang: string = 'en', turnKind?: string) {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
@@ -931,7 +931,7 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   const isSdkReady = await loadSdk();
 
   if (isSdkReady) {
-    await streamWithSdk(cboId, userMessage, state, pushEvent, lang);
+    await streamWithSdk(cboId, userMessage, state, pushEvent, lang, turnKind);
   } else {
     pushEvent({ type: 'error', message: 'Claude Agent SDK not available.' });
   }
@@ -944,7 +944,50 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
 // live in the encontro skill's YAML frontmatter (`model:` field).
 const DEFAULT_CBO_MODEL = 'claude-sonnet-4-6';
 
-async function streamWithSdk(cboId: string, userMessage: string, state: CboState, pushEvent: EventPusher, lang: string = 'en') {
+// Adaptive turn routing (Ana's "agent too slow on basic questions"). Trivial
+// turns — a chip answer, a short conversational reply in the interview phases —
+// don't need the big model: route them to the fast tier so they feel instant
+// (~3× cheaper, materially lower latency). Everything with real reasoning load
+// (file uploads, map payloads, phase starts, scoring phases) stays on the
+// skill/default model, and HEAVY IS THE DEFAULT — an unclassified turn behaves
+// exactly as before this feature. Only the `model` value changes: same system
+// prompt, same tools, same turn guards, so a light-model slip is caught by the
+// same guardrails (inline-options converter, turn-ender recovery, persisted
+// prompts). Kill switch: CBO_ADAPTIVE_MODEL=0 (no redeploy needed).
+const LIGHT_CBO_MODEL = process.env.CBO_LIGHT_MODEL || 'claude-haiku-4-5';
+
+function resolveTurnModel(
+  cboId: string,
+  state: CboState,
+  userMessage: string,
+  turnKind: string | undefined,
+  heavyModel: string,
+): { model: string; routing: 'light' | 'heavy'; reason: string } {
+  const heavy = (reason: string) => ({ model: heavyModel, routing: 'heavy' as const, reason });
+  const light = (reason: string) => ({ model: LIGHT_CBO_MODEL, routing: 'light' as const, reason });
+
+  if (process.env.CBO_ADAPTIVE_MODEL === '0') return heavy('disabled');
+  // The langDirective is appended server-side — strip it before classifying,
+  // or a 3-char chip answer looks like a 240-char message.
+  const raw = userMessage.split('\n[LANGUAGE:')[0].trim();
+
+  // Reasoning-heavy shapes ALWAYS stay on the big model.
+  if (state.phase > 2) return heavy('phase>2');
+  if (turnKind === 'upload' || raw.startsWith("I'm uploading:") || raw.startsWith('Uploaded "')) return heavy('upload');
+  if (turnKind === 'map' || raw.startsWith('Map selection (')) return heavy('map-result');
+  if (turnKind === 'system') return heavy('system-turn');
+  if (/(?:vamos\s+(?:começar|comecar)|let'?s\s+start)\s+(?:o\s+)?encontro/i.test(raw)) return heavy('phase-start');
+  // First user message of the session = the intro turn (set_phase + framing).
+  if (getCboMessages(cboId).filter(m => m.messageType === 'content').length < 2) return heavy('first-turn');
+
+  // Trivial conversational turns in the interview phases → fast model.
+  if (turnKind === 'chip') return light('chip-answer');
+  if (turnKind === 'text' && raw.length <= 200) return light('short-text');
+
+  return heavy('default');
+}
+
+async function streamWithSdk(cboId: string, userMessage: string, state: CboState, pushEvent: EventPusher, lang: string = 'en', turnKind?: string) {
   const mcpServer = getMcpServer(cboId);
   const sysCtx = await buildSystemContext(state, lang);
   const stateSummary = buildStateSummary(state);
@@ -961,7 +1004,9 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // name even when the invite already prefilled it.
   const skillPhase = Math.max(1, state.phase);
   const skill = await loadEncontroSkill(skillPhase);
-  const model = skill?.model ?? DEFAULT_CBO_MODEL;
+  const heavyModel = skill?.model ?? DEFAULT_CBO_MODEL;
+  const { model, routing, reason } = resolveTurnModel(cboId, state, userMessage, turnKind, heavyModel);
+  console.log(`[cbo] turn routing for ${cboId}: ${routing} (${reason}) kind=${turnKind ?? 'none'} model=${model}`);
 
   // System prompt = the durable facts the agent needs (persona, tools, skill,
   // state, recent conversation, access policy). User prompt = just the new


### PR DESCRIPTION
**Adaptive effort per turn** (your ask: E1 questions should feel instant). Every turn paid the same cost — `claude-sonnet-4-6` over a ~10K-token prompt — whether the user tapped a chip or dropped a 40-page proposal.

**Routing (deterministic, no extra LLM call):**
- **LIGHT → `claude-haiku-4-5`** (fastest tier, 3× cheaper: $1/$5 vs $3/$15 per MTok): chip answers + short (≤200 char) typed/voice replies in phases 1–2.
- **HEAVY → unchanged** (skill/default model): uploads, map payloads, "vamos começar o Encontro N", the session's first turn, system turns, phases ≥3, and **anything unclassified — heavy is the default**, so the worst case is exactly today's behavior.

**Why it's safe now:** only the `model` value changes — same prompt, same tools, same guards. A light-model turn-contract slip is caught by the guardrails we shipped this week (inline-options→buttons #316, turn-ender recovery #320, persist-prompts #328). Client sends a `turnKind` hint; the server only ever *downgrades* on its own checks (a spoofed hint can't escalate anything).

**Observability + kill switch (per your rollout choice — on by default):** every decision logs `[cbo] turn routing: light|heavy (reason) kind=… model=…`; `CBO_ADAPTIVE_MODEL=0` disables instantly with no redeploy; `CBO_LIGHT_MODEL` overrides the fast model.

Fake-model e2e seam is upstream of routing → deterministic suite unaffected (golden-path + inline-options + map-step green). TS clean. After merge+republish, grep the Repl logs for `turn routing` to watch it work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY