### PR TITLE
Desktop: showcase/type strips wrap into rows instead of horizontal scroll

### DIFF
--- a/client/src/core/components/cbo/NbsShowcaseCard.tsx
+++ b/client/src/core/components/cbo/NbsShowcaseCard.tsx
@@ -74,7 +74,7 @@ export function NbsShowcaseCardItem({
 
   return (
     <div
-      className={`shrink-0 w-[240px] rounded-xl border bg-card overflow-hidden transition-all ${
+      className={`shrink-0 w-[240px] md:w-full rounded-xl border bg-card overflow-hidden transition-all ${
         isSaved ? 'border-emerald-500 ring-2 ring-emerald-500/20' : 'border-foreground/10 hover:border-foreground/25'
       }`}
       data-testid={`showcase-card-${card.id}`}
@@ -160,7 +160,7 @@ export function NbsShowcaseCardStrip({
       )}
       <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x md:flex-wrap md:overflow-x-visible md:snap-none">
         {cards.map(card => (
-          <div key={card.id} className="snap-start">
+          <div key={card.id} className="snap-start md:flex-1 md:min-w-[220px] md:max-w-[320px]">
             <NbsShowcaseCardItem
               card={card}
               lang={lang}

--- a/client/src/core/components/cbo/NbsShowcaseCard.tsx
+++ b/client/src/core/components/cbo/NbsShowcaseCard.tsx
@@ -158,7 +158,7 @@ export function NbsShowcaseCardStrip({
       {intro && (
         <p className="text-xs text-muted-foreground px-1 leading-relaxed">{intro}</p>
       )}
-      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x md:flex-wrap md:overflow-x-visible md:snap-none">
         {cards.map(card => (
           <div key={card.id} className="snap-start">
             <NbsShowcaseCardItem

--- a/client/src/core/components/cbo/NbsTypeStrip.tsx
+++ b/client/src/core/components/cbo/NbsTypeStrip.tsx
@@ -46,7 +46,7 @@ function NbsTypeCardItem({ type, lang }: { type: NbsType; lang: 'pt' | 'en' }) {
 
   return (
     <div
-      className="shrink-0 w-[240px] rounded-xl border border-foreground/10 bg-card overflow-hidden transition-all hover:border-foreground/25"
+      className="shrink-0 w-[240px] md:w-full rounded-xl border border-foreground/10 bg-card overflow-hidden transition-all hover:border-foreground/25"
       data-testid={`type-card-${type.id}`}
     >
       <div
@@ -120,7 +120,7 @@ export function NbsTypeStrip({ typeIds, intro }: { typeIds: string[]; intro?: st
       )}
       <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x md:flex-wrap md:overflow-x-visible md:snap-none">
         {types.map(type => (
-          <div key={type.id} className="snap-start">
+          <div key={type.id} className="snap-start md:flex-1 md:min-w-[220px] md:max-w-[320px]">
             <NbsTypeCardItem type={type} lang={lang} />
           </div>
         ))}

--- a/client/src/core/components/cbo/NbsTypeStrip.tsx
+++ b/client/src/core/components/cbo/NbsTypeStrip.tsx
@@ -118,7 +118,7 @@ export function NbsTypeStrip({ typeIds, intro }: { typeIds: string[]; intro?: st
       {intro && (
         <p className="text-xs text-muted-foreground px-1 leading-relaxed">{intro}</p>
       )}
-      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
+      <div className="flex gap-2.5 overflow-x-auto pb-2 -mx-1 px-1 snap-x md:flex-wrap md:overflow-x-visible md:snap-none">
         {types.map(type => (
           <div key={type.id} className="snap-start">
             <NbsTypeCardItem type={type} lang={lang} />

--- a/e2e/cougar-desktop-strip-grid.spec.ts
+++ b/e2e/cougar-desktop-strip-grid.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Desktop examples/types strip: on phones the strip is a horizontal swipe row
+// (snap-x); on desktop that pattern left cards half-cut behind a scrollbar.
+// At md+ the strip wraps into rows instead — every card fully visible, no
+// horizontal scroll inside the chat column.
+
+test.describe('COUGAR — showcase strip wraps into a grid on desktop', () => {
+  test.use({ viewport: { width: 1512, height: 950 }, locale: 'pt-BR' });
+
+  test('all cards visible, strip does not scroll horizontally at 1512px', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'show_examples', cardIds: ['curitiba-barigui', 'poa-goncalo-de-carvalho', 'bh-drenurbs', 'poa-varzea-lab'], mode: 'browse', intro: 'Exemplos reais' } as any,
+      { op: 'say', text: 'Esses são exemplos reais.' },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('Quero ver exemplos');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    const cards = page.locator('[data-testid^="showcase-card-"]');
+    await expect(cards.first()).toBeVisible();
+    const n = await cards.count();
+    expect(n).toBeGreaterThanOrEqual(3);
+
+    // Every card sits fully inside the chat column — none clipped at an edge.
+    const vw = await page.evaluate(() => document.documentElement.clientWidth);
+    for (let i = 0; i < n; i++) {
+      const box = (await cards.nth(i).boundingBox())!;
+      expect(box.x).toBeGreaterThanOrEqual(-1);
+      expect(box.x + box.width).toBeLessThanOrEqual(vw / 2 + 2);
+    }
+
+    // The strip container itself has nothing to scroll (it wrapped instead).
+    const strip = cards.first().locator('xpath=ancestor::div[contains(@class,"md:flex-wrap")]');
+    const scroll = await strip.evaluate(el => ({ sw: el.scrollWidth, cw: el.clientWidth }));
+    expect(scroll.sw).toBeLessThanOrEqual(scroll.cw + 1);
+  });
+});


### PR DESCRIPTION
Part 2 of the desktop pass (after #337). The NBS examples and types strips are phone patterns — horizontal swipe with snap. On desktop they left cards half-cut behind a scrollbar. At `md+` both strips now `flex-wrap` into rows: every card fully visible, nothing to scroll sideways. Phone behavior is untouched (same classes below `md`).

Spec: `cougar-desktop-strip-grid.spec.ts` — 4 cards at 1512px, asserts every card box sits inside the chat column and the strip has zero horizontal scroll. Mobile guards green: cbo-mobile-no-hscroll, cbo-mobile-layout, cougar-inline-options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY