### PR TITLE
Instant kickoff: E1's first message is a template, not a 10-17s model turn (P2)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1095,12 +1095,26 @@ export default function CboProfilePage() {
   // user-side trigger — keep it minimal so it doesn't compete with or
   // contradict the system prompt. In particular: do NOT name a specific
   // skill or restate per-turn rules here; let the system prompt drive.
-  const kickoffChat = useCallback(() => {
+  const kickoffChat = useCallback(async () => {
+    // Instant kickoff (W1 latency pack, P2): turn 1 is deterministic, so the
+    // server serves it from a template with zero model time. Falls back to the
+    // model turn if the transcript isn't virgin (resume, race) or on error.
+    try {
+      const r = await fetch(`/api/cbo/${cboId}/kickoff`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lang }),
+      });
+      const data = await r.json();
+      if (data?.ok && data.message) {
+        setMessages(prev => [...prev, data.message]);
+        return;
+      }
+    } catch {}
     const text = lang === 'pt'
       ? "Vamos começar."
       : "Let's begin.";
     sendMessage(text, true, false, undefined, 'system');
-  }, [lang, sendMessage]);
+  }, [cboId, lang, sendMessage]);
 
   // File drop handler
   const { isDragging, isUploading, dragHandlers } = useFileDrop({

--- a/e2e/cbo-instant-kickoff.spec.ts
+++ b/e2e/cbo-instant-kickoff.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// W1 latency pack P2: turn 1 of E1 is deterministic, so /api/cbo/:id/kickoff
+// serves it from a template with ZERO model time. The greeting must appear
+// near-instantly, carry the invite prefill (org name), persist as a normal
+// transcript message (reload-safe), and fire only on a virgin transcript.
+
+test.describe('CBO — instant templated kickoff', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('cohort invite: greeting is instant, carries the org name, survives reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    const { cohort } = await api.createCohort('e2e instant-kickoff');
+    const m = await api.inviteMember(cohort.id, { orgName: 'Horta do Beco', neighborhood: 'Cascata' });
+
+    await page.goto(m.inviteUrl);
+    const t0 = Date.now();
+    await page.getByTestId('button-cbo-welcome-cta').click({ timeout: 30_000 });
+    const pre = page.getByTestId('button-encontro-1-start');
+    if (await pre.isVisible({ timeout: 8_000 }).catch(() => false)) await pre.click();
+
+    // The templated greeting: org name + the name/role question, fast.
+    await expect(page.getByText('Horta do Beco', { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('com quem eu tô falando', { exact: false })).toBeVisible();
+    // Sanity: this arrived in UI-time, not model-time (generous CI bound; a
+    // model turn is 6-17s + the fake path would need a scripted turn anyway).
+    expect(Date.now() - t0).toBeLessThan(9_000);
+
+    // Persisted: a reload still shows the greeting (it's a transcript message).
+    await page.reload();
+    // isVisible() doesn't wait — use waiting clicks with a tolerant catch.
+    await page.getByTestId('button-cbo-welcome-cta').click({ timeout: 15_000 }).catch(() => {});
+    await page.getByTestId('button-encontro-1-start').click({ timeout: 5_000 }).catch(() => {});
+    await expect(page.getByText('com quem eu tô falando', { exact: false })).toBeVisible({ timeout: 20_000 });
+
+    // Virgin-only: calling it again no-ops.
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    const second = await page.evaluate(async (id) => {
+      const r = await fetch(`/api/cbo/${id}/kickoff`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ lang: 'pt' }) });
+      return r.json();
+    }, cboId);
+    expect(second.ok).toBe(false);
+
+    // And the user's first answer flows into a normal (scripted) model turn.
+    await api.scriptCbo(cboId, [[
+      { op: 'update_section', sectionId: 'org_profile', field: 'contact_name', value: 'Maria' },
+      { op: 'say', text: 'Anotado.' },
+      { op: 'ask_user', question: 'O que vocês fazem?', options: [{ label: 'Hortas' }, { label: 'Educação ambiental' }] },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Maria, coordenadora');
+    await input.press('Enter');
+    await expect(page.getByTestId('cbo-question-card')).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -126,6 +126,8 @@ The question set does **not branch** within E1 — everyone answers the same thi
 
 ### Step 0 — Open, and use what you already know
 
+**The opening greeting is usually already posted for you.** The platform serves the standard Step-0 message (greeting + doc invite + invite confirmation + the name/role question) instantly, before you're ever called. If RECENT CONVERSATION starts with that assistant greeting: do NOT re-greet or re-ask — the user's first message IS the answer to it. Persist what they gave (name, role, org correction) and go straight to Batch A. Only produce the opening yourself if the transcript has no greeting.
+
 - One short greeting line, then invite a document (it can do most of the work):
   > *"Se vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho."*
 - **Check CURRENT STATE and any uploaded document FIRST.** Anything already known (org name + bairro from the invite; anything a document gives you) is a **confirmation, never a question.**

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -163,6 +163,47 @@ export function registerCboRoutes(app: Express): void {
     debouncedPersist(req.params.id);
   });
 
+  // Instant kickoff (W1 latency pack, P2). Turn 1 of E1 is 100% deterministic —
+  // greeting + doc invite + invite-prefill confirmation + the name/role question —
+  // so it is served from a template with ZERO model time instead of a 10-17s
+  // SDK turn. The message persists as a normal assistant transcript message, so
+  // the agent sees it in RECENT CONVERSATION on the user's first real answer
+  // (the E1 skill knows not to re-greet). Fires only on a virgin transcript;
+  // anything else no-ops and the client falls back to the model kickoff.
+  app.post("/api/cbo/:id/kickoff", async (req: Request, res: Response) => {
+    const state = getCboState(req.params.id);
+    if (!state) return res.status(404).json({ error: "Not found" });
+    const existing = getCboMessages(req.params.id).filter(m => m.messageType === 'content');
+    if (existing.length > 0) return res.json({ ok: false, reason: 'already-started' });
+
+    const cohortLang = await getCohortLanguageForCbo(req.params.id);
+    const bodyLang = typeof req.body?.lang === 'string' ? req.body.lang : undefined;
+    const isPt = (cohortLang ?? (bodyLang === 'en' ? 'en' : 'pt')) === 'pt';
+
+    const org = (state.orgName || String(state.sections.org_profile?.fields?.org_name?.value || '')).trim();
+    const bairro = String(state.sections.org_profile?.fields?.bairro_of_operation?.value || '').trim();
+
+    // Copy mirrors the E1 skill's Step-0 lines verbatim — the skill and the
+    // template must never drift apart in tone or content.
+    let content: string;
+    if (isPt) {
+      const confirm = org
+        ? `Conferindo: vocês são a **${org}**${bairro ? `, atuando no ${bairro}` : ''}, certo? Me corrige se eu errei. E com quem eu tô falando — seu nome e seu papel por aí?`
+        : `Pra começar: qual é o nome da organização de vocês, e com quem eu tô falando — seu nome e seu papel por aí?`;
+      content = `Oi! 👋 Eu vou te ajudar a montar o perfil da ${org || 'organização de vocês'} — leva uns 20 minutinhos, no seu ritmo.\n\nSe vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho.\n\n${confirm}`;
+    } else {
+      const confirm = org
+        ? `Checking: you are **${org}**${bairro ? `, working in ${bairro}` : ''}, right? Correct me if I got it wrong. And who am I talking to — your name and your role?`
+        : `To start: what is your organization's name, and who am I talking to — your name and your role?`;
+      content = `Hi! 👋 I'll help you build ${org ? `${org}'s` : 'your organization\u2019s'} profile — about 20 minutes, at your pace.\n\nIf you already have any material — a proposal, a report, even photos of a project — drop it here and I'll read it and pre-fill what I can. Otherwise we'll just have a quick chat.\n\n${confirm}`;
+    }
+
+    const msg = { role: 'assistant' as const, content, messageType: 'content' as const, timestamp: new Date().toISOString() };
+    addCboMessage(req.params.id, msg);
+    debouncedPersist(req.params.id);
+    return res.json({ ok: true, message: msg });
+  });
+
   // Seed from invite — when a CBO is part of a cohort, the orchestrator
   // already collected org name (and sometimes neighborhood) at invite time.
   // Re-asking on E1 is bad UX. This endpoint pre-fills those values into


### PR DESCRIPTION
Part 2 of the W1 latency plan (part 1: #344). The opening turn is fully deterministic — greeting, doc invite, "Conferindo: vocês são a {org}, no {bairro}?", name/role question — so it now comes from `POST /api/cbo/:id/kickoff` with **zero model time**. First paint: 10–17s → instant.

Design kept boring:
- Template copy mirrors the E1 skill's Step-0 lines verbatim (they can't drift apart).
- Persisted as a normal assistant transcript message → the agent sees it in RECENT CONVERSATION on the user's first real answer; the skill now says "never re-greet, the first message IS the answer".
- Gated to a **virgin transcript**; the client falls back to the old model kickoff on any failure or resume race.
- Cohort language authority respected (coordinator-forced language wins).

Spec: `cbo-instant-kickoff.spec.ts` — invite → greeting with org name in UI-time, survives reload, second call no-ops, first user answer flows into a normal model turn. Guards green: invite-session, golden-path, mobile-no-hscroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY