### PR TITLE
Fix restart-from-scratch: re-prefill invite data, re-post greeting, clear member progress

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1148,10 +1148,46 @@ export default function CboProfilePage() {
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
     clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setStreamDraft(''); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
+    // The server just cleared cohort_members.path — mirror it locally so the
+    // UI doesn't keep showing the old run's E1 triage answer.
+    setMemberPath(null);
     const res = await fetch('/api/cbo', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ city: 'porto-alegre' }) });
     const data = await res.json();
     setCboId(data.cboId); setState(data.state); saveId(data.cboId);
-  }, [cboId, abortActiveStream]);
+    // Re-seed the invite prefill for the NEW session, synchronously and
+    // BEFORE the greeting — the prefill effect is one-shot (prefillSentRef
+    // already consumed by the old session), and the kickoff template reads
+    // org name + bairro from state, so ordering matters. Field report
+    // 2026-07-08: after a restart the org lost its name/neighborhood and
+    // was never greeted again.
+    if (memberInfo) {
+      try {
+        const pr = await fetch(`/api/cbo/${data.cboId}/prefill`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ orgName: memberInfo.orgName, neighborhood: memberInfo.neighborhood ?? undefined }),
+        });
+        const pd = await pr.json();
+        if (pd?.state) setState(migrateCboState(pd.state));
+      } catch {}
+      prefillSentRef.current = true;
+    } else {
+      prefillSentRef.current = false;
+    }
+    // Re-post the instant-kickoff greeting so the fresh session opens with
+    // Step 0 (confirmation + name/role question) instead of a silent empty
+    // chat. Uses the explicit new id — the cboId state update hasn't
+    // committed yet, so kickoffChat() would race it. Fresh transcript is
+    // always virgin, so no model fallback is needed; on error the user just
+    // sees the (previous) empty-chat behavior.
+    try {
+      const kr = await fetch(`/api/cbo/${data.cboId}/kickoff`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lang }),
+      });
+      const kd = await kr.json();
+      if (kd?.ok && kd.message) setMessages([kd.message]);
+    } catch {}
+  }, [cboId, abortActiveStream, memberInfo, lang]);
 
   // Kick off the agent chat with the standard intake prompt. Hidden from the
   // visible message stream — the agent's first response is what the user sees.

--- a/e2e/cbo-restart-invite-reset.spec.ts
+++ b/e2e/cbo-restart-invite-reset.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Field report 2026-07-08 — restarting ("recomeçar do zero") on an invite
+// link left the new session in a broken half-state: the org lost its invited
+// name/neighborhood (the prefill effect is one-shot and had already fired for
+// the OLD session), the chat sat silent (no kickoff greeting was re-posted),
+// and the E1 path answer SURVIVED (it lives on cohort_members, which DELETE
+// /api/cbo/:id didn't touch). This spec drives the full restart cycle on an
+// invite session and pins all three fixes.
+//
+// No fake model needed: the kickoff greeting is a server template, and the
+// spec never sends a chat turn.
+
+test.describe('CBO restart on an invite link resets cleanly', () => {
+  test('restart re-seeds prefill, re-greets, and clears member progress', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const { cohort } = await api.createCohort('e2e restart-reset');
+    const invite = await api.inviteMember(cohort.id, {
+      orgName: 'Org Rewind',
+      neighborhood: 'Sarandi',
+      path: 'has-idea', // the run-derived answer that must NOT survive a restart
+    });
+    const token = new URLSearchParams(invite.inviteUrl.split('?')[1] ?? '').get('t')!;
+
+    // Open the invite and land in the chat.
+    await page.goto(invite.inviteUrl);
+    await page.getByTestId('button-cbo-welcome-cta').click({ timeout: 30_000 });
+    const pre = page.getByTestId('button-encontro-1-start');
+    if (await pre.isVisible({ timeout: 8_000 }).catch(() => false)) await pre.click();
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const firstId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // The invite prefill landed: greeting confirms the org by name.
+    await expect(marker).toHaveAttribute('data-org-name', 'Org Rewind', { timeout: 15_000 });
+    await expect(page.getByText(/Conferindo|Checking/).first()).toBeVisible({ timeout: 15_000 });
+
+    // Restart from scratch.
+    await page.getByTestId('cbo-restart-trigger').click();
+    await page.getByTestId('cbo-restart-confirm').click();
+    await expect(marker).not.toHaveAttribute('data-cbo-id', firstId, { timeout: 15_000 });
+    const secondId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // (1) Prefill re-seeded: the NEW session knows the org again.
+    await expect(marker).toHaveAttribute('data-org-name', 'Org Rewind', { timeout: 15_000 });
+
+    // (2) Kickoff re-posted: the fresh chat opens with the Step-0 greeting,
+    // confirming the invited identity instead of sitting silent.
+    await expect(page.getByText(/Conferindo|Checking/).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Org Rewind').first()).toBeVisible();
+
+    // (3) Member progress cleared server-side: path gone, binding moved to
+    // the new session. Poll — the client PATCHes the new binding async.
+    await expect
+      .poll(async () => (await (await request.get(`/api/cbo-member/by-token/${token}`)).json()).cboStateId, {
+        timeout: 15_000,
+      })
+      .toBe(secondId);
+    const member = await (await request.get(`/api/cbo-member/by-token/${token}`)).json();
+    expect(member.path, 'the E1 path answer must not survive a restart').toBeNull();
+  });
+});

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -16,7 +16,9 @@ import {
   deleteCboState as dbDeleteCboState,
   loadCboState as dbLoadCboState,
   loadCboMessages as dbLoadCboMessages,
+  resetMemberProgressForCboState,
 } from "../services/cboPersistence";
+import { clearMaturityTierForCboState } from "../services/orgPersistence";
 import { createEmptyCboState, CBO_SECTIONS, type CboState } from "@shared/cbo-schema";
 import {
   listDocumentsForScope,
@@ -291,8 +293,16 @@ export function registerCboRoutes(app: Express): void {
     debouncedPersist(req.params.id);
   });
 
-  // Delete / restart
+  // Delete / restart. Run-derived member/org data (path, site, snapshots,
+  // maturity tier) is cleared alongside the state itself — otherwise a
+  // "recomeçar do zero" session inherits ghosts of the run being thrown away
+  // (field report 2026-07-08: the E1 path answer survived a restart because
+  // it lives on cohort_members). Both cleanups must run BEFORE the state row
+  // is deleted: the tier clear resolves the org through cbo_states.orgId.
   app.delete("/api/cbo/:id", async (req: Request, res: Response) => {
+    await clearMaturityTierForCboState(req.params.id).catch((e) =>
+      console.error(`[cbo] clearMaturityTier(${req.params.id}) on delete failed`, e));
+    await resetMemberProgressForCboState(req.params.id);
     await dbDeleteCboState(req.params.id);
     setCboState(req.params.id, undefined as any);
     res.json({ deleted: true });

--- a/server/routes/testRoutes.ts
+++ b/server/routes/testRoutes.ts
@@ -216,6 +216,9 @@ export function registerTestRoutes(app: Express): void {
     const neighborhood = typeof req.body?.neighborhood === 'string' ? req.body.neighborhood : null;
     const role = req.body?.role === 'alternate' ? 'alternate' : 'priority';
     const unlockedPhases = Array.isArray(req.body?.unlockedPhases) ? req.body.unlockedPhases : [1];
+    // Seedable E1 triage answer — lets specs assert that run-derived member
+    // data (path) is cleared on restart without driving a full scripted E1.
+    const path = (['has-project', 'has-idea', 'needs-help'] as const).includes(req.body?.path) ? req.body.path : null;
 
     let orgId: string | null = null;
     try {
@@ -245,6 +248,7 @@ export function registerTestRoutes(app: Express): void {
       role,
       origin: 'cohort',
       unlockedPhases,
+      path,
       cboStateId,
     }).returning();
 

--- a/server/services/cboPersistence.ts
+++ b/server/services/cboPersistence.ts
@@ -221,6 +221,35 @@ async function syncMemberSnapshot(state: CboState): Promise<void> {
 }
 
 /**
+ * Restart-from-scratch cleanup — when a CBO session is deleted, every piece
+ * of member/org data DERIVED from that run must go with it, or the fresh
+ * session inherits ghosts of the old one (field report 2026-07-08: after
+ * "recomeçar do zero" the E1 path answer survived because it lives on
+ * cohort_members, not cbo_state). Clears the run-derived columns only —
+ * identity (orgName, neighborhood, tokens), coordinator-controlled unlocks,
+ * and support-request history are NOT touched. cboStateId is nulled; the
+ * client re-binds its new session via the member-link effect immediately.
+ */
+export async function resetMemberProgressForCboState(cboStateId: string): Promise<void> {
+  try {
+    await db.update(cohortMembers).set({
+      cboStateId: null,
+      path: null,
+      site: null,
+      inspirationPicks: [],
+      snapshotPhase: null,
+      snapshotSectionsComplete: null,
+      snapshotMaturityScore: null,
+      snapshotFlagsMet: null,
+      snapshotIntervention: null,
+      snapshotUpdatedAt: new Date(),
+    }).where(eq(cohortMembers.cboStateId, cboStateId));
+  } catch (e) {
+    logDbError('resetMemberProgressForCboState', cboStateId, e);
+  }
+}
+
+/**
  * Self-check at boot — probes for the cbo_states table. If it doesn't exist,
  * log a single LOUD line so the dev sees the fix immediately instead of
  * chasing the symptom (re-introducing agent, 404s on cold load, etc).

--- a/server/services/orgPersistence.ts
+++ b/server/services/orgPersistence.ts
@@ -50,6 +50,16 @@ export async function setMaturityTierForCboState(
   return org?.name ?? null;
 }
 
+/** Drop the org's persisted tier when its cbo_state is deleted (restart from
+ *  scratch). The tier was inferred from the run being thrown away — leaving it
+ *  would inject the OLD run's calibration block into the new conversation.
+ *  Must run BEFORE the cbo_states row is deleted (it resolves org via the join). */
+export async function clearMaturityTierForCboState(cboStateId: string): Promise<void> {
+  const [row] = await db.select({ orgId: cboStates.orgId }).from(cboStates).where(eq(cboStates.id, cboStateId)).limit(1);
+  if (!row?.orgId) return;
+  await db.update(organizations).set({ maturityTier: null }).where(eq(organizations.id, row.orgId));
+}
+
 /** The persisted tier for a cbo_state's org, or null. Read on E2+ turns to
  *  inject the calibration block into the system context. */
 export async function getMaturityTierForCboState(cboStateId: string): Promise<MaturityTier | null> {


### PR DESCRIPTION
## Field report (Vila Flores testing)

After pressing **restart** ("recomeçar do zero") on an invite session:
- the agent never asked the opening question again (silent empty chat),
- the org **lost its name and neighborhood** from the invite,
- the **E1 path answer survived** into the new run.

## Root causes → fixes

| Symptom | Cause | Fix |
|---|---|---|
| Lost org name/bairro | `prefillSentRef` is one-shot; already consumed by the old session | `handleRestart` re-seeds the prefill for the new session, synchronously **before** the greeting (the kickoff template reads org from state) |
| No greeting after restart | Kickoff only fires from welcome/preamble entry points | `handleRestart` calls `/kickoff` with the explicit new id (fresh transcript = template always serves) |
| Path answer survived | `path`, `site`, `inspirationPicks`, snapshots live on `cohort_members`; tier on `organizations` — DELETE only removed `cbo_state` | `DELETE /api/cbo/:id` now clears run-derived member data + org maturity tier (join resolved before the state row dies) |

**Deliberately untouched on restart:** member identity (orgName, neighborhood, tokens), coordinator-controlled `unlockedPhases`, support-request history.

## Verification
- New e2e spec `cbo-restart-invite-reset` drives the full invite → restart cycle and asserts all three fixes (no fake model needed — kickoff is a template).
- All 3 restart specs pass locally; `tsc` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iXQHNn6stMsr4BUAm416s