### PR TITLE
Desktop: fix silent right-rail clipping (min-width:auto on the app-shell slot)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -86,7 +86,7 @@ function AppLayout() {
   
   return (
     <div className="flex min-h-screen">
-      <div className={`flex-1 transition-all duration-300 ${isChatOpen ? 'mr-[400px]' : ''}`}>
+      <div className={`flex-1 min-w-0 transition-all duration-300 ${isChatOpen ? 'mr-[400px]' : ''}`}>
         <Router />
       </div>
       <ChatDrawer />

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1886,7 +1886,7 @@ export default function CboProfilePage() {
             On mobile: visible only when mobileActiveTab === 'panel' (the user
             tapped a non-Chat tab, or the agent invoked a microapp). */}
         <div
-          className={`w-full md:w-1/2 md:flex flex-col bg-muted/30 ${
+          className={`w-full md:w-1/2 min-w-0 md:flex flex-col bg-muted/30 ${
             mobileActiveTab === 'panel' ? 'flex' : 'hidden'
           }`}
         >

--- a/e2e/cougar-desktop-no-clip.spec.ts
+++ b/e2e/cougar-desktop-no-clip.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Desktop clipping regression (JVP, 2026-07-07): the app-shell page slot
+// (App.tsx) had CSS's default min-width:auto, so a page whose intrinsic
+// content width exceeded the window (CBO chat strip + map rail ≈ 1650px)
+// inflated the shell past the viewport; the two w-1/2 columns split the
+// inflated width and an outer overflow-hidden clipped the right rail with no
+// scrollbar — the map tour card and controls simply lost their right edge.
+// Fixed with min-w-0 on the shell slot and the right rail.
+
+const DESKTOP_WIDTHS = [1512, 1280];
+
+for (const width of DESKTOP_WIDTHS) {
+  test.describe(`COUGAR — no horizontal clipping at ${width}px`, () => {
+    test.use({ viewport: { width, height: 950 }, locale: 'pt-BR' });
+
+    test(`examples strip + map rail fit the viewport at ${width}px`, async ({ page, request }) => {
+      const api = new TestApi(request);
+      test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+      await page.goto('/cbo-profile');
+      const marker = page.getByTestId('cbo-stream-status');
+      await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+      const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+      // The worst-case intrinsic-width turn from the field screenshot: a
+      // showcase strip in chat AND the hazard-tour map in the right rail.
+      await api.scriptCbo(cboId, [[
+        { op: 'show_examples', cardIds: ['barigui-park', 'goncalo-tunnel'], mode: 'browse', intro: 'Exemplos reais' } as any,
+        { op: 'say', text: 'Esses são exemplos reais — em Porto Alegre e no Brasil.' },
+        {
+          op: 'open_map',
+          params: {
+            selectionMode: 'composite',
+            zoneSource: 'neighborhood_zones',
+            layers: ['osm_parks', 'osm_schools'],
+            tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+            showLegendSimple: true,
+            hazardTour: true,
+            allowDeferSite: true,
+            prompt: 'Conheça os riscos e marque onde vocês atuam.',
+          },
+        } as any,
+      ]]);
+      await page.getByTestId('cbo-chat-input').fill('Abrir o mapa');
+      await page.getByTestId('cbo-chat-input').press('Enter');
+      await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId('map-tour-next')).toBeVisible({ timeout: 15_000 });
+
+      const m = await page.evaluate(() => {
+        const vw = document.documentElement.clientWidth;
+        const cols = Array.from(document.querySelectorAll('div'))
+          .filter(d => d.className && String(d.className).includes('md:w-1/2'))
+          .slice(0, 2)
+          .map(d => d.getBoundingClientRect());
+        return {
+          vw,
+          docScrollW: document.documentElement.scrollWidth,
+          colRights: cols.map(r => Math.round(r.right)),
+          colWidths: cols.map(r => Math.round(r.width)),
+        };
+      });
+
+      // No page-level horizontal overflow…
+      expect(m.docScrollW).toBeLessThanOrEqual(m.vw + 1);
+      // …and both columns end inside the viewport (the rail used to end ~140px past it).
+      for (const right of m.colRights) expect(right).toBeLessThanOrEqual(m.vw + 1);
+      // True 50/50 split, not an inflated row split.
+      for (const w of m.colWidths) expect(w).toBeLessThanOrEqual(Math.ceil(m.vw / 2) + 1);
+
+      // The tour card's scale labels — the exact pixels cut off in the field
+      // screenshot — are fully visible.
+      const label = page.getByText('mais risco');
+      await expect(label).toBeVisible();
+      const box = (await label.boundingBox())!;
+      expect(box.x + box.width).toBeLessThanOrEqual(m.vw + 1);
+    });
+  });
+}


### PR DESCRIPTION
## The screenshot

On desktop the CBO page's right rail ran past the window: the hazard-tour card lost its right edge ("mais risco", the 1/3 counter), the map lost its zoom controls — and no scrollbar appeared, so it just looked like the app "doesn't fit".

## Root cause (measured with a DOM probe, then verified by fix)

`AppLayout` wraps every page in `flex min-h-screen` next to the ChatDrawer. The page slot had CSS's default **`min-width: auto`** — a flex child with that never shrinks below its content's intrinsic width. The CBO page's two columns have ~830px intrinsic content each (showcase cards, map chrome), so the slot inflated to ~1650px; both `w-1/2` columns split the *inflated* row (827/827 in a 1512px window), and an outer `overflow-hidden` clipped the last ~140px silently. Hiding either column made it fit — only the sum broke, which is why the phone layout (single column) never showed it.

## Fix

Two `min-w-0`s: the app-shell page slot (`App.tsx` — protects every route from the same class of clipping) and the CBO right rail (the chat column already had it from the mobile overflow pass). Columns now measure a true 756/756 at 1512px; tour card, scale labels, and zoom controls all inside the viewport.

## Tests

New `cougar-desktop-no-clip.spec.ts` — reproduces the worst-case turn (examples strip + hazard-tour map) at **1512 and 1280px** and asserts: no document-level horizontal overflow, both columns end inside the viewport, true 50/50 split, and the exact label that was cut in the screenshot is fully visible. Mobile guards re-run green: cbo-mobile-no-hscroll, cbo-mobile-layout, cougar-e2-map-step, cougar-site-step-panning.

Follow-ups agreed with JVP (separate PRs): examples strip becomes a grid at md+, chat readability tuning at lg+, then a documented desktop walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY