### PR TITLE
Latency-pack audit hardening: partial writes, kickoff race, E2 template single-flight

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1120,6 +1120,10 @@ export default function CboProfilePage() {
     // Instant kickoff (W1 latency pack, P2): turn 1 is deterministic, so the
     // server serves it from a template with zero model time. Falls back to the
     // model turn if the transcript isn't virgin (resume, race) or on error.
+    // Streaming flag ON during the fetch: an eager user typing before the
+    // template lands would otherwise race it (double greeting / out-of-order
+    // transcript — adversarial-review catch).
+    setIsStreaming(true);
     try {
       const r = await fetch(`/api/cbo/${cboId}/kickoff`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -1128,9 +1132,11 @@ export default function CboProfilePage() {
       const data = await r.json();
       if (data?.ok && data.message) {
         setMessages(prev => [...prev, data.message]);
+        setIsStreaming(false);
         return;
       }
     } catch {}
+    setIsStreaming(false);
     const text = lang === 'pt'
       ? "Vamos começar."
       : "Let's begin.";

--- a/docs/agent-turn-latency-standards.md
+++ b/docs/agent-turn-latency-standards.md
@@ -53,8 +53,12 @@ with their own turn.
 If the next step is a tool the agent can call (`open_map`, `show_examples`,
 `show_types`, …), it calls the tool in the same response as its message. A
 chip whose only effect is triggering a tool call costs two waits for one
-action. Chips are for **answers**. (Client-side: the right-panel registry
-keeps map/selector always reachable with no model at all.)
+action. Chips are for **answers**. One legitimate exception: a
+**reading-pace gate** — a strip the user needs time to read may end with a
+"done reading → continue" chip, because only the user knows when they're done
+(E2's "Ver exemplos" chip is this). The standard targets *permission* chips,
+where the agent could simply have acted. (Client-side: the right-panel
+registry keeps map/selector always reachable with no model at all.)
 
 ### 5. Route turns by weight — and let the classifier see new turn kinds
 `resolveTurnModel` sends chips + short text (phase ≤2) to the light model;

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -178,7 +178,15 @@ export function registerCboRoutes(app: Express): void {
 
     const cohortLang = await getCohortLanguageForCbo(req.params.id);
     const bodyLang = typeof req.body?.lang === 'string' ? req.body.lang : undefined;
-    const isPt = (cohortLang ?? (bodyLang === 'en' ? 'en' : 'pt')) === 'pt';
+    const resolved: 'pt' | 'en' = (cohortLang ?? (bodyLang === 'en' ? 'en' : 'pt')) as 'pt' | 'en';
+    const isPt = resolved === 'pt';
+    // Seed the sticky session language so the agent's first real turn can't
+    // diverge from the greeting's language (adversarial-review catch: the
+    // detection fallback could flip an unseeded standalone session).
+    if (state.metadata.language !== resolved) {
+      state.metadata.language = resolved;
+      setCboState(req.params.id, state);
+    }
 
     const org = (state.orgName || String(state.sections.org_profile?.fields?.org_name?.value || '')).trim();
     const bairro = String(state.sections.org_profile?.fields?.bairro_of_operation?.value || '').trim();

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -240,7 +240,7 @@ function createCboMcpTools(cboId: string) {
     "Update fields in the CBO intervention profile (document panel updates live). PREFERRED: pass ALL of a turn's fields for a section in ONE call via `fields` — never one call per field.",
     {
       sectionId: z.string().describe("Section ID: org_profile, intervention_site, intervention_type, impact_monitoring, operations_sustain, needs_assessment, results_evidence"),
-      fields: z.record(z.string()).optional().describe("PREFERRED: { fieldName: value, … } — every field this turn captured, in one call"),
+      fields: z.record(z.union([z.string(), z.number(), z.boolean()])).optional().describe("PREFERRED: { fieldName: value, … } — every field this turn captured, in one call"),
       field: z.string().optional().describe("Single-field form (legacy)"),
       value: z.string().optional().describe("Single-field form (legacy)"),
       confidence: z.enum(["high", "medium", "low"]).default("medium"),
@@ -262,17 +262,22 @@ function createCboMcpTools(cboId: string) {
       if (entries.length === 0) {
         return { content: [{ type: "text" as const, text: "Nothing to update: pass `fields: { name: value, … }` (preferred) or `field` + `value`." }], isError: true };
       }
+      // Foolproofing (Ana 2026-07-07): invented field names ("current_leadership")
+      // land facts in chat that never reach the document, and machine enum ids
+      // ("funded") leak to the user raw. PARTIAL WRITE: persist every valid
+      // field, report the invalid ones — rejecting the whole batch over one
+      // hallucinated name would silently lose the good answers of the turn.
+      const rejected: string[] = [];
+      let writable = entries;
       if (args.sectionId === 'org_profile') {
-        // Foolproofing (Ana 2026-07-07): invented field names ("current_leadership")
-        // land facts in chat that never reach the document, and machine enum ids
-        // ("funded") leak to the user raw. Reject the former, canonicalize the latter.
-        const bad = entries.filter(([k]) => !isKnownOrgProfileField(k)).map(([k]) => k);
-        if (bad.length > 0) {
-          return { content: [{ type: "text" as const, text: `Unknown org_profile field(s) ${bad.map(b => `"${b}"`).join(', ')}. Use exactly: ${ORG_PROFILE_FIELDS.join(', ')}. If a fact fits none of these, mention it in chat but do not store it.` }], isError: true };
+        rejected.push(...entries.filter(([k]) => !isKnownOrgProfileField(k)).map(([k]) => k));
+        writable = entries.filter(([k]) => isKnownOrgProfileField(k));
+        if (writable.length === 0) {
+          return { content: [{ type: "text" as const, text: `Unknown org_profile field(s) ${rejected.map(b => `"${b}"`).join(', ')} — nothing saved. Use exactly: ${ORG_PROFILE_FIELDS.join(', ')}. If a fact fits none of these, mention it in chat but do not store it.` }], isError: true };
         }
       }
       const updated: string[] = [];
-      for (const [fieldName, rawValue] of entries) {
+      for (const [fieldName, rawValue] of writable) {
         const finalValue = args.sectionId === 'org_profile'
           ? canonicalizeOrgProfileValue(fieldName, rawValue, getActiveCboLang(cboId))
           : rawValue;
@@ -287,7 +292,10 @@ function createCboMcpTools(cboId: string) {
       section.confidence = args.confidence as Confidence;
       if (args.source && !section.sources.includes(args.source)) section.sources.push(args.source);
       setCboState(cboId, state);
-      return { content: [{ type: "text" as const, text: `Updated ${args.sectionId}: ${updated.join(', ')}` }] };
+      const note = rejected.length > 0
+        ? ` REJECTED (not stored, unknown field name${rejected.length > 1 ? 's' : ''}): ${rejected.join(', ')} — valid org_profile fields are: ${ORG_PROFILE_FIELDS.join(', ')}. The saved fields above do NOT need resending.`
+        : '';
+      return { content: [{ type: "text" as const, text: `Updated ${args.sectionId}: ${updated.join(', ')}.${note}` }] };
     },
     { annotations: { readOnlyHint: false } }
   );

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -891,14 +891,22 @@ function applySkipData(state: CboState, targetPhase: string): { phase: number; a
 // through the normal pushEvent, so persistence (chat + composers) and reload
 // behavior are identical to an agent-produced turn. Returns false to fall
 // through to the model (already-shown strip, lookup errors).
+const e2EntryInFlight = new Set<string>();
 async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: EventPusher, lang: string): Promise<boolean> {
+  // Single-flight per cbo: a double-tapped banner fires two overlapping /chat
+  // requests; without this both pass the virgin gate (it sits before awaits)
+  // and the transcript gets two greetings + two strips (adversarial-review
+  // catch). Concurrent duplicates fall through to the model, whose own gate
+  // (the skill's don't-re-greet rule) is conversational, not duplicating.
+  if (e2EntryInFlight.has(cboId)) return false;
+  e2EntryInFlight.add(cboId);
   try {
     // If the types strip already exists in the transcript (banner re-fire,
     // resume race), this is not a virgin E2 entry — let the model handle it.
     const seen = getCboMessages(cboId).some(m => m.messageType === 'composer' && m.content.includes('"kind":"types"'));
     if (seen) return false;
 
-    const isPt = lang !== 'en';
+    const isPt = lang === 'pt';
     const nome = String(state.sections.org_profile?.fields?.contact_name?.value || '').trim().split(/\s+/)[0] || '';
 
     // needs-help orgs don't get the skip option (skill Turn 1 rule).
@@ -906,11 +914,19 @@ async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: Ev
     try {
       const rows = await db.select({ path: cohortMembers.path }).from(cohortMembers).where(eq(cohortMembers.cboStateId, cboId)).limit(1);
       path = rows[0]?.path ?? null;
-    } catch {}
+    } catch {
+      // Can't know if this is a needs-help org → don't guess the chip set;
+      // the model path sees the same data through its own context.
+      return false;
+    }
+
+    // Re-check the gate after the awaits above — the cheap half of the race
+    // defense (the in-flight set covers the concurrent half).
+    if (getCboMessages(cboId).some(m => m.messageType === 'composer' && m.content.includes('"kind":"types"'))) return false;
 
     const greeting = isPt
-      ? `Oi${nome ? `, ${nome}` : ''}! Antes de falar do seu território, dois minutos sobre os tipos de Solução baseada na Natureza — pra gente falar a mesma língua.`
-      : `Hi${nome ? `, ${nome}` : ''}! Before we talk about your territory, two minutes on the types of Nature-based Solutions — so we speak the same language.`;
+      ? `Oi${nome ? `, ${nome}` : ''}. Antes de falar do seu território, dois minutos sobre os tipos de Solução baseada na Natureza — pra gente falar a mesma língua.`
+      : `Hi${nome ? `, ${nome}` : ''}. Before we talk about your territory, two minutes on the types of Nature-based Solutions — so we speak the same language.`;
     pushEvent({ type: 'chat', content: greeting, role: 'assistant' } as any);
     // Same expansion the show_intervention_types tool does: empty = all types.
     const schemaMod = await import("@shared/cbo-schema");
@@ -938,6 +954,8 @@ async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: Ev
     return true;
   } catch {
     return false;
+  } finally {
+    e2EntryInFlight.delete(cboId);
   }
 }
 


### PR DESCRIPTION
The adversarial audit of #344/#345/#346 landed these fixes after the merges snapshotted the branches — consolidated here as one PR.

## From the #344 audit (multi-field `update_section`)
- **Partial writes** (was HIGH): one hallucinated field name in a 4-field batch rejected the whole call — and the model's retry typically resends only the corrected field, silently losing the 3 good answers. Valid fields now persist; invalid ones are reported by name with the valid list and an explicit "the saved fields do NOT need resending."
- `fields` values accept number/boolean (coerced) instead of failing at the zod layer with an unactionable error.

## From the #345 audit (instant kickoff)
- **Streaming lock during the template fetch** (was MEDIUM): the composer stayed enabled while `/kickoff` was in flight — an eager first answer could race it into a double greeting / out-of-order transcript.
- The kickoff now **seeds `state.metadata.language`**, so a standalone session can't get a PT greeting followed by an EN agent when the client lang goes missing.

## From the #346 audit (E2 entry template)
- **Single-flight guard + post-await gate re-check** (was MEDIUM): a double-tapped banner fired two overlapping requests that both passed the virgin gate before either wrote the strip → duplicated Turn 1. Concurrent duplicates now fall through to the model.
- A failed `path` lookup falls through to the model instead of guessing the chip set (a needs-help org must never see the skip chip).
- `isPt` matches the codebase convention; greeting punctuation matches the skill verbatim; the standards doc gains the reading-pace-gate exception so Standard 4 doesn't contradict its own flagship example.

Audit context: triple-integration full suite was 58 passed / 3 @live skipped / 0 failed; two adversarial reviewers on the diffs produced the findings above; everything else came back clean (gate string reliability, banner regex vs client text, composer persistence + reload rehydration, debouncedPersist on the template path).

Guards green here: instant-kickoff, e2-instant-entry, golden-path, e1-enum-labels, language, e2-map-step (9 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzBVm9y6zL9zLs4Lv3xKEY