### PR TITLE
E2 tour: show hazard overlays, not H×E×V risk composites (+ real legends for all three)

### DIFF
--- a/client/public/sample-data/layer-legends.json
+++ b/client/public/sample-data/layer-legends.json
@@ -131,6 +131,84 @@
     "source": "sampled",
     "note": "colors recovered from tiles"
   },
+  "poa_heat_hazard": {
+    "layerId": "poa_heat_hazard",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.239,
+        "color": "#addc70"
+      },
+      {
+        "value": 0.319,
+        "color": "#bae27d"
+      },
+      {
+        "value": 0.399,
+        "color": "#daef9c"
+      },
+      {
+        "value": 0.479,
+        "color": "#fff8b6"
+      },
+      {
+        "value": 0.559,
+        "color": "#feeaa7"
+      },
+      {
+        "value": 0.639,
+        "color": "#fed088"
+      },
+      {
+        "value": 0.719,
+        "color": "#fdbd72"
+      }
+    ],
+    "min": 0.239,
+    "max": 0.719,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
+  "poa_landslide_hazard": {
+    "layerId": "poa_landslide_hazard",
+    "kind": "gradient",
+    "unit": "index 0–1",
+    "stops": [
+      {
+        "value": 0.007,
+        "color": "#289f53"
+      },
+      {
+        "value": 0.071,
+        "color": "#41aa57"
+      },
+      {
+        "value": 0.136,
+        "color": "#64ba5e"
+      },
+      {
+        "value": 0.2,
+        "color": "#89cb65"
+      },
+      {
+        "value": 0.264,
+        "color": "#a7d96b"
+      },
+      {
+        "value": 0.329,
+        "color": "#bfe482"
+      },
+      {
+        "value": 0.393,
+        "color": "#d7ee99"
+      }
+    ],
+    "min": 0.007,
+    "max": 0.393,
+    "source": "sampled",
+    "note": "colors recovered from tiles"
+  },
   "oef_dynamic_world": {
     "layerId": "oef_dynamic_world",
     "kind": "classes",

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -165,7 +165,7 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
       selectionMode: 'composite',
       zoneSource: 'neighborhood_zones',  // risk-scored bairros (typologyLabel/meanFlood…) — same as the orchestrator
       layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
-      tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+      tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
       showLegendSimple: true,
       hazardTour: false,        // re-entry skips the guided tour, straight to selection
       allowDeferSite: true,

--- a/e2e/cougar-data-provenance.spec.ts
+++ b/e2e/cougar-data-provenance.spec.ts
@@ -24,7 +24,7 @@ test.describe('COUGAR — data provenance dialog (CBO map)', () => {
         params: {
           selectionMode: 'composite',
           zoneSource: 'neighborhood_zones',
-          tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+          tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
           showLegendSimple: true,
           hazardTour: false,
           allowDeferSite: true,

--- a/e2e/cougar-e2-map-step.spec.ts
+++ b/e2e/cougar-e2-map-step.spec.ts
@@ -13,7 +13,7 @@ test.describe('COUGAR — E2 map step (tour + always-on)', () => {
       selectionMode: 'composite',
       zoneSource: 'neighborhood_zones',
       layers: ['osm_parks', 'osm_schools'],
-      tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],
+      tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
       showLegendSimple: true,
       hazardTour: true,
       allowDeferSite: true,

--- a/e2e/cougar-site-step-panning.spec.ts
+++ b/e2e/cougar-site-step-panning.spec.ts
@@ -22,7 +22,7 @@ test.describe('COUGAR — site step: pan by default, arm to drop', () => {
     await api.scriptCbo(cboId, [[
       { op: 'open_map', params: {
         selectionMode: 'composite', zoneSource: 'neighborhood_zones',
-        tileLayers: ['risk_flood_250m'], showLegendSimple: true,
+        tileLayers: ['poa_flood_hazard'], showLegendSimple: true,
         hazardTour: false, allowDeferSite: true, prompt: 'Marque onde vocês atuam.',
       } },
     ]]);

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -174,7 +174,7 @@ open_map({
   selectionMode: 'composite',
   zoneSource: 'neighborhood_zones',  // risk-scored bairros (colored by risk like the orchestrator) — NOT 'neighborhoods' (raw IBGE, no risk colors)
   layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
-  tileLayers: ['risk_flood_250m', 'risk_heat_250m', 'risk_landslide_250m'],  // risk layers — all have legends; the tour shows them one at a time with the real color scale
+  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],  // HAZARD overlays (not H×E×V risk) — the tour teaches where each hazard is, one at a time, with the real color scale
   showLegendSimple: true,
   hazardTour: true,        // false if they tapped "Já conheço os riscos"
   allowDeferSite: true,    // lets them tap "Usar o bairro todo" if no site yet

--- a/scripts/generate-legends.ts
+++ b/scripts/generate-legends.ts
@@ -14,7 +14,7 @@
 import fs from 'fs';
 import path from 'path';
 import { PNG } from 'pngjs';
-import { TILE_LAYERS, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS } from '../shared/geospatial-layers';
+import { TILE_LAYERS, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS, LANDSLIDE_INDEX_LAYERS } from '../shared/geospatial-layers';
 import type { LegendSpec, LegendStop, LegendIndex } from '../shared/legend-types';
 
 const S3 = 'https://geo-test-api.s3.us-east-1.amazonaws.com';
@@ -122,7 +122,7 @@ async function sampleRamp(valueUrl: string, scale: number, offset: number): Prom
 }
 
 async function main() {
-  const all = [...LOCAL_RISK_LAYERS, ...FLOOD_INDEX_LAYERS, ...TILE_LAYERS];
+  const all = [...LOCAL_RISK_LAYERS, ...FLOOD_INDEX_LAYERS, ...HEAT_INDEX_LAYERS, ...LANDSLIDE_INDEX_LAYERS, ...TILE_LAYERS];
   const legends: LegendIndex = {};
   let nFile = 0, nClass = 0, nCode = 0, nSample = 0, nSkip = 0;
 


### PR DESCRIPTION
## JVP's catch

The tour card says *"onde a água tende a se acumular quando chove forte"* — that's **hazard** — but the tiles were `poa_*_risk`, the H×E×V composites (hazard × exposure × vulnerability). Colors contradicted the words: a flood-prone empty field shows low *risk* (no people) but high *hazard*.

## Change

- Tour + CBO map re-entry config now use the **hazard overlays** (`poa_flood_hazard` / `poa_heat_hazard` / `poa_landslide_hazard`) — gap-free, with value tiles, already registered in `shared/geospatial-layers.ts`.
- **Legends**: only flood-hazard had one — the tour card's color scale would have silently vanished on the heat and landslide steps. Added the heat/landslide index layers to `scripts/generate-legends.ts` and regenerated from the real S3 tiles (sampled, not hand-written): heat = green→orange, landslide = green ramp.
- The H×E×V composites are untouched everywhere else (zone choropleth, provenance dialog, coordinator views) — risk remains the decision layer; hazard is the teaching layer.

Guards green: e2-map-step, site-step-panning, data-provenance, e2-risk-legend (5 passed).

Companion commit on #341 bumps the tour's bairro-outline contrast — the new heat/landslide ramps are light, so the thin gray hairlines washed out (verified with screenshots there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY