### PR TITLE
Desktop polish: question-card measure (D1) + post-stream banner reveal (D3)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -755,7 +755,7 @@ export default function CboProfilePage() {
     init();
   }, []);
 
-  useEffect(() => { chatEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+  useEffect(() => { chatEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages, isStreaming]);
 
   // Keyboard nav
   useEffect(() => {
@@ -2247,7 +2247,7 @@ function CboQuestionCard({
   };
 
   return (
-    <div data-testid="cbo-question-card" className={`rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
+    <div data-testid="cbo-question-card" className={`md:max-w-[560px] rounded-lg border bg-background p-3 space-y-2 transition-all ${answeredValue ? 'border-green-200 bg-green-50/30' : ''}`}>
       <div className="flex items-start justify-between gap-2">
         <div className="text-sm font-medium prose prose-sm max-w-none flex-1">
           {questionNumber && <span className="text-muted-foreground mr-1">{questionNumber}.</span>}


### PR DESCRIPTION
Findings D1 and D3 from the desktop walkthrough (report shared in session):

- **D1** — question cards spanned the full 740px chat column (a 700px "Sim" button). Capped at `md:max-w-[560px]`, matching the bubble measure from #339. Phone unchanged.
- **D3** — the "Começar Encontro" banner renders when streaming ends, with no `messages` change, so the `[messages]`-keyed autoscroll never revealed it — it sat half-clipped below the fold. `isStreaming` added to the autoscroll deps: one extra scroll at end-of-turn reveals anything that renders post-stream (banner, resume gate, retry chip).

**D2** (ragged grid rows) lands as a commit on #338, where the grid wrap lives — keeping it here would have conflicted.

Guards green: cbo-golden-path, cbo-batched-questions, cbo-prompt-persist, cougar-inline-options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY