### PR TITLE
fix(cbo): persist open_map / open_intervention_selector as composer rows + isDone-aware resume gate (RL-1)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -380,6 +380,30 @@ export default function CboProfilePage() {
   // user back on the exact question instead of a dead transcript.
   const hydrateMessages = useCallback((msgs: CboChatMessage[]) => {
     setMessages(msgs);
+    // Right-panel tools (map / intervention selector) restore from ANY composer
+    // row in the TRAILING ASSISTANT RUN — everything after the last user
+    // message — because the agent routinely opens the tool and then asks a
+    // question in the same turn, so the tool row is rarely the very last
+    // message (RL-1). Restoring params (not just activeTool's {kind}) means
+    // the exact step re-renders: custom prompt, hazardTour, suggestedSite,
+    // recommended types. No forced tab switch — the tab chip + pulse are the
+    // affordance.
+    let runStart = msgs.length;
+    while (runStart > 0 && msgs[runStart - 1].role === 'assistant') runStart--;
+    for (let i = runStart; i < msgs.length; i++) {
+      const m = msgs[i];
+      if (m.messageType !== 'composer') continue;
+      let p: any = null;
+      try { p = JSON.parse(m.content); } catch { continue; }
+      if (p?.kind === 'open_map' && p.params) {
+        setOpenMapParams(p.params);
+        setMapRelevant(true);
+      } else if (p?.kind === 'open_intervention_selector' && p.params) {
+        setInterventionSelectorParams(p.params);
+      }
+    }
+    // Question-type composers keep the stricter trailing-message-only rule: a
+    // question is only PENDING when nothing at all followed it.
     const last = msgs[msgs.length - 1];
     if (!last || last.role !== 'assistant' || last.messageType !== 'composer') return;
     let parsed: any = null;
@@ -1671,6 +1695,12 @@ export default function CboProfilePage() {
               // ANY live affordance suppresses the banner — not just ask_user.
               // Rank/anchoring/map composers previously co-rendered with it.
               if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
+              // Also suppress while a persisted right-panel tool step is
+              // pending (isDone-aware — pendingTool clears itself once the
+              // step's fields are filled, so this can never stick forever).
+              // Covers pre-composer-persistence transcripts where activeTool
+              // {kind} exists but no composer row was written to restore params.
+              if (pendingTool(state)) return null;
 
               // Forward-progress gate — the phase must be complete before we
               // offer the next workshop. Uses the shared phaseComplete() predicate
@@ -1752,6 +1782,12 @@ export default function CboProfilePage() {
               // UNDER a live rank/anchoring/map composer (tapping it derails).
               if (isStreaming || !stableStreamEnded || state.phase === 0 || messages.length === 0) return null;
               if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
+              // Also suppress while a persisted right-panel tool step is
+              // pending (isDone-aware — pendingTool clears itself once the
+              // step's fields are filled, so this can never stick forever).
+              // Covers pre-composer-persistence transcripts where activeTool
+              // {kind} exists but no composer row was written to restore params.
+              if (pendingTool(state)) return null;
               const lastContent = [...messages].reverse().find(m => m.messageType === 'content');
               const agentOwesResponse = !lastContent || lastContent.role === 'user';
               if (state.phase < 6 && !agentOwesResponse) return null;

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1012,11 +1012,17 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
     } else if (event.type === 'ask_community_anchoring') {
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'anchoring', prompt: event.prompt }), messageType: 'composer', timestamp: new Date().toISOString() });
     } else if (event.type === 'open_map') {
-      // Persist that the map step is active so the right-panel tool stays
-      // reachable across reloads (not gated behind a transient button).
+      // Persist BOTH signals (invariant 5 / RL-1). activeTool {kind} keeps the
+      // tab + nudge chip alive across reloads; the composer row carries the
+      // agent's ACTUAL params so a reload restores the exact map step (custom
+      // prompt, hazardTour, suggestedSite, …) instead of the phase defaults —
+      // {kind}-only persistence dropped the params and left the resume chip
+      // rendering over a pending map step.
+      addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'open_map', params: (event as any).params }), messageType: 'composer', timestamp: new Date().toISOString() });
       state.activeTool = { kind: 'map' };
       setCboState(cboId, state); debouncedPersist(cboId);
     } else if (event.type === 'open_intervention_selector') {
+      addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'open_intervention_selector', params: (event as any).params }), messageType: 'composer', timestamp: new Date().toISOString() });
       state.activeTool = { kind: 'interventions' };
       setCboState(cboId, state); debouncedPersist(cboId);
     }


### PR DESCRIPTION
## What

Closes the **invariant-5 residual** from the foolproof spec — PR #328 persisted ask_user/priority/anchoring, but the two right-panel tools (`open_map`, `open_intervention_selector`) persisted only `state.activeTool = {kind}`: no params, no transcript row. Field consequences on reload mid-step:

- The map fell back to **phase defaults**, losing the agent's actual params (custom prompt, `hazardTour`, `suggestedSite` doc-mined candidates, recommended types).
- The intervention selector showed its *"will open when the agent asks"* placeholder **after the agent had already asked**.
- "Continuar da Fase X" could render over a pending tool step (tapping it derails the agent).

## How

- **Server** (`cboAgent.ts`): both events now also persist a `messageType:'composer'` row with the event params — same pattern as `show_types`/`ask_user`.
- **Client** (`cbo-profile.tsx`): hydration scans the **trailing assistant run** (everything after the last user message), not just the final message — the agent routinely opens a tool then asks a question in the same turn, so the tool row is rarely last. Params restore without force-switching tabs (per the audit note: the tab chip + pulse are the affordance). Question composers keep the stricter last-message-only rule.
- Advance banner + resume block additionally suppress on `pendingTool(state)` — **isDone-aware**, so suppression clears when the step's fields fill (a raw `activeTool` check would suppress forever), and it covers **pre-PR transcripts** that have `activeTool` but no composer row.

## Tradeoffs

- Forward-only for full param restore: old transcripts get the `pendingTool` fallback (defaults-based re-entry), not exact params — same forward-only posture as #328.
- Composer JSON is parsed defensively (`try/catch → skip`) so schema drift can't crash hydration.

## Verification

- e2e chromium green: `cbo-prompt-persist`, `cougar-e2-map-step` (incl. the always-on-reload test), `cougar-e2-site-persist`, `cbo-golden-path`, `cbo-restart-confirm`.
- `tsc` clean on touched files.
- Workshop-surface behavior change → merge after the Jul 8–12 demo window (or before, if you want reload resilience during the live demo — this is exactly the phone-reload failure mode Ana's cohort hits).

From `docs/system-complexity-audit-2026-07.md` item **RL-1** (order-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)