### PR TITLE
Link/document ingestion: real WebFetch, canonical chip values, no re-asking

### DIFF
--- a/e2e/cougar-e1-enum-labels.spec.ts
+++ b/e2e/cougar-e1-enum-labels.spec.ts
@@ -50,6 +50,41 @@ test.describe('COUGAR — E1 enum fields render human labels, never machine ids'
     await expect(page.getByText(/\bfunded\b/)).toHaveCount(0);
   });
 
+  test('document paraphrases fuzzy-map to a chip label; off-list document values are NOT stored', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Field report 2026-07-08: a link produced "categories related to ours but
+    // not exactly them". Containment: exactly one option's tokens inside the
+    // paraphrase → that chip label. No containable option → rejected, field
+    // stays empty (the agent is told to ask with chips instead).
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'Associação comunitária de moradores', source: 'document' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'nbs_experience', value: 'Oficinas de reciclagem e compostagem', source: 'document' },
+        { op: 'say', text: 'Li o material que vocês mandaram.' },
+        { op: 'ask_user', question: 'Tá tudo certo?', options: [{ label: 'Sim' }] },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('https://exemplo.com/quem-somos');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // Fuzzy hit: the paraphrase landed on the canonical chip label.
+    await expect(page.getByText('ONG / Associação', { exact: false }).first()).toBeVisible();
+    await expect(page.getByText('Associação comunitária de moradores', { exact: false })).toHaveCount(0);
+    // Off-list value: never stored, never rendered.
+    await expect(page.getByText('Oficinas de reciclagem', { exact: false })).toHaveCount(0);
+  });
+
   test('a free-text value that matches no option passes through untouched', async ({ page, request }) => {
     const api = new TestApi(request);
     const ping = await api.ping();

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -144,6 +144,10 @@ The question set does **not branch** within E1 — everyone answers the same thi
 
 When a document, link, or article arrives (now or later), read it and `update_section` the **descriptive** fields you can extract — `org_name`, `mission_summary`, `legal_form`, `year_founded`, `team_size`, `paid_vs_volunteer`, `bairro_of_operation`, `groups_served`, `proud_moment` — each with `source: 'document'`.
 
+**A pasted URL must be FETCHED with `WebFetch` before you extract anything.** You cannot know what a page says from its address — extracting "from a link" without fetching is inventing data about someone's organization. If the fetch fails or the page is empty/irrelevant, say so honestly (*"Não consegui abrir o link — pode mandar o arquivo ou colar o texto aqui?"*) and continue the normal question flow. Never fill a single field from an unfetched URL.
+
+**Enum fields extracted from a document must land EXACTLY on a chip label from the question lists below** (e.g. `legal_form` gets "ONG / Associação", never "Associação de moradores"; `groups_served` picks from the eight listed groups, never the article's own category names). If the document's phrasing doesn't map cleanly onto one of the options, do **not** store an approximation — leave the field empty and ask that one question with its normal chips, **leading with your best guess**: *"Pelo material, vocês parecem ser uma associação — confere?"*. The server rejects off-list document values, so an approximation would silently not save and the panel and your recap would disagree.
+
 **Four fields are NEVER filled from a document:**
 
 - `prior_project_scale` and `nbs_experience` — these drive the maturity scores; a journalist's phrasing is not evidence. Instead, when you reach Batch B, **lead with your read as a suggestion**: *"Pelo artigo, parece que vocês já tocaram projeto com financiamento — confere?"* with the normal chips. One extra tap beats a silent wrong score.
@@ -168,6 +172,8 @@ A document never replaces the user's confirmation — extracted fields stay low-
 ### Step 2 — Batch the remaining capture questions
 
 For everything still unknown, send **grouped `ask_user` calls** — one call carrying several related questions. The UI renders them as a quick tap-through ("Pergunta 2 de 4"); the user answers the whole group in a few taps and you process them in **one turn**. Each question still has its own chips; the free-text input is always available as a fallback. You may lead a batch with a ≤5-word line (*"Umas perguntas rápidas:"*) — never more.
+
+**Build each batch ONLY from questions whose fields are still empty in CURRENT STATE.** A document (or the invite) filling a field removes its question from the batch — the bulk-confirm in Step 1 already validated it. Re-asking something the panel already shows is the single most-reported field bug: after a link upload the org answered the same questions twice. If a batch would end up with zero questions, skip it entirely.
 
 **Batch A — basics** (one `ask_user` with all four questions):
 1. *O que vocês fazem?* — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -30,7 +30,7 @@ import { setMaturityTierForCboState, getMaturityTierForCboState } from "./orgPer
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { emitAssistantText } from "./agentOutput";
-import { isKnownOrgProfileField, canonicalizeOrgProfileValue, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
+import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -277,11 +277,26 @@ function createCboMcpTools(cboId: string) {
           return { content: [{ type: "text" as const, text: `Unknown org_profile field(s) ${rejected.map(b => `"${b}"`).join(', ')} — nothing saved. Use exactly: ${ORG_PROFILE_FIELDS.join(', ')}. If a fact fits none of these, mention it in chat but do not store it.` }], isError: true };
         }
       }
+      // Document-sourced extractions get the containment fallback ("Associação
+      // comunitária de moradores" → 'ONG / Associação'), and anything STILL
+      // off-list is rejected below — a link's paraphrase must land exactly on
+      // a chip label or become a question to the user, never a stored value
+      // outside the list (field report 2026-07-08). User-sourced values keep
+      // exact-match-or-pass-through: never destroy what the human said.
+      const isDocSource = String(args.source ?? '').toLowerCase() === 'document';
+      const offList: string[] = [];
       const updated: string[] = [];
       for (const [fieldName, rawValue] of writable) {
         const finalValue = args.sectionId === 'org_profile'
-          ? canonicalizeOrgProfileValue(fieldName, rawValue, getActiveCboLang(cboId))
+          ? canonicalizeOrgProfileValue(fieldName, rawValue, getActiveCboLang(cboId), isDocSource)
           : rawValue;
+        if (
+          isDocSource && args.sectionId === 'org_profile' &&
+          isEnumOrgProfileField(fieldName) && !isCanonicalOrgProfileValue(fieldName, finalValue)
+        ) {
+          offList.push(fieldName);
+          continue;
+        }
         const oldValue = section.fields[fieldName]?.value ?? null;
         section.fields[fieldName] = { value: finalValue, confidence: args.confidence as Confidence, source: args.source, userEdited: false };
         state.editLog.push({ timestamp: new Date().toISOString(), sectionId: args.sectionId, field: fieldName, oldValue, newValue: finalValue, source: 'agent' });
@@ -296,7 +311,11 @@ function createCboMcpTools(cboId: string) {
       const note = rejected.length > 0
         ? ` REJECTED (not stored, unknown field name${rejected.length > 1 ? 's' : ''}): ${rejected.join(', ')} — valid org_profile fields are: ${ORG_PROFILE_FIELDS.join(', ')}. The saved fields above do NOT need resending.`
         : '';
-      return { content: [{ type: "text" as const, text: `Updated ${args.sectionId}: ${updated.join(', ')}.${note}` }] };
+      const offListNote = offList.length > 0
+        ? ` NOT STORED (off-list value from document): ${offList.map(f => `${f} — allowed values are exactly: ${orgProfileOptionLabels(f, getActiveCboLang(cboId)).join(' · ')}`).join('; ')}. Either resend with one of those exact labels, or leave the field empty and ask the user that question with the normal chips, leading with your best guess from the document.`
+        : '';
+      const summary = updated.length > 0 ? `Updated ${args.sectionId}: ${updated.join(', ')}.` : `Nothing stored in ${args.sectionId}.`;
+      return { content: [{ type: "text" as const, text: `${summary}${note}${offListNote}` }] };
     },
     { annotations: { readOnlyHint: false } }
   );
@@ -1209,6 +1228,11 @@ function resolveTurnModel(
   // Reasoning-heavy shapes ALWAYS stay on the big model.
   if (state.phase > 2) return heavy('phase>2');
   if (turnKind === 'upload' || raw.startsWith("I'm uploading:") || raw.startsWith('Uploaded "')) return heavy('upload');
+  // A pasted link is an extraction turn (WebFetch → multi-field
+  // update_section → bulk-confirm), not a short chat reply — live testing
+  // showed the light model fetching the page and then "recapping" fields it
+  // never persisted. Same class as uploads: always heavy.
+  if (/https?:\/\/\S+/i.test(raw)) return heavy('link-paste');
   if (turnKind === 'map' || raw.startsWith('Map selection (')) return heavy('map-result');
   if (turnKind === 'system') return heavy('system-turn');
   if (/(?:vamos\s+(?:começar|comecar)|let'?s\s+start)\s+(?:o\s+)?encontro/i.test(raw)) return heavy('phase-start');
@@ -1321,6 +1345,12 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           "mcp__cbo__list_org_documents",
           "mcp__cbo__read_org_document",
           "mcp__cbo__search_org_documents",
+          // Pasted links (field report 2026-07-08): the flow invites "manda o
+          // link" but NOTHING could fetch a URL, so the model role-played
+          // having read the page and invented near-miss categories from the
+          // URL slug. WebFetch makes link ingestion real; the E1 skill pairs
+          // it with an honesty rule (fetch fails → say so, ask for an upload).
+          "WebFetch",
         ],
         mcpServers: mcpServer ? { cbo: mcpServer } : {},
         permissionMode: "bypassPermissions",

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -34,7 +34,7 @@ import {
 } from '@shared/cbo-schema';
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { emitAssistantText } from './agentOutput';
-import { canonicalizeOrgProfileValue } from '@shared/cbo-field-catalog';
+import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue } from '@shared/cbo-field-catalog';
 
 export function isFakeModelEnabled(): boolean {
   return process.env.CBO_FAKE_MODEL === '1';
@@ -116,10 +116,17 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       const section = state.sections[op.sectionId as keyof typeof state.sections];
       if (!section) break;
       // Same write-path canonicalization as the real update_section tool, so
-      // specs exercise the id -> label mapping deterministically.
+      // specs exercise the id -> label mapping deterministically — including
+      // the document-source rules: containment fallback, and off-list values
+      // rejected (not stored) instead of persisted as approximations.
+      const isDocSource = String(op.source ?? '').toLowerCase() === 'document';
       const value = op.sectionId === 'org_profile'
-        ? canonicalizeOrgProfileValue(op.field, op.value, lang === 'en' ? 'en' : 'pt')
+        ? canonicalizeOrgProfileValue(op.field, op.value, lang === 'en' ? 'en' : 'pt', isDocSource)
         : op.value;
+      if (
+        isDocSource && op.sectionId === 'org_profile' &&
+        isEnumOrgProfileField(op.field) && !isCanonicalOrgProfileValue(op.field, value)
+      ) break;
       section.fields[op.field] = {
         value,
         confidence: (op.confidence ?? 'high') as Confidence,

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -122,32 +122,79 @@ function matchOption(field: string, raw: string): CboEnumOption | null {
   return null;
 }
 
+// Containment fallback for DOCUMENT-sourced extractions (field report
+// 2026-07-08: a link produced "categories related to ours but not exactly
+// them"). A model reading an article writes phrases like "Associação
+// comunitária de moradores" — no exact match, but exactly one option's tokens
+// ("associação") appear in it. Match only when precisely ONE option is
+// contained; two hits = ambiguous = no match (the caller then asks the user).
+// Never used for user-typed values — exact matching stays the only path there.
+function matchOptionFuzzy(field: string, raw: string): CboEnumOption | null {
+  const options = ORG_PROFILE_ENUMS[field];
+  if (!options) return null;
+  const rawTokens = norm(raw).split(' ').filter(Boolean);
+  if (rawTokens.length === 0) return null;
+  const contains = (needle: string): boolean => {
+    const toks = norm(needle).split(' ').filter(Boolean);
+    return toks.length > 0 && toks.every(t => rawTokens.includes(t));
+  };
+  const hits = options.filter(opt =>
+    contains(opt.pt) || contains(opt.en) || (opt.aliases ?? []).some(contains),
+  );
+  return hits.length === 1 ? hits[0] : null;
+}
+
 /** groups_served is a multi-select stored as one string — split on the
  *  separators the agent/chips produce, map each item independently. */
 const MULTI_FIELDS = new Set(['groups_served']);
 const MULTI_SEPARATOR = /\s*[,;·|]\s*|\s+e\s+(?=[A-ZÀ-Ú])/;
 
-function mapValue(field: string, raw: string, pick: (opt: CboEnumOption) => string): string {
+function mapValue(field: string, raw: string, pick: (opt: CboEnumOption) => string, fuzzy = false): string {
+  const resolve = (s: string) => matchOption(field, s) ?? (fuzzy ? matchOptionFuzzy(field, s) : null);
   if (MULTI_FIELDS.has(field)) {
     return raw
       .split(MULTI_SEPARATOR)
       .filter(part => part.trim().length > 0)
       .map(part => {
-        const opt = matchOption(field, part);
+        const opt = resolve(part);
         return opt ? pick(opt) : part.trim();
       })
       .join(', ');
   }
-  const opt = matchOption(field, raw);
+  const opt = resolve(raw);
   return opt ? pick(opt) : raw;
 }
 
 /** Write path: turn whatever the agent produced (machine id, English label,
  *  chip label) into the canonical human label for the session language.
- *  Unrecognized values pass through unchanged. */
-export function canonicalizeOrgProfileValue(field: string, raw: string, lang: 'pt' | 'en' = 'pt'): string {
+ *  Unrecognized values pass through unchanged. `fuzzy` adds the containment
+ *  fallback — pass it ONLY for document-sourced extractions. */
+export function canonicalizeOrgProfileValue(field: string, raw: string, lang: 'pt' | 'en' = 'pt', fuzzy = false): string {
   if (typeof raw !== 'string' || !ORG_PROFILE_ENUMS[field]) return raw;
-  return mapValue(field, raw, opt => (lang === 'pt' ? opt.pt : opt.en));
+  return mapValue(field, raw, opt => (lang === 'pt' ? opt.pt : opt.en), fuzzy);
+}
+
+/** True when `field` is one of the closed-list (enum) org_profile fields. */
+export function isEnumOrgProfileField(field: string): boolean {
+  return !!ORG_PROFILE_ENUMS[field];
+}
+
+/** True when `value` already sits on the closed list for `field` (multi-select:
+ *  every part must). Used to REJECT document-sourced off-list values at the
+ *  write path — the agent is told to ask the user with chips instead. */
+export function isCanonicalOrgProfileValue(field: string, value: string): boolean {
+  if (!ORG_PROFILE_ENUMS[field] || typeof value !== 'string') return true;
+  if (MULTI_FIELDS.has(field)) {
+    const parts = value.split(MULTI_SEPARATOR).filter(p => p.trim().length > 0);
+    return parts.length > 0 && parts.every(p => matchOption(field, p) !== null);
+  }
+  return matchOption(field, value) !== null;
+}
+
+/** The chip labels for an enum field in one language — for tool-error messages
+ *  that teach the model the exact allowed list. */
+export function orgProfileOptionLabels(field: string, lang: 'pt' | 'en' = 'pt'): string[] {
+  return (ORG_PROFILE_ENUMS[field] ?? []).map(o => (lang === 'pt' ? o.pt : o.en));
 }
 
 /** Read path: render any stored form (including legacy machine ids already in


### PR DESCRIPTION
## Field report (Vila Flores)

> If you enter a link, it identifies categories that are related to the ones that we are using but not exactly them and for sure does not use the list. After writing down those fields it continued to ask the same things…

## What was actually happening (found live)

**The agent could never read links at all.** No `WebFetch` in its allowed tools, no server-side fetcher — when someone pasted a URL, the model **invented** plausible content from the URL slug. That's exactly the 'related but not exact' categories.

## Fixes

1. **`WebFetch` enabled** for the CBO agent + skill rule: a pasted URL must be fetched before extracting anything; fetch failure → honest *"Não consegui abrir o link — pode mandar o arquivo?"* fallback. Never fill a field from an unfetched URL.
2. **Link turns route heavy.** Live run showed the adaptive router sending a link paste to Haiku ('short-text'), which fetched the page and then *recapped fields it never persisted*. Any message containing a URL now routes like an upload.
3. **Canonical enum enforcement for document extractions** (`shared/cbo-field-catalog.ts`):
   - containment fallback: *"Associação comunitária de moradores"* → **ONG / Associação** (only when exactly one option matches; ambiguous = no match)
   - values still off-list are **rejected at `update_section`** with a teaching error listing the exact allowed labels and telling the model to ask the user with chips, leading with its guess.
   - user-sourced values unchanged: exact-match-or-pass-through, never destroy human input.
4. **Skill: no re-asking.** Batches are built only from questions whose fields are still empty in CURRENT STATE.

`fakeCboModel` mirrors the same write-path rules so e2e stays faithful to prod.

## Verification
- **Live model + real link** (`vilaflores.org/sobre`): WebFetch fires, fields stored with canonical labels (`ONG / Associação`, `Mais de 10 anos`, bairro `Floresta`), routing logs `heavy (link-paste)`, and `prior_project_scale` correctly left for the chip flow.
- e2e: `cougar-e1-enum-labels` extended with fuzzy-map + off-list-rejection cases — 3/3 pass; upload + batched-questions specs green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iXQHNn6stMsr4BUAm416s