### PR TITLE
perf(cbo): split volatile blocks out of the system prompt — enable prompt caching (LT-1)

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1225,7 +1225,19 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // turn. This mirrors conceptNoteAgent and is the SDK's expected shape;
   // tool-use rules placed in the system prompt are followed more reliably
   // than rules concatenated into the user message string.
-  const systemPrompt = `${sysCtx}\n\n## CURRENT STATE\n${stateSummary}${documentsBlock}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}`;
+  // Prompt-cache split (audit LT-1). The system prompt carries ONLY the
+  // stable, phase-keyed material (persona + rules + skill = sysCtx, ~8-9K
+  // tokens); everything that changes turn-to-turn (CURRENT STATE, DOCUMENTS,
+  // RECENT CONVERSATION, access policy) rides in front of the user message.
+  // Before this, one changed character in the volatile blocks invalidated the
+  // whole prefix, so Anthropic prompt caching never hit across turns — every
+  // turn re-prefilled the full skill. With the split, consecutive same-model
+  // turns reuse the cached prefix (~1-1.5s off round 1 + ~90% input-cost cut
+  // on the prefix). The section names stay identical — sysCtx rules that say
+  // "check CURRENT STATE first" keep working; the blocks just arrive in the
+  // conversation instead of the system message.
+  const systemPrompt = sysCtx;
+  const turnContext = `## CURRENT STATE\n${stateSummary}${documentsBlock}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}\n\n## NEW MESSAGE FROM THE USER\n`;
 
   console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, model ${model}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 
@@ -1243,7 +1255,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
 
   try {
     for await (const message of sdkQuery({
-      prompt: userMessage,
+      prompt: turnContext + userMessage,
       options: {
         cwd: process.cwd(),
         model,


### PR DESCRIPTION
## What

The per-turn system prompt was `sysCtx (stable, ~8-9K tokens) + CURRENT STATE + DOCUMENTS + RECENT CONVERSATION + access policy`. The volatile tail invalidated the cache prefix every turn, so **Anthropic prompt caching never hit** — every turn re-prefilled the full skill.

Now the system prompt is **sysCtx only**, and the volatile blocks ride in front of the user message (`## CURRENT STATE … ## RECENT CONVERSATION … ## NEW MESSAGE FROM THE USER`). Section names are unchanged so every sysCtx rule referencing them keeps resolving.

**Expected effect:** ~1–1.5 s off round 1 of consecutive same-model turns + ~90% input-cost cut on the prefix. Caveat (from the audit): adaptive haiku/sonnet routing splits the cache per model, so mixed-model sequences only benefit within same-model runs.

## Verification — real-agent regression (the audit's required check)

Two **live model turns** (sonnet round + haiku chip round) against this branch:
- Opener captured `org_name`/`contact_name`/`contact_role` via update_section — the rules and state blocks are being read.
- Batch chip answer persisted all 4 fields, **no re-greeting, no re-asking**, PT held, update_section+ask_user pairing intact — the RECENT CONVERSATION block works from its new position.

Fake-model e2e also green: golden path, instant kickoff, batched questions, E2 instant entry. tsc clean.

## Tradeoffs

- Behavior drift risk is the real cost of any prompt restructure — mitigated by the live regression above, but worth one eye on the first live cohort session after deploy.
- Cache wins require the SDK/API prompt-caching path on the deployment (it's automatic in the Agent SDK); nothing breaks if it doesn't hit — worst case is exactly today's behavior.

From `docs/system-complexity-audit-2026-07.md` item **LT-1** (order-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)