### PR TITLE
fix(cbo): start sessions at phase 1 again + self-heal phase-0 strandings (E1→E2 handoff)

### DIFF
--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -99,6 +99,19 @@ export function registerCboRoutes(app: Express): void {
     }
     if (!state) return res.status(404).json({ error: "Not found" });
 
+    // Self-heal sessions stranded at phase 0. New states now start at phase 1
+    // (createEmptyCboState), but sessions created while the 020fe0a7 rollback
+    // was live ran ALL of E1 at phase 0 — and the "Começar Encontro 2" banner
+    // is hard-gated to phase >= 1, so they finished the diagnostic with no way
+    // forward. Phase 0 has no content of its own (the turn already loads E1's
+    // skill via max(1, phase)), so lifting is semantically a no-op for the
+    // agent and unblocks the handoff card on the next reply.
+    if ((state.phase ?? 0) === 0) {
+      state.phase = 1;
+      setCboState(req.params.id, state);
+      console.log(`[cbo] lifted ${req.params.id} from stranded phase 0 to phase 1`);
+    }
+
     // Detect "start encontro N" / "vamos começar o encontro N" — the message
     // the Start-Next-Workshop banner sends. Advance state.phase BEFORE the
     // SDK turn fires so the right encontro-N.md skill loads. This is the

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -304,7 +304,15 @@ export function createEmptyCboState(city: string): CboState {
     id: crypto.randomUUID(),
     orgName: '',
     city,
-    phase: 0,
+    // Start at phase 1 — Encontro 1 begins on the first chat turn. Phase 0
+    // ("pre-introduction") required the agent to call set_phase(1) on its
+    // first response; the only prompt rule that triggers it is gated on
+    // RECENT CONVERSATION being empty, which the instant-kickoff template
+    // (persisted before the first agent turn) makes never true — so sessions
+    // finished E1 stuck at phase 0 and the "Começar Encontro 2" banner
+    // (hard-gated to phase >= 1) never appeared. This restores 431eb98e,
+    // which was collateral damage in the 020fe0a7 rollback.
+    phase: 1,
     sections: sections as Record<CboSectionId, CboSectionState>,
     gaps: [],
     maturityScores: [],


### PR DESCRIPTION
## What happened (field report)

After resetting an org and completing all of E1, the **"Começar Encontro 2" banner never appeared** even with Workshop 2 open. The server log shows every turn at `phase 0` and no `set_phase` in any tool list — and the banner hard-returns `null` below phase 1. The agent even narrated the green card (the skill promises it) that the client would never render.

## Root cause chain

1. `431eb98e` fixed this class by starting new CBO states at **phase 1** — its comment predicted this exact failure (*"if the agent forgot set_phase(1), more likely on Haiku…"*). The `020fe0a7` rollback reverted `createEmptyCboState` to `phase: 0` as collateral.
2. The only remaining 0→1 trigger is the prompt rule *"IF phase = 0 AND RECENT CONVERSATION is empty → call set_phase(1)"* — but **instant kickoff** persists the templated greeting *before* the first agent turn, so the conversation is never empty and the rule can never fire. The E1 skill's only phase instruction is "do NOT call set_phase(2)". The client's `/advance-phase` lives inside the banner itself — circular.
3. `skillPhase = max(1, phase)` loads E1's skill at phase 0 anyway, so the interview runs perfectly and nothing looks wrong until the handoff. Adaptive Haiku routing (#333) removed the last chance of a spontaneous advance.

This affects **every session created since instant kickoff merged** (restarts and fresh invites alike), not just resets.

## Fix

- `createEmptyCboState` starts at **phase 1** (restores `431eb98e`, comment expanded to document the kickoff interaction so the next rollback doesn't silently re-break it).
- The chat handler **lifts any phase-0 state to 1** before the turn — already-stranded sessions (like the Test PT org) self-heal on their next message; no reset needed. Phase 0 has no content of its own, so the lift is a semantic no-op for the agent.

## Verification

- Live probe: fresh `POST /api/cbo` reports `phase: 1`.
- e2e chromium, 10 specs green: golden path, instant kickoff, phase-1 walkthrough (full profile → advances to Phase 2), prompt persist, restart confirm, restart mid-stream, E2 instant entry, batched questions, invite sessions.
- Client already compatible: the welcome screen keys off `messages.length` (it was adapted for phase-1 initials before the rollback).

## Tradeoffs

- The now-dead prompt bullets ("IF phase = 0 …") were left in `buildPhaseInstructions` to keep this diff prompt-neutral days before the demo; they can never match after the lift. Fold their removal into the LT-1 prompt-cache work.
- Workshop-surface fix with real field impact → worth having **before** the Vila Flores demo; it's the W1→W2 handoff itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)