### PR TITLE
E1 enum fields: canonical label catalog — no more raw machine ids on the document

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
 import { AlertTriangle, Lightbulb, Compass, Target } from 'lucide-react';
 import type { CboSectionState, CboGapEntry } from '@shared/cbo-schema';
+import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 
 type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
 
@@ -88,7 +89,7 @@ export function E1Cards({
                           </td>
                           <td className="px-3 py-1.5 text-sm">
                             <EditableField
-                              value={String(v.value || '')}
+                              value={orgProfileDisplayValue(k, String(v.value || ''), isPt ? 'pt' : 'en')}
                               userEdited={v.userEdited}
                               onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
                             />
@@ -151,7 +152,7 @@ export function E1Cards({
                       </td>
                       <td className="px-3 py-1.5 text-sm">
                         <EditableField
-                          value={String(v.value || '')}
+                          value={orgProfileDisplayValue(k, String(v.value || ''), isPt ? 'pt' : 'en')}
                           userEdited={v.userEdited}
                           onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
                         />

--- a/client/src/core/components/orchestrator/CboProfileSummary.tsx
+++ b/client/src/core/components/orchestrator/CboProfileSummary.tsx
@@ -4,6 +4,7 @@
  * snapshot-on-open (re-fetches on `reloadKey`).
  */
 import { useEffect, useState } from 'react';
+import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 import { useTranslation } from 'react-i18next';
 import { Loader2, FileText } from 'lucide-react';
 import { CBO_SECTIONS, type CboState } from '@shared/cbo-schema';
@@ -19,7 +20,8 @@ export function CboProfileSummary({
   memberId: string;
   reloadKey: number;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const isPt = !!i18n.language?.startsWith('pt');
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +65,12 @@ export function CboProfileSummary({
         const section = profile.sections?.[sec.id];
         if (!section) return null;
         const rows = Object.entries(section.fields)
-          .map(([k, f]) => [k, fmt(f?.value)] as const)
+          .map(([k, f]) => {
+            const v = fmt(f?.value);
+            // org_profile enum fields may hold legacy machine ids ("funded") —
+            // render the viewer-language label instead.
+            return [k, v !== null && sec.id === 'org_profile' ? orgProfileDisplayValue(k, v, isPt ? 'pt' : 'en') : v] as const;
+          })
           .filter(([, v]) => v !== null);
         return (
           <div key={sec.id}>

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -27,6 +27,7 @@ import {
   type OpenInterventionSelectorParams,
   type InterventionSelectorResult,
 } from '@shared/cbo-schema';
+import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/concept-note-schema';
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
@@ -1973,7 +1974,7 @@ export default function CboProfilePage() {
                                   <td className="px-3 py-1.5 text-xs text-muted-foreground w-[120px] font-medium">{t(`cbo.fields.${k}`, k.replace(/_/g, ' '))}</td>
                                   <td className="px-3 py-1.5 text-sm">
                                     <EditableField
-                                      value={String(v.value || '')}
+                                      value={sec.id === 'org_profile' ? orgProfileDisplayValue(k, String(v.value || ''), lang === 'pt' ? 'pt' : 'en') : String(v.value || '')}
                                       userEdited={v.userEdited}
                                       onSave={(newVal) => handleFieldEdit(sec.id, k, newVal)}
                                     />

--- a/e2e/cougar-e1-enum-labels.spec.ts
+++ b/e2e/cougar-e1-enum-labels.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// CBO-ENUM-LABELS (Ana, 2026-07-07): the doc-extraction path stored the E1
+// skill's machine enum ids ("funded", "gardens-and-greening") and the Documento
+// panel rendered them raw, in English. update_section now canonicalizes
+// org_profile enum values to the human chip label (shared/cbo-field-catalog),
+// and the panel maps any legacy id on render. The fake model shares the same
+// canonicalize call, so this exercises the real write path deterministically.
+
+test.describe('COUGAR — E1 enum fields render human labels, never machine ids', () => {
+  // Ana's real scenario is a pt session — pin the browser locale so the
+  // session language (and therefore the canonical labels) is Portuguese.
+  test.use({ locale: 'pt-BR' });
+
+  test('machine ids written by the agent surface as Portuguese chip labels', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // The bug scenario: agent extracts a news article and stores the raw enum
+    // ids from the skill spec instead of the chip labels.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'prior_project_scale', value: 'funded', source: 'document' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'nbs_experience', value: 'gardens-and-greening', source: 'document' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'groups_served', value: 'women, jovens', source: 'document' },
+        { op: 'say', text: 'Li o artigo e preenchi o histórico de vocês.' },
+        { op: 'ask_user', question: 'Tá tudo certo?', options: [{ label: 'Sim' }, { label: 'Quero ajustar' }] },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('https://exemplo.com/artigo-sobre-nos');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // Histórico card shows the Portuguese chip labels…
+    await expect(page.getByText('Projeto com financiamento', { exact: false })).toBeVisible();
+    await expect(page.getByText('Hortas / arborização', { exact: false })).toBeVisible();
+    // …multi-select items map per-item (mixed en id + pt id)…
+    await expect(page.getByText('Mulheres, Jovens', { exact: false })).toBeVisible();
+    // …and the raw machine ids never reach the user.
+    await expect(page.getByText('gardens-and-greening', { exact: false })).toHaveCount(0);
+    await expect(page.getByText(/\bfunded\b/)).toHaveCount(0);
+  });
+
+  test('a free-text value that matches no option passes through untouched', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // The richer chip label (with the R$ bracket) is NOT a catalog option — it
+    // must be stored and rendered exactly as tapped, not squashed to the
+    // generic label.
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'prior_project_scale', value: 'Projeto financiado (R$ 50k+)' },
+        { op: 'say', text: 'Anotei o porte do maior projeto.' },
+        { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Projeto financiado (R$ 50k+)');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    await expect(page.getByText('Projeto financiado (R$ 50k+)', { exact: false }).first()).toBeVisible();
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -29,6 +29,7 @@ import { getOrgIdForCboState, listDocumentsByOrg, getDocumentForOrg } from "./do
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { emitAssistantText } from "./agentOutput";
+import { isKnownOrgProfileField, canonicalizeOrgProfileValue, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -219,6 +220,13 @@ const pushEventRegistry = new Map<string, EventPusher>();
 
 function setActivePushEvent(id: string, pusher: EventPusher) { pushEventRegistry.set(id, pusher); }
 
+// Session language per CBO, refreshed on every turn. The MCP server (and its
+// tool closures) is cached per cboId, so tools can't take lang at creation —
+// they read it here instead. pt is the product default.
+const cboLangRegistry = new Map<string, 'pt' | 'en'>();
+function setActiveCboLang(id: string, lang: string) { cboLangRegistry.set(id, lang === 'en' ? 'en' : 'pt'); }
+function getActiveCboLang(id: string): 'pt' | 'en' { return cboLangRegistry.get(id) ?? 'pt'; }
+
 function createCboMcpTools(cboId: string) {
   if (!sdkTool || !sdkCreateMcpServer) return null;
 
@@ -245,6 +253,15 @@ function createCboMcpTools(cboId: string) {
       }
       const section = state.sections[args.sectionId as keyof typeof state.sections];
       if (!section) return { content: [{ type: "text" as const, text: `Unknown section: ${args.sectionId}` }], isError: true };
+      if (args.sectionId === 'org_profile') {
+        // Foolproofing (Ana 2026-07-07): invented field names ("current_leadership")
+        // land facts in chat that never reach the document, and machine enum ids
+        // ("funded") leak to the user raw. Reject the former, canonicalize the latter.
+        if (!isKnownOrgProfileField(args.field)) {
+          return { content: [{ type: "text" as const, text: `Unknown org_profile field "${args.field}". Use exactly one of: ${ORG_PROFILE_FIELDS.join(', ')}. If the fact fits none of these, mention it in chat but do not store it.` }], isError: true };
+        }
+        args.value = canonicalizeOrgProfileValue(args.field, args.value, getActiveCboLang(cboId));
+      }
       const oldValue = section.fields[args.field]?.value ?? null;
       section.fields[args.field] = { value: args.value, confidence: args.confidence as Confidence, source: args.source, userEdited: false };
       section.lastUpdatedBy = 'agent';
@@ -929,6 +946,7 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   }
 
   setActivePushEvent(cboId, pushEvent);
+  setActiveCboLang(cboId, lang);
 
   // Test-only deterministic seam. When CBO_FAKE_MODEL=1 (set ONLY in the
   // test/preview env, never the prod Deployment), drive the turn from a scripted

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -34,6 +34,7 @@ import {
 } from '@shared/cbo-schema';
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { emitAssistantText } from './agentOutput';
+import { canonicalizeOrgProfileValue } from '@shared/cbo-field-catalog';
 
 export function isFakeModelEnabled(): boolean {
   return process.env.CBO_FAKE_MODEL === '1';
@@ -92,13 +93,13 @@ export async function streamWithFakeModel(
   const turn = queue && queue.length > 0 ? queue.shift()! : defaultTurn(lang, userMessage);
 
   for (const op of turn) {
-    runOp(cboId, op, state, pushEvent, deps);
+    runOp(cboId, op, state, pushEvent, deps, lang);
   }
 
   pushEvent({ type: 'done', summary: 'Response complete (fake model)' });
 }
 
-function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent, deps: FakeDeps): void {
+function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent, deps: FakeDeps, lang: string): void {
   switch (op.op) {
     case 'say': {
       emitAssistantText(op.text, pushEvent);
@@ -108,18 +109,23 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       if (!isValidSectionId(op.sectionId)) break;
       const section = state.sections[op.sectionId as keyof typeof state.sections];
       if (!section) break;
+      // Same write-path canonicalization as the real update_section tool, so
+      // specs exercise the id -> label mapping deterministically.
+      const value = op.sectionId === 'org_profile'
+        ? canonicalizeOrgProfileValue(op.field, op.value, lang === 'en' ? 'en' : 'pt')
+        : op.value;
       section.fields[op.field] = {
-        value: op.value,
+        value,
         confidence: (op.confidence ?? 'high') as Confidence,
         source: op.source ?? 'user',
         userEdited: false,
       };
       section.lastUpdatedBy = 'agent';
       if (op.sectionId === 'org_profile' && op.field === 'org_name' && !state.orgName) {
-        state.orgName = op.value;
+        state.orgName = value;
       }
       deps.setCboState(cboId, state);
-      pushEvent({ type: 'field_update', sectionId: op.sectionId, field: op.field, value: String(op.value), confidence: (op.confidence ?? 'high') as Confidence, source: op.source ?? 'user' });
+      pushEvent({ type: 'field_update', sectionId: op.sectionId, field: op.field, value: String(value), confidence: (op.confidence ?? 'high') as Confidence, source: op.source ?? 'user' });
       break;
     }
     case 'ask_user': {

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -1,0 +1,158 @@
+// Canonical catalog for the E1 org_profile enum fields.
+//
+// Field trip that motivated this (Ana, 2026-07-07): the agent extracted a news
+// article and stored the skill spec's machine ids ("funded",
+// "gardens-and-greening") — which the doc panel rendered raw, in English. The
+// skill spec defines machine enums, the system prompt demands Portuguese
+// values, and the chip flow stores whatever label the user tapped, so storage
+// was a lottery. This catalog is the single source of truth that reconciles
+// the three: writes are canonicalized to the human chip label (the value every
+// consumer — panel, coordinator drawer, decision log, exports — actually
+// wants), and reads map any legacy id to the viewer-language label.
+//
+// Values that don't match any option (e.g. the richer chip "Projeto financiado
+// (R$ 50k+)", or free text) pass through untouched — never destroy user input.
+
+export type CboEnumOption = {
+  /** Machine id from the E1 skill spec (knowledge/_skills/encontro-1.md). */
+  id: string;
+  /** Portuguese chip label — the canonical stored form for pt sessions. */
+  pt: string;
+  en: string;
+  /** Extra spellings the agent has plausibly produced. Matched normalized. */
+  aliases?: string[];
+};
+
+/** The complete org_profile field set from the E1 skill spec. update_section
+ *  rejects anything else for this section — inventing field names (e.g.
+ *  "current_leadership") is how facts end up in chat but not on the document. */
+export const ORG_PROFILE_FIELDS = [
+  'org_name',
+  'contact_name',
+  'contact_role',
+  'mission_summary',
+  'legal_form',
+  'year_founded',
+  'team_size',
+  'paid_vs_volunteer',
+  'prior_project_scale',
+  'nbs_experience',
+  'bairro_of_operation',
+  'groups_served',
+  'proud_moment',
+] as const;
+
+export function isKnownOrgProfileField(field: string): boolean {
+  return (ORG_PROFILE_FIELDS as readonly string[]).includes(field);
+}
+
+export const ORG_PROFILE_ENUMS: Record<string, CboEnumOption[]> = {
+  legal_form: [
+    { id: 'ngo', pt: 'ONG / Associação', en: 'NGO / Association', aliases: ['associação', 'associacao', 'association', 'ong'] },
+    { id: 'cooperativa', pt: 'Cooperativa', en: 'Cooperative', aliases: ['cooperative', 'coop'] },
+    { id: 'informal', pt: 'Coletivo informal', en: 'Informal collective', aliases: ['coletivo', 'informal collective', 'grupo informal'] },
+    { id: 'social-enterprise', pt: 'Empresa social', en: 'Social enterprise' },
+    { id: 'implementer', pt: 'Empresa / estúdio / escritório técnico', en: 'Company / studio / technical office', aliases: ['empresa', 'company', 'studio', 'estúdio', 'escritório técnico'] },
+    { id: 'other', pt: 'Outra', en: 'Other', aliases: ['outro'] },
+  ],
+  year_founded: [
+    { id: 'starting', pt: 'Começando agora', en: 'Just starting', aliases: ['começando', 'starting now'] },
+    { id: 'lt-2', pt: 'Menos de 2 anos', en: 'Less than 2 years', aliases: ['<2 anos', 'less than 2'] },
+    { id: '2-5', pt: '2 a 5 anos', en: '2–5 years', aliases: ['2-5 anos', '2 to 5 years'] },
+    { id: '5-10', pt: '5 a 10 anos', en: '5–10 years', aliases: ['5-10 anos', '5 to 10 years'] },
+    { id: 'gt-10', pt: 'Mais de 10 anos', en: 'More than 10 years', aliases: ['10+ anos', '10+ years', 'more than 10 years'] },
+  ],
+  team_size: [
+    { id: '1-2', pt: '1–2', en: '1–2', aliases: ['1-2 pessoas', '1 a 2'] },
+    { id: '3-5', pt: '3–5', en: '3–5', aliases: ['3-5 pessoas', '3 a 5'] },
+    { id: '6-15', pt: '6–15', en: '6–15', aliases: ['6-15 pessoas', '6 a 15'] },
+    { id: '16+', pt: '16+', en: '16+', aliases: ['16+ pessoas', 'mais de 16'] },
+  ],
+  paid_vs_volunteer: [
+    { id: 'all-volunteer', pt: 'Todas voluntárias', en: 'All volunteers', aliases: ['todos voluntários', 'all volunteer'] },
+    { id: 'mostly-volunteer', pt: 'Maioria voluntárias (1–2 pagas)', en: 'Mostly volunteers (1–2 paid)', aliases: ['maioria voluntárias', 'mostly volunteers'] },
+    { id: 'half-half', pt: 'Metade e metade', en: 'Half and half', aliases: ['metade', '50/50', 'half half'] },
+    { id: 'mostly-paid', pt: 'Maioria pagas', en: 'Mostly paid', aliases: ['maioria remuneradas', 'mostly paid staff'] },
+  ],
+  prior_project_scale: [
+    { id: 'none', pt: 'Nenhum formal ainda', en: 'None formal yet', aliases: ['nenhum', 'none yet', 'no formal projects'] },
+    { id: 'ad-hoc', pt: 'Atividades pontuais', en: 'Ad-hoc activities', aliases: ['adhoc', 'pontuais', 'one-off activities'] },
+    { id: 'funded', pt: 'Projeto com financiamento', en: 'Funded project', aliases: ['projeto financiado', 'com financiamento'] },
+    { id: 'partnership', pt: 'Parceria com órgão público / fundação', en: 'Partnership with public agency / foundation', aliases: ['parceria', 'partnership with public agency'] },
+  ],
+  nbs_experience: [
+    { id: 'none', pt: 'Ainda não', en: 'Not yet', aliases: ['nenhuma', 'ainda nao'] },
+    { id: 'env-education', pt: 'Educação ambiental', en: 'Environmental education', aliases: ['env education', 'educação ambiental'] },
+    { id: 'gardens-and-greening', pt: 'Hortas / arborização', en: 'Gardens and greening', aliases: ['hortas', 'arborização', 'hortas e arborização', 'gardens', 'greening'] },
+    { id: 'implemented-nbs', pt: 'Já implementamos SbN', en: 'Already implemented NbS', aliases: ['já implementamos', 'implementamos', 'implemented nbs'] },
+  ],
+  groups_served: [
+    { id: 'mulheres', pt: 'Mulheres', en: 'Women', aliases: ['women'] },
+    { id: 'idosos', pt: 'Idosos', en: 'Elderly', aliases: ['elderly', 'seniors', 'pessoas idosas'] },
+    { id: 'pessoas-com-deficiencia', pt: 'Pessoas com deficiência', en: 'People with disabilities', aliases: ['people with disabilities', 'pcd', 'disabled people'] },
+    { id: 'comunidades-tradicionais', pt: 'Comunidades tradicionais', en: 'Traditional communities', aliases: ['traditional communities'] },
+    { id: 'jovens', pt: 'Jovens', en: 'Youth', aliases: ['youth', 'young people', 'juventude'] },
+    { id: 'pessoas-negras', pt: 'Pessoas negras', en: 'Black people', aliases: ['black people'] },
+    { id: 'povos-indigenas', pt: 'Povos indígenas', en: 'Indigenous peoples', aliases: ['indigenous', 'indigenous peoples'] },
+    { id: 'comunidade-do-bairro', pt: 'Comunidade do bairro', en: 'Neighborhood community', aliases: ['neighborhood community', 'comunidade em geral', 'comunidade do bairro em geral'] },
+  ],
+};
+
+// Accent/punctuation-insensitive full-string match ("Educação ambiental" ≡
+// "educacao ambiental" ≡ "env-education"). Digits and '+' survive so team-size
+// buckets ("3–5", "16+") normalize distinctly.
+function norm(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9+]+/g, ' ')
+    .trim();
+}
+
+function matchOption(field: string, raw: string): CboEnumOption | null {
+  const options = ORG_PROFILE_ENUMS[field];
+  if (!options) return null;
+  const n = norm(raw);
+  if (!n) return null;
+  for (const opt of options) {
+    if (norm(opt.id) === n || norm(opt.pt) === n || norm(opt.en) === n) return opt;
+    if (opt.aliases?.some(a => norm(a) === n)) return opt;
+  }
+  return null;
+}
+
+/** groups_served is a multi-select stored as one string — split on the
+ *  separators the agent/chips produce, map each item independently. */
+const MULTI_FIELDS = new Set(['groups_served']);
+const MULTI_SEPARATOR = /\s*[,;·|]\s*|\s+e\s+(?=[A-ZÀ-Ú])/;
+
+function mapValue(field: string, raw: string, pick: (opt: CboEnumOption) => string): string {
+  if (MULTI_FIELDS.has(field)) {
+    return raw
+      .split(MULTI_SEPARATOR)
+      .filter(part => part.trim().length > 0)
+      .map(part => {
+        const opt = matchOption(field, part);
+        return opt ? pick(opt) : part.trim();
+      })
+      .join(', ');
+  }
+  const opt = matchOption(field, raw);
+  return opt ? pick(opt) : raw;
+}
+
+/** Write path: turn whatever the agent produced (machine id, English label,
+ *  chip label) into the canonical human label for the session language.
+ *  Unrecognized values pass through unchanged. */
+export function canonicalizeOrgProfileValue(field: string, raw: string, lang: 'pt' | 'en' = 'pt'): string {
+  if (typeof raw !== 'string' || !ORG_PROFILE_ENUMS[field]) return raw;
+  return mapValue(field, raw, opt => (lang === 'pt' ? opt.pt : opt.en));
+}
+
+/** Read path: render any stored form (including legacy machine ids already in
+ *  the database) as the viewer-language label. */
+export function orgProfileDisplayValue(field: string, stored: string, lang: 'pt' | 'en'): string {
+  if (typeof stored !== 'string' || !ORG_PROFILE_ENUMS[field]) return stored;
+  return mapValue(field, stored, opt => (lang === 'pt' ? opt.pt : opt.en));
+}


### PR DESCRIPTION
## Field report (Ana, 2026-07-07)

Sharing a news article made the agent fill **Escala anterior: `funded`** and **Experiência SbN: `gardens-and-greening`** — raw machine ids, in English, on the CBO's document.

## Root cause

Three contradicting conventions and no mapping layer:
- the E1 skill spec defines **machine enums** (`funded`, `gardens-and-greening`)
- the system prompt demands **all values in Portuguese**
- the chip flow stores **whatever label the user tapped**

So storage was a lottery, and both display surfaces (`E1Cards`, coordinator `CboProfileSummary`) rendered `String(v.value)` raw.

## Fix — one catalog, three enforcement points

- **`shared/cbo-field-catalog.ts` (new)**: `{id, pt, en, aliases}` for the 7 enum fields + the 13-field org_profile whitelist. Canonical stored form = the human chip label in the session language. Unmatched values (e.g. the richer chip "Projeto financiado (R\$ 50k+)", free text) pass through untouched — never destroy user input.
- **Write path** (`update_section`): canonicalizes org_profile values (session language via a per-turn registry — the MCP server is cached per cboId, so tools can't take lang at creation) and **rejects unknown org_profile field names** with a corrective error. That closes the "current_leadership" class of bug where facts live in chat but never reach the document.
- **Read path** (`E1Cards` + `CboProfileSummary`): map any legacy id already in the DB to the viewer-language label — Ana's existing broken rows display correctly without a migration.
- **Fake model**: shares the same canonicalize call (whitelist intentionally off there — scripted specs simulate arbitrary model behavior).

## Tradeoff note

Canonical form is the **human label**, not the machine id: every consumer of these values (panel, coordinator drawer, decision log, exports) wants the label, and no code string-matches the ids (the maturity rubric is applied by the LLM). Ids-in-storage would force every surface to map.

## Tests

New `cougar-e1-enum-labels.spec.ts` (pt-BR locale): id→label mapping, per-item multi-select mapping ("women, jovens" → "Mulheres, Jovens"), free-text pass-through. Regression: golden-path, batched-questions, upload, inline-options, prompt-persist all green. tsc clean on touched files.

Companion PR (skill contract: no silent doc-inference of scoring fields, recap = written fields, re-ask name/role) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY