### PR TITLE
fix(orchestrator): derive roster coords + sectionsComplete from live data (EF-2)

### DIFF
--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -97,6 +97,10 @@ type CboDemoProject = {
   supportPendingCount: number;
   /** How many files this CBO has uploaded — drives the 📎 chip + files drawer. */
   documentCount: number;
+  /** E2 "usar o bairro todo": the org committed a neighborhood but deferred the
+   *  exact site (coords are the bairro centroid). Drives an amber chip and is
+   *  excluded from the sites-mapped KPI. */
+  siteDeferred: boolean;
 };
 
 const TOTAL_SECTIONS = 7;
@@ -129,19 +133,29 @@ const NEXT_ACTION_KEY: Record<number, string> = {
 };
 
 function memberToView(m: CohortMember): CboDemoProject {
-  const sm = m as CohortMember & { displayName?: { en: string; pt: string }; coords?: [number, number] | null };
+  const sm = m as CohortMember & {
+    displayName?: { en: string; pt: string };
+    derivedSectionsComplete?: number;
+  };
   const updatedAt = m.snapshotUpdatedAt ? new Date(m.snapshotUpdatedAt) : null;
   const daysAgo = updatedAt
     ? Math.max(0, Math.floor((Date.now() - updatedAt.getTime()) / 86400000))
     : 0;
   const phaseNum = m.snapshotPhase ?? 1;
+  // Coords come from the structured E2 site commit (member.site.coordinates,
+  // [lat,lng] centroid) — the previous read (`sm.coords`) was a field nothing
+  // populates, so the cohort map rendered zero markers for live cohorts.
+  const site = m.site ?? null;
   return {
     id: m.id,
     name: sm.displayName ?? { en: m.orgName, pt: m.orgName },
     neighborhood: m.neighborhood ?? '',
-    coords: sm.coords ?? null,
+    coords: site?.coordinates ?? null,
     currentPhase: PHASE_TO_KEY[phaseNum] ?? 'who',
-    sectionsComplete: m.snapshotSectionsComplete ?? 0,
+    // Server-derived from the live cbo_state (attachDerivedSections); the raw
+    // snapshot column is only written by a PATCH no client sends, so it reads
+    // 0 forever. Snapshot kept as fallback for pre-derivation payloads.
+    sectionsComplete: sm.derivedSectionsComplete ?? m.snapshotSectionsComplete ?? 0,
     interventionKey: (m.snapshotIntervention as InterventionKey | null) ?? null,
     maturityScore: m.snapshotMaturityScore ?? 0,
     priorityFlagsMet: m.snapshotFlagsMet ?? 0,
@@ -152,6 +166,7 @@ function memberToView(m: CohortMember): CboDemoProject {
       ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
       : 0,
     documentCount: (m as any).documentCount ?? 0,
+    siteDeferred: site?.deferred === true,
   };
 }
 
@@ -627,6 +642,11 @@ function ProjectCard({
                     {t('orchestrator.demo.locationPending')}
                   </span>
                 )}
+                {project.coords && project.siteDeferred && (
+                  <span className="ml-1.5 inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-full border border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400">
+                    {t('orchestrator.demo.siteDeferred', { defaultValue: 'Site TBD — neighborhood level' })}
+                  </span>
+                )}
               </div>
             </div>
           </div>
@@ -846,7 +866,9 @@ export default function OrchestratorLandingPage() {
   }, [cohort?.id, cohortLanguage, i18n]);
 
   const stats = useMemo(() => {
-    const sitesMapped = projects.filter(p => p.coords).length;
+    // Deferred sites ("usar o bairro todo") have centroid coords for the map
+    // but are not a mapped SITE — counting them would overstate E2 completion.
+    const sitesMapped = projects.filter(p => p.coords && !p.siteDeferred).length;
     const profilesInProgress = projects.filter(
       p => p.sectionsComplete > 0 && p.sectionsComplete < TOTAL_SECTIONS
     ).length;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -90,6 +90,7 @@
       "portfolioTitle": "Community projects",
       "portfolioSubtitle": "Each CBO sits somewhere in the profile diagnostic. Hover a card to find its site on the map.",
       "locationPending": "Location pending",
+      "siteDeferred": "Site TBD — neighborhood level",
       "sectionsLabel": "Sections complete",
       "sectionsCount": "{{done}} of {{total}}",
       "flagsCount": "{{met}} of {{total}} priority flags",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -178,6 +178,7 @@
       "portfolioTitle": "Projetos comunitários",
       "portfolioSubtitle": "Cada OBC está em algum ponto do diagnóstico. Passe o mouse sobre um card para localizar o ponto no mapa.",
       "locationPending": "Local pendente",
+      "siteDeferred": "Local a definir — nível de bairro",
       "sectionsLabel": "Seções concluídas",
       "sectionsCount": "{{done}} de {{total}}",
       "flagsCount": "{{met}} de {{total}} flags prioritárias",

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response, RequestHandler } from 'express';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db } from '../db';
 import {
@@ -20,6 +20,8 @@ import {
   type MemberSite,
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { cboStates } from '@shared/cbo-db-schema';
+import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
 import { getCboMessages, getCboState, loadCboFromDb } from '../services/cboAgent';
 import {
   requireCoordinator,
@@ -194,6 +196,46 @@ async function attachDocCounts<T extends { id: string; orgId: string | null; cbo
   return members.map(m => ({ ...m, documentCount: counts.get(m.id) ?? 0 }));
 }
 
+// Roster progress derived from the LIVE cbo_state, not the pushed snapshot.
+// snapshotSectionsComplete is only written by the client PATCH, and no client
+// code sends that field — so the coordinator's sections ring and the
+// "profiles in progress / complete" KPIs sat at 0 for every member. Derive the
+// count server-side with one grouped query (same shape as attachDocCounts).
+// A section counts when it has >=1 filled, non-invite field — the same signal
+// phaseComplete() in shared/cbo-schema.ts uses, so the coordinator view and
+// the CBO's own advance banner can never disagree. Falls back to the snapshot
+// for members whose cbo_state hasn't been created yet.
+async function attachDerivedSections<
+  T extends { cboStateId: string | null; snapshotSectionsComplete: number | null },
+>(members: T[]): Promise<(T & { derivedSectionsComplete: number })[]> {
+  const ids = Array.from(new Set(members.map(m => m.cboStateId).filter((v): v is string => !!v)));
+  const byState = new Map<string, number>();
+  if (ids.length > 0) {
+    const rows = await db
+      .select({ id: cboStates.id, sections: cboStates.sections })
+      .from(cboStates)
+      .where(inArray(cboStates.id, ids));
+    for (const row of rows) {
+      const sections = (row.sections ?? {}) as Record<
+        string,
+        { fields?: Record<string, CboFieldState> } | undefined
+      >;
+      const n = CBO_SECTIONS.filter(sec => {
+        const fields = sections[sec.id]?.fields ?? {};
+        return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
+      }).length;
+      byState.set(row.id, n);
+    }
+  }
+  return members.map(m => ({
+    ...m,
+    derivedSectionsComplete:
+      m.cboStateId && byState.has(m.cboStateId)
+        ? byState.get(m.cboStateId)!
+        : (m.snapshotSectionsComplete ?? 0),
+  }));
+}
+
 export function registerCohortRoutes(app: Express): void {
   // Phase 3c-ii — gate the entire coordinator surface behind a coordinator
   // session. Every /api/cohort/* route is coordinator-facing (the CBO-facing
@@ -233,7 +275,7 @@ export function registerCohortRoutes(app: Express): void {
       cohort = c;
     }
     if (!cohort) cohort = await getOrCreateDefaultCohort();
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     res.json({ cohort, members, isAdmin: !coordinator?.cohortId });
   }));
 
@@ -306,7 +348,7 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/default', wrap(async (req, res) => {
     const cohort = await getOrCreateDefaultCohort();
     if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     res.json({ cohort, members });
   }));
 
@@ -370,7 +412,7 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     res.json({ cohort, members });
   }));
 
@@ -532,7 +574,7 @@ export function registerCohortRoutes(app: Express): void {
     const phaseNum = Number(phase);
     if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
 
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     const targets = memberIds === 'all'
       ? members
       : members.filter(m => Array.isArray(memberIds) && memberIds.includes(m.id));
@@ -603,7 +645,7 @@ export function registerCohortRoutes(app: Express): void {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
     const filter = String(req.query.status ?? 'all');
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     const items: Array<{
       requestId: string;
       memberId: string;
@@ -672,7 +714,7 @@ export function registerCohortRoutes(app: Express): void {
     const { resolvedNote } = req.body ?? {};
     const note = typeof resolvedNote === 'string' && resolvedNote.trim() ? resolvedNote.trim().slice(0, 1000) : null;
 
-    const members = await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)));
+    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
     for (const m of members) {
       const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
       const idx = arr.findIndex(r => r.id === req.params.requestId);


### PR DESCRIPTION
## What

The coordinator console renders **zero map markers and permanently-0 progress KPIs** for live cohorts, because it reads fields nothing populates. E2 is the site-mapping workshop — its output was invisible to the person running it.

1. **Map markers**: `memberToView` read `sm.coords`, a field that doesn't exist on any payload. Now reads the structured E2 site commit (`member.site.coordinates`, the `[lat,lng]` centroid saved by `PUT /api/cbo-member/:slug/site`).
2. **Sections ring + profiles-in-progress/complete KPIs**: `snapshotSectionsComplete` is only written by a client PATCH no client sends with that field. New `attachDerivedSections` helper (grouped query, same shape as `attachDocCounts`) derives the count from the **live `cbo_state`** on every roster read — a section counts when it has ≥1 filled non-invite field, the exact signal `phaseComplete()` uses, so the coordinator view and the CBO's own advance banner can never disagree. Applied to all six roster-returning endpoints; snapshot kept as fallback for members without a cbo_state yet.
3. **Deferred sites** ("usar o bairro todo"): amber "Local a definir — nível de bairro" chip on the card; excluded from the sites-mapped KPI (the marker still shows at the bairro centroid).

## Tradeoffs

- One extra grouped SELECT per roster read (~10 members → trivial). Derivation-at-read beats snapshot-at-write here because the write path is the thing that's broken; EF-4 (server-side snapshot writes) can later make the snapshot trustworthy again, at which point this helper simply agrees with it.
- Deferred sites no longer count as "mapped" — the KPI reads lower but honest.

## Audit / verification

- Read-path only; no writes changed. The `PATCH` snapshot route is untouched (it also does org-linking + the unlock clamp).
- Derivation unit-checked: invite-prefilled and empty sections don't count (matches `phaseComplete`'s guard that stopped phase-1 auto-completing at turn 0).
- `tsc` clean on touched files; e2e chromium green: `coordinator-auth`, `cohort-isolation`, `cougar-admin-cohort-panel`, `cbo-golden-path`.
- ⚠️ `cougar-coordinator-risk-map` fails **identically on clean origin/main** (expects EN 'Zone priority', page renders PT) — pre-existing, not from this PR. Worth a separate look.
- Behavior-changing for the coordinator surface → merge after the Jul 8–12 demo window, or before it if you want Julia/Antônia to actually see member pins during the demo (arguably the point).

From `docs/system-complexity-audit-2026-07.md` item **EF-2** (order-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)