### PR TITLE
Remove the dead Prioridade/Suplente picker from the CBO invite dialog

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -368,7 +368,7 @@ export function InviteCboDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Pure invite — no side effects. Called once per CBO in either mode. */
-  onSubmit: (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => Promise<{ memberSlug: string; orgName: string } | null>;
+  onSubmit: (params: { orgName: string; neighborhood?: string }) => Promise<{ memberSlug: string; orgName: string } | null>;
   /** Called after a successful single-mode invite — parent typically opens
       the ShareLinkDialog for that CBO. NOT called in bulk mode. */
   onSingleSuccess?: (result: { memberSlug: string; orgName: string }) => void;
@@ -380,7 +380,6 @@ export function InviteCboDialog({
   const [mode, setMode] = useState<'single' | 'bulk'>('single');
   const [orgName, setOrgName] = useState('');
   const [neighborhood, setNeighborhood] = useState('');
-  const [role, setRole] = useState<'priority' | 'alternate'>('priority');
   const [bulkText, setBulkText] = useState('');
   const [bulkProgress, setBulkProgress] = useState<{ done: number; total: number } | null>(null);
   const [busy, setBusy] = useState(false);
@@ -391,7 +390,6 @@ export function InviteCboDialog({
       setMode('single');
       setOrgName('');
       setNeighborhood('');
-      setRole('priority');
       setBulkText('');
       setBulkProgress(null);
     }
@@ -409,7 +407,6 @@ export function InviteCboDialog({
         const result = await onSubmit({
           orgName: orgName.trim(),
           neighborhood: neighborhood.trim() || undefined,
-          role,
         });
         if (result) {
           onOpenChange(false);
@@ -428,7 +425,7 @@ export function InviteCboDialog({
     try {
       for (let i = 0; i < parsed.length; i++) {
         const p = parsed[i];
-        const r = await onSubmit({ orgName: p.orgName, neighborhood: p.neighborhood, role });
+        const r = await onSubmit({ orgName: p.orgName, neighborhood: p.neighborhood });
         if (r) results.push({ memberSlug: r.memberSlug, orgName: r.orgName, neighborhood: p.neighborhood });
         setBulkProgress({ done: i + 1, total: parsed.length });
       }
@@ -554,57 +551,6 @@ export function InviteCboDialog({
             </div>
           )}
 
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-foreground/80">
-              {mode === 'bulk'
-                ? t('orchestrator.cohort.roleAll', { defaultValue: 'Role (applies to all)' })
-                : t('orchestrator.cohort.role', { defaultValue: 'Role in cohort' })}
-            </label>
-            {/* Radio cards — both descriptions always visible so the coordinator
-                sees the operational consequence of each role at selection time.
-                Mirrors RequestSupportDialog's option-card pattern. */}
-            <div className="space-y-1.5">
-              {(['priority', 'alternate'] as const).map((r) => {
-                const isActive = role === r;
-                const label = r === 'priority'
-                  ? t('orchestrator.cohort.rolePriority', { defaultValue: 'Priority' })
-                  : t('orchestrator.cohort.roleAlternate', { defaultValue: 'Alternate' });
-                const hint = r === 'priority'
-                  ? t('orchestrator.cohort.rolePriorityHint', { defaultValue: 'Running the pilot. One of the 10 active seats.' })
-                  : t('orchestrator.cohort.roleAlternateHint', { defaultValue: 'Waitlist. Promotes to cohort if a priority CBO drops out.' });
-                return (
-                  <button
-                    key={r}
-                    type="button"
-                    onClick={() => setRole(r)}
-                    className={`w-full text-left p-3 rounded-lg border transition-colors flex items-start gap-3 ${
-                      isActive
-                        ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/30 ring-1 ring-emerald-500'
-                        : 'border-foreground/10 hover:border-foreground/20 hover:bg-muted/50'
-                    }`}
-                    data-testid={`button-role-${r}`}
-                  >
-                    <span
-                      className={`shrink-0 mt-0.5 w-3.5 h-3.5 rounded-full border flex items-center justify-center ${
-                        isActive ? 'border-emerald-600' : 'border-foreground/30'
-                      }`}
-                      aria-hidden="true"
-                    >
-                      {isActive && <span className="w-2 h-2 rounded-full bg-emerald-600" />}
-                    </span>
-                    <span className="flex-1 min-w-0">
-                      <span className={`block text-sm font-medium leading-tight ${isActive ? 'text-foreground' : 'text-foreground/85'}`}>
-                        {label}
-                      </span>
-                      <span className="block text-xs text-muted-foreground mt-0.5 leading-snug">
-                        {hint}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
         </div>
 
         <DialogFooter>

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -47,7 +47,7 @@ export interface UseCohortResult {
   /** Admin: create a coordinator + their cohort in one shot, then load it. */
   provisionCohort: (input: ProvisionInput) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
   resetCohort: () => Promise<void>;
-  invite: (params: { orgName: string; neighborhood?: string; role?: 'priority' | 'alternate' }) => Promise<CohortMember | null>;
+  invite: (params: { orgName: string; neighborhood?: string }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
   saveLanguage: (language: 'pt' | 'en' | null) => Promise<void>;
@@ -139,11 +139,11 @@ export function useCohort(): UseCohortResult {
     }
   }, []);
 
-  const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, role }) => {
+  const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood }) => {
     const r = await fetch(`/api/cohort/${slugRef.current}/invite`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orgName, neighborhood, role }),
+      body: JSON.stringify({ orgName, neighborhood }),
     });
     if (!r.ok) return null;
     const { member } = await r.json();

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -979,7 +979,7 @@ export default function OrchestratorLandingPage() {
   // Pure: just makes the invite. The post-success share dialog is wired
   // separately via onSingleSuccess so the bulk-invite loop doesn't trigger
   // N share dialogs (it uses onBulkComplete instead).
-  const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string; role: 'priority' | 'alternate' }) => {
+  const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string }) => {
     const created = await invite(params);
     if (!created) {
       toast({ title: t('orchestrator.cohort.inviteFailed', { defaultValue: 'Could not create invitation' }) });

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -78,12 +78,6 @@
     "status": "Estamos desenhando isso junto com parceiros. Quer acesso antecipado? Entre em contato com a equipe.",
     "switchRole": "Voltar para seleção de perfil",
     "cohort": {
-      "role": "Papel no grupo",
-      "roleAll": "Papel (aplica-se a todas)",
-      "rolePriority": "Prioridade",
-      "roleAlternate": "Suplente",
-      "rolePriorityHint": "Rodando o piloto. Uma das 10 vagas ativas.",
-      "roleAlternateHint": "Lista de espera. Promovida se uma OBC prioritária desistir.",
       "addDate": "Adicionar data",
       "allUnlocked": "Todas as fases já liberadas",
       "bulkList": "Lista de CBOs",


### PR DESCRIPTION
## Ana's request (2026-07-07)

> delete the "role in the group" option? … checking because it might have impacts in something else that may be tricky to change after we have real users in

## Verified: zero implications — the field is write-only

Traced every reader of `cohortMembers.role`:
- set at invite (`cohortRoutes.ts` — defaults `'priority'`) and by a test route
- read by **nothing**: no roster badge, no enforcement of the "10 active seats", no waitlist promotion when someone drops out, no phase gating, no export

The picker's copy ("Uma das 10 vagas ativas" / "Promovida se uma OBC prioritária desistir") described behavior that was never built.

## Change — UI-only, deliberately shallow

- Invite dialog (both "Uma por vez" and "Colar uma lista") loses the picker; client stops sending `role`
- Server unchanged: still accepts the field and defaults every new member to `'priority'`; **DB column stays**
- 6 unused pt.json keys removed

Why not drop the column: that needs a drizzle migration on the prod DB and buys nothing — exactly the "tricky after real users" risk Ana flagged. If a real waitlist is ever wanted, the data model is already there.

## Tests

Invite-flow specs green: cougar-invite-session, cougar-invite-emoji, cougar-invite-message-lang, cohort-isolation, cbo-invite-error (7 passed). tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY