### PR TITLE
Per-organization profile reset on the orchestrator console

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -874,6 +874,55 @@ export function ShareLinkDialog({
 }
 
 // ---------------------------------------------------------------------------
+// MemberResetConfirmDialog — resets ONE org's profile (field report
+// 2026-07-08: the console could only wipe the whole cohort at once). The
+// member keeps its invite link and workshop unlocks; the working session and
+// run-derived progress are erased.
+// ---------------------------------------------------------------------------
+export function MemberResetConfirmDialog({
+  open, orgName, onOpenChange, onConfirm,
+}: {
+  open: boolean;
+  orgName: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}) {
+  const { t } = useTranslation();
+  const [busy, setBusy] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-amber-600" />
+            {t('orchestrator.memberReset.title', { defaultValue: 'Reset {{org}}?', org: orgName })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.memberReset.desc', {
+              defaultValue: 'Erases this organization’s profile, conversation, and progress so it can start Encontro 1 from scratch. The invite link keeps working and workshop unlocks stay. This can’t be undone.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => { setBusy(true); try { await onConfirm(); } finally { setBusy(false); } }}
+            disabled={busy}
+            data-testid="button-confirm-member-reset"
+          >
+            <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+            {busy ? t('common.working', { defaultValue: 'Working…' }) : t('orchestrator.memberReset.confirm', { defaultValue: 'Yes, reset this org' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ResetConfirmDialog — wipes members + restores default workshops. Used in
 // the pilot's singleton-cohort model where there's only one cohort and the
 // orchestrator needs a quick "start fresh" for demo dry runs.

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -47,6 +47,7 @@ export interface UseCohortResult {
   /** Admin: create a coordinator + their cohort in one shot, then load it. */
   provisionCohort: (input: ProvisionInput) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
   resetCohort: () => Promise<void>;
+  resetMember: (memberId: string) => Promise<boolean>;
   invite: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
@@ -139,6 +140,15 @@ export function useCohort(): UseCohortResult {
     }
   }, []);
 
+  // Reset ONE org's profile — deletes its working session and run-derived
+  // progress server-side; the member row (identity, invite link, unlocks)
+  // stays. Returns false on failure so the card can toast an error.
+  const resetMember = useCallback(async (memberId: string) => {
+    const r = await fetch(`/api/cohort/${slugRef.current}/member/${memberId}/reset`, { method: 'POST' });
+    await refresh();
+    return r.ok;
+  }, [refresh]);
+
   const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, orgType }) => {
     const r = await fetch(`/api/cohort/${slugRef.current}/invite`, {
       method: 'POST',
@@ -193,6 +203,6 @@ export function useCohort(): UseCohortResult {
   return {
     loading, cohort, members, isAdmin, allCohorts,
     refresh, refreshAllCohorts, switchCohort, provisionCohort,
-    resetCohort, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
+    resetCohort, resetMember, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
   };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -36,6 +36,7 @@ import {
   ShareLinkDialog,
   BulkInviteSummaryDialog,
   ResetConfirmDialog,
+  MemberResetConfirmDialog,
   DeleteCohortConfirmDialog,
   ProvisionCohortDialog,
   type BulkInviteResult,
@@ -590,6 +591,7 @@ function ProjectCard({
   onOpen,
   onOpenCbo,
   onSetTier,
+  onResetProfile,
 }: {
   project: CboDemoProject;
   locale: 'en' | 'pt';
@@ -598,6 +600,7 @@ function ProjectCard({
   onOpen: (p: CboDemoProject) => void;
   onOpenCbo: (p: CboDemoProject, tab: 'arquivos' | 'conversa' | 'perfil') => void;
   onSetTier: (p: CboDemoProject, tier: 'emerging' | 'developing' | 'advanced') => void;
+  onResetProfile: (p: CboDemoProject) => void;
 }) {
   const { t } = useTranslation();
   const hasIntervention = project.interventionKey !== null;
@@ -737,6 +740,19 @@ function ProjectCard({
               <Eye className="w-3 h-3" strokeWidth={2} />
               {t('orchestrator.cboView.open', { defaultValue: 'View' })}
             </button>
+            {/* Per-org reset (field report 2026-07-08): before this, the only
+                way to erase ONE org was resetting the entire cohort. Opens a
+                confirm dialog — the action itself is irreversible. */}
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); onResetProfile(project); }}
+              className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full border border-foreground/15 text-foreground/70 hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
+              title={t('orchestrator.memberReset.chipTooltip', { defaultValue: 'Reset this organization’s profile from scratch' })}
+              data-testid={`button-cbo-reset-${project.id}`}
+            >
+              <RotateCcw className="w-3 h-3" strokeWidth={2} />
+              {t('orchestrator.memberReset.chip', { defaultValue: 'Reset' })}
+            </button>
             {hasIntervention ? (
               <span
                 className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}
@@ -860,7 +876,7 @@ export default function OrchestratorLandingPage() {
 
   const {
     cohort, members, isAdmin, allCohorts,
-    invite, unlockPhase, saveWorkshops, resetCohort, saveLanguage, deleteCohort,
+    invite, unlockPhase, saveWorkshops, resetCohort, resetMember, saveLanguage, deleteCohort,
     switchCohort, provisionCohort, refresh,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
@@ -926,6 +942,8 @@ export default function OrchestratorLandingPage() {
   const [bulkInvitations, setBulkInvitations] = useState<BulkInviteResult[]>([]);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  // Per-org reset: the card whose profile is about to be erased (null = closed).
+  const [memberResetTarget, setMemberResetTarget] = useState<CboDemoProject | null>(null);
   const [provisionOpen, setProvisionOpen] = useState(false);
   const [supportInboxOpen, setSupportInboxOpen] = useState(false);
   // Mirrored from /support-requests?status=pending — drives the badge on
@@ -994,6 +1012,18 @@ export default function OrchestratorLandingPage() {
     setResetConfirmOpen(false);
     await resetCohort();
     toast({ title: t('orchestrator.cohort.resetDone', { defaultValue: 'Cohort reset' }) });
+  };
+
+  const handleMemberResetConfirm = async () => {
+    const target = memberResetTarget;
+    setMemberResetTarget(null);
+    if (!target) return;
+    const ok = await resetMember(target.id);
+    toast({
+      title: ok
+        ? t('orchestrator.memberReset.done', { defaultValue: '{{org}} reset — the invite link starts fresh', org: target.name[locale] })
+        : t('orchestrator.memberReset.failed', { defaultValue: 'Could not reset {{org}}', org: target.name[locale] }),
+    });
   };
 
   const handleDeleteConfirm = async () => {
@@ -1342,6 +1372,7 @@ export default function OrchestratorLandingPage() {
                     onOpen={(p) => openCbo(p, 'convite')}
                     onOpenCbo={openCbo}
                     onSetTier={handleSetTier}
+                    onResetProfile={setMemberResetTarget}
                   />
                   {member && (
                     <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">
@@ -1377,6 +1408,12 @@ export default function OrchestratorLandingPage() {
         open={resetConfirmOpen}
         onOpenChange={setResetConfirmOpen}
         onConfirm={handleResetConfirm}
+      />
+      <MemberResetConfirmDialog
+        open={memberResetTarget != null}
+        orgName={memberResetTarget?.name[locale] ?? ''}
+        onOpenChange={(open) => { if (!open) setMemberResetTarget(null); }}
+        onConfirm={handleMemberResetConfirm}
       />
       <DeleteCohortConfirmDialog
         open={deleteConfirmOpen}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -310,6 +310,15 @@
     "cboView": {
       "open": "Ver",
       "openTooltip": "Ver conversa + perfil"
+    },
+    "memberReset": {
+      "chip": "Resetar",
+      "chipTooltip": "Recomeçar o perfil desta organização do zero",
+      "title": "Resetar {{org}}?",
+      "desc": "Apaga o perfil, a conversa e o progresso desta organização para recomeçar o Encontro 1 do zero. O link de convite continua funcionando e os encontros liberados são mantidos. Não dá para desfazer.",
+      "confirm": "Sim, resetar esta org",
+      "done": "{{org}} resetada — o link de convite recomeça do zero",
+      "failed": "Não foi possível resetar {{org}}"
     }
   },
   "citySelection": {

--- a/e2e/cougar-member-reset.spec.ts
+++ b/e2e/cougar-member-reset.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Field report 2026-07-08 — "it is impossible to erase the profile of a
+// selected organization, just all at the same time." The console only had the
+// cohort-wide Reset. This spec covers the new per-org reset: card chip →
+// confirm dialog → the member's working session is deleted and every
+// run-derived column cleared, while the member row (identity, invite link)
+// survives.
+
+test.describe('COUGAR — per-organization profile reset', () => {
+  test('reset chip erases one org’s session + progress, keeps the member', async ({ page }) => {
+    const api = new TestApi(page.request);
+    const { cohort } = await api.createCohort('e2e member-reset');
+    // Scoped coordinator for this cohort — cookie lands on the page context.
+    await api.createCoordinator({ email: `coord-${randomUUID()}@e2e.test`, password: 'coord-pass-1', cohortId: cohort.id });
+
+    const invited = await api.inviteMember(cohort.id, { orgName: 'Org ResetMe', neighborhood: 'Sarandi', withSession: true });
+    const stateId: string = invited.member.cboStateId;
+    expect(stateId).toBeTruthy();
+
+    // Give the member visible progress so the reset has something to erase.
+    await page.request.patch(`/api/cbo-member/${invited.member.memberSlug}/snapshot`, {
+      data: { cboStateId: stateId, phase: 1, sectionsComplete: 3, maturityScore: 4, flagsMet: 1 },
+    });
+
+    await page.goto('/orchestrator');
+    const card = page.getByTestId(`card-orchestrator-project-${invited.member.id}`);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+
+    // Reset chip → confirm dialog names the org → confirm.
+    await card.getByTestId(`button-cbo-reset-${invited.member.id}`).click();
+    await expect(page.getByText('Org ResetMe?')).toBeVisible();
+    await page.getByTestId('button-confirm-member-reset').click();
+
+    // The member row survives (card still on the board) with progress cleared.
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => {
+      const mine = await (await page.request.get('/api/cohort/mine')).json();
+      const m = (mine.members ?? []).find((x: any) => x.id === invited.member.id);
+      return m ? { cboStateId: m.cboStateId, path: m.path, snapshotPhase: m.snapshotPhase, sections: m.snapshotSectionsComplete } : null;
+    }, { timeout: 15_000 }).toEqual({ cboStateId: null, path: null, snapshotPhase: null, sections: null });
+
+    // The working session itself is gone.
+    const gone = await page.request.get(`/api/cbo/${stateId}`);
+    expect(gone.status(), 'the old session must be deleted').toBe(404);
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -22,7 +22,8 @@ import {
 import { createOrganization, linkCboStateToOrg, setMaturityTierForCboState } from '../services/orgPersistence';
 import { cboStates } from '@shared/cbo-db-schema';
 import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
-import { getCboMessages, getCboState, loadCboFromDb } from '../services/cboAgent';
+import { getCboMessages, getCboState, setCboState, loadCboFromDb } from '../services/cboAgent';
+import { deleteCboState } from '../services/cboPersistence';
 import {
   requireCoordinator,
   createCoordinator,
@@ -679,6 +680,43 @@ export function registerCohortRoutes(app: Express): void {
     const orgName = await setMaturityTierForCboState(member.cboStateId, tier);
     if (!orgName) { res.status(409).json({ error: 'member has no linked organization yet' }); return; }
     res.json({ ok: true, tier, orgName });
+  }));
+
+  // Reset ONE organization's profile (field report 2026-07-08: the console
+  // could only wipe the whole cohort at once). Deletes the member's working
+  // session (state + transcript, DB and memory) and clears every run-derived
+  // member/org column — path, site, inspiration picks, snapshots, maturity
+  // tier — so the org's next visit starts a genuinely clean E1. Identity
+  // (orgName, neighborhood, invite tokens), coordinator-controlled unlocks,
+  // support-request history, and uploaded org documents are deliberately
+  // kept. Guarded by the :coordinatorSlug app.param ownership check like
+  // every cohort route.
+  app.post('/api/cohort/:coordinatorSlug/member/:memberId/reset', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    if (member.cboStateId) {
+      await deleteCboState(member.cboStateId);
+      setCboState(member.cboStateId, undefined as any);
+    }
+    if (member.orgId) {
+      await db.update(organizations).set({ maturityTier: null }).where(eq(organizations.id, member.orgId));
+    }
+    await db.update(cohortMembers).set({
+      cboStateId: null,
+      path: null,
+      site: null,
+      inspirationPicks: [],
+      startedAt: null,
+      snapshotPhase: null,
+      snapshotSectionsComplete: null,
+      snapshotMaturityScore: null,
+      snapshotFlagsMet: null,
+      snapshotIntervention: null,
+      snapshotUpdatedAt: new Date(),
+    }).where(eq(cohortMembers.id, member.id));
+
+    res.json({ ok: true, memberId: member.id, orgName: member.orgName });
   }));
 
   app.get('/api/cohort/:coordinatorSlug/support-requests', wrap(async (req, res) => {


### PR DESCRIPTION
## Field report (Vila Flores)

> It is impossible to erase the profile of a selected organization, just all at the same time.

The console only had the cohort-wide **Reset** (wipes every member). This adds a per-org reset.

## What it does
- **New endpoint** `POST /api/cohort/:coordinatorSlug/member/:memberId/reset` — deletes the member's working session (state + transcript, DB **and** memory) and clears every run-derived column: `path`, `site`, `inspirationPicks`, all `snapshot*`, `startedAt`, and the org's `maturityTier`.
- **Kept on purpose:** member identity (org name, neighborhood, invite token — the link keeps working), coordinator-controlled workshop unlocks, support-request history, uploaded org documents. Same keep/erase line as the CBO-side restart (#370).
- **UI:** a `Resetar` chip on each org card (next to *View*) → confirm dialog naming the org → toast. Ownership enforced by the existing `:coordinatorSlug` app.param guard.

## Notes
- Self-contained (no dependency on #370) — the two PRs merge in any order.
- i18n follows the convention: keys in `pt.json` only, EN via inline `defaultValue`.

## Verification
- New e2e spec `cougar-member-reset`: chip → confirm → session 404s, run-derived columns null, member row survives. Passes locally; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iXQHNn6stMsr4BUAm416s