### PR TITLE
E1 skill: document-extraction contract — suggest scoring fields, recap only what was persisted, never drop name/role

### DIFF
--- a/docs/cbo-ux-audit-backlog.md
+++ b/docs/cbo-ux-audit-backlog.md
@@ -337,3 +337,19 @@ Symptoms: `prior_project_scale`/`nbs_experience` filled silently from the articl
 Root causes and fixes:
 1. **Enum storage lottery** (skill spec says machine ids, system prompt says PT, chips store labels; no display mapping) → `shared/cbo-field-catalog.ts`: canonical `{id, pt, en}` catalog; `update_section` canonicalizes writes + rejects unknown org_profile field names; `E1Cards`/`CboProfileSummary` map legacy ids on render. PR #334.
 2. **Doc over-inference + recap divergence** → E1 skill Step 1 contract: docs fill descriptive fields only; the two scoring enums become Batch-B suggestions ("Pelo artigo parece que… confere?"); contact_name/role only from the human; recap = exactly the persisted fields; "O que mudo?" chips = same list; re-ask name/role after a doc-first opening. PR #335.
+
+## Audit 2026-07-07 — same bug classes elsewhere (3-agent sweep after the field report)
+
+Fixed immediately: phase-3+ flat table rendered org_profile values raw, bypassing the E1Cards mapping (→ #334); E2 photo-upload turn said "silently update_section anything useful", contradicting its own confirm-don't-assert rule (→ #335).
+
+Open, by priority:
+1. **InterventionSelector confirm payload (P1, S)** — `cbo-profile.tsx` onConfirm sends `Selected NBS types: … (rain_gardens, …). Knowledge files: nbs/….md` with NO displayText → raw English machine string visible in the bubble immediately AND persisted. Same family as backlog v2 #5 (map raw payload on reload); fix both with a persisted displayText.
+2. **E2 deferred beats store English enum ids (P1 before those beats ship, P3 today)** — `current_use` (encontro-2.md:307), hazard ranking ids (322-326), `land_tenure` (342), consolidated write (392); closing references `{primary_hazard_label}` that nothing produces (398). Port the E1 "store the PT chip label" rule + extend cbo-field-catalog to intervention_site enums when enabling.
+3. **intervention_site machine fields render as document rows (P2, S)** — `site_lat/site_lng/site_geometry/site_deferred` show as table rows ("site geometry: POLYGON((…))"); most E2 field names have no `cbo.fields.*` locale key (bairro, current_use, primary/secondary_hazard, community_anchoring_lead, community_engagement_methods) → humanized English fallbacks. Hide machine fields from render + add labels.
+4. **bairro ↔ neighborhood split (P2, S)** — map-nudge isDone checks `bairro`/`site_name` but SAMPLE_CBO_DATA skip path writes `neighborhood` → dev skip leaves "Abrir o mapa" nudge stuck; locale vocabulary also uses `neighborhood`/`current_conditions`. Reconcile on the E2 skill names.
+5. **flag_gap.sectionId unvalidated (P2, S)** — bogus sectionId (or org_profile field outside FIELD_GROUPS) makes the gap silently invisible; agent believes it flagged. Validate like update_section.
+6. **Markdown export is all-English (P2, S/M)** — `exportCboMarkdown` headers + raw values; community-facing download button.
+7. **MapMicroapp hover tooltip shows raw intervention type (P3, S)** — `interventionType.replace(/_/g,' ')` → "urban forest" in EN.
+8. **open_map layer ids unvalidated (P3, S)** — unknown id = silently missing hazard layer.
+
+Verified clean: Placar metrics/flags fully localized; roster bands localized; phaseComplete does NOT key on field names (synonym field can't dead-end the banner); E2 recaps are field-bound; no one-shot-question drop in E2.

--- a/docs/cbo-ux-audit-backlog.md
+++ b/docs/cbo-ux-audit-backlog.md
@@ -329,3 +329,11 @@ _After the v1 wave (#312–#320, all merged), a second deep audit ran against th
 ### Deferred product decisions (Ana)
 - Site selection E2 → E3 with a "do you have a site idea?" gate (meeting decision, due 07-22).
 - NBS example photos in WS2; clustering mechanism (known platform gap).
+
+## Field report — Ana, 2026-07-07 (org profile via news-article link)
+
+Symptoms: `prior_project_scale`/`nbs_experience` filled silently from the article as raw machine ids ("funded", "gardens-and-greening") shown in English on the panel and wrong; the "Quero ajustar" list omitted those two fields but offered "Liderança atual", which isn't a schema field; name/role never re-asked when the first user message is a link.
+
+Root causes and fixes:
+1. **Enum storage lottery** (skill spec says machine ids, system prompt says PT, chips store labels; no display mapping) → `shared/cbo-field-catalog.ts`: canonical `{id, pt, en}` catalog; `update_section` canonicalizes writes + rejects unknown org_profile field names; `E1Cards`/`CboProfileSummary` map legacy ids on render. PR #334.
+2. **Doc over-inference + recap divergence** → E1 skill Step 1 contract: docs fill descriptive fields only; the two scoring enums become Batch-B suggestions ("Pelo artigo parece que… confere?"); contact_name/role only from the human; recap = exactly the persisted fields; "O que mudo?" chips = same list; re-ask name/role after a doc-first opening. PR #335.

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -97,6 +97,8 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 8. `paid_vs_volunteer` — rough split, e.g. "2 pagas · 8 voluntárias"
 9. `prior_project_scale` — enum: none, ad-hoc, funded, partnership
 10. `nbs_experience` — enum: none, env-education, gardens-and-greening, implemented-nbs
+
+For every enum field, **store the Portuguese chip label the user tapped** (e.g. "Projeto financiado (R$ 50k+)", "Hortas / arborização"), never the machine id — the ids above exist only so you can reason about the rubric. The server canonicalizes known values, but raw ids like `funded` leaking to the user's document is exactly the bug this rule prevents. Field names are a **closed list**: `update_section` rejects anything not in fields 1–13 above — if a fact fits none of them (e.g. who the current leader is), mention it in chat but do not store it.
 11. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
 12. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
 13. `proud_moment` — optional free-text
@@ -130,22 +132,28 @@ The question set does **not branch** within E1 — everyone answers the same thi
   - Invite pre-fill: *"Conferindo: vocês são a {orgName}, atuando no {bairro}, certo? Me corrige se eu errei."*
   - In the same opening, ask the one human thing as plain prose: *"E com quem eu tô falando — seu nome e seu papel por aí?"*
 
-### Step 1 — If a document was shared: pre-fill, then BULK-confirm (don't re-ask)
+### Step 1 — If a document was shared: pre-fill DESCRIPTIVE fields, then BULK-confirm (don't re-ask)
 
-When a document arrives (now or later), read it and **`update_section` every field you can extract** — org name, mission, legal form, age, team size, prior projects, NBS experience, who they serve — each with `source: 'document'`. Then confirm them **all at once**, concisely, in chat:
+When a document, link, or article arrives (now or later), read it and `update_section` the **descriptive** fields you can extract — `org_name`, `mission_summary`, `legal_form`, `year_founded`, `team_size`, `paid_vs_volunteer`, `bairro_of_operation`, `groups_served`, `proud_moment` — each with `source: 'document'`.
+
+**Four fields are NEVER filled from a document:**
+
+- `prior_project_scale` and `nbs_experience` — these drive the maturity scores; a journalist's phrasing is not evidence. Instead, when you reach Batch B, **lead with your read as a suggestion**: *"Pelo artigo, parece que vocês já tocaram projeto com financiamento — confere?"* with the normal chips. One extra tap beats a silent wrong score.
+- `contact_name` and `contact_role` — the person named in an article is often **not** the person chatting. These come only from the human, in chat.
+
+Then confirm what you wrote **all at once**, concisely. **The recap lists exactly the fields you called `update_section` on — one bullet per field, same wording the document panel shows — nothing more, nothing less.** Never recap a fact you didn't persist (e.g. who the current leader is): the user will try to "correct" a field that doesn't exist, and the chat and the document panel stop matching.
 
 > *"Li o documento e já preenchi bastante:*
-> *• Organização: {org}*
-> *• O que fazem: {mission}*
-> *• Equipe: ~{team}*
-> *• Tempo de atuação: {age}*
-> *• Experiência: {nbs}*
+> *• Organização: {org_name}*
+> *• O que fazem: {mission_summary}*
+> *• Equipe: {team_size}, {paid_vs_volunteer}*
+> *• Tempo de atuação: {year_founded}*
 > *Tá tudo certo?"*
 >
 > Chips: **[✅ Tá tudo certo]** **[✏️ Quero ajustar]**
 
-- **Tá tudo certo** → go straight to whatever the document did **not** cover (batched, below). Skip everything it filled.
-- **Quero ajustar** → *"O que mudo?"*, fix only that field, leave the rest.
+- **Tá tudo certo** → next, **if `contact_name` is still empty, ask it now in prose** (*"E com quem eu tô falando — seu nome e seu papel por aí?"*) — a user whose first message is a link never answered the Step-0 opening, and this question must not be dropped. Then go straight to whatever the document did **not** cover (batched, below). Skip everything it filled.
+- **Quero ajustar** → *"O que mudo?"* with **one chip per field from the same recap list** — fix only that field, leave the rest.
 
 A document never replaces the user's confirmation — extracted fields stay low-confidence (`source: 'document'`) until they validate.
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -219,7 +219,7 @@ ask_user({
 })
 ```
 
-- **"Tenho arquivos pra anexar"** → *"Show! Toca no 📎 e manda o que tiver. Quando terminar, me avisa."* Wait for the upload(s). Each arrives as an `I'm uploading: "…"` message — acknowledge briefly (≤3 words), silently `update_section` anything useful you can read from it, then re-offer `ask_user` `[ Anexar mais , Pronto, pode seguir ]`. On **Pronto** → closing.
+- **"Tenho arquivos pra anexar"** → *"Show! Toca no 📎 e manda o que tiver. Quando terminar, me avisa."* Wait for the upload(s). Each arrives as an `I'm uploading: "…"` message — acknowledge briefly (≤3 words). If a file clearly gives a **descriptive site fact** (a site name, the bairro, an address), `update_section` it with `source: 'document'` and fold a one-line confirmation into your next message (*"Pelo documento, o terreno é na {X} — confere?"*). **Never fill scoring-relevant fields (tenure, hazards, community anchoring, current use) from an uploaded file** — those come only from the user's own answers; at most, lead the later question with your read as a suggestion. This is the same confirm-don't-assert rule as "Mine the org's documents" above — an upload is not an exception to it. Then re-offer `ask_user` `[ Anexar mais , Pronto, pode seguir ]`. On **Pronto** → closing.
 - **"Não tenho agora"** → closing.
 
 Never block on this — it's optional. Don't push if they don't have files.


### PR DESCRIPTION
## The prompt-side half of Ana's 2026-07-07 report (code half: #334)

Four behaviors from the news-article test, all traced to the Step-1 doc-extraction instructions:

1. **"update_section every field you can extract" explicitly licensed** inferring `prior_project_scale`/`nbs_experience` from a journalist's prose — the two fields that drive the maturity scores, guessed silently and wrongly.
2. The bulk-confirm recap was free prose composed **from the article**, not from what was written — so it offered "Liderança atual" (not a schema field) as correctable and omitted the two fields that were actually written.
3. "O que mudo?" chips derived from that recap → chat and document panel diverge.
4. Name/role is asked once in the Step-0 opening; a link-first reply skips it forever.

## New contract in `knowledge/_skills/encontro-1.md`

- Docs/links fill **descriptive fields only**. The two scoring enums are **never doc-filled** — the agent leads Batch B with its read as a suggestion: *"Pelo artigo, parece que vocês já tocaram projeto com financiamento — confere?"* One extra tap, zero silent wrong scores.
- `contact_name`/`contact_role` come **only from the human in chat** — the person named in an article is often not the person typing. If still empty after the doc confirm, the question is re-asked in prose.
- **Recap = exactly the persisted fields**, worded as the panel shows them; the "Quero ajustar" chips are that same list. Never recap a fact that wasn't stored.
- Enum fields store the tapped Portuguese chip label, never the machine id; field names are a closed list (#334 makes the server enforce both).

Also logs the field report + fixes in `docs/cbo-ux-audit-backlog.md`.

Prompt-only change — no code paths touched; merge order vs #334 doesn't matter, but both should land before the demo week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY