### PR TITLE
fix(cbo): phase-integrity follow-up — pendingness + regex writer (stranded #358 commits)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -149,6 +149,12 @@ interface RightPanelToolDef {
   defaultParams: (state: CboState) => any | null;
   // Task complete → the nudge clears; re-entry is just "revisit".
   isDone: (state: CboState) => boolean;
+  // The earliest phase this tool legitimately belongs to (map = E2,
+  // selector = E3) — mirrors the server-side tool fence. A persisted
+  // activeTool BELOW this phase is damage from a role-played encontro
+  // (fake-E2 report 2026-07-08) and must never count as pending — else it
+  // holds the advance banner hostage on a step the org shouldn't be in.
+  minPhase: number;
   nudge: { pt: string; en: string };
 }
 
@@ -172,6 +178,7 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
       prompt: 'Marque o bairro e o lugar onde vocês atuam.',
     } : null,
     isDone: (s) => fieldVal(s, 'intervention_site', 'bairro', 'site_name'),
+    minPhase: 2,
     nudge: { pt: 'Abrir o mapa', en: 'Open the map' },
   },
   interventions: {
@@ -179,6 +186,7 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
     icon: Layers,
     defaultParams: () => null,  // wired when E3 (NBS-type selection) lands
     isDone: (s) => fieldVal(s, 'intervention_type', 'intervention_type', 'nbs_type'),
+    minPhase: 3,
     nudge: { pt: 'Escolher o tipo de SbN', en: 'Choose the NBS type' },
   },
 };
@@ -189,6 +197,9 @@ function pendingTool(state: CboState | null): { kind: ToolKind; def: RightPanelT
   const kind = (state as any)?.activeTool?.kind as ToolKind | undefined;
   if (!kind || !RIGHT_PANEL_TOOLS[kind] || !state) return null;
   const def = RIGHT_PANEL_TOOLS[kind];
+  // Below the tool's phase = illegitimate residue of a role-played encontro;
+  // never pending (the banner must stay available to do the REAL entry).
+  if ((state.phase ?? 0) < def.minPhase) return null;
   return def.isDone(state) ? null : { kind, def };
 }
 // Has this tool's step been reached (active now, or already done)? → the tab
@@ -1708,7 +1719,12 @@ export default function CboProfilePage() {
               if (isStreaming || !stableStreamEnded || messages.length === 0 || state.phase === 0) return null;
               // ANY live affordance suppresses the banner — not just ask_user.
               // Rank/anchoring/map composers previously co-rendered with it.
-              if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
+              // Tool params only suppress at/above the tool's own phase — a
+              // map/selector restored from a role-played encontro (fake-E2)
+              // must not hide the banner that performs the REAL entry.
+              const mapHolds = openMapParams != null && (state.phase ?? 0) >= RIGHT_PANEL_TOOLS.map.minPhase;
+              const selHolds = interventionSelectorParams != null && (state.phase ?? 0) >= RIGHT_PANEL_TOOLS.interventions.minPhase;
+              if (currentQuestion || priorityRankPrompt || anchoringPrompt || mapHolds || selHolds) return null;
               // Also suppress while a persisted right-panel tool step is
               // pending (isDone-aware — pendingTool clears itself once the
               // step's fields are filled, so this can never stick forever).
@@ -1795,7 +1811,12 @@ export default function CboProfilePage() {
               // currentQuestion-only check let "Continuar da Fase X" render
               // UNDER a live rank/anchoring/map composer (tapping it derails).
               if (isStreaming || !stableStreamEnded || state.phase === 0 || messages.length === 0) return null;
-              if (currentQuestion || priorityRankPrompt || anchoringPrompt || openMapParams || interventionSelectorParams) return null;
+              // Tool params only suppress at/above the tool's own phase — a
+              // map/selector restored from a role-played encontro (fake-E2)
+              // must not hide the banner that performs the REAL entry.
+              const mapHolds = openMapParams != null && (state.phase ?? 0) >= RIGHT_PANEL_TOOLS.map.minPhase;
+              const selHolds = interventionSelectorParams != null && (state.phase ?? 0) >= RIGHT_PANEL_TOOLS.interventions.minPhase;
+              if (currentQuestion || priorityRankPrompt || anchoringPrompt || mapHolds || selHolds) return null;
               // Also suppress while a persisted right-panel tool step is
               // pending (isDone-aware — pendingTool clears itself once the
               // step's fields are filled, so this can never stick forever).

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -109,35 +109,14 @@ export function registerCboRoutes(app: Express): void {
       if (persisted) { setCboState(req.params.id, persisted.state); state = persisted.state; }
     }
     if (!state) return res.status(404).json({ error: "Not found" });
-    // The phase-0 self-heal lives in streamCboChat now, where it can emit a
-    // phase_change event — the client must LEARN about the lift or the green
-    // advance banner stays suppressed and users talk the model into a
-    // role-played Encontro 2 (fake-E2 field report 2026-07-08). The GET
-    // handler above also lifts, so a plain reload shows the banner too.
-
-    // Detect "start encontro N" / "vamos começar o encontro N" — the message
-    // the Start-Next-Workshop banner sends. Advance state.phase BEFORE the
-    // SDK turn fires so the right encontro-N.md skill loads. This is the
-    // server-side belt to the client's /advance-phase endpoint suspenders —
-    // even if the client doesn't call advance-phase, the chat handler does
-    // the right thing.
-    const startEncontroMatch = message.match(/(?:vamos\s+(?:começar|comecar)\s+(?:o\s+)?encontro|let'?s\s+start\s+encontro)\s+(\d+)/i);
-    if (startEncontroMatch) {
-      const target = parseInt(startEncontroMatch[1], 10);
-      if (target >= 1 && target <= 6 && target > (state.phase ?? 0)) {
-        const { getPhasePolicyForCbo, isPhaseAllowed } = await import("../services/phaseGating");
-        let allowed = true;
-        if (target <= 5) {
-          const policy = await getPhasePolicyForCbo(req.params.id);
-          if (policy.gated && !isPhaseAllowed(policy, target)) allowed = false;
-        }
-        if (allowed) {
-          state.phase = target;
-          setCboState(req.params.id, state);
-          console.log(`[cbo] chat handler advanced ${req.params.id} to phase ${target} via "start Encontro" pattern`);
-        }
-      }
-    }
+    // The phase-0 self-heal AND the "vamos começar o encontro N" advance both
+    // live in streamCboChat now, where they can emit phase_change — the client
+    // must LEARN about server-side phase writes or the header/banner go stale
+    // and users talk the model into a role-played encontro (fake-E2 field
+    // report 2026-07-08; backlog CBO-PHASE-WRITERS). The regex path also runs
+    // through advanceCboPhase there, the same gate as /advance-phase and the
+    // set_phase tool, instead of a duplicated inline policy check. The GET
+    // handler above lifts phase 0 too, so a plain reload shows the banner.
 
     // Session language authority (CBO-LANG-AUTH). If this CBO belongs to a
     // cohort with a coordinator-forced language, that ALWAYS wins — it overrides

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1080,6 +1080,26 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
     console.log(`[cbo] lifted ${cboId} from stranded phase 0 to phase 1`);
   }
 
+  // "vamos começar o encontro N" — the banner's fixed message (belt to the
+  // client's /advance-phase call), or a user typing the phrase by hand. This
+  // previously lived in the route with its own duplicated policy check and a
+  // silent `state.phase = target` write: no phase_change event, no durable
+  // flush (backlog CBO-PHASE-WRITERS — the manual-typed case left the client
+  // header/banner stale, the same desync class as the fake-E2 report). Route
+  // it through advanceCboPhase — the single gate every other phase writer
+  // uses — and TELL the client.
+  const startEncontroMatch = userMessage.match(/(?:vamos\s+(?:começar|comecar)\s+(?:o\s+)?encontro|let'?s\s+start\s+encontro)\s+(\d+)/i);
+  if (startEncontroMatch) {
+    const target = parseInt(startEncontroMatch[1], 10);
+    if (target >= 1 && target <= 6 && target > (state.phase ?? 0)) {
+      const advanced = await advanceCboPhase(cboId, target);
+      if (advanced.ok) {
+        pushEvent({ type: 'phase_change', phase: target });
+        console.log(`[cbo] chat handler advanced ${cboId} to phase ${target} via "start Encontro" pattern`);
+      }
+    }
+  }
+
   // Handle [SKIP TO phase:X] magic prefix
   const skipMatch = userMessage.match(SKIP_PATTERN);
   if (skipMatch) {


### PR DESCRIPTION
## What

#358 was merged with only its **first** commit — these two landed on the branch minutes after the merge and never reached main (good catch). Cherry-picked cleanly onto current main, re-verified:

1. **Phase-aware pendingness (client).** Sessions that lived through a role-played encontro carry residue (`activeTool={kind:'map'}` + an open_map composer row at phase 1) that held the 'Começar Encontro 2' banner hostage through both suppression gates. `RIGHT_PANEL_TOOLS` now declares `minPhase` (map=2, selector=3) mirroring #358's server fence; `pendingTool()` and both gates ignore below-phase tool state. **Without this, the damaged Test PT-style sessions still don't show the banner on reload** — this is the piece that completes tonight's fix.
2. **The 'vamos começar o encontro N' regex goes through `advanceCboPhase` + emits `phase_change`** (backlog CBO-PHASE-WRITERS). It was the last silent phase writer: typing the phrase by hand advanced the server and left the client header/banner stale — the same desync class. Moved from the route into `streamCboChat` (before the instant-E2 template check, so the banner path still gets the templated entry), replacing its duplicated inline policy check with the shared gate + durable flush.

## Verification (re-run on top of merged main)

- e2e chromium green ×6: golden path, **E2 instant entry** (banner→template path), E2 map step ×2 (always-on reload), prompt persist, phase-1 walkthrough (banner advance to phase 2).
- tsc clean on touched files; cherry-picks applied without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)