### PR TITLE
fix(cbo): cut the one-tap escape paths from live CBOs into the legacy demo (DC-1)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -420,7 +420,15 @@ export default function CboProfilePage() {
   // (timeout/offline/5xx). Renders a retryable error card instead of the bare
   // infinite spinner; the 30s poll + focus refetch self-heal it when transient.
   const [sessionError, setSessionError] = useState<'invalid-token' | 'network' | null>(null);
-  const [viaInviteLink, setViaInviteLink] = useState(false);
+  // Synchronous initializer (not an effect): the header renders on the first
+  // commit, and an invited member must never see the legacy-demo back button
+  // — not even for a flash. ?t= / ?cbo= presence is the earliest membership
+  // signal we have.
+  const [viaInviteLink, setViaInviteLink] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const p = new URLSearchParams(window.location.search);
+    return !!(p.get('t') || p.get('cbo'));
+  });
   const [memberInfo, setMemberInfo] = useState<{ orgName: string; neighborhood: string | null } | null>(null);
   // Project-readiness triage from E1: 'has-project' | 'has-idea' | 'needs-help'
   // | null (until triaged). has-project + has-idea are project-forward.
@@ -1351,11 +1359,17 @@ export default function CboProfilePage() {
               buttons keep the right side narrow even on small viewports. */}
           <div className="px-3 sm:px-4 pt-2.5 pb-2 border-b bg-background space-y-2">
             <div className="flex items-center gap-1.5">
-              <Link href="/sample/project/sample-ada-1">
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0 shrink-0">
-                  <ArrowLeft className="w-4 h-4" />
-                </Button>
-              </Link>
+              {/* Back into the legacy sample-project hub is for STANDALONE demo
+                  visitors only. Cohort members (invite token / slug link) have
+                  no "back" — the hub is an English city-prototype demo, and
+                  navigating there drops their token and strands the session. */}
+              {!viaInviteLink && !memberSlug && (
+                <Link href="/sample/project/sample-ada-1">
+                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0 shrink-0">
+                    <ArrowLeft className="w-4 h-4" />
+                  </Button>
+                </Link>
+              )}
               <div className="min-w-0 flex-1">
                 {memberInfo ? (
                   <h2 className="text-sm font-semibold tracking-tight truncate leading-tight">

--- a/shared/roles.ts
+++ b/shared/roles.ts
@@ -192,7 +192,12 @@ export const ROLE_CONFIGS: Record<AudienceRole, RoleConfig> = {
       en: 'Community group building or running a nature-based project.',
       pt: 'Grupo comunitário construindo ou mantendo um projeto de base natural.',
     },
-    entryRoute: '/sample/project/sample-ada-1',
+    // Straight into the CBO chat — the workshop product. The legacy sample
+    // hub (/sample/project/sample-ada-1) stays reachable for standalone demo
+    // visitors via the chat header's back button; it must NOT be the entry:
+    // it is an English city-prototype page, and invited members who wandered
+    // in lost their token on the way back (stranded fresh sessions).
+    entryRoute: '/cbo-profile',
     bypassAuth: true,
     // All 5 modules visible, reordered for CBO priority: funding + impact
     // lead (what CBOs care about most), site/operations/business-model trail.


### PR DESCRIPTION
## What

Two one-tap paths routed **live invited CBOs** into `/sample/project/sample-ada-1` — the English city-prototype demo hub — and the return path dropped their invite token, stranding them in a fresh session:

1. **Chat header back button** (`cbo-profile.tsx`): unconditional link to the demo hub, shown to every user including token-link members. Now shown **only to standalone demo visitors**; cohort members get no back button — the chat is their app.
2. **Landing page CBO card** (`ROLE_CONFIGS.cbo.entryRoute`): routed to the demo hub. Now goes straight to `/cbo-profile`.

`viaInviteLink` becomes a synchronous `useState` lazy initializer (was set in an effect) so the button can't flash for members on first paint.

## Tradeoffs

- Standalone demo visitors keep the hub link via the back button, and `seedSampleProjects` still runs so the hub is initialized if they tap it. The full legacy demo remains reachable at its URL — nothing is deleted.
- After this merges, the entire legacy client tree becomes URL-only reachable, which is what makes the later quarantine wave (DC-2) safe.

## Audit / verification

- `grep` shows no other consumers of `entryRoute` beyond role-selection (deep-link auto-skip + card click), and no e2e references `sample/project` or the old entry.
- `tsc --noEmit`: no errors in touched files (18 pre-existing elsewhere, unchanged).
- e2e (chromium): `cougar-hide-city`, `cbo-golden-path`, `cougar-invite-session` (both invite-isolation tests — exercises the ?t= path), `cbo-invite-error` — **all green**.
- Behavior-changing for the workshop surface → suggest merging **after** the Jul 8–12 Vila Flores demo window unless you want it in for the demo (it removes a known field-failure mode, so it may be worth having).

From `docs/system-complexity-audit-2026-07.md` item **DC-1** (order-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)