### PR TITLE
perf(cbo): collapse pre-model DB roundtrips + document summary projection (LT-2, LT-3)

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -25,7 +25,7 @@ import {
 import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
 import { eq } from "drizzle-orm";
-import { getOrgIdForCboState, listDocumentsByOrg, getDocumentForOrg } from "./documentPersistence";
+import { getOrgIdForCboState, listDocumentsByOrg, listDocumentSummariesByOrg, getDocumentForOrg } from "./documentPersistence";
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { emitAssistantText } from "./agentOutput";
@@ -684,7 +684,7 @@ USE THIS TOOL PROACTIVELY when guiding the user. Don't just ask questions — re
     async () => {
       const orgId = await getOrgIdForCboState(cboId);
       if (!orgId) return { content: [{ type: "text" as const, text: "No documents on file yet." }] };
-      const docs = await listDocumentsByOrg(orgId);
+      const docs = await listDocumentSummariesByOrg(orgId); // summaries only — no fullText on a listing (LT-3)
       if (docs.length === 0) return { content: [{ type: "text" as const, text: "No documents on file yet." }] };
       const lines = docs.map(d => `- [${d.id}] ${d.filename} (${d.kind ?? 'file'}${d.droppedInPhase ? `, Encontro ${d.droppedInPhase}` : ''}) — ${(d.summary || '').slice(0, 160)}`);
       return { content: [{ type: "text" as const, text: `Documents on file (${docs.length}):\n${lines.join('\n')}\n\nUse read_org_document with an [id] to read the full text.` }] };
@@ -1201,11 +1201,17 @@ function resolveTurnModel(
 
 async function streamWithSdk(cboId: string, userMessage: string, state: CboState, pushEvent: EventPusher, lang: string = 'en', turnKind?: string) {
   const mcpServer = getMcpServer(cboId);
-  const sysCtx = await buildSystemContext(state, lang);
+  // Independent reads — run concurrently instead of serially. Together with
+  // the cohortLanguage JOIN this collapses the pre-model DB wait from 5
+  // sequential round-trips to ~1 (audit LT-2); matters most on light-model
+  // fast turns where the DB wait was a visible share of the turn.
+  const [sysCtx, documentsBlock, policy] = await Promise.all([
+    buildSystemContext(state, lang),
+    buildDocumentsBlock(cboId),
+    getPhasePolicyForCbo(cboId),
+  ]);
   const stateSummary = buildStateSummary(state);
-  const documentsBlock = await buildDocumentsBlock(cboId);
   const decisionLog = buildDecisionLog(cboId);
-  const policy = await getPhasePolicyForCbo(cboId);
   const accessPolicy = buildAccessPolicyPrompt(policy);
 
   // Pull the per-phase model from skill frontmatter, fall back to default.
@@ -1389,7 +1395,9 @@ async function buildDocumentsBlock(cboId: string): Promise<string> {
   try {
     const orgId = await getOrgIdForCboState(cboId);
     if (!orgId) return '';
-    const docs = await listDocumentsByOrg(orgId);
+    // Projection only — the full rows carry fullText, which for a doc-heavy
+    // org is megabytes pulled from Postgres on EVERY chat turn (LT-3).
+    const docs = await listDocumentSummariesByOrg(orgId);
     if (docs.length === 0) return '';
     const lines = docs.slice(0, 20).map(d =>
       `- [${d.id}] ${d.filename} (${d.kind ?? 'file'}${d.droppedInPhase ? `, Encontro ${d.droppedInPhase}` : ''}) — ${(d.summary || '').slice(0, 120)}`);

--- a/server/services/cohortLanguage.ts
+++ b/server/services/cohortLanguage.ts
@@ -15,18 +15,15 @@ import { eq } from 'drizzle-orm';
 export async function getCohortLanguageForCbo(cboStateId: string): Promise<'pt' | 'en' | null> {
   if (!cboStateId) return null;
   try {
-    const [member] = await db
-      .select({ cohortId: cohortMembers.cohortId })
+    // One JOIN instead of two serial round-trips — this runs on the hot
+    // per-turn chat path before the model can even start (audit LT-2).
+    const [row] = await db
+      .select({ settings: cohorts.settings })
       .from(cohortMembers)
+      .innerJoin(cohorts, eq(cohorts.id, cohortMembers.cohortId))
       .where(eq(cohortMembers.cboStateId, cboStateId))
       .limit(1);
-    if (!member?.cohortId) return null;
-    const [cohort] = await db
-      .select({ settings: cohorts.settings })
-      .from(cohorts)
-      .where(eq(cohorts.id, member.cohortId))
-      .limit(1);
-    return (cohort?.settings as CohortSettings | null)?.language ?? null;
+    return (row?.settings as CohortSettings | null)?.language ?? null;
   } catch {
     return null;
   }

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -91,6 +91,32 @@ export async function listDocumentsByOrg(orgId: string): Promise<DocumentRow[]> 
   return db.select().from(documents).where(eq(documents.orgId, orgId)).orderBy(desc(documents.createdAt));
 }
 
+/** Summary metadata only — distinctly typed so `.fullText` misuse is a compile
+ *  error. The per-turn DOCUMENTS ON FILE block needs a 120-char summary line,
+ *  but listDocumentsByOrg ships every column INCLUDING fullText — for a
+ *  doc-heavy org that's megabytes pulled from Postgres on every single chat
+ *  turn (audit LT-3). Search/read paths keep the full rows. */
+export interface DocumentSummary {
+  id: string;
+  filename: string;
+  kind: string | null;
+  droppedInPhase: number | null;
+  summary: string | null;
+}
+export async function listDocumentSummariesByOrg(orgId: string): Promise<DocumentSummary[]> {
+  return db
+    .select({
+      id: documents.id,
+      filename: documents.filename,
+      kind: documents.kind,
+      droppedInPhase: documents.droppedInPhase,
+      summary: documents.summary,
+    })
+    .from(documents)
+    .where(eq(documents.orgId, orgId))
+    .orderBy(desc(documents.createdAt));
+}
+
 /** Document counts for a set of orgs, in one grouped query — powers the per-CBO
  *  file-count chip on the orchestrator cards without an N+1. */
 export async function countDocumentsByOrgIds(orgIds: string[]): Promise<Map<string, number>> {


### PR DESCRIPTION
## What

Every CBO chat turn paid **5 serial DB round-trips before the model could start**: cohort language (2 SELECTs), documents block (2, all-columns), phase policy (1) — the same `cboStateId` looked up three times across two tables.

1. `getCohortLanguageForCbo`: one INNER JOIN replaces two serial SELECTs.
2. `streamWithSdk`: the three independent pre-model reads run under `Promise.all`.
3. New `listDocumentSummariesByOrg` projection — the per-turn DOCUMENTS ON FILE block and the `list_org_documents` tool rendered 120-char summary lines from an all-columns select that **shipped `fullText` for every doc on every turn** (megabytes for doc-heavy orgs). Distinctly typed (`DocumentSummary`) so `.fullText` misuse is a compile error. `search_org_documents` keeps full rows — it greps `fullText` by design.

## Tradeoffs

- ~50–200 ms/turn (most visible on light-model fast turns) + less DB egress; not the headline latency fix (that's LT-1/LT-4, next PRs).
- No caching added — audit's explicit call: invalidate-on-write beats TTL here because coordinator language/unlock changes must apply promptly. JOIN semantics are identical to the two-step read.

## Verification

e2e chromium green: golden path, **upload** (documents path), **cohort-language** (exercises the JOIN), instant kickoff. tsc clean on touched files.

From `docs/system-complexity-audit-2026-07.md` items **LT-2 + LT-3** (order-5, same-PR by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)