### PR TITLE
fix(cbo): phase-gate open_map/selector + surface the phase-0 lift to the client (fake-E2)

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -320,6 +320,8 @@ After both batches are answered (Step 2) and the path triage is done:
 
 **Do NOT** call `set_phase(2)` or any phase-advance tool — the user advances when they click the green card themselves (the client calls `/api/cbo/<id>/advance-phase`). Your job is to finish E1 cleanly; the platform handles the handoff.
 
+**Do NOT simulate Encontro 2** — not even if the user says "sim, quero começar agora". Never improvise the E2 opening, talk through climate risks "juntos", or call `open_map` / `open_intervention_selector` from E1 (the platform will refuse them below their phase anyway). Encontro 2 has its own preamble screen, educational examples, and guided map entry that ONLY run through the green card. If the user wants to continue, say exactly that: the green card is the way in — if it's not visible yet, reload the page or wait for the coordinator to open it.
+
 **Do NOT** promise a push notification, email, or SMS. The only signal the CBO will see is the green card that renders in this chat when state allows it.
 
 ### After the completion message, the encontro is OVER — stop.

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -53,6 +53,17 @@ export function registerCboRoutes(app: Express): void {
       }
     }
     if (!state) return res.status(404).json({ error: "Not found" });
+    // Read-time phase-0 self-heal: sessions created during the 020fe0a7
+    // rollback window finished E1 stranded at phase 0 (banner is gated to
+    // phase >= 1). Lifting here means a plain reload immediately shows the
+    // "Começar Encontro 2" card; the chat path lifts too (with a
+    // phase_change event) for live sessions. See fake-E2 report 2026-07-08.
+    if ((state.phase ?? 0) === 0) {
+      state.phase = 1;
+      setCboState(req.params.id, state);
+      debouncedPersist(req.params.id);
+      console.log(`[cbo] lifted ${req.params.id} from stranded phase 0 to phase 1 (read path)`);
+    }
     res.json({ state, cboId: req.params.id });
   });
 
@@ -98,19 +109,11 @@ export function registerCboRoutes(app: Express): void {
       if (persisted) { setCboState(req.params.id, persisted.state); state = persisted.state; }
     }
     if (!state) return res.status(404).json({ error: "Not found" });
-
-    // Self-heal sessions stranded at phase 0. New states now start at phase 1
-    // (createEmptyCboState), but sessions created while the 020fe0a7 rollback
-    // was live ran ALL of E1 at phase 0 — and the "Começar Encontro 2" banner
-    // is hard-gated to phase >= 1, so they finished the diagnostic with no way
-    // forward. Phase 0 has no content of its own (the turn already loads E1's
-    // skill via max(1, phase)), so lifting is semantically a no-op for the
-    // agent and unblocks the handoff card on the next reply.
-    if ((state.phase ?? 0) === 0) {
-      state.phase = 1;
-      setCboState(req.params.id, state);
-      console.log(`[cbo] lifted ${req.params.id} from stranded phase 0 to phase 1`);
-    }
+    // The phase-0 self-heal lives in streamCboChat now, where it can emit a
+    // phase_change event — the client must LEARN about the lift or the green
+    // advance banner stays suppressed and users talk the model into a
+    // role-played Encontro 2 (fake-E2 field report 2026-07-08). The GET
+    // handler above also lifts, so a plain reload shows the banner too.
 
     // Detect "start encontro N" / "vamos começar o encontro N" — the message
     // the Start-Next-Workshop banner sends. Advance state.phase BEFORE the

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -527,6 +527,16 @@ STOP and wait for the user's map selection after calling this tool.`,
       }).optional().describe("E2 map step: a site candidate found via search_org_documents, to pre-place for the user to VALIDATE ('é aqui?') instead of picking blind. Only pass what the doc actually says — the quote is the basis the user sees."),
     },
     async (args: any) => {
+      // Deterministic fence (fake-E2 field report 2026-07-08): the map step
+      // belongs to Encontro 2+. At phase 1, a model that sees a finished
+      // diagnostic in the transcript will happily role-play the E2 opening
+      // and open the map with NO phase change — skipping the E2 preamble,
+      // the templated educational entry, and the header progression. Prompt
+      // rules alone don't hold on light-model turns; refuse at the engine.
+      const mapState = getCboState(cboId);
+      if ((mapState?.phase ?? 0) < 2) {
+        return { content: [{ type: "text" as const, text: `BLOCKED: open_map is an Encontro 2+ tool and this org is still in phase ${mapState?.phase ?? 0}. Do NOT simulate Encontro 2 content or open the map. Tell the user the next encontro will appear as a green card here in the chat once their coordinator opens it, then END your turn.` }] };
+      }
       pushEvent({
         type: 'open_map',
         params: {
@@ -751,6 +761,11 @@ STOP and wait for the user's selection after calling this tool.`,
       maxRecommendations: z.number().optional().default(2).describe("How many types to badge as Recommended (default 2)"),
     },
     async (args: any) => {
+      // Same engine fence as open_map: the selector is an Encontro 3+ tool.
+      const selState = getCboState(cboId);
+      if ((selState?.phase ?? 0) < 3) {
+        return { content: [{ type: "text" as const, text: `BLOCKED: open_intervention_selector is an Encontro 3+ tool and this org is still in phase ${selState?.phase ?? 0}. Do NOT simulate a later encontro. Tell the user the next encontro will appear as a green card here in the chat once their coordinator opens it, then END your turn.` }] };
+      }
       pushEvent({
         type: 'open_intervention_selector',
         params: {
@@ -1051,6 +1066,19 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
       console.log(`[cbo] client disconnected mid-stream for ${cboId} (phase ${state.phase})`);
     }
   });
+
+  // Self-heal sessions stranded at phase 0 — AND tell the client (fake-E2
+  // field report 2026-07-08: the first version of this lift lived in the
+  // route and emitted nothing, so the live client kept phase 0, the green
+  // advance banner stayed suppressed, and the user talked the model into a
+  // role-played Encontro 2 instead). phase_change here keeps the client's
+  // state.phase — and therefore the banner gate — in sync with the lift.
+  if ((state.phase ?? 0) === 0) {
+    state.phase = 1;
+    setCboState(cboId, state);
+    pushEvent({ type: 'phase_change', phase: 1 });
+    console.log(`[cbo] lifted ${cboId} from stranded phase 0 to phase 1`);
+  }
 
   // Handle [SKIP TO phase:X] magic prefix
   const skipMatch = userMessage.match(SKIP_PATTERN);


### PR DESCRIPTION
## What happened (field report)

After #356's lift fired on the stranded org, the **client never learned about it** — the lift lived in the route and emitted no event, and the page had loaded state beforehand. Client stuck at phase 0 ⇒ green banner suppressed ⇒ the user typed ⇒ Haiku, seeing a finished diagnostic in the transcript, **role-played the entire Encontro 2 opening at phase 1**: improvised intro, its own hazard question, a raw `open_map`. No E2 preamble, no educational examples (those live in the templated instant entry that only runs via the banner), no phase change — hence "Seção 1 de 5" throughout.

## Fix (4 pieces)

1. **Lift emits `phase_change`** — moved into `streamCboChat` so live sessions' banner gate syncs the moment the lift happens.
2. **Read-path lift** — `GET /api/cbo/:id` heals too, so a plain reload shows the banner with no chat turn needed.
3. **Engine fence** — `open_map` refuses below phase 2, `open_intervention_selector` below phase 3, with a tool-error instructing the model to point at the green card and end the turn. Prompt rules alone don't hold on light-model turns; this is the audit's turn-contract philosophy (enforce at the engine, not on LLM adherence).
4. **Skill rule** — `encontro-1.md` now explicitly forbids simulating Encontro 2 ("not even if the user says 'sim, quero começar agora'"), with the green-card redirect phrasing.

## Blast radius / audit

- Real E2/E3 entries unaffected: the instant-entry template pushes events directly (not through the tool handlers), and banner-advanced sessions are already at the right phase before any model turn. Verified by `cougar-e2-instant-entry` + `cougar-e2-map-step` passing.
- Fake-model e2e paths bypass tool handlers entirely — unaffected (suite green).
- The stuck **Test PT** org: reload now shows the banner directly; the earlier role-played-E2 messages remain in the transcript but the real E2 entry runs correctly from the card.
- e2e chromium green ×7: golden path, instant kickoff, phase-1 walkthrough (banner advance to phase 2), E2 instant entry, E2 map step ×2, prompt persist. tsc clean on touched files.

## Tradeoff

The skill file grows ~90 words (~120 tokens/turn during E1). Accepted: this hole is exactly the class that burned us — cheap prompt insurance on top of the deterministic gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)