### PR TITLE
perf(cbo): token streaming — text renders as it generates (LT-4)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -438,6 +438,11 @@ export default function CboProfilePage() {
   // A turn whose SSE stream dropped/stalled — holds the original message text
   // so a "Tentar de novo" tap can resend it (hidden — no duplicate user bubble).
   const [streamRetry, setStreamRetry] = useState<string | null>(null);
+  // Live token-streaming draft (LT-4). Accumulates transient chat_delta
+  // events into a draft bubble; the finalizing 'chat' (whole block, post
+  // inline-options normalizer) REPLACES it, so persistence and conversion
+  // still operate on whole blocks. Never persisted, cleared on any finalizer.
+  const [streamDraft, setStreamDraft] = useState('');
   // Live mirror of cboId + the in-flight stream's handle. Restart/unmount
   // abort the stream DELIBERATELY; the catch below must distinguish that (and
   // an abort belonging to an already-replaced session) from a genuine drop —
@@ -876,6 +881,13 @@ export default function CboProfilePage() {
   // Process SSE events
   const processEvent = useCallback((event: CboEvent) => {
     switch (event.type) {
+      case 'chat_delta': {
+        // Transient draft text — replaced wholesale when the finalizing
+        // 'chat' arrives. Mobile unread flag matches the 'chat' behavior.
+        if (mobileActiveTabRef.current !== 'chat') setMobileChatUnread(true);
+        setStreamDraft(prev => prev + (event as any).content);
+        break;
+      }
       case 'chat': {
         // All 'chat' events render as regular chat bubbles. The old
         // isNarration heuristic (regex + length<300 fallback) hid brief
@@ -890,6 +902,7 @@ export default function CboProfilePage() {
         if (mobileActiveTabRef.current !== 'chat') {
           setMobileChatUnread(true);
         }
+        setStreamDraft(''); // finalizer replaces the live draft
         setMessages(prev => {
           const last = prev[prev.length - 1];
           // Concatenate consecutive assistant chat chunks into one bubble
@@ -956,6 +969,7 @@ export default function CboProfilePage() {
         }
         break;
       case 'ask_user': {
+        setStreamDraft(''); // an inline-options conversion also finalizes the draft
         // Open the map only when the agent explicitly signals it via `showMap`
         // on the question (or the `open_map` tool). A keyword regex on the
         // question text used to also auto-open it — but that fired for any
@@ -1011,8 +1025,10 @@ export default function CboProfilePage() {
         setAnchoringPrompt({ prompt: event.prompt });
         setIsStreaming(false);
         break;
-      case 'done': setIsStreaming(false); break;
-      case 'error': setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `${i18n.resolvedLanguage === 'pt' ? 'Erro' : 'Error'}: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
+      case 'done':
+        setStreamDraft(''); setIsStreaming(false); break;
+      case 'error':
+        setStreamDraft(''); setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `${i18n.resolvedLanguage === 'pt' ? 'Erro' : 'Error'}: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
     }
   }, []);
 
@@ -1084,6 +1100,7 @@ export default function CboProfilePage() {
         messageType: 'content', timestamp: new Date().toISOString(),
       }]);
       if (!suppress) setStreamRetry(text);
+      setStreamDraft(''); // dropped stream — the partial draft was never finalized/persisted
     } finally {
       clearTimeout(watchdog);
       if (activeStreamRef.current === streamHandle) activeStreamRef.current = null;
@@ -1142,7 +1159,7 @@ export default function CboProfilePage() {
   const handleRestart = useCallback(async () => {
     abortActiveStream();
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
-    clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+    clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setStreamDraft(''); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
@@ -1697,7 +1714,16 @@ export default function CboProfilePage() {
               </div>
             )}
 
-            {isStreaming && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
+            {streamDraft && (
+              <div className="flex justify-start">
+                <div className="max-w-[90%] md:max-w-[560px] rounded-lg px-4 py-2.5 bg-muted">
+                  <div className="prose prose-sm max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{streamDraft}</ReactMarkdown>
+                  </div>
+                </div>
+              </div>
+            )}
+            {isStreaming && !streamDraft && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
 
             {/* Start Next Workshop banner.
                 When the coordinator opens a workshop higher than the user's

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1248,6 +1248,10 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
         cwd: process.cwd(),
         model,
         systemPrompt,
+        // Token streaming (LT-4): emit stream_event deltas so text reaches the
+        // phone as it generates instead of arriving as whole blocks after each
+        // inference round (~1-3s of staring at "Processando…" per round).
+        includePartialMessages: true,
         // Turn cap — a runaway tool loop otherwise burns the full ~10K-token
         // prompt once per roundtrip while the user watches "Processando…".
         // Normal turns use 2-5 tool calls; 12 is generous headroom.
@@ -1280,6 +1284,16 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
         permissionMode: "bypassPermissions",
       },
     })) {
+      // Live text deltas — transient chat_delta events (never persisted; the
+      // whole-block 'chat' below is the durable record + normalizer input).
+      if ((message as any).type === "stream_event") {
+        const ev: any = (message as any).event;
+        if (ev?.type === 'content_block_delta' && ev.delta?.type === 'text_delta' && ev.delta.text) {
+          if (!firstEventMs) firstEventMs = Date.now() - turnStart;
+          pushEvent({ type: 'chat_delta', content: ev.delta.text });
+        }
+        continue;
+      }
       if (message.type === "assistant" && message.message?.content) {
         inferenceRounds++;
         if (!firstEventMs) firstEventMs = Date.now() - turnStart;

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -260,6 +260,12 @@ export interface InterventionSelectorResult {
 // SSE events — same structure as concept note but with CBO types
 export type CboEvent =
   | { type: 'chat'; content: string; role: 'assistant'; messageType?: 'content' | 'thinking' | 'tool_status' }
+  // Transient token-streaming delta (LT-4): NOT persisted — the finalizing
+  // 'chat' event (whole block, post-normalizer) is the durable record. The
+  // client accumulates deltas into a live draft bubble and replaces it when
+  // the finalizer arrives, so the inline-options converter keeps operating
+  // on whole blocks (buffer-then-finalize).
+  | { type: 'chat_delta'; content: string }
   | { type: 'chat_thinking'; content: string }
   | { type: 'thinking_step'; step: { id: string; label: string; status: 'pending' | 'active' | 'complete' | 'error' } }
   | { type: 'field_update'; sectionId: string; field: string; value: string; confidence: Confidence; source?: string }


### PR DESCRIPTION
## What

Ana's field report: *"agent too slow on basic questions."* Turns are LLM-dominated and text arrived as **whole blocks after each inference round** — the user stares at 'Processando…' for the full round (1.5–5 s each). This enables `includePartialMessages` in the SDK call and forwards `text_delta`s as a new **transient `chat_delta` event**.

## Design — buffer-then-finalize (resolves the audit's normalizer tension)

- `chat_delta` is never persisted and never touches the inline-options converter. The whole-block `chat` event — normalizer → persistence, unchanged — stays the single durable record.
- The client accumulates deltas into a live draft bubble and **replaces it wholesale** on any finalizer (`chat`, an `ask_user` conversion, `done`, `error`); draft also clears on restart and dropped-stream retry, so a partial can never linger or persist.
- The bounce indicator hides while draft text is visible.
- RL-2 (sentence-fusing residual) is masked: deltas render verbatim; whole-block joins now only shape the persisted transcript, which reloads as separate bubbles.

## Verification

- **Live model turn**: 6 deltas, first at 5.7 s (vs. waiting for the whole round), draft **byte-identical** to the finalizing chat event — replace is invisible.
- Fake-model e2e ×8 green (that path emits no deltas — graceful degradation): golden path, sse-heartbeat, stream-retry, restart-mid-stream, instant kickoff ×2, inline-options ×2.
- tsc clean.

## Tradeoffs

- An inline option list that the normalizer converts to buttons will briefly render as streaming text before becoming a card — rare (the skill forbids inline lists; the converter is the backstop), and strictly better than the previous blank wait.
- Perceived-latency win (~1–3 s per text-bearing turn), not a total-time win — rounds still cost what they cost. Pairs with #362 (prompt caching) which attacks the actual round time.

From `docs/system-complexity-audit-2026-07.md` item **LT-4** (order-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)