### PR TITLE
CBO chat: trusted SSE stream — heartbeat, zombie-abort suppression, honest disconnect logs

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -403,6 +403,19 @@ export default function CboProfilePage() {
   // A turn whose SSE stream dropped/stalled — holds the original message text
   // so a "Tentar de novo" tap can resend it (hidden — no duplicate user bubble).
   const [streamRetry, setStreamRetry] = useState<string | null>(null);
+  // Live mirror of cboId + the in-flight stream's handle. Restart/unmount
+  // abort the stream DELIBERATELY; the catch below must distinguish that (and
+  // an abort belonging to an already-replaced session) from a genuine drop —
+  // otherwise a zombie stream from the previous session detonates a spurious
+  // "conexão caiu" bubble into the new chat (field report 2026-07-07).
+  const cboIdRef = useRef<string | null>(null);
+  const activeStreamRef = useRef<{ ctrl: AbortController; deliberate: boolean } | null>(null);
+  const abortActiveStream = useCallback(() => {
+    const stream = activeStreamRef.current;
+    if (stream) { stream.deliberate = true; stream.ctrl.abort(); }
+  }, []);
+  cboIdRef.current = cboId; // render-time mirror (an effect would lag a commit)
+  useEffect(() => () => { abortActiveStream(); }, [abortActiveStream]);
   // Invite-link resolution failure — 'invalid-token' (404/empty) vs 'network'
   // (timeout/offline/5xx). Renders a retryable error card instead of the bare
   // infinite spinner; the 30s poll + focus refetch self-heal it when transient.
@@ -989,6 +1002,9 @@ export default function CboProfilePage() {
     // arrives for 60s (well beyond the slowest tool roundtrip), abort and offer
     // a retry instead.
     const ctrl = new AbortController();
+    const streamHandle = { ctrl, deliberate: false };
+    activeStreamRef.current = streamHandle;
+    const sendForCbo = cboId;
     let watchdog: ReturnType<typeof setTimeout> | undefined;
     const armWatchdog = () => {
       clearTimeout(watchdog);
@@ -1014,16 +1030,20 @@ export default function CboProfilePage() {
     } catch {
       // Dropped/stalled stream — a human, localized message + a self-service
       // retry (resends the same message hidden, so no duplicate user bubble).
-      setMessages(prev => [...prev, {
+      // NOT for deliberate aborts (restart/unmount) or streams whose session
+      // was already replaced — those must die silently.
+      const suppress = streamHandle.deliberate || cboIdRef.current !== sendForCbo;
+      if (!suppress) setMessages(prev => [...prev, {
         role: 'assistant',
         content: lang === 'pt'
           ? 'A conexão caiu no meio da resposta. Toque em "Tentar de novo" que eu retomo daqui.'
           : 'The connection dropped mid-response. Tap "Try again" and I\'ll pick it up.',
         messageType: 'content', timestamp: new Date().toISOString(),
       }]);
-      setStreamRetry(text);
+      if (!suppress) setStreamRetry(text);
     } finally {
       clearTimeout(watchdog);
+      if (activeStreamRef.current === streamHandle) activeStreamRef.current = null;
     }
     setIsStreaming(false);
     setCompletedTurns(n => n + 1);
@@ -1077,13 +1097,14 @@ export default function CboProfilePage() {
   }, [cboId, processEvent]);
 
   const handleRestart = useCallback(async () => {
+    abortActiveStream();
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
     clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
     setCboId(data.cboId); setState(data.state); saveId(data.cboId);
-  }, [cboId]);
+  }, [cboId, abortActiveStream]);
 
   // Kick off the agent chat with the standard intake prompt. Hidden from the
   // visible message stream — the agent's first response is what the user sees.

--- a/docs/cbo-ux-audit-backlog.md
+++ b/docs/cbo-ux-audit-backlog.md
@@ -353,3 +353,11 @@ Open, by priority:
 8. **open_map layer ids unvalidated (P3, S)** — unknown id = silently missing hazard layer.
 
 Verified clean: Placar metrics/flags fully localized; roster bands localized; phaseComplete does NOT key on field names (synonym field can't dead-end the banner); E2 recaps are field-bound; no one-shot-question drop in E2.
+
+## SSE stream trust — 2026-07-07 evening (PR #343)
+
+Fixed: 15s heartbeat, deliberate-abort suppression on restart/unmount, stale-session error suppression, honest disconnect log. Fake model gained a `wait` op for simulating thinking gaps.
+
+Open:
+9. **Same-session-in-two-tabs degrades (P3, M)** — `pushEventRegistry` is one slot per cboId, so two live streams for the same member hijack each other's tool events; the starved tab hits the watchdog. Not a real-user pattern (each CBO has one phone), hit only when testing with duplicated tabs. Fix would be per-connection pushers with broadcast.
+10. **Kickoff double-send under StrictMode (P3, S)** — dev-mode double-mount fires the auto-kickoff twice (doubled `sample/init`/`by-token` in logs); prod unaffected. A sent-once ref on the kickoff effect closes it.

--- a/e2e/cbo-restart-mid-stream.spec.ts
+++ b/e2e/cbo-restart-mid-stream.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// SSE trust hardening (field report 2026-07-07): restarting while a turn was
+// streaming left a zombie stream whose 60s watchdog later detonated a
+// spurious "A conexão caiu" bubble INTO THE NEW SESSION. Restart now aborts
+// the in-flight stream as deliberate, and the error path also ignores aborts
+// whose session is no longer current.
+
+test.describe('CBO — restart mid-stream leaves no zombie error', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('restarting during a slow turn: new session stays clean', async ({ page, request }) => {
+    test.setTimeout(90_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const oldCboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // A turn that will still be "thinking" when we restart.
+    await api.scriptCbo(oldCboId, [[
+      { op: 'wait', ms: 12_000 } as any,
+      { op: 'say', text: 'Nunca deve aparecer.' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Oi');
+    await input.press('Enter');
+    await page.waitForTimeout(1500); // the stream is now open and silent
+
+    // Restart while it streams.
+    await page.getByTestId('cbo-restart-trigger').click();
+    await page.getByTestId('cbo-restart-confirm').click();
+
+    // New session created…
+    await expect
+      .poll(async () => marker.getAttribute('data-cbo-id'), { timeout: 20_000 })
+      .not.toBe(oldCboId);
+
+    // …and across the window where the zombie's turn (and its old watchdog)
+    // would have fired, no drop card and none of the old turn's text appears.
+    await page.waitForTimeout(13_000);
+    await expect(page.getByText('A conexão caiu', { exact: false })).toHaveCount(0);
+    await expect(page.getByTestId('cbo-stream-retry')).toHaveCount(0);
+    await expect(page.getByText('Nunca deve aparecer', { exact: false })).toHaveCount(0);
+  });
+});

--- a/e2e/cbo-sse-heartbeat.spec.ts
+++ b/e2e/cbo-sse-heartbeat.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// SSE trust hardening (field report 2026-07-07): the SDK can think 10-20s
+// between events; proxies idle-kill silent sockets and the client's 60s
+// watchdog needs bytes to know the stream is alive. The server now emits a
+// `: ping` comment every 15s. This spec opens a raw chat stream against a
+// scripted 17s thinking gap and asserts (a) heartbeat bytes arrive mid-gap,
+// (b) the turn still completes with its done event, (c) the UI never shows
+// the connection-drop card for a healthy-but-slow turn.
+
+test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('a 17s silent turn carries pings and completes without the drop card', async ({ page, request }) => {
+    test.setTimeout(90_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'wait', ms: 17_000 } as any,
+      { op: 'say', text: 'Demorei mas cheguei.' },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
+    ]]);
+
+    // Raw fetch from the page context so we can inspect the actual bytes the
+    // browser receives (Playwright's request API buffers whole bodies).
+    const result = await page.evaluate(async (id) => {
+      const res = await fetch(`/api/cbo/${id}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'oi', lang: 'pt' }),
+      });
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let raw = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        raw += decoder.decode(value, { stream: true });
+      }
+      return {
+        pings: (raw.match(/: ping/g) || []).length,
+        sawDone: raw.includes('"type":"done"'),
+        sawSay: raw.includes('Demorei mas cheguei'),
+      };
+    }, cboId);
+
+    // 17s gap at a 15s cadence → at least one ping, plus the full turn.
+    expect(result.pings).toBeGreaterThanOrEqual(1);
+    expect(result.sawDone).toBe(true);
+    expect(result.sawSay).toBe(true);
+  });
+
+  test('the UI rides out a slow turn — no drop card, question arrives', async ({ page, request }) => {
+    test.setTimeout(90_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'wait', ms: 16_000 } as any,
+      { op: 'say', text: 'Pensei bastante nessa.' },
+      { op: 'ask_user', question: 'Tudo certo?', options: [{ label: 'Sim' }] },
+    ]]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Oi');
+    await input.press('Enter');
+
+    // The slow turn completes into a question card…
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible({ timeout: 40_000 });
+    // …and the drop card never appeared.
+    await expect(page.getByText('A conexão caiu', { exact: false })).toHaveCount(0);
+    await expect(page.getByTestId('cbo-stream-retry')).toHaveCount(0);
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -921,11 +921,28 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
     }
   };
 
+  // SSE heartbeat. The SDK can think for 10-20s between events; proxies
+  // (Replit's dev domain included) may idle-kill a silent socket, and the
+  // client's 60s inactivity watchdog needs SOMETHING arriving to know the
+  // stream is alive. A comment line every 15s keeps both fed — the client
+  // parser only consumes `data: ` lines, so this is invisible to it beyond
+  // resetting the watchdog. With the heartbeat in place, 60s of true silence
+  // now reliably means the connection is dead.
+  const heartbeat = setInterval(() => {
+    if (!clientGone && !res.writableEnded) res.write(': ping\n\n');
+  }, 15_000);
+
   res.on('close', () => {
+    clearInterval(heartbeat);
     if (clientGone) return;
     clientGone = true;
     if (pushEventRegistry.get(cboId) === pushEvent) pushEventRegistry.delete(cboId);
-    console.log(`[cbo] client disconnected mid-stream for ${cboId} (phase ${state.phase})`);
+    // Node fires 'close' after every NORMAL completion too — only a close
+    // before end() is a real disconnect. (The unguarded version logged a
+    // spurious "disconnected" after every healthy turn.)
+    if (!res.writableEnded) {
+      console.log(`[cbo] client disconnected mid-stream for ${cboId} (phase ${state.phase})`);
+    }
   });
 
   // Handle [SKIP TO phase:X] magic prefix

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -45,6 +45,7 @@ export function isFakeModelEnabled(): boolean {
 // op names mirror the real MCP tools so a script reads like the agent's intent.
 export type FakeOp =
   | { op: 'say'; text: string }
+  | { op: 'wait'; ms: number } // test seam: simulate SDK thinking time (capped 25s)
   | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
   | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean }[]; multiSelect?: boolean; showMap?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
@@ -93,6 +94,11 @@ export async function streamWithFakeModel(
   const turn = queue && queue.length > 0 ? queue.shift()! : defaultTurn(lang, userMessage);
 
   for (const op of turn) {
+    if (op.op === 'wait') {
+      // Simulated thinking gap — lets specs exercise heartbeat/watchdog paths.
+      await new Promise(r => setTimeout(r, Math.min(Math.max(op.ms || 0, 0), 25_000)));
+      continue;
+    }
     runOp(cboId, op, state, pushEvent, deps, lang);
   }
 


### PR DESCRIPTION
## JVP's field report

"A conexão caiu no meio da resposta" + retry cards appearing on healthy turns while testing on the Repl.

## Diagnosis (from the Repl logs)

- The spurious errors lined up **exactly +60s after the previous session's last turns** — the #326 watchdog was killing zombie streams left open across a Restart, and its catch posted the drop-card into the *new* session.
- Separately, `client disconnected mid-stream` was being logged after **every healthy 200** — Node fires `close` after normal completion and the handler didn't check `writableEnded`. Noise, not signal.
- Underlying fragility: the SDK thinks 10–20s between events; a silent SSE socket is indistinguishable from a dead one, both for proxies (idle-kill) and for the client watchdog.

## Fix — deliberately boring, three pieces

1. **15s SSE heartbeat** (`: ping` comment) during every turn. Client parser ignores it (only `data: ` lines are consumed) but any chunk feeds the watchdog. 60s of silence now means *actually dead*.
2. **Deliberate-abort suppression**: Restart and unmount abort the in-flight stream marked deliberate; the error path also ignores aborts whose session is no longer current. A genuine watchdog abort still shows the retry card.
3. **Honest logging**: the disconnect line only fires when the close precedes `end()` — when you grep it now, it's a real drop.

## Proof

New fake-model `wait` op (capped 25s) simulates thinking gaps deterministically:
- `cbo-sse-heartbeat.spec.ts` — reads the **raw bytes** of a 17s-silent turn: pings arrive mid-gap, the done event lands, and the UI never shows the drop card on a slow-but-healthy turn.
- `cbo-restart-mid-stream.spec.ts` — restarts during a streaming turn, then asserts across the zombie window: no drop card, no retry chip, none of the old turn's text in the new session.
- Guards green: cbo-stream-retry (genuine drop still recovers), cbo-restart-confirm, golden-path, prompt-persist, batched-questions, invite-session, upload (11 specs total).

What can't be simulated locally: Replit's proxy behavior itself. After republish, `grep "client disconnected"` — it should now appear only on real drops (phone lock, network loss), each paired with a client retry card that recovers.

Note: testing with the same member link open in **two tabs** still degrades (the per-cbo event channel is single-slot; tabs hijack each other's tool events) — separate, pre-existing, and not a real-user pattern; flagged in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY
