### PR TITLE
fix(cohort): roster snapshots written server-side on every flush (EF-4)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -931,29 +931,16 @@ export default function CboProfilePage() {
         setState(prev => prev ? { ...prev, gaps: [...prev.gaps, { sectionId: event.sectionId as CboSectionId, field: event.field, reason: event.reason, severity: event.severity as any }] } : prev);
         break;
       case 'phase_change':
+        // Roster snapshots (phase/maturity/flags/last-active) are written
+        // SERVER-SIDE on every durable flush now (EF-4, syncMemberSnapshot in
+        // cboPersistence): the old client PATCH here only fired when a live
+        // socket delivered the event, so progress made during a dead stream
+        // never reached the coordinator. The PATCH route itself stays — the
+        // cboStateId-link effect and the unlock clamp still use it.
         setState(prev => prev ? { ...prev, phase: event.phase } : prev);
-        if (memberSlug) {
-          fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ phase: event.phase, cboStateId: cboId }),
-          }).catch(() => {});
-        }
         break;
       case 'maturity_update':
         setState(prev => prev ? { ...prev, maturityScores: event.scores, totalMaturityScore: event.total, priorityFlags: event.flags } : prev);
-        if (memberSlug) {
-          // Count filled sections from current state for the snapshot.
-          fetch(`/api/cbo-member/${memberSlug}/snapshot`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              maturityScore: event.total,
-              flagsMet: (event.flags || []).filter((f: PriorityFlag) => f.met).length,
-              cboStateId: cboId,
-            }),
-          }).catch(() => {});
-        }
         break;
       case 'ask_user': {
         // Open the map only when the agent explicitly signals it via `showMap`

--- a/server/services/cboPersistence.ts
+++ b/server/services/cboPersistence.ts
@@ -13,6 +13,8 @@
 
 import { db } from '../db';
 import { cboStates, cboMessages } from '@shared/cbo-db-schema';
+import { cohortMembers } from '@shared/cohort-schema';
+import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
 import { eq, asc } from 'drizzle-orm';
 import type { CboState, CboChatMessage } from '@shared/cbo-schema';
 
@@ -180,6 +182,16 @@ export async function flushCbo(
         })));
       }
     });
+    // Mirror the roster snapshot server-side (audit EF-4). These columns used
+    // to be written only by a client PATCH fired from the SSE handler on the
+    // CBO's phone — pushEvent silently drops events with no live socket, so
+    // scores earned during a dead stream (or with the app backgrounded) never
+    // reached the coordinator roster. The flush path runs on every durable
+    // save regardless of any client, so the roster can't silently go stale.
+    // Standalone CBOs simply match zero member rows. Best-effort: a snapshot
+    // miss must never fail the flush (the read path derives sections live —
+    // EF-2 — so worst case the roster lags one flush).
+    await syncMemberSnapshot(state).catch((e) => logDbError('syncMemberSnapshot', state.id, e));
     return { committed: true, flushedCount: startPosition + newMessages.length };
   } catch (e) {
     logDbError('flushCbo', state.id, e);
@@ -187,6 +199,25 @@ export async function flushCbo(
     // and the state row will be re-upserted (idempotent), so nothing is lost.
     return { committed: false, flushedCount: startPosition };
   }
+}
+
+/** Derived roster snapshot from the live state — single source of truth for
+ *  what the coordinator cards show between workshops. */
+async function syncMemberSnapshot(state: CboState): Promise<void> {
+  const sectionsComplete = CBO_SECTIONS.filter(sec => {
+    const fields = (state.sections as Record<string, { fields?: Record<string, CboFieldState> } | undefined>)?.[sec.id]?.fields ?? {};
+    return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
+  }).length;
+  const interventionRaw = (state.sections as any)?.intervention_type?.fields;
+  const intervention = (interventionRaw?.intervention_type?.value ?? interventionRaw?.nbs_type?.value ?? null) as string | null;
+  await db.update(cohortMembers).set({
+    snapshotPhase: state.phase ?? 1,
+    snapshotSectionsComplete: sectionsComplete,
+    snapshotMaturityScore: state.totalMaturityScore ?? 0,
+    snapshotFlagsMet: (state.priorityFlags ?? []).filter(f => f.met).length,
+    ...(intervention ? { snapshotIntervention: String(intervention) } : {}),
+    snapshotUpdatedAt: new Date(),
+  }).where(eq(cohortMembers.cboStateId, state.id));
 }
 
 /**


### PR DESCRIPTION
## What

The roster snapshot columns (phase / sections / maturity / flags / intervention / last-active) were pushed **from the CBO's phone**: a PATCH fired inside the SSE event handler. `pushEvent` silently drops events when the socket is dead, so scores earned during a dropped stream or with the app backgrounded **never reached the coordinator roster** — on a phone-first audience with patchy mobile data, that's routine, not edge-case.

- `syncMemberSnapshot` (new, in `cboPersistence`) runs on **every durable flush** (`flushCbo`, the single save funnel): derives all snapshot fields from live state. `sectionsComplete` uses the exact filled-non-invite-field signal that `phaseComplete()` and EF-2's `attachDerivedSections` use — the CBO banner, the roster read path, and the roster write path can no longer disagree.
- Best-effort by design: a snapshot failure never fails the flush (the EF-2 read path derives live anyway, so worst case the roster lags one flush).
- **Client PATCH writers removed in the same release** (audit's explicit warning — they'd race the server writes). The PATCH **route stays**: the cboStateId-link effect and the coordinator unlock clamp live there.
- Standalone CBOs: the UPDATE matches zero member rows — no-op.

## Verification

e2e chromium green ×7: golden path, phase-1 walkthrough (fake-model flush path exercises the sync), admin cohort panel, cohort isolation, invite sessions ×2. tsc clean.

## Tradeoff

One extra UPDATE per durable flush (flushes are already debounced/boundary-driven, not per-token). In exchange the roster is correct even when the phone's socket is not.

From `docs/system-complexity-audit-2026-07.md` item **EF-4** (order-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)