### PR TITLE
feat(server): ENABLE_LEGACY_ROUTES flag over unauthenticated legacy endpoints (DS-2)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -70,6 +70,27 @@ import { registerKnowledgeRoutes } from './routes/knowledgeRoutes';
 import { registerOverpassRoutes } from './routes/overpassRoutes';
 
 export async function registerRoutes(app: Express): Promise<Server> {
+  // Legacy city-prototype routes (impact-model LLM endpoints, the project
+  // state machine, project agent chat, concept note) are UNAUTHENTICATED and
+  // several stream Claude/OpenAI completions. Default ON so nothing changes
+  // until explicitly flipped; set ENABLE_LEGACY_ROUTES=0 on a deployment to
+  // disable them (404, same as if never registered). Workshop routes
+  // (/api/cbo, /api/cohort, /api/coordinator, tiles, OSM) are unaffected.
+  // See docs/system-complexity-audit-2026-07.md items DS-2/DS-3.
+  const legacyRoutesEnabled = process.env.ENABLE_LEGACY_ROUTES !== '0';
+  if (!legacyRoutesEnabled) {
+    const LEGACY_PATHS =
+      /^\/api\/(impact-model\/|concept-note(\/|$)|projects\/[^/]+\/(agent(\/|$)|patches(\/|$)|state$|patch$|apply$|backfill-interventions$|intervention-sites$|reject$|actions$|blocks\/|evidence$|assumptions$))/;
+    app.use((req, res, next) => {
+      if (LEGACY_PATHS.test(req.path)) {
+        return res
+          .status(404)
+          .json({ error: 'Legacy routes are disabled on this deployment (ENABLE_LEGACY_ROUTES=0)' });
+      }
+      next();
+    });
+  }
+
   // Authentication routes
   app.get('/api/auth/oauth/initiate', async (req, res) => {
     try {
@@ -1993,9 +2014,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  registerAgentRoutes(app);
+  // Legacy-only route files: skip registration entirely when disabled (the
+  // early middleware above also covers their paths — belt and suspenders).
+  if (legacyRoutesEnabled) {
+    registerAgentRoutes(app);
+    registerConceptNoteRoutes(app);
+  }
   registerKnowledgeRoutes(app);
-  registerConceptNoteRoutes(app);
   registerCboRoutes(app);
   registerCohortRoutes(app);
   registerCoordinatorRoutes(app);


### PR DESCRIPTION
## What

Adds an `ENABLE_LEGACY_ROUTES` env flag (mirroring the `ENABLE_TEST_ROUTES` pattern) over the legacy city-prototype endpoints, which are **unauthenticated on prod** and several of which **stream Claude/OpenAI on demand**:

| Group | Endpoints | Risk today |
|---|---|---|
| `/api/impact-model/*` | 6 | open OpenAI spend |
| `/api/concept-note/*` | 4 | open Claude agent spend |
| `/api/projects/:id/agent/*` + `/patches/*` | 8 | open Claude agent spend + patch writes |
| project state machine (`/state`, `/patch`, `/apply`, `/blocks/*`, `/evidence`, `/assumptions`, …) | 11 | unauth writes |

**Default is ON — this PR is a no-op when merged.** Flip by setting `ENABLE_LEGACY_ROUTES=0` on the deployment (suggested after the Jul 8–12 Vila Flores demo window). Flag off ⇒ 404 with an explanatory JSON body.

Two mechanisms: `registerAgentRoutes`/`registerConceptNoteRoutes` are skipped at registration, and an early middleware guards the blocks still inside `routes.ts` (they stay put until the DS-3 extraction).

## Tradeoffs

- Flag-off kills the self-serve city demo (`/sample/project/sample-ada-1` agent + impact-model features) on that deployment — confirm nobody demos it on prod before flipping. The pages still render; only agent/state-machine calls 404.
- Path-regex guard is coarser than per-route auth, but sample mode is no-login by design and the OAuth path is itself legacy — an env gate is the honest mechanism (audit rejected `requireAuth` here for that reason).

## Audit / verification

- Smoke-tested locally in both states: `=0` blocks all five groups while `osm-search` (400 validation), `/api/cbo/:id` (handler 404), `/api/cohort/mine` (401 auth) behave normally; unset hits the original handlers ("Project not found", "Note not found", `[]`).
- `tsc --noEmit`: 18 pre-existing errors, none in touched files, none new.
- Workshop path unaffected; safe to merge during the freeze (flag stays on until you flip it on the Repl).

From `docs/system-complexity-audit-2026-07.md` item **DS-2** (order-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)