### PR TITLE
E2 map: one color encoding per step (tour raster · zone choropleth · site boundary-only)

### DIFF
--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -88,12 +88,18 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const tileLayerRefs = useRef<Record<string, L.TileLayer>>({});
   const osmLayerRefs = useRef<Record<string, L.GeoJSON>>({});
   const zonesLayerRef = useRef<L.GeoJSON | null>(null);
+  const zoneDefaultStyleRef = useRef<((p: any) => any) | null>(null);
+  // Site-step boundary of the chosen bairro(s) — the interactive zones layer
+  // is removed on advanceToAssets, so this inert outline is what orients the
+  // user while they drop points on satellite imagery.
+  const focusOutlineRef = useRef<L.GeoJSON | null>(null);
   const politicalBaseRef = useRef<L.TileLayer | null>(null);
   const satelliteBaseRef = useRef<L.TileLayer | null>(null);
   const customMarkersRef = useRef<L.Layer[]>([]);
   const selectedHighlightsRef = useRef<Map<string, L.Layer>>(new Map());
 
   const [mapReady, setMapReady] = useState(false);
+  const [zonesLoaded, setZonesLoaded] = useState(false);
   const [selectedAssets, setSelectedAssets] = useState<SelectedAsset[]>([]);
   // Live mirror of selectedAssets for once-bound Leaflet handlers (avoids the
   // stale-closure that wiped a zone's highlight on mouseout — see MAP-SEL-STALE).
@@ -182,6 +188,76 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
   const enabledTileLayerDefs = Array.from(enabledTiles)
     .map(id => ALL_TILE_LAYERS.find(l => l.id === id))
     .filter(Boolean) as typeof TILE_LAYERS;
+
+  // ── One color encoding per step (CBO E2) ────────────────────────────────────
+  // The zones choropleth used to render fully colored from map-ready onward, so
+  // the hazard tour stacked TWO encodings (raster + typology fills) and the site
+  // step kept 90+ colored polygons under the point-drop tools. Contract:
+  //   tour  → hazard raster only; bairros as thin inert outlines (orientation)
+  //   zone  → choropleth only (rasters are already off post-tour), interactive
+  //   site  → selected bairro as a bold blue OUTLINE (no fill — satellite must
+  //           show through to find the spot); every other bairro hidden & inert.
+  // Scoped to the CBO flow (allowDeferSite) — city/orchestrator flows keep the
+  // always-on choropleth. pointerEvents doubles as the interactivity gate: inert
+  // zones also stop stealing taps from point-dropping on the site step.
+  const zoneDisplayMode: 'outline' | 'focus' | 'choropleth' =
+    params.allowDeferSite && tourActive ? 'outline'
+    : params.allowDeferSite && isComposite && compositeStep === 'assets' ? 'focus'
+    : 'choropleth';
+  const zoneDisplayModeRef = useRef(zoneDisplayMode);
+  zoneDisplayModeRef.current = zoneDisplayMode;
+  useEffect(() => {
+    const zl = zonesLayerRef.current;
+    const styleOf = zoneDefaultStyleRef.current;
+    if (!zl || !styleOf) return;
+    zl.eachLayer((layer: any) => {
+      const props = layer.feature?.properties || {};
+      const name = props.neighbourhoodName || props.neighbourhood_name || props.zoneId;
+      const isSelected = selectedAssetsRef.current.some(a => a.type === 'zone' && a.name === name);
+      const el = layer.getElement?.();
+      if (zoneDisplayMode === 'outline') {
+        layer.setStyle({ color: '#64748b', weight: 0.7, opacity: 0.7, fillOpacity: 0, dashArray: undefined });
+        layer.closeTooltip?.();
+        if (el) el.style.pointerEvents = 'none';
+      } else if (zoneDisplayMode === 'focus') {
+        if (isSelected) layer.setStyle({ color: '#1d4ed8', weight: 3, opacity: 1, fillOpacity: 0 });
+        else layer.setStyle({ opacity: 0, fillOpacity: 0 });
+        layer.closeTooltip?.();
+        if (el) el.style.pointerEvents = 'none';
+      } else {
+        layer.setStyle(isSelected ? SELECTED_ZONE_STYLE : { ...styleOf(props), opacity: 1 });
+        if (el) el.style.pointerEvents = '';
+      }
+    });
+    // The zones may finish loading after this effect ran (async fetch) — the
+    // load path applies the choropleth default, so re-run once they land.
+  }, [zoneDisplayMode, mapReady, zonesLoaded]);
+
+  // Focus mode's boundary overlay. advanceToAssets removes the interactive
+  // zones layer wholesale (the site step used to show NO boundary at all);
+  // the chosen bairro's outline is re-drawn as a separate inert layer so the
+  // user sees where their bairro ends without any fill over the satellite.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (focusOutlineRef.current) {
+      map.removeLayer(focusOutlineRef.current);
+      focusOutlineRef.current = null;
+    }
+    if (zoneDisplayMode !== 'focus') return;
+    const zoneAssets = selectedAssetsRef.current.filter(a => a.type === 'zone' && a.geometry);
+    if (zoneAssets.length === 0) return;
+    const fc = {
+      type: 'FeatureCollection',
+      features: zoneAssets.map(a => ({ type: 'Feature', geometry: a.geometry, properties: {} })),
+    };
+    const outline = L.geoJSON(fc as any, {
+      style: { color: '#1d4ed8', weight: 3, opacity: 1, fillOpacity: 0 },
+      interactive: false,
+    });
+    outline.addTo(map);
+    focusOutlineRef.current = outline;
+  }, [zoneDisplayMode, mapReady]);
 
   // ── Init map ────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -300,6 +376,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
           return { color: '#1e293b', weight: 1.5, fillColor: interventionColor, fillOpacity, dashArray: undefined as string | undefined };
         };
 
+        zoneDefaultStyleRef.current = getDefaultStyle;
         const zonesLayer = L.geoJSON(geojson, {
           style: (feature) => getDefaultStyle(feature?.properties),
           onEachFeature: (feature, featureLayer) => {
@@ -351,6 +428,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
             const featureDefaultStyle = getDefaultStyle(p);
 
             (featureLayer as any).on('click', (e: any) => {
+              if (zoneDisplayModeRef.current !== 'choropleth') return;
               if (drawModeRef.current !== 'off') return;
               L.DomEvent.stopPropagation(e);
               const centroid = geometryCentroid(feature.geometry);
@@ -377,8 +455,12 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
               });
             });
 
-            (featureLayer as any).on('mouseover', () => (featureLayer as any).setStyle({ weight: 3, fillOpacity: Math.max(featureDefaultStyle.fillOpacity + 0.1, 0.15) }));
+            (featureLayer as any).on('mouseover', () => {
+              if (zoneDisplayModeRef.current !== 'choropleth') return;
+              (featureLayer as any).setStyle({ weight: 3, fillOpacity: Math.max(featureDefaultStyle.fillOpacity + 0.1, 0.15) });
+            });
             (featureLayer as any).on('mouseout', () => {
+              if (zoneDisplayModeRef.current !== 'choropleth') return;
               // Read the live ref, not the stale closure — otherwise a just-selected
               // zone loses its highlight the instant the pointer leaves (worst on
               // touch, where tap fires mouseover→click→mouseout in a burst).
@@ -390,6 +472,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
         });
         zonesLayer.addTo(map);
         zonesLayerRef.current = zonesLayer;
+        setZonesLoaded(true);
       } catch {}
       setLoading(false);
     })();

--- a/client/src/core/components/concept-note/MapMicroapp.tsx
+++ b/client/src/core/components/concept-note/MapMicroapp.tsx
@@ -216,7 +216,7 @@ export default function MapMicroapp({ params, onConfirm, onCancel }: Props) {
       const isSelected = selectedAssetsRef.current.some(a => a.type === 'zone' && a.name === name);
       const el = layer.getElement?.();
       if (zoneDisplayMode === 'outline') {
-        layer.setStyle({ color: '#64748b', weight: 0.7, opacity: 0.7, fillOpacity: 0, dashArray: undefined });
+        layer.setStyle({ color: '#1e293b', weight: 1.2, opacity: 0.85, fillOpacity: 0, dashArray: undefined });
         layer.closeTooltip?.();
         if (el) el.style.pointerEvents = 'none';
       } else if (zoneDisplayMode === 'focus') {

--- a/e2e/cougar-e2-one-encoding-per-step.spec.ts
+++ b/e2e/cougar-e2-one-encoding-per-step.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// E2 map: one color encoding per step (JVP, 2026-07-07). During the hazard
+// tour the zones choropleth used to render fully colored UNDER the hazard
+// raster — two encodings at once. Contract now:
+//   tour  → raster only, bairros as thin inert outlines (fill 0, no taps)
+//   zone  → choropleth only (rasters already off), interactive
+//   site  → selected bairro as a bold outline with NO fill; other bairros
+//           hidden and inert (taps go to point-dropping, not zone-select)
+
+const OPEN_MAP = {
+  op: 'open_map' as const,
+  params: {
+    selectionMode: 'composite', zoneSource: 'neighborhood_zones',
+    layers: ['osm_parks'],
+    tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+    showLegendSimple: true, hazardTour: true, allowDeferSite: true,
+    prompt: 'Conheça os riscos e marque onde vocês atuam.',
+  },
+};
+
+// All zone paths live in the overlay pane as SVG paths. Read their effective
+// fill-opacity (attribute set by Leaflet setStyle).
+async function zoneFillOpacities(page: import('@playwright/test').Page): Promise<number[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('.leaflet-overlay-pane path'))
+      .map(p => parseFloat(p.getAttribute('fill-opacity') ?? '0')),
+  );
+}
+
+test.describe('COUGAR — E2 map shows one encoding per step', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('tour: outlines only; zone step: choropleth; site step: selected outline, rest hidden', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[{ op: 'say', text: 'Vamos pro mapa.' }, OPEN_MAP as any]]);
+    await page.getByTestId('cbo-chat-input').fill('Abrir o mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    const tourNext = page.getByTestId('map-tour-next');
+    await expect(tourNext).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the zones GeoJSON (94 bairros → >50 paths).
+    await expect
+      .poll(async () => (await zoneFillOpacities(page)).length, { timeout: 20_000 })
+      .toBeGreaterThan(50);
+
+    // TOUR: every zone is outline-only — no fill competes with the raster.
+    const tourFills = await zoneFillOpacities(page);
+    expect(Math.max(...tourFills)).toBeLessThanOrEqual(0.1);
+
+    // A tap on a bairro mid-tour selects nothing (zones are inert).
+    const tourBox = (await page.locator('.leaflet-container').first().boundingBox())!;
+    await page.mouse.click(tourBox.x + tourBox.width / 2, tourBox.y + tourBox.height / 2);
+    await expect(page.getByRole('button', { name: /próximo: selecionar/i })).toHaveCount(0);
+
+    // Finish the tour → ZONE step: the choropleth is back and colored.
+    await tourNext.click();
+    await tourNext.click();
+    await tourNext.click();
+    await expect(tourNext).toHaveCount(0, { timeout: 10_000 });
+    await expect
+      .poll(async () => Math.max(...(await zoneFillOpacities(page))), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(0.3);
+
+    // Select a bairro and advance to the SITE step. Re-measure the map: the
+    // stepper + risk-chip rows appear when the tour ends and shift it down;
+    // give the layout/animation a beat to settle before clicking.
+    await page.waitForTimeout(1000);
+    const mapBox = (await page.locator('.leaflet-container').first().boundingBox())!;
+    await page.mouse.click(mapBox.x + mapBox.width / 2, mapBox.y + mapBox.height / 2);
+    const nextBtn = page.getByRole('button', { name: /próximo: selecionar/i }).first();
+    await expect(nextBtn).toBeVisible({ timeout: 10_000 });
+    await nextBtn.click();
+    await expect(page.getByTestId('map-draw-point')).toBeVisible({ timeout: 15_000 });
+
+    // SITE step: no zone fill at all (selected = outline only; satellite must
+    // show through). OSM park polygons may carry fill — exclude them by
+    // checking strokes: exactly the zone paths with visible stroke should be
+    // few (the selected bairro), and every zone fill is 0.
+    await expect
+      .poll(async () => page.evaluate(() => {
+        const paths = Array.from(document.querySelectorAll('.leaflet-overlay-pane path'));
+        // Zone paths are the ones Leaflet styled with our dark slate or blue
+        // strokes; OSM layers use their own colors but ALSO fill. The contract
+        // we assert: no path has BOTH stroke #1d4ed8-blue fill... keep simple:
+        // count paths with fill-opacity > 0.1 that are NOT osm (osm paths have
+        // stroke-width 2 and stroke != #1d4ed8/#64748b/#334155/rgba slate).
+        const zoneStrokes = new Set(['#334155', '#1d4ed8', '#64748b', '#1e293b']);
+        return paths.filter(p => {
+          const fo = parseFloat(p.getAttribute('fill-opacity') ?? '0');
+          const stroke = (p.getAttribute('stroke') || '').toLowerCase();
+          return zoneStrokes.has(stroke) && fo > 0.05;
+        }).length;
+      }), { timeout: 15_000 })
+      .toBe(0);
+
+    // And the selected bairro's bold blue outline IS present.
+    const blueOutlines = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('.leaflet-overlay-pane path'))
+        .filter(p => (p.getAttribute('stroke') || '').toLowerCase() === '#1d4ed8'
+          && parseFloat(p.getAttribute('stroke-opacity') ?? '1') > 0.5).length,
+    );
+    expect(blueOutlines).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## JVP's report

During the E2 hazard tour the map showed the flood raster **and** the bairros colored by risk typology — two color systems at once, unreadable for first-time users.

## Root cause

The zones choropleth rendered fully colored from map-ready onward and was never restyled. A `showZones` gating variable existed for exactly this — computed and **wired to nothing** (dead code). The tiles half was already right (one raster during the tour, none after).

## The per-step contract (CBO flow only; city/orchestrator flows unchanged)

| Step | Shows | Interactive |
|---|---|---|
| Hazard tour | active raster + thin gray bairro outlines | no (taps inert) |
| Choose bairro | risk choropleth only (rasters already off) | yes |
| Locais (site) | chosen bairro as bold blue **outline, no fill** over satellite; other bairros hidden | zones inert — taps go to point-dropping |

The site step previously showed **no boundary at all** (`advanceToAssets` removes the whole zones layer) — the outline is a new dedicated inert overlay, so users see where their bairro ends while marking a point. Bonus: inert zones stop stealing taps — mid-tour clicks can no longer silently select a bairro, and site-step taps can't toggle zones.

## Tests

New `cougar-e2-one-encoding-per-step.spec.ts` walks tour→zone→site asserting per-step fill-opacities, the mid-tour tap being inert, and the boundary at the site step. Full map family green (11 passed): e2-map-step, site-step-panning, e2-add-site, e2-site-persist, risk-legend, risk-summary, coordinator-risk-map, coord-decimal-comma.

Screenshots verified: tour = raster only with legend-matched gradient; site = satellite + blue Partenon boundary, zero fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY