### PR TITLE
perf(client): route-level code splitting — entry 722 kB → 367 kB gzip (DC-3)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,29 +7,52 @@ import { SampleDataProvider } from '@/core/contexts/sample-data-context';
 import { ProjectContextProvider } from '@/core/contexts/project-context';
 import { ChatProvider, useChatState } from '@/core/contexts/chat-context';
 import { RoleProvider } from '@/core/contexts/role-context';
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
 
-// Core pages
-import Login from '@/core/pages/login';
+// Route-level code splitting (audit item DC-3): every page loads its own
+// chunk on first navigation instead of riding in the entry bundle. Before
+// this, the entry was ~722 kB gzip — site-explorer's STATIC leaflet import
+// alone dragged the whole map stack into first paint, defeating the
+// workshop's carefully lazy-loaded MapMicroapp — on a phone-first product.
+// The landing gate stays EAGER: it is the first paint for every visitor and
+// must never flash a route spinner.
 import RoleSelectionPage from '@/core/pages/role-selection';
-import OrchestratorLandingPage from '@/core/pages/orchestrator-landing';
-import CoordinatorLoginPage from '@/core/pages/coordinator-login';
-import CitySelection from '@/core/pages/city-selection';
-import ProjectPage from '@/core/pages/project';
-import SiteExplorerPage from '@/core/pages/site-explorer';
-import FunderSelectionPage from '@/core/pages/funder-selection';
-import ProjectOperationsPage from '@/core/pages/project-operations';
-import BusinessModelPage from '@/core/pages/business-model';
-import ImpactModelPage from '@/core/pages/impact-model';
-import ConceptNotePage from '@/core/pages/concept-note';
-import CboProfilePage from '@/core/pages/cbo-profile';
-import { OAuthCallback } from '@/core/components/auth/oauth-callback';
 import NotFound from '@/core/pages/not-found';
+
+const Login = lazy(() => import('@/core/pages/login'));
+const OrchestratorLandingPage = lazy(() => import('@/core/pages/orchestrator-landing'));
+const CoordinatorLoginPage = lazy(() => import('@/core/pages/coordinator-login'));
+const CitySelection = lazy(() => import('@/core/pages/city-selection'));
+const ProjectPage = lazy(() => import('@/core/pages/project'));
+const SiteExplorerPage = lazy(() => import('@/core/pages/site-explorer'));
+const FunderSelectionPage = lazy(() => import('@/core/pages/funder-selection'));
+const ProjectOperationsPage = lazy(() => import('@/core/pages/project-operations'));
+const BusinessModelPage = lazy(() => import('@/core/pages/business-model'));
+const ImpactModelPage = lazy(() => import('@/core/pages/impact-model'));
+const ConceptNotePage = lazy(() => import('@/core/pages/concept-note'));
+const CboProfilePage = lazy(() => import('@/core/pages/cbo-profile'));
+// Named exports — lazy() wants a default, so remap.
+const OAuthCallback = lazy(() =>
+  import('@/core/components/auth/oauth-callback').then(m => ({ default: m.OAuthCallback })),
+);
+const ChatDrawer = lazy(() =>
+  import('@/core/components/agent/ChatDrawer').then(m => ({ default: m.ChatDrawer })),
+);
 
 // Dynamic module routing
 import { DynamicModuleRoutes } from '@/core/routing/dynamic-routes';
-import { ChatDrawer } from '@/core/components/agent/ChatDrawer';
+
+// Route-chunk loading state. Brief (chunks are small and cached after first
+// hit) — a centered spinner, no layout shift.
+function RouteFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
 
 function Router() {
   return (
@@ -102,9 +125,18 @@ function AppLayout() {
   return (
     <div className="flex min-h-screen">
       <div className={`flex-1 min-w-0 transition-all duration-300 ${isChatOpen && showAgentDrawer ? 'mr-[400px]' : ''}`}>
-        <Router />
+        <Suspense fallback={<RouteFallback />}>
+          <Router />
+        </Suspense>
       </div>
-      {showAgentDrawer && <ChatDrawer />}
+      {/* Lazy + route-gated: the drawer chunk only ever downloads on legacy
+          project pages. Suspense fallback null — it's a floating button, not
+          page content. */}
+      {showAgentDrawer && (
+        <Suspense fallback={null}>
+          <ChatDrawer />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/client/src/core/routing/module-registry.ts
+++ b/client/src/core/routing/module-registry.ts
@@ -1,5 +1,9 @@
+import { lazy } from 'react';
 import { ModuleRegistry } from '@/core/types/module';
-import CityInformation from '@/modules/city-information/pages/city-information';
+
+// Lazy so the whole city-information module tree (13 files) splits out of the
+// entry bundle with the rest of the route-level code splitting (DC-3).
+const CityInformation = lazy(() => import('@/modules/city-information/pages/city-information'));
 
 // Module registry - this is where new modules can be registered
 export const moduleRegistry: ModuleRegistry = {


### PR DESCRIPTION
## What

Route-level `React.lazy` for every page. Before: a single **2,481 kB (721.9 kB gzip)** entry chunk — `site-explorer`'s static leaflet import dragged the entire map stack into first paint for every phone-first CBO user, defeating the workshop's carefully lazy `MapMicroapp`.

**After: entry = 1,179 kB (367.2 kB gzip), −49%.** Leaflet (43 kB gz) is now a shared chunk loaded only by map routes; `cbo-profile` (44 kB), `orchestrator-landing` (34 kB), and each legacy page (12–33 kB) load on demand and cache after first hit.

Details:
- Landing gate + NotFound stay **eager** — first paint never flashes a route spinner.
- `OAuthCallback` and `ChatDrawer` are named exports → remapped; the drawer chunk is additionally route-gated by #355, so it only ever downloads on legacy project pages.
- `module-registry` lazies `CityInformation` (13-file module tree splits out).
- Suspense fallback: minimal centered spinner, no layout shift.

## Audit / verification

The audit flagged three traps, all handled: OAuthCallback named-export remap ✓; module-registry static import ✓; **SSE kickoff fires exactly once under Suspense** — verified by `cbo-instant-kickoff` (greeting appears once, survives reload).

- e2e chromium green ×13: landing/hide-city, golden path, instant kickoff, prompt persist, E2 map step ×2, coordinator auth, admin cohort panel, mobile layout, invite sessions ×2.
- `tsc`: only the pre-existing `dynamic-routes` TS2322 (same line on main). Full `npm run build` passes.

## Tradeoffs

- First navigation to each surface costs one small chunk fetch (~10–45 kB gz, then cached). On the workshop path that's one fetch on the way into `/cbo-profile` — a good trade against 355 kB less on first load for every phone.
- Remaining 367 kB entry is React + Radix + i18n + shared libs; further slicing (manualChunks) has diminishing returns and wasn't attempted.

From `docs/system-complexity-audit-2026-07.md` item **DC-3** (order-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)