### PR TITLE
fix(ui): mount the city ChatDrawer only on legacy project routes (DC-7 interim)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from 'wouter';
+import { Switch, Route, useLocation } from 'wouter';
 import { queryClient } from '@/core/lib/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/core/components/ui/toaster';
@@ -81,15 +81,30 @@ function Router() {
   );
 }
 
+// The floating chat button + drawer is the CITY project agent (it talks to
+// /api/projects/:id/agent/*). It only belongs on the legacy project surfaces:
+// the project hub + the 5 module pages (and their /sample variants). Mounted
+// globally it leaked onto the CBO chat and the orchestrator console — sample
+// mode gives it a projectId anywhere, so its button rendered there too
+// (audit item DC-7; full move into the legacy pages comes with the
+// quarantine wave).
+const LEGACY_AGENT_ROUTES =
+  /^\/(sample\/)?(project|site-explorer|funder-selection|project-operations|business-model|impact-model|city-information)(\/|$)/;
+
 function AppLayout() {
   const { isChatOpen } = useChatState();
-  
+  const [location] = useLocation();
+  const showAgentDrawer = LEGACY_AGENT_ROUTES.test(location);
+
+  // Margin only applies while the drawer can actually render — isChatOpen
+  // survives SPA navigation, and a stale 400px gutter would squeeze the
+  // workshop views after leaving a legacy page with the drawer open.
   return (
     <div className="flex min-h-screen">
-      <div className={`flex-1 min-w-0 transition-all duration-300 ${isChatOpen ? 'mr-[400px]' : ''}`}>
+      <div className={`flex-1 min-w-0 transition-all duration-300 ${isChatOpen && showAgentDrawer ? 'mr-[400px]' : ''}`}>
         <Router />
       </div>
-      <ChatDrawer />
+      {showAgentDrawer && <ChatDrawer />}
     </div>
   );
 }

--- a/client/src/core/components/agent/ChatDrawer.tsx
+++ b/client/src/core/components/agent/ChatDrawer.tsx
@@ -794,7 +794,10 @@ export function ChatDrawer() {
 
   return (
     <>
-      {!isOpen && !location.includes('/concept-note') && !location.includes('/cbo') && (
+      {/* Route gating lives at the mount site (AppLayout's LEGACY_AGENT_ROUTES
+          allowlist) — the drawer only ever renders on legacy project pages, so
+          the old per-path excludes (/concept-note, /cbo) are gone. */}
+      {!isOpen && (
         <Button
           variant="outline"
           size="icon"


### PR DESCRIPTION
## What

The floating chat button (bottom-right, your screenshot) is the **city project agent** — it talks to `/api/projects/:id/agent/*`, one of the legacy endpoints. It was mounted unconditionally in `AppLayout`, and since the CBO/orchestrator flows run in sample mode it always had a projectId, so its button leaked onto the orchestrator console (it already self-hid on `/cbo*` paths via an inline check, but not there or on the landing).

- `AppLayout` mounts `ChatDrawer` only on the legacy project routes: `/project`, the five module pages, `/city-information`, and their `/sample` variants. Orchestrator, `/cbo-profile`, landing, and coordinator pages never mount it (nor its 1,070-line subtree).
- The 400px open-drawer margin now applies only while the drawer can render — `isChatOpen` survives SPA navigation and would otherwise leave a stale gutter squeezing the workshop views.
- Removed the drawer's stale inline per-path excludes — route gating now has one home.

## Verification

Live browser probe with sample mode on: button **absent** on `/`, `/orchestrator`, `/cbo-profile`, `/coordinator-login`; **present** on `/sample/project/sample-ada-1` and `/sample/impact-model/sample-ada-1`. `tsc` clean; e2e chromium green on `cougar-hide-city`, `cbo-golden-path`, `cbo-mobile-layout`, `cougar-e2-map-step`.

## Tradeoffs

- City flow untouched (including `/city-information`, kept in the allowlist to be conservative). Concept-note loses nothing — it has its own full-page agent.
- This is the freeze-safe interim of audit item **DC-7**; the full move of ChatDrawer into the legacy pages (bundle-size win) comes with the quarantine wave after DC-3 code splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)