### PR TITLE
W1 latency pack: parallel tool calls, no role-chasing, direct actions, per-turn timing

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -203,11 +203,16 @@ Render the completion message (see Closing). Do not advance the phase.
 
 The SDK is stateless per turn. The CURRENT STATE block of your prompt is the **only** memory you have — if you don't persist an answer, it's gone the next time the user speaks.
 
-**When a batch comes back, call `update_section('org_profile', { … })` for EVERY field in it before you send the next batch.** One consolidated call (or one per field) — then the next batch, with no chat ack. Same for a confirmed document pre-fill and for free-text answers.
+**When a batch comes back: ONE response containing ALL the tool calls, in parallel.** `update_section` takes a single field per call (`sectionId`, `field`, `value`) — so a 4-answer batch means 4 `update_section` calls PLUS the next batch's `ask_user`, all five emitted as parallel tool calls **in the same assistant message**, with no chat text. Same for a confirmed document pre-fill and for free-text answers.
 
-Example (Batch A returns "Hortas e segurança alimentar; Associação; 5 a 10 anos; 6–15"):
-> You (silently): `update_section('org_profile', { mission_summary: 'Hortas e segurança alimentar', legal_form: 'associação', year_founded: '5 a 10 anos', team_size: '6–15' })`
-> You: send Batch B — no chat text.
+Example (Batch A returns "Hortas e segurança alimentar; ONG / Associação; 5 a 10 anos; 6–15") — ONE response, five parallel calls:
+> `update_section('org_profile', 'mission_summary', 'Hortas e segurança alimentar')`
+> `update_section('org_profile', 'legal_form', 'ONG / Associação')`
+> `update_section('org_profile', 'year_founded', '5 a 10 anos')`
+> `update_section('org_profile', 'team_size', '6–15')`
+> `ask_user(<Batch B>)`
+
+⚡ Emitting these one per message is a bug, not a style choice: every extra message is a full model round-trip the user spends staring at the screen. One user answer = one response = all its tool calls.
 
 If an answer is ambiguous, persist their literal input first, then clarify.
 

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -30,6 +30,8 @@ Warmth comes from speed, not from words. Long acks make the user wait. Default t
 
 **After a chip selection** (the user clicked a button): emit `update_section` + the next `ask_user` with **no chat text at all**. The chip click IS the user's answer — confirming it back wastes their time.
 
+⚡ **Fire them as PARALLEL tool calls in ONE response** — `update_section` (all of them, one per field) AND the next `ask_user`, together, in the same assistant message. Never sequentially (write → wait → then ask): each sequential round is a full model round-trip the user spends staring at the screen. This applies to every capture turn, including batch returns (4 `update_section` + 1 `ask_user`, all parallel).
+
 **After a free-text answer** (org name, mission, year, story, proud-moment): a maximum of **3 words** of ack, then immediately the next question. Examples of acceptable acks:
 - "Anotado."
 - "Show!"
@@ -46,6 +48,10 @@ Warmth comes from speed, not from words. Long acks make the user wait. Default t
 If you find yourself writing more than 3 words between a user answer and your next `ask_user`, **delete it and just ask the next question**. The user will not feel ignored — they will feel respected.
 
 The closing message at the very end of E1 is the only exception (≤6 lines, see Closing section).
+
+## ⚠️ Actions are never confirmation questions
+
+If the next step is a tool YOU can call (`open_map`, `show_examples`, `show_types`, `open_intervention_selector`), **call it directly in the same response as your message** — never present a chip like "Abrir o mapa" whose only effect is that you then call the tool. That pattern costs the user two waits for one action. Chips exist for **answers** (choices that change what happens next), not for permission.
 
 ## ⚠️ Every mid-encontro turn ends with a tool call — never silent, never idle
 
@@ -89,7 +95,7 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 
 1. `org_name` — the organization's name
 2. `contact_name` — who's talking with us
-3. `contact_role` — their role in the org
+3. `contact_role` — their role in the org — **capture only if volunteered.** Ask name+role together once (Step 0); if the answer brings only a name, take it and move on. Never spend a turn chasing the role — it gates nothing.
 4. `mission_summary` — one-sentence description
 5. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
 6. `year_founded` — org-age **bucket**, captured as a chip (Começando agora / Menos de 2 anos / 2 a 5 anos / 5 a 10 anos / Mais de 10 anos) — a tap, not a typed year; works for informal groups too ("tempo que vocês fazem esse trabalho")

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -30,7 +30,7 @@ Warmth comes from speed, not from words. Long acks make the user wait. Default t
 
 **After a chip selection** (the user clicked a button): emit `update_section` + the next `ask_user` with **no chat text at all**. The chip click IS the user's answer — confirming it back wastes their time.
 
-⚡ **Fire them as PARALLEL tool calls in ONE response** — `update_section` (all of them, one per field) AND the next `ask_user`, together, in the same assistant message. Never sequentially (write → wait → then ask): each sequential round is a full model round-trip the user spends staring at the screen. This applies to every capture turn, including batch returns (4 `update_section` + 1 `ask_user`, all parallel).
+⚡ **Two tool calls, ONE response**: a single `update_section` carrying ALL the turn's fields (`fields: { … }`) AND the next `ask_user`, together in the same assistant message. Never one call per field, never write → wait → ask: each extra tool round is a full model round-trip the user spends staring at the screen.
 
 **After a free-text answer** (org name, mission, year, story, proud-moment): a maximum of **3 words** of ack, then immediately the next question. Examples of acceptable acks:
 - "Anotado."
@@ -203,16 +203,13 @@ Render the completion message (see Closing). Do not advance the phase.
 
 The SDK is stateless per turn. The CURRENT STATE block of your prompt is the **only** memory you have — if you don't persist an answer, it's gone the next time the user speaks.
 
-**When a batch comes back: ONE response containing ALL the tool calls, in parallel.** `update_section` takes a single field per call (`sectionId`, `field`, `value`) — so a 4-answer batch means 4 `update_section` calls PLUS the next batch's `ask_user`, all five emitted as parallel tool calls **in the same assistant message**, with no chat text. Same for a confirmed document pre-fill and for free-text answers.
+**When a batch comes back: ONE `update_section` call with ALL the fields, plus the next `ask_user` — two tool calls total, emitted together.** `update_section` takes a `fields` object, so a 4-answer batch is a single call. Same for a confirmed document pre-fill and for free-text answers.
 
-Example (Batch A returns "Hortas e segurança alimentar; ONG / Associação; 5 a 10 anos; 6–15") — ONE response, five parallel calls:
-> `update_section('org_profile', 'mission_summary', 'Hortas e segurança alimentar')`
-> `update_section('org_profile', 'legal_form', 'ONG / Associação')`
-> `update_section('org_profile', 'year_founded', '5 a 10 anos')`
-> `update_section('org_profile', 'team_size', '6–15')`
+Example (Batch A returns "Hortas e segurança alimentar; ONG / Associação; 5 a 10 anos; 6–15") — ONE response, two calls:
+> `update_section('org_profile', fields: { mission_summary: 'Hortas e segurança alimentar', legal_form: 'ONG / Associação', year_founded: '5 a 10 anos', team_size: '6–15' })`
 > `ask_user(<Batch B>)`
 
-⚡ Emitting these one per message is a bug, not a style choice: every extra message is a full model round-trip the user spends staring at the screen. One user answer = one response = all its tool calls.
+⚡ One `update_section` call **per field** is a bug, not a style choice: every extra tool round is a model round-trip the user spends staring at the screen. One user answer = one response = one consolidated write + the next question.
 
 If an answer is ambiguous, persist their literal input first, then clarify.
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -33,7 +33,7 @@ Same rule as E1. Warmth comes from speed.
 
 **After a chip selection** (or any composer tool result — map, priority rank, anchoring, examples): no chat text at all. Just the next tool call.
 
-⚡ **Parallel tool calls in ONE response**: when a turn needs `update_section` + the next composer/`ask_user`, emit them together in the same assistant message, never sequentially — each extra round is a full model round-trip of user waiting.
+⚡ **Two tool calls, ONE response**: a single `update_section` carrying ALL the turn's fields (`fields: { … }`) + the next composer/`ask_user`, together in the same assistant message — never one call per field, each extra tool round is a full model round-trip of user waiting.
 
 **After a free-text answer**: max 3 words of ack ("Anotado.", "Show!", "Faz sentido."), then the next question.
 

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -33,11 +33,17 @@ Same rule as E1. Warmth comes from speed.
 
 **After a chip selection** (or any composer tool result — map, priority rank, anchoring, examples): no chat text at all. Just the next tool call.
 
+⚡ **Parallel tool calls in ONE response**: when a turn needs `update_section` + the next composer/`ask_user`, emit them together in the same assistant message, never sequentially — each extra round is a full model round-trip of user waiting.
+
 **After a free-text answer**: max 3 words of ack ("Anotado.", "Show!", "Faz sentido."), then the next question.
 
 **Never**: repeat the user's answer back, flatter, evaluate ("good choice"), or add connective filler ("Now let me ask about…").
 
 If you find yourself writing more than 3 words between a user answer and your next tool call, delete it and just ask the next question. The closing message at the end of E2 is the only allowed long message.
+
+## ⚠️ Actions are never confirmation questions
+
+If the next step is a tool YOU can call (`open_map`, `show_examples`, `show_types`), call it directly in the same response as your message — never a chip like "Abrir o mapa" whose only effect is that you then call the tool. Chips are for answers, not permission. (Turn 3 already does this: the map opens in the same turn that announces it.)
 
 ## ⚠️ Every mid-encontro turn ends with a tool call — never silent, never idle
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1057,6 +1057,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const turnStart = Date.now();
   let firstEventMs = 0;
   let inferenceRounds = 0;
+  const roundsDetail: string[] = [];
 
   try {
     for await (const message of sdkQuery({
@@ -1100,6 +1101,9 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
       if (message.type === "assistant" && message.message?.content) {
         inferenceRounds++;
         if (!firstEventMs) firstEventMs = Date.now() - turnStart;
+        roundsDetail.push(message.message.content.map((b: any) =>
+          b.type === 'tool_use' ? String(b.name).replace(/^mcp__cbo__/, '') : b.type
+        ).join('+'));
         for (const block of message.message.content) {
           if (block.type === "text" && block.text) {
             emittedText = true;
@@ -1122,7 +1126,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   }
 
   // One greppable line per turn — the before/after for every latency change.
-  console.log(`[cbo] timing for ${cboId}: model=${model} rounds=${inferenceRounds} first_event=${firstEventMs}ms total=${Date.now() - turnStart}ms kind=${turnKind ?? 'none'}`);
+  console.log(`[cbo] timing for ${cboId}: model=${model} rounds=${inferenceRounds} first_event=${firstEventMs}ms total=${Date.now() - turnStart}ms kind=${turnKind ?? 'none'} detail=${roundsDetail.join(' | ')}`);
 
   // Post-turn guard. The skill (encontro-*.md) requires every mid-encontro
   // turn to end with a user-prompting tool (ask_user / a composer / a closing

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -237,11 +237,12 @@ function createCboMcpTools(cboId: string) {
 
   const updateSection = sdkTool(
     "update_section",
-    "Update a field in the CBO intervention profile. The document panel updates in real-time.",
+    "Update fields in the CBO intervention profile (document panel updates live). PREFERRED: pass ALL of a turn's fields for a section in ONE call via `fields` — never one call per field.",
     {
       sectionId: z.string().describe("Section ID: org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence"),
-      field: z.string().describe("Field name"),
-      value: z.string().describe("Content to set"),
+      fields: z.record(z.string()).optional().describe("PREFERRED: { fieldName: value, … } — every field this turn captured, in one call"),
+      field: z.string().optional().describe("Single-field form (legacy)"),
+      value: z.string().optional().describe("Single-field form (legacy)"),
       confidence: z.enum(["high", "medium", "low"]).default("medium"),
       source: z.string().optional(),
     },
@@ -253,25 +254,40 @@ function createCboMcpTools(cboId: string) {
       }
       const section = state.sections[args.sectionId as keyof typeof state.sections];
       if (!section) return { content: [{ type: "text" as const, text: `Unknown section: ${args.sectionId}` }], isError: true };
+
+      // Multi-field form (preferred — one call per turn) or legacy single-field.
+      const entries: [string, string][] = args.fields && Object.keys(args.fields).length > 0
+        ? Object.entries(args.fields).map(([k, v]) => [k, String(v)] as [string, string])
+        : (args.field != null && args.value != null ? [[String(args.field), String(args.value)]] : []);
+      if (entries.length === 0) {
+        return { content: [{ type: "text" as const, text: "Nothing to update: pass `fields: { name: value, … }` (preferred) or `field` + `value`." }], isError: true };
+      }
       if (args.sectionId === 'org_profile') {
         // Foolproofing (Ana 2026-07-07): invented field names ("current_leadership")
         // land facts in chat that never reach the document, and machine enum ids
         // ("funded") leak to the user raw. Reject the former, canonicalize the latter.
-        if (!isKnownOrgProfileField(args.field)) {
-          return { content: [{ type: "text" as const, text: `Unknown org_profile field "${args.field}". Use exactly one of: ${ORG_PROFILE_FIELDS.join(', ')}. If the fact fits none of these, mention it in chat but do not store it.` }], isError: true };
+        const bad = entries.filter(([k]) => !isKnownOrgProfileField(k)).map(([k]) => k);
+        if (bad.length > 0) {
+          return { content: [{ type: "text" as const, text: `Unknown org_profile field(s) ${bad.map(b => `"${b}"`).join(', ')}. Use exactly: ${ORG_PROFILE_FIELDS.join(', ')}. If a fact fits none of these, mention it in chat but do not store it.` }], isError: true };
         }
-        args.value = canonicalizeOrgProfileValue(args.field, args.value, getActiveCboLang(cboId));
       }
-      const oldValue = section.fields[args.field]?.value ?? null;
-      section.fields[args.field] = { value: args.value, confidence: args.confidence as Confidence, source: args.source, userEdited: false };
+      const updated: string[] = [];
+      for (const [fieldName, rawValue] of entries) {
+        const finalValue = args.sectionId === 'org_profile'
+          ? canonicalizeOrgProfileValue(fieldName, rawValue, getActiveCboLang(cboId))
+          : rawValue;
+        const oldValue = section.fields[fieldName]?.value ?? null;
+        section.fields[fieldName] = { value: finalValue, confidence: args.confidence as Confidence, source: args.source, userEdited: false };
+        state.editLog.push({ timestamp: new Date().toISOString(), sectionId: args.sectionId, field: fieldName, oldValue, newValue: finalValue, source: 'agent' });
+        state.gaps = state.gaps.filter(g => !(g.sectionId === args.sectionId && g.field === fieldName));
+        pushEvent({ type: 'field_update', sectionId: args.sectionId, field: fieldName, value: finalValue, confidence: args.confidence as Confidence, source: args.source });
+        updated.push(fieldName);
+      }
       section.lastUpdatedBy = 'agent';
-      state.editLog.push({ timestamp: new Date().toISOString(), sectionId: args.sectionId, field: args.field, oldValue, newValue: args.value, source: 'agent' });
       section.confidence = args.confidence as Confidence;
       if (args.source && !section.sources.includes(args.source)) section.sources.push(args.source);
-      state.gaps = state.gaps.filter(g => !(g.sectionId === args.sectionId && g.field === args.field));
       setCboState(cboId, state);
-      pushEvent({ type: 'field_update', sectionId: args.sectionId, field: args.field, value: args.value, confidence: args.confidence as Confidence, source: args.source });
-      return { content: [{ type: "text" as const, text: `Updated ${args.sectionId}.${args.field}` }] };
+      return { content: [{ type: "text" as const, text: `Updated ${args.sectionId}: ${updated.join(', ')}` }] };
     },
     { annotations: { readOnlyHint: false } }
   );

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1052,6 +1052,11 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // (the "silent turn" that strands the user behind a Continue button).
   const calledTools = new Set<string>();
   let emittedText = false;
+  // Latency attribution (W1 latency pack): spawn+prefill shows up as time-to-
+  // first-assistant-message; each assistant message is one inference round.
+  const turnStart = Date.now();
+  let firstEventMs = 0;
+  let inferenceRounds = 0;
 
   try {
     for await (const message of sdkQuery({
@@ -1093,6 +1098,8 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
       },
     })) {
       if (message.type === "assistant" && message.message?.content) {
+        inferenceRounds++;
+        if (!firstEventMs) firstEventMs = Date.now() - turnStart;
         for (const block of message.message.content) {
           if (block.type === "text" && block.text) {
             emittedText = true;
@@ -1113,6 +1120,9 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   } catch (error: any) {
     pushEvent({ type: 'error', message: error.message || 'Agent error' });
   }
+
+  // One greppable line per turn — the before/after for every latency change.
+  console.log(`[cbo] timing for ${cboId}: model=${model} rounds=${inferenceRounds} first_event=${firstEventMs}ms total=${Date.now() - turnStart}ms kind=${turnKind ?? 'none'}`);
 
   // Post-turn guard. The skill (encontro-*.md) requires every mid-encontro
   // turn to end with a user-prompting tool (ask_user / a composer / a closing


### PR DESCRIPTION
Part 1 of the W1 latency plan (storyboard shared in session). Adaptive routing (#333) is live and working — the remaining cost is turn *shape*: a fresh SDK process per turn plus ~3 **sequential** inference rounds, because the skills said "same turn" but never "same response".

- **P1 — parallel tool calls** (both encontro skills): all `update_section` writes + the next `ask_user` fire together in ONE assistant response. Removes a full inference round from every capture turn.
- **P3 — stop chasing `contact_role`**: ask name+role together once; if only a name comes back, move on. No more dedicated turn for a field that gates nothing.
- **P5 — actions are never confirmation questions**: a tool the agent can call is called in the same response — never a chip whose only effect is triggering the call ("Abrir o mapa" → wait → map = two waits for one action).
- **P4 — timing instrumentation**: `[cbo] timing model=… rounds=N first_event=Xms total=Yms kind=…` once per turn. `first_event` captures spawn+prefill; `rounds` measures P1 compliance directly.

## How we verify (not assume)

Prompt rules are checked by measurement: after republish, `grep "\[cbo\] timing"` — capture turns should show `rounds=2` (was ~3) and totals ~4-7s on Haiku. Baseline from tonight's logs: 5.9–17.4s. Part 2 (templated instant kickoff — turn 1 with zero model) follows as its own PR.

Guards green: cbo-golden-path, cbo-batched-questions, cougar-e2-map-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY