### PR TITLE
feat(cohort): maturity tier persisted + injected + coordinator-overridable; invite org type (EF-5)

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -368,7 +368,7 @@ export function InviteCboDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Pure invite — no side effects. Called once per CBO in either mode. */
-  onSubmit: (params: { orgName: string; neighborhood?: string }) => Promise<{ memberSlug: string; orgName: string } | null>;
+  onSubmit: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<{ memberSlug: string; orgName: string } | null>;
   /** Called after a successful single-mode invite — parent typically opens
       the ShareLinkDialog for that CBO. NOT called in bulk mode. */
   onSingleSuccess?: (result: { memberSlug: string; orgName: string }) => void;
@@ -380,6 +380,10 @@ export function InviteCboDialog({
   const [mode, setMode] = useState<'single' | 'bulk'>('single');
   const [orgName, setOrgName] = useState('');
   const [neighborhood, setNeighborhood] = useState('');
+  // EF-5: the invite used to hardcode type 'community' — wrong default for
+  // the implementer cohort. Coordinator declares it here; agent calibration
+  // and (later) tier read start from the org row.
+  const [orgType, setOrgType] = useState<'community' | 'implementer'>('community');
   const [bulkText, setBulkText] = useState('');
   const [bulkProgress, setBulkProgress] = useState<{ done: number; total: number } | null>(null);
   const [busy, setBusy] = useState(false);
@@ -390,6 +394,7 @@ export function InviteCboDialog({
       setMode('single');
       setOrgName('');
       setNeighborhood('');
+      setOrgType('community');
       setBulkText('');
       setBulkProgress(null);
     }
@@ -407,6 +412,7 @@ export function InviteCboDialog({
         const result = await onSubmit({
           orgName: orgName.trim(),
           neighborhood: neighborhood.trim() || undefined,
+          orgType,
         });
         if (result) {
           onOpenChange(false);
@@ -505,6 +511,27 @@ export function InviteCboDialog({
                   onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
                   data-testid="input-neighborhood"
                 />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-foreground/80">
+                  {t('orchestrator.cohort.orgType', { defaultValue: 'Organization type' })}
+                </label>
+                <div className="flex gap-1.5">
+                  {(['community', 'implementer'] as const).map(v => (
+                    <button
+                      key={v}
+                      type="button"
+                      onClick={() => setOrgType(v)}
+                      aria-pressed={orgType === v}
+                      data-testid={`orgtype-${v}`}
+                      className={`px-2.5 py-1.5 rounded-md border text-xs font-medium transition-colors ${orgType === v ? 'bg-foreground text-background border-foreground' : 'bg-background text-foreground/70 border-foreground/15 hover:border-foreground/40'}`}
+                    >
+                      {v === 'community'
+                        ? t('orchestrator.cohort.orgTypeCommunity', { defaultValue: 'Community org' })
+                        : t('orchestrator.cohort.orgTypeImplementer', { defaultValue: 'Implementer / studio' })}
+                    </button>
+                  ))}
+                </div>
               </div>
             </>
           ) : (

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -47,7 +47,7 @@ export interface UseCohortResult {
   /** Admin: create a coordinator + their cohort in one shot, then load it. */
   provisionCohort: (input: ProvisionInput) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
   resetCohort: () => Promise<void>;
-  invite: (params: { orgName: string; neighborhood?: string }) => Promise<CohortMember | null>;
+  invite: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
   saveLanguage: (language: 'pt' | 'en' | null) => Promise<void>;
@@ -139,11 +139,11 @@ export function useCohort(): UseCohortResult {
     }
   }, []);
 
-  const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood }) => {
+  const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, orgType }) => {
     const r = await fetch(`/api/cohort/${slugRef.current}/invite`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orgName, neighborhood }),
+      body: JSON.stringify({ orgName, neighborhood, orgType }),
     });
     if (!r.ok) return null;
     const { member } = await r.json();

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -97,6 +97,9 @@ type CboDemoProject = {
   supportPendingCount: number;
   /** How many files this CBO has uploaded — drives the 📎 chip + files drawer. */
   documentCount: number;
+  /** Persisted org maturity tier (EF-5): set by the agent at E1 close,
+   *  coordinator-overridable from the card. Null until E1 completes. */
+  maturityTier: 'emerging' | 'developing' | 'advanced' | null;
   /** E2 "usar o bairro todo": the org committed a neighborhood but deferred the
    *  exact site (coords are the bairro centroid). Drives an amber chip and is
    *  excluded from the sites-mapped KPI. */
@@ -166,6 +169,7 @@ function memberToView(m: CohortMember): CboDemoProject {
       ? ((m as any).supportRequests as { resolvedAt: string | null }[]).filter(r => !r.resolvedAt).length
       : 0,
     documentCount: (m as any).documentCount ?? 0,
+    maturityTier: ((m as any).maturityTier as 'emerging' | 'developing' | 'advanced' | null) ?? null,
     siteDeferred: site?.deferred === true,
   };
 }
@@ -585,6 +589,7 @@ function ProjectCard({
   onHover,
   onOpen,
   onOpenCbo,
+  onSetTier,
 }: {
   project: CboDemoProject;
   locale: 'en' | 'pt';
@@ -592,6 +597,7 @@ function ProjectCard({
   onHover: (id: string | null) => void;
   onOpen: (p: CboDemoProject) => void;
   onOpenCbo: (p: CboDemoProject, tab: 'arquivos' | 'conversa' | 'perfil') => void;
+  onSetTier: (p: CboDemoProject, tier: 'emerging' | 'developing' | 'advanced') => void;
 }) {
   const { t } = useTranslation();
   const hasIntervention = project.interventionKey !== null;
@@ -656,6 +662,23 @@ function ProjectCard({
             <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wide px-2 py-0.5 rounded-full border border-foreground/10 bg-foreground/5 text-foreground/75">
               {t(`orchestrator.demo.phase.${project.currentPhase}`)}
             </span>
+            {/* Maturity tier (EF-5): shown once E1 persists it; the select IS
+                the coordinator override — a wrong persisted tier is stickier
+                than per-turn inference, so correction must be one tap. */}
+            {project.maturityTier && (
+              <select
+                value={project.maturityTier}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => { e.stopPropagation(); onSetTier(project, e.target.value as 'emerging' | 'developing' | 'advanced'); }}
+                data-testid={`tier-select-${project.id}`}
+                className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-full border border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300 cursor-pointer"
+                title={t('orchestrator.demo.tierTitle', { defaultValue: 'Maturity tier (agent-read at E1 — you can override it)' })}
+              >
+                <option value="emerging">{t('orchestrator.demo.tier.emerging', { defaultValue: 'Emerging' })}</option>
+                <option value="developing">{t('orchestrator.demo.tier.developing', { defaultValue: 'Developing' })}</option>
+                <option value="advanced">{t('orchestrator.demo.tier.advanced', { defaultValue: 'Advanced' })}</option>
+              </select>
+            )}
             {project.path && (
               <span
                 className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200/60 dark:border-emerald-900/40"
@@ -838,11 +861,26 @@ export default function OrchestratorLandingPage() {
   const {
     cohort, members, isAdmin, allCohorts,
     invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage, deleteCohort,
-    switchCohort, provisionCohort,
+    switchCohort, provisionCohort, refresh,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
 
   const projects = useMemo(() => members.map(memberToView), [members]);
+
+  // Coordinator tier override (EF-5) — one tap on the card's tier select.
+  const handleSetTier = async (p: CboDemoProject, tier: 'emerging' | 'developing' | 'advanced') => {
+    if (!cohort?.coordinatorSlug) return;
+    const r = await fetch(`/api/cohort/${cohort.coordinatorSlug}/member/${p.id}/tier`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tier }),
+    });
+    if (!r.ok) {
+      toast({ title: t('orchestrator.demo.tierFailed', { defaultValue: 'Could not update the tier' }) });
+      return;
+    }
+    await refresh();
+  };
   const memberById = useMemo(() => new Map(members.map(m => [m.id, m])), [members]);
 
   // Initialize the inbox badge from already-loaded members so it lights up
@@ -1001,7 +1039,7 @@ export default function OrchestratorLandingPage() {
   // Pure: just makes the invite. The post-success share dialog is wired
   // separately via onSingleSuccess so the bulk-invite loop doesn't trigger
   // N share dialogs (it uses onBulkComplete instead).
-  const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string }) => {
+  const handleInviteSubmit = async (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => {
     const created = await invite(params);
     if (!created) {
       toast({ title: t('orchestrator.cohort.inviteFailed', { defaultValue: 'Could not create invitation' }) });
@@ -1303,6 +1341,7 @@ export default function OrchestratorLandingPage() {
                     onHover={setSelectedId}
                     onOpen={(p) => openCbo(p, 'convite')}
                     onOpenCbo={openCbo}
+                    onSetTier={handleSetTier}
                   />
                   {member && (
                     <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -163,7 +163,10 @@
       "workshops": "Cronograma de encontros",
       "phaseUnlocked": "Fase {{phase}} liberada",
       "unlockedThrough": "Liberado até a Fase {{phase}}",
-      "workshopOpened": "{{workshop}} aberto para o grupo"
+      "workshopOpened": "{{workshop}} aberto para o grupo",
+      "orgType": "Tipo de organização",
+      "orgTypeCommunity": "Org comunitária",
+      "orgTypeImplementer": "Implementadora / estúdio"
     },
     "demo": {
       "headerEyebrow": "Visão da articuladora",
@@ -229,6 +232,13 @@
       "support": {
         "pendingChip": "{{n}} pendência(s)",
         "pendingTooltip": "{{n}} pedido(s) de apoio aguardando"
+      },
+      "tierTitle": "Nível de maturidade (lido pelo agente no E1 — você pode corrigir)",
+      "tierFailed": "Não foi possível atualizar o nível",
+      "tier": {
+        "emerging": "Emergente",
+        "developing": "Em desenvolvimento",
+        "advanced": "Avançada"
       }
     },
     "map": {

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -59,7 +59,7 @@ Each turn you take MUST end with one of these:
 
 1. An `ask_user` tool call (the next question in the sequence). This is the most common case.
 2. A composer tool call: `open_map`, `ask_priority_rank`, `ask_community_anchoring`, `show_examples` (N/A in E1, used in E2+).
-3. The closing message + closing tool calls (`score_maturity` × 2 + `set_path`) — ONLY at the end of E1 after all questions answered.
+3. The closing message + closing tool calls (`score_maturity` × 2 + `set_path` + `set_maturity_tier`) — ONLY at the end of E1 after all questions answered.
 
 **If you respond to a user answer with only silent tool calls (e.g. `update_section` and nothing else), the user sees an empty screen with a "Continue" button instead of the next question.** That is a critical failure. Always pair an `update_section` with the next `ask_user` in the same turn.
 
@@ -256,7 +256,7 @@ advanced    org_delivery_capacity ≥ 2 AND team_technical_experience ≥ 2,
 - **developing** → standard depth and pace.
 - **advanced** → crisper, assume fluency. When it's natural, you may go a touch deeper on a prior funded project or partnership (without turning E1 into the later encontros) — these orgs move faster and a thin profile wastes their time.
 
-You don't announce the tier or show it to the org. Use it to calibrate, and let it inform your `score_maturity` justifications. (A coordinator override of the tier is a future platform feature; for now, infer and adapt.)
+You don't announce the tier or show it to the org. Use it to calibrate, and let it inform your `score_maturity` justifications. **At the E1 close, persist your read with `set_maturity_tier(tier)`** — the later encontros load the stored tier instead of re-deriving it, and the coordinator can override it from the console.
 
 ## Path triage — the most important question
 

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -19,7 +19,7 @@ import {
   type WorkshopConfig,
   type MemberSite,
 } from '@shared/cohort-schema';
-import { createOrganization, linkCboStateToOrg } from '../services/orgPersistence';
+import { createOrganization, linkCboStateToOrg, setMaturityTierForCboState } from '../services/orgPersistence';
 import { cboStates } from '@shared/cbo-db-schema';
 import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
 import { getCboMessages, getCboState, loadCboFromDb } from '../services/cboAgent';
@@ -31,6 +31,7 @@ import {
   type CoordinatorRequest,
 } from '../services/coordinatorAuth';
 import { coordinators } from '@shared/coordinator-schema';
+import { organizations } from '@shared/org-schema';
 
 // Slug-as-secret: 24 chars of url-safe nanoid. Used as a fallback when the
 // human-readable slug derivation collides too many times.
@@ -236,6 +237,23 @@ async function attachDerivedSections<
   }));
 }
 
+// Org maturity tier per member, one grouped query (EF-5) — drives the
+// coordinator's tier chip/override on the roster cards.
+async function attachOrgTiers<T extends { orgId: string | null }>(
+  members: T[],
+): Promise<(T & { maturityTier: string | null })[]> {
+  const ids = Array.from(new Set(members.map(m => m.orgId).filter((v): v is string => !!v)));
+  const byOrg = new Map<string, string | null>();
+  if (ids.length > 0) {
+    const rows = await db
+      .select({ id: organizations.id, tier: organizations.maturityTier })
+      .from(organizations)
+      .where(inArray(organizations.id, ids));
+    for (const r of rows) byOrg.set(r.id, r.tier ?? null);
+  }
+  return members.map(m => ({ ...m, maturityTier: (m.orgId && byOrg.get(m.orgId)) || null }));
+}
+
 export function registerCohortRoutes(app: Express): void {
   // Phase 3c-ii — gate the entire coordinator surface behind a coordinator
   // session. Every /api/cohort/* route is coordinator-facing (the CBO-facing
@@ -275,7 +293,7 @@ export function registerCohortRoutes(app: Express): void {
       cohort = c;
     }
     if (!cohort) cohort = await getOrCreateDefaultCohort();
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     res.json({ cohort, members, isAdmin: !coordinator?.cohortId });
   }));
 
@@ -348,7 +366,7 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/default', wrap(async (req, res) => {
     const cohort = await getOrCreateDefaultCohort();
     if (!mayAccessCohort(req, cohort.id)) { res.status(403).json({ error: 'forbidden' }); return; }
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     res.json({ cohort, members });
   }));
 
@@ -412,7 +430,7 @@ export function registerCohortRoutes(app: Express): void {
   app.get('/api/cohort/:coordinatorSlug', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     res.json({ cohort, members });
   }));
 
@@ -485,7 +503,11 @@ export function registerCohortRoutes(app: Express): void {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
 
-    const { orgName, neighborhood, role, origin } = req.body ?? {};
+    // orgType (EF-5): 'community' (default) or 'implementer'. The hardcoded
+    // 'community' was exactly wrong for the August implementer cohort — the
+    // agent's tier/type calibration starts from the org row, so the invite is
+    // where the coordinator declares it.
+    const { orgName, neighborhood, role, origin, orgType } = req.body ?? {};
     if (!orgName) { res.status(400).json({ error: 'orgName required' }); return; }
 
     const memberSlug = await uniqueMemberSlug(slugify(orgName));
@@ -511,7 +533,7 @@ export function registerCohortRoutes(app: Express): void {
     // block the invite, so org_id just stays null and the backfill picks it up.
     let orgId: string | null = null;
     try {
-      const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: 'community', cohortId: cohort.id });
+      const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: orgType === 'implementer' ? 'implementer' : 'community', cohortId: cohort.id });
       orgId = org.id;
     } catch (e: any) {
       console.error('[cohort] org creation failed on invite (continuing, backfill will link):', e?.message || e);
@@ -574,7 +596,7 @@ export function registerCohortRoutes(app: Express): void {
     const phaseNum = Number(phase);
     if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase' }); return; }
 
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     const targets = memberIds === 'all'
       ? members
       : members.filter(m => Array.isArray(memberIds) && memberIds.includes(m.id));
@@ -641,11 +663,29 @@ export function registerCohortRoutes(app: Express): void {
   // Coordinator support inbox — list all support requests across the cohort,
   // newest first. Returns flattened entries with member context so the UI
   // doesn't need to re-correlate. `status=pending` filters to unresolved.
+  // Coordinator override of the org's maturity tier (EF-5). The agent
+  // persists its read at E1 close; a persisted-wrong tier is stickier than
+  // per-turn inference, so the console MUST be able to correct it. Guarded by
+  // the :coordinatorSlug app.param ownership check like every cohort route.
+  app.patch('/api/cohort/:coordinatorSlug/member/:memberId/tier', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+    const tier = req.body?.tier;
+    if (!['emerging', 'developing', 'advanced'].includes(tier)) {
+      res.status(400).json({ error: "tier must be 'emerging' | 'developing' | 'advanced'" });
+      return;
+    }
+    if (!member.cboStateId) { res.status(409).json({ error: 'member has no linked session yet' }); return; }
+    const orgName = await setMaturityTierForCboState(member.cboStateId, tier);
+    if (!orgName) { res.status(409).json({ error: 'member has no linked organization yet' }); return; }
+    res.json({ ok: true, tier, orgName });
+  }));
+
   app.get('/api/cohort/:coordinatorSlug/support-requests', wrap(async (req, res) => {
     const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
     if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
     const filter = String(req.query.status ?? 'all');
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     const items: Array<{
       requestId: string;
       memberId: string;
@@ -714,7 +754,7 @@ export function registerCohortRoutes(app: Express): void {
     const { resolvedNote } = req.body ?? {};
     const note = typeof resolvedNote === 'string' && resolvedNote.trim() ? resolvedNote.trim().slice(0, 1000) : null;
 
-    const members = await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id))));
+    const members = await attachOrgTiers(await attachDerivedSections(await attachDocCounts(await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id)))));
     for (const m of members) {
       const arr = Array.isArray(m.supportRequests) ? (m.supportRequests as SupportRequest[]) : [];
       const idx = arr.findIndex(r => r.id === req.params.requestId);

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -26,6 +26,7 @@ import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
 import { eq } from "drizzle-orm";
 import { getOrgIdForCboState, listDocumentsByOrg, listDocumentSummariesByOrg, getDocumentForOrg } from "./documentPersistence";
+import { setMaturityTierForCboState, getMaturityTierForCboState } from "./orgPersistence";
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { emitAssistantText } from "./agentOutput";
@@ -360,6 +361,28 @@ function createCboMcpTools(cboId: string) {
         return { content: [{ type: "text" as const, text: `Path set to '${args.path}' for ${result[0].orgName}.` }] };
       } catch (err: any) {
         return { content: [{ type: "text" as const, text: `Error setting path: ${err.message}` }], isError: true };
+      }
+    },
+    { annotations: { readOnlyHint: false } }
+  );
+
+  // E1 close: persist the maturity-tier read (audit EF-5). The tier used to
+  // be inferred fresh from the transcript every turn and never written
+  // anywhere — organizations.maturity_tier stayed null, and E2+ (whose
+  // skills don't re-derive it) ran with no calibration signal at all.
+  const setMaturityTier = sdkTool(
+    "set_maturity_tier",
+    "Persist the org's maturity-tier read at the END of Encontro 1 (with the closing score_maturity + set_path calls). 'emerging' = plainest language, hide jargon; 'developing' = standard depth; 'advanced' = crisper, assume fluency. Grounded in the COUGAR Gate-2 rubric. Later encontros read this instead of re-deriving it, and the coordinator can override it.",
+    { tier: z.enum(["emerging", "developing", "advanced"]) },
+    async (args: any) => {
+      try {
+        const orgName = await setMaturityTierForCboState(cboId, args.tier);
+        if (!orgName) {
+          return { content: [{ type: "text" as const, text: `No organization linked to this session; tier '${args.tier}' not persisted (standalone session).` }] };
+        }
+        return { content: [{ type: "text" as const, text: `Maturity tier set to '${args.tier}' for ${orgName}.` }] };
+      } catch (err: any) {
+        return { content: [{ type: "text" as const, text: `Error setting tier: ${err.message}` }], isError: true };
       }
     },
     { annotations: { readOnlyHint: false } }
@@ -786,7 +809,7 @@ STOP and wait for the user's selection after calling this tool.`,
   return sdkCreateMcpServer({
     name: "cbo",
     version: "1.0.0",
-    tools: [updateSection, flagGap, setPhase, setPath, showInterventionTypes, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, searchKnowledge, listOrgDocuments, readOrgDocument, searchOrgDocuments, openInterventionSelector],
+    tools: [updateSection, flagGap, setPhase, setPath, setMaturityTier, showInterventionTypes, showExamples, askPriorityRank, askCommunityAnchoring, askUser, openMap, scoreMaturity, setPriorityFlag, readKnowledge, searchKnowledge, listOrgDocuments, readOrgDocument, searchOrgDocuments, openInterventionSelector],
   });
 }
 
@@ -1284,6 +1307,7 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__flag_gap",
           "mcp__cbo__set_phase",
           "mcp__cbo__set_path",
+          "mcp__cbo__set_maturity_tier",
           "mcp__cbo__show_examples",
           "mcp__cbo__ask_priority_rank",
           "mcp__cbo__ask_community_anchoring",
@@ -1540,6 +1564,28 @@ async function buildSystemContext(state: CboState, lang: string = 'en'): Promise
   const encontroSkill = await loadEncontroSkill(skillPhase);
   const phaseInstructions = encontroSkill?.markdown ?? buildPhaseInstructions(state.phase, isPt);
 
+  // Persisted maturity tier (EF-5): E1 infers and persists it via
+  // set_maturity_tier; from E2 on we inject the stored value so later
+  // encontros calibrate depth without re-deriving it from a transcript that
+  // no longer contains the E1 signals. Stable per phase, so it lives in the
+  // cached system prefix, not the volatile blocks.
+  let tierBlock = '';
+  if (state.phase >= 2) {
+    const tier = await getMaturityTierForCboState(state.id).catch(() => null);
+    if (tier) {
+      const guidance: Record<string, string> = {
+        emerging: isPt
+          ? 'linguagem simples, sem jargão técnico ("hotspots", "tipologias"); reforço extra de acolhimento; nunca pressuponha orçamento ou estrutura formal.'
+          : 'plainest language, no technical jargon; extra reassurance; never assume budget or formal structure.',
+        developing: isPt ? 'profundidade e ritmo padrão.' : 'standard depth and pace.',
+        advanced: isPt
+          ? 'tom mais direto, assuma fluência; pode aprofundar em projetos anteriores e parcerias — perfis rasos desperdiçam o tempo dessa org.'
+          : 'crisper tone, assume fluency; go deeper on prior projects and partnerships — a thin profile wastes this org\'s time.',
+      };
+      tierBlock = `\n\n## MATURITY TIER: ${tier}\nCalibration (persisted at E1, coordinator can override — adapt TONE and depth, never which steps you run): ${guidance[tier]}`;
+    }
+  }
+
   // ── City summary (condensed, always loaded) ──
   const citySummary = isPt
     ? `Porto Alegre, RS, Brasil. Pop 1,4M. Enchentes catastróficas em maio 2024 (piores da história do RS). Riscos: inundação (Guaíba), ilhas de calor (4° Distrito, Centro), deslizamento (morros). Planos: PCVR, World Bank P178072 (US$85M regeneração verde). Precedentes: Orla do Guaíba (5,7ha, espécies nativas), Regenera Dilúvio. COUGAR mapeou 50+ atores no ecossistema.`
@@ -1571,7 +1617,7 @@ ${isPt
   : `1. Who We Are (org_profile) · 2. Where We Work (intervention_site, use open_map) · 3a. What We're Building (intervention_type, use open_intervention_selector) · 3b. Expected Impact (impact_monitoring) · 3c. Operations & Sustainability (operations_sustain) · 4. What We Need (needs_assessment) · 5. Results & Evidence (results_evidence) · 6. Maturity Scorecard (set_phase 6 to complete)`}
 
 ## CURRENT PHASE INSTRUCTIONS
-${phaseInstructions}
+${phaseInstructions}${tierBlock}
 
 ## RULES
 ${isPt

--- a/server/services/orgPersistence.ts
+++ b/server/services/orgPersistence.ts
@@ -32,3 +32,32 @@ export async function getOrganization(id: string): Promise<Organization | null> 
 export async function linkCboStateToOrg(cboStateId: string, orgId: string): Promise<void> {
   await db.update(cboStates).set({ orgId }).where(eq(cboStates.id, cboStateId));
 }
+
+/** Resolve the org for a cbo_state (member link preferred, cboStates.orgId
+ *  fallback) and set its maturity tier. Returns the org name, or null when
+ *  no org exists (standalone session). Used by the agent's set_maturity_tier
+ *  tool at E1 close and the coordinator override endpoint (audit EF-5 — the
+ *  tier used to be inferred fresh every turn and never persisted anywhere,
+ *  so E2+ had no tier signal at all). */
+export async function setMaturityTierForCboState(
+  cboStateId: string,
+  tier: MaturityTier,
+): Promise<string | null> {
+  const [row] = await db.select({ orgId: cboStates.orgId }).from(cboStates).where(eq(cboStates.id, cboStateId)).limit(1);
+  const orgId = row?.orgId ?? null;
+  if (!orgId) return null;
+  const [org] = await db.update(organizations).set({ maturityTier: tier }).where(eq(organizations.id, orgId)).returning();
+  return org?.name ?? null;
+}
+
+/** The persisted tier for a cbo_state's org, or null. Read on E2+ turns to
+ *  inject the calibration block into the system context. */
+export async function getMaturityTierForCboState(cboStateId: string): Promise<MaturityTier | null> {
+  const [row] = await db
+    .select({ tier: organizations.maturityTier })
+    .from(cboStates)
+    .innerJoin(organizations, eq(organizations.id, cboStates.orgId))
+    .where(eq(cboStates.id, cboStateId))
+    .limit(1);
+  return (row?.tier as MaturityTier | null) ?? null;
+}


### PR DESCRIPTION
## What

The audit called the adaptive tier *"folklore"*: the session-1-hardening design shipped skill-side only — `organizations.maturity_tier` was never written, never read, E2+ had no calibration signal, and invites hardcoded `type='community'` (wrong for the August implementer cohort). Four pieces:

1. **`set_maturity_tier` tool** — E1's closing calls now persist the tier read (`emerging|developing|advanced`, COUGAR Gate-2 rubric). Skill updated; standalone sessions no-op.
2. **E2+ injection** — later encontros load the stored tier as a calibration block in the system context (tone/depth only, never which steps), instead of re-deriving from a transcript that no longer contains the E1 signals. Phase-stable → cache-friendly with #362.
3. **Coordinator override** — `PATCH /member/:id/tier` (ownership-guarded like all cohort routes) + a one-tap select on the roster card. The audit's warning: *"a persisted-wrong tier is stickier than per-turn inference — override UI is not optional."* Rosters carry the tier via a grouped `attachOrgTiers` (no N+1).
4. **Invite org type** — community/implementer toggle in the invite dialog; server honors it in `createOrganization`.

## Verification

- e2e green ×6: golden path, admin cohort panel, invite-message-lang, cohort isolation ×2, phase-1 walkthrough. tsc clean.
- pt.json keys added; EN via inline `defaultValue` (the repo's orchestrator-string convention).

## Tradeoffs

- The tier select only appears after E1 persists a tier (no chip clutter for fresh invites). Pre-existing orgs (E1 done before this) have no tier until the coordinator sets one or E1 is redone — backfill wasn't attempted (would mean re-deriving from transcripts).
- E1 behavior change is one extra closing tool call — same shape as set_path, low risk; worth an eye on the first live E1 after deploy.

From `docs/system-complexity-audit-2026-07.md` item **EF-5** (order-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)