### PR TITLE
E1 questionnaire v2 — Vila Flores field feedback (flagged items only)

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -17,12 +17,13 @@ import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
 
 const FIELD_GROUPS: Record<Exclude<GroupKey, 'outros'>, string[]> = {
-  // Identity — what + who
-  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'legal_form', 'year_founded'],
+  // Identity — what + who (questionnaire v2 added main_activities + has_cnpj)
+  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'main_activities', 'has_cnpj', 'legal_form', 'year_founded'],
   // Team — size + composition
   equipe: ['team_size', 'paid_vs_volunteer'],
-  // History — prior work + NBS experience
-  historico: ['prior_project_scale', 'nbs_experience', 'proud_moment'],
+  // History — funding track record + NBS experience (prior_project_scale is
+  // the pre-v2 legacy field; old sessions still carry it, so it stays listed)
+  historico: ['funding_history', 'funded_project_count', 'biggest_project_budget', 'prior_project_scale', 'nbs_experience', 'nbs_experience_detail', 'proud_moment'],
   // Path — the triage answer + community served + bairro
   caminho: ['bairro_of_operation', 'groups_served'],
 };

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1828,7 +1828,13 @@
       "nbs_experience": "NBS experience",
       "bairro_of_operation": "Neighborhood",
       "groups_served": "Groups served",
-      "proud_moment": "Proud moment"
+      "proud_moment": "Proud moment",
+      "main_activities": "Main activities",
+      "has_cnpj": "CNPJ",
+      "funding_history": "Funding history",
+      "funded_project_count": "Funded projects",
+      "biggest_project_budget": "Biggest project budget",
+      "nbs_experience_detail": "NBS experience detail"
     },
     "sections": {
       "org_profile": "1. Who We Are",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1999,7 +1999,13 @@
       "nbs_experience": "Experiência SbN",
       "bairro_of_operation": "Bairro de atuação",
       "groups_served": "Comunidades servidas",
-      "proud_moment": "Momento de orgulho"
+      "proud_moment": "Momento de orgulho",
+      "main_activities": "Principais atividades",
+      "has_cnpj": "CNPJ",
+      "funding_history": "Já recebeu financiamento",
+      "funded_project_count": "Projetos financiados",
+      "biggest_project_budget": "Maior orçamento",
+      "nbs_experience_detail": "Experiência SbN — detalhe"
     },
     "sections": {
       "org_profile": "1. Quem Somos",

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -70,7 +70,7 @@ Forbidden patterns:
 
 ### Free-text questions are PLAIN PROSE — never wrapped in `ask_user`
 
-A handful of questions have no natural buckets: **org name** (when not pre-filled), **contact name**, **contact role**, **year founded**, **proud moment**. Ask these as a **plain-text question** and stop. The chat always shows a text input below the conversation, so the user just types their answer.
+A handful of questions have no natural buckets: **org name** (when not pre-filled), **contact name**, **contact role**, **mission**, **NbS experience detail**, **proud moment**. Ask these as a **plain-text question** and stop. The chat always shows a text input below the conversation, so the user just types their answer.
 
 This is an **explicit exception** to "every turn ends with a tool call." A plain-text *question* is NOT a stranded turn — the turn carries text (the question), the input box is right there, and the user answers. The stranded-turn failure is only when you call `update_section` and end with **nothing at all** (no question, no tool).
 
@@ -96,19 +96,24 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 1. `org_name` — the organization's name
 2. `contact_name` — who's talking with us
 3. `contact_role` — their role in the org — **capture only if volunteered.** Ask name+role together once (Step 0); if the answer brings only a name, take it and move on. Never spend a turn chasing the role — it gates nothing.
-4. `mission_summary` — one-sentence description
-5. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
-6. `year_founded` — org-age **bucket**, captured as a chip (Começando agora / Menos de 2 anos / 2 a 5 anos / 5 a 10 anos / Mais de 10 anos) — a tap, not a typed year; works for informal groups too ("tempo que vocês fazem esse trabalho")
-7. `team_size` — enum: 1-2, 3-5, 6-15, 16+
-8. `paid_vs_volunteer` — rough split, e.g. "2 pagas · 8 voluntárias"
-9. `prior_project_scale` — enum: none, ad-hoc, funded, partnership
-10. `nbs_experience` — enum: none, env-education, gardens-and-greening, implemented-nbs
+4. `mission_summary` — the org's mission in one sentence, **in their words** — asked as the SECOND question of the encontro (free-text prose, right after Step 0), before the activity list. It matters for almost any funding application, and answering it first makes the org reflect before picking activities.
+5. `main_activities` — **multi-select, up to 3**: Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária. (Most orgs do more than one thing; the list itself is still being refined with Vila Flores.)
+6. `has_cnpj` — enum: Sim, temos CNPJ · Ainda não · Não temos certeza. Asked BEFORE the org-type question — formalization is what actually gates fundraising.
+7. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
+8. `year_founded` — org-age **bucket**, captured as a chip (Começando agora / Menos de 2 anos / 2 a 5 anos / 5 a 10 anos / Mais de 10 anos) — a tap, not a typed year; works for informal groups too ("tempo que vocês fazem esse trabalho")
+9. `team_size` — enum: 1-2, 3-5, 6-15, 16+
+10. `paid_vs_volunteer` — enum: Todas voluntárias · Maioria voluntárias · Metade e metade · Maioria pagas · Todas pagas
+11. `funding_history` — enum: Sim, já recebemos · Ainda não ("Já receberam financiamento pra executar um projeto?")
+12. `funded_project_count` — enum, only if funding_history = Sim: 1 projeto · 2 a 5 projetos · Mais de 5 projetos
+13. `biggest_project_budget` — enum, only if funding_history = Sim: Até R$ 10 mil · R$ 10 a 50 mil · R$ 50 a 200 mil · Mais de R$ 200 mil
+14. `nbs_experience` — enum: Sim · Ainda não · Não temos certeza
+15. `nbs_experience_detail` — free-text follow-up: if Sim, *"Que tipo de SbN vocês já trabalharam?"*; if Não temos certeza, *"Me conta um pouco da iniciativa que vocês acham que pode ser SbN"*. (Legacy field `prior_project_scale` is no longer asked — old sessions still carry it.)
 
-For every enum field, **store the Portuguese chip label the user tapped** (e.g. "Projeto financiado (R$ 50k+)", "Hortas / arborização"), never the machine id — the ids above exist only so you can reason about the rubric. The server canonicalizes known values, but raw ids like `funded` leaking to the user's document is exactly the bug this rule prevents. Field names are a **closed list**: `update_section` rejects anything not in fields 1–13 above — if a fact fits none of them (e.g. who the current leader is), mention it in chat but do not store it.
-11. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
-12. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
-13. `proud_moment` — optional free-text
-14. (cohort-level) `path` — enum on `cohort_members`: has-project | has-idea | needs-help
+For every enum field, **store the Portuguese chip label the user tapped**, never the machine id — the ids above exist only so you can reason about the rubric. The server canonicalizes known values, but raw ids like `funded` leaking to the user's document is exactly the bug this rule prevents. Field names are a **closed list**: `update_section` rejects anything not in the numbered fields on this page — if a fact fits none of them (e.g. who the current leader is), mention it in chat but do not store it.
+16. `bairro_of_operation` — where they primarily work (suggests from a POA bairro list)
+17. `groups_served` — multi-select: mulheres, idosos, pessoas com deficiência, comunidades tradicionais, jovens, pessoas negras, povos indígenas, comunidade do bairro
+18. `proud_moment` — optional free-text
+19. (cohort-level) `path` — enum on `cohort_members`: has-project | has-idea | needs-help
 
 Plus on `state.maturityScores`:
 
@@ -128,11 +133,11 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 
 Phase 1 is almost entirely **information capture**. Only two things need real reasoning, and both happen **once, at the very end**: the two maturity scores and the path triage. So do **not** take a full turn per question — that makes the user wait for the model after every tap. **Capture in batches; reason once.**
 
-The question set does **not branch** within E1 — everyone answers the same things; org type and maturity tier change only your *tone*, never *which* questions you ask. Because nothing downstream depends on an earlier answer, you can safely put several questions on one screen.
+The question set **barely branches** within E1 — everyone answers the same batches; org type and maturity tier change only your *tone*, never *which* questions you ask. The ONLY conditional questions are the post-Batch-B follow-ups (funding count/budget when funding_history = Sim; the NbS detail when nbs_experience ≠ Ainda não). Because nothing inside a batch depends on an earlier answer, you can safely put several questions on one screen.
 
 ### Step 0 — Open, and use what you already know
 
-**The opening greeting is usually already posted for you.** The platform serves the standard Step-0 message (greeting + doc invite + invite confirmation + the name/role question) instantly, before you're ever called. If RECENT CONVERSATION starts with that assistant greeting: do NOT re-greet or re-ask — the user's first message IS the answer to it. Persist what they gave (name, role, org correction) and go straight to Batch A. Only produce the opening yourself if the transcript has no greeting.
+**The opening greeting is usually already posted for you.** The platform serves the standard Step-0 message (greeting + doc invite + invite confirmation + the name/role question) instantly, before you're ever called. If RECENT CONVERSATION starts with that assistant greeting: do NOT re-greet or re-ask — the user's first message IS the answer to it. Persist what they gave (name, role, org correction) and go straight to the mission question (Step 1.5). Only produce the opening yourself if the transcript has no greeting.
 
 - One short greeting line, then invite a document (it can do most of the work):
   > *"Se vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho."*
@@ -142,15 +147,15 @@ The question set does **not branch** within E1 — everyone answers the same thi
 
 ### Step 1 — If a document was shared: pre-fill DESCRIPTIVE fields, then BULK-confirm (don't re-ask)
 
-When a document, link, or article arrives (now or later), read it and `update_section` the **descriptive** fields you can extract — `org_name`, `mission_summary`, `legal_form`, `year_founded`, `team_size`, `paid_vs_volunteer`, `bairro_of_operation`, `groups_served`, `proud_moment` — each with `source: 'document'`.
+When a document, link, or article arrives (now or later), read it and `update_section` the **descriptive** fields you can extract — `org_name`, `mission_summary`, `main_activities`, `has_cnpj`, `legal_form`, `year_founded`, `team_size`, `paid_vs_volunteer`, `bairro_of_operation`, `groups_served`, `proud_moment` — each with `source: 'document'`.
 
 **A pasted URL must be FETCHED with `WebFetch` before you extract anything.** You cannot know what a page says from its address — extracting "from a link" without fetching is inventing data about someone's organization. If the fetch fails or the page is empty/irrelevant, say so honestly (*"Não consegui abrir o link — pode mandar o arquivo ou colar o texto aqui?"*) and continue the normal question flow. Never fill a single field from an unfetched URL.
 
 **Enum fields extracted from a document must land EXACTLY on a chip label from the question lists below** (e.g. `legal_form` gets "ONG / Associação", never "Associação de moradores"; `groups_served` picks from the eight listed groups, never the article's own category names). If the document's phrasing doesn't map cleanly onto one of the options, do **not** store an approximation — leave the field empty and ask that one question with its normal chips, **leading with your best guess**: *"Pelo material, vocês parecem ser uma associação — confere?"*. The server rejects off-list document values, so an approximation would silently not save and the panel and your recap would disagree.
 
-**Four fields are NEVER filled from a document:**
+**These fields are NEVER filled from a document:**
 
-- `prior_project_scale` and `nbs_experience` — these drive the maturity scores; a journalist's phrasing is not evidence. Instead, when you reach Batch B, **lead with your read as a suggestion**: *"Pelo artigo, parece que vocês já tocaram projeto com financiamento — confere?"* with the normal chips. One extra tap beats a silent wrong score.
+- `funding_history`, `funded_project_count`, `biggest_project_budget`, `nbs_experience`, `nbs_experience_detail` — these drive the maturity scores; a journalist's phrasing is not evidence. Instead, when you reach Batch B, **lead with your read as a suggestion**: *"Pelo artigo, parece que vocês já receberam financiamento — confere?"* with the normal chips. One extra tap beats a silent wrong score.
 - `contact_name` and `contact_role` — the person named in an article is often **not** the person chatting. These come only from the human, in chat.
 
 Then confirm what you wrote **all at once**, concisely. **The recap lists exactly the fields you called `update_section` on — one bullet per field, same wording the document panel shows — nothing more, nothing less.** Never recap a fact you didn't persist (e.g. who the current leader is): the user will try to "correct" a field that doesn't exist, and the chat and the document panel stop matching.
@@ -169,25 +174,42 @@ Then confirm what you wrote **all at once**, concisely. **The recap lists exactl
 
 A document never replaces the user's confirmation — extracted fields stay low-confidence (`source: 'document'`) until they validate.
 
+### Step 1.5 — The mission question (SECOND question of the encontro)
+
+Right after the Step-0 answer lands (name/role — or the document bulk-confirm), ask the **mission** as plain prose, before any batch:
+
+> *"E me conta: qual é a missão de vocês — em uma frase, o que a organização busca fazer?"*
+
+Persist it verbatim-ish into `mission_summary` (their words, lightly tightened). It matters for almost any funding application, and reflecting on the mission first makes the activity answers better. Skip only if a document already filled `mission_summary` and the bulk-confirm validated it. In the same message, mention once — one short line, only here — that anything can be corrected later: *"E qualquer resposta dá pra ajustar depois, é só me dizer."*
+
 ### Step 2 — Batch the remaining capture questions
 
-For everything still unknown, send **grouped `ask_user` calls** — one call carrying several related questions. The UI renders them as a quick tap-through ("Pergunta 2 de 4"); the user answers the whole group in a few taps and you process them in **one turn**. Each question still has its own chips; the free-text input is always available as a fallback. You may lead a batch with a ≤5-word line (*"Umas perguntas rápidas:"*) — never more.
+For everything still unknown, send **grouped `ask_user` calls** — one call carrying several related questions. The UI renders them as a quick tap-through ("Pergunta 2 de 5"); the user answers the whole group in a few taps and you process them in **one turn**. Each question still has its own chips; the free-text input is always available as a fallback. You may lead a batch with a ≤5-word line (*"Umas perguntas rápidas:"*) — never more.
 
 **Build each batch ONLY from questions whose fields are still empty in CURRENT STATE.** A document (or the invite) filling a field removes its question from the batch — the bulk-confirm in Step 1 already validated it. Re-asking something the panel already shows is the single most-reported field bug: after a link upload the org answered the same questions twice. If a batch would end up with zero questions, skip it entirely.
 
-**Batch A — basics** (one `ask_user` with all four questions):
-1. *O que vocês fazem?* — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária
-2. *Que tipo de organização?* — ONG / Associação · Cooperativa · Coletivo informal · Empresa social · Empresa / estúdio / escritório técnico · Outra
-3. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos
-4. *Quantas pessoas na equipe?* — 1–2 · 3–5 · 6–15 · 16+
+**Batch A — quem são** (one `ask_user`):
+1. *O que vocês fazem? Pode escolher até 3.* (multi-select, max 3) — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária → `main_activities`
+2. *Vocês têm CNPJ?* — Sim, temos CNPJ · Ainda não · Não temos certeza → `has_cnpj`
+3. *Que tipo de organização?* — ONG / Associação · Cooperativa · Coletivo informal · Empresa social · Empresa / estúdio / escritório técnico · Outra → `legal_form`
+4. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos → `year_founded`
+5. *Quantas pessoas na equipe?* — 1–2 · 3–5 · 6–15 · 16+ → `team_size`
 
 **Batch B — experiência e alcance** (one `ask_user`):
-1. *Como é a equipe?* — Todas voluntárias · Maioria voluntárias (1–2 pagas) · Metade e metade · Maioria pagas
-2. *Maior projeto que já tocaram?* — Nenhum formal ainda · Atividades pontuais · Projeto com financiamento (até R$ 50k) · Projeto financiado (R$ 50k+) · Parceria com órgão público / fundação
-3. *Já trabalharam com soluções baseadas na natureza?* — Ainda não · Educação ambiental · Hortas / arborização · Já implementamos · Não tenho certeza
-4. *Quem vocês atendem?* (multi-select) — Mulheres · Idosos · Pessoas com deficiência · Comunidades tradicionais · Jovens · Pessoas negras · Povos indígenas · Comunidade do bairro
+1. *Como é a equipe?* — Todas voluntárias · Maioria voluntárias · Metade e metade · Maioria pagas · Todas pagas → `paid_vs_volunteer`
+2. *Já receberam financiamento pra executar um projeto?* — Sim, já recebemos · Ainda não → `funding_history`
+3. *Já trabalharam com soluções baseadas na natureza?* — Sim · Ainda não · Não temos certeza → `nbs_experience`
+4. *Quem vocês atendem?* (multi-select) — Mulheres · Idosos · Pessoas com deficiência · Comunidades tradicionais · Jovens · Pessoas negras · Povos indígenas · Comunidade do bairro → `groups_served`
 
-After each batch comes back, `update_section` **every** field in it (see Persisting), then send the next batch. Two batches cover all the capture you need. If the invite didn't pre-fill the bairro, add it as one extra chip/prose in Batch A.
+**Follow-ups — the ONLY conditional questions in E1** (send after Batch B returns, skip entirely when they don't apply):
+- If `funding_history` = **Sim** → one grouped `ask_user` with both:
+  1. *Quantos projetos financiados vocês já executaram?* — 1 projeto · 2 a 5 projetos · Mais de 5 projetos → `funded_project_count`
+  2. *Qual foi o orçamento do maior projeto?* — Até R$ 10 mil · R$ 10 a 50 mil · R$ 50 a 200 mil · Mais de R$ 200 mil → `biggest_project_budget`
+- If `nbs_experience` = **Sim** → prose: *"Que tipo de solução baseada na natureza vocês já trabalharam?"* → `nbs_experience_detail`
+- If `nbs_experience` = **Não temos certeza** → prose: *"Me conta um pouco da iniciativa que vocês acham que pode ser SbN."* → `nbs_experience_detail`
+(Funding follow-up batch first, then the NbS prose question — each in its own turn.)
+
+After each batch comes back, `update_section` **every** field in it (see Persisting), then send the next batch. If the invite didn't pre-fill the bairro, add it as one extra chip/prose in Batch A.
 
 ### Step 3 — The two things that need thought (do them ONCE, now)
 
@@ -213,9 +235,11 @@ The SDK is stateless per turn. The CURRENT STATE block of your prompt is the **o
 
 **When a batch comes back: ONE `update_section` call with ALL the fields, plus the next `ask_user` — two tool calls total, emitted together.** `update_section` takes a `fields` object, so a 4-answer batch is a single call. Same for a confirmed document pre-fill and for free-text answers.
 
-Example (Batch A returns "Hortas e segurança alimentar; ONG / Associação; 5 a 10 anos; 6–15") — ONE response, two calls:
-> `update_section('org_profile', fields: { mission_summary: 'Hortas e segurança alimentar', legal_form: 'ONG / Associação', year_founded: '5 a 10 anos', team_size: '6–15' })`
+Example (Batch A returns "Hortas e segurança alimentar, Educação ambiental; Sim, temos CNPJ; ONG / Associação; 5 a 10 anos; 6–15") — ONE response, two calls:
+> `update_section('org_profile', fields: { main_activities: 'Hortas e segurança alimentar, Educação ambiental', has_cnpj: 'Sim, temos CNPJ', legal_form: 'ONG / Associação', year_founded: '5 a 10 anos', team_size: '6–15' })`
 > `ask_user(<Batch B>)`
+
+(`main_activities` stores the tapped chips comma-joined — never squash them into `mission_summary`; the mission is its own free-text answer from Step 1.5.)
 
 ⚡ One `update_section` call **per field** is a bug, not a style choice: every extra tool round is a model round-trip the user spends staring at the screen. One user answer = one response = one consolidated write + the next question.
 
@@ -225,18 +249,25 @@ If an answer is ambiguous, persist their literal input first, then clarify.
 
 ```
 ORG_DELIVERY_CAPACITY (0-3)
-  Score 0:  prior_project_scale = 'none' AND legal_form = 'informal'
-  Score 1:  prior_project_scale = 'ad-hoc'  OR  (formal org, no funded projects)
-  Score 2:  prior_project_scale = 'funded' AND team_size ≥ '3-5' AND org age ≥ 2 years
+  Score 0:  funding_history = 'Ainda não' AND has_cnpj = 'Ainda não' (informal, no funded track record)
+  Score 1:  funding_history = 'Ainda não' but formalized (has CNPJ)  OR  one funded project ≤ R$ 10 mil
+  Score 2:  funding_history = Sim AND biggest_project_budget ≥ 'R$ 10 a 50 mil'
+            AND team_size ≥ '3-5' AND org age ≥ 2 years
             (i.e. year_founded bucket is '2 a 5 anos', '5 a 10 anos', or 'Mais de 10 anos')
-  Score 3:  prior_project_scale = 'partnership'  OR  funded project with evidence ≥ BRL 100k
+  Score 3:  funded_project_count = 'Mais de 5 projetos'  OR  biggest_project_budget ≥ 'R$ 50 a 200 mil'
             OR  uploaded grant approval / partnership letter
 
+  Legacy sessions (recorded before questionnaire v2) carry `prior_project_scale`
+  instead — read it as: none→0, ad-hoc→1, funded→2, partnership→3 signal.
+
 TEAM_TECHNICAL_EXPERIENCE (0-3)
-  Score 0:  nbs_experience = 'none'
-  Score 1:  nbs_experience = 'env-education'
-  Score 2:  nbs_experience = 'gardens-and-greening'
-  Score 3:  nbs_experience = 'implemented-nbs' (any evidence corroborates)
+  Score 0:  nbs_experience = 'Ainda não'
+  Score 1:  nbs_experience = 'Não temos certeza' (an initiative described in nbs_experience_detail
+            that plausibly IS SbN bumps to 2)
+  Score 2:  nbs_experience = Sim with detail describing education / gardens / greening work
+  Score 3:  nbs_experience = Sim with detail describing an IMPLEMENTED intervention (any evidence corroborates)
+
+  Legacy values still appear: 'Educação ambiental'→1, 'Hortas / arborização'→2, 'Já implementamos SbN'→3.
 ```
 
 Call `score_maturity` immediately after the relevant questions. Justification: 1 sentence each, in Portuguese.
@@ -245,7 +276,7 @@ Call `score_maturity` immediately after the relevant questions. Justification: 1
 
 ## Maturity tier — calibrate depth, never the path
 
-The two metrics above, plus `prior_project_scale`, `nbs_experience`, `legal_form`, and whether a real project doc was uploaded, give an early **tier read**. Tier is grounded in the COUGAR Gate-2 rubric (the same one the NbS expert uses to map projects), so it's a real signal, not a vibe.
+The two metrics above, plus `funding_history` (+ count/budget), `nbs_experience`, `has_cnpj`, `legal_form`, and whether a real project doc was uploaded, give an early **tier read**. Tier is grounded in the COUGAR Gate-2 rubric (the same one the NbS expert uses to map projects), so it's a real signal, not a vibe.
 
 ```
 emerging    org_delivery_capacity ≤ 1 AND team_technical_experience ≤ 1
@@ -292,7 +323,7 @@ The document invitation happens in **Step 0** (it can pre-fill most of the profi
 
 Files auto-parse via the existing fileParser flow. Use the parsed content to:
 - Pre-fill and **bulk-confirm** fields (Step 1) instead of asking them
-- Triangulate `prior_project_scale` (a real grant approval bumps score 2→3)
+- Triangulate the funding history (a real grant approval bumps score 2→3)
 - Fill `mission_summary` if the doc is more articulate than the user's own words (it's part of the bulk-confirm, so they validate it)
 
 ### Search the org's files, don't just hope you read them

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -31,12 +31,25 @@ export const ORG_PROFILE_FIELDS = [
   'contact_name',
   'contact_role',
   'mission_summary',
+  // Questionnaire v2 (Vila Flores field feedback 2026-07-08): activities got
+  // their own field (they were being squashed into mission_summary, which is
+  // why the mission question silently disappeared from the flow), CNPJ is
+  // asked before org type, and the single prior_project_scale question became
+  // funding_history → funded_project_count + biggest_project_budget.
+  'main_activities',
+  'has_cnpj',
   'legal_form',
   'year_founded',
   'team_size',
   'paid_vs_volunteer',
+  'funding_history',
+  'funded_project_count',
+  'biggest_project_budget',
+  // Legacy — no longer asked; kept so sessions recorded before v2 still
+  // validate, display, and feed the delivery-capacity rubric.
   'prior_project_scale',
   'nbs_experience',
+  'nbs_experience_detail',
   'bairro_of_operation',
   'groups_served',
   'proud_moment',
@@ -68,11 +81,42 @@ export const ORG_PROFILE_ENUMS: Record<string, CboEnumOption[]> = {
     { id: '6-15', pt: '6–15', en: '6–15', aliases: ['6-15 pessoas', '6 a 15'] },
     { id: '16+', pt: '16+', en: '16+', aliases: ['16+ pessoas', 'mais de 16'] },
   ],
+  // Questionnaire v2: "(1–2 pagas)" dropped from the mostly-volunteers label
+  // (it wrongly excluded orgs with 3+ paid among many volunteers) and "Todas
+  // pagas" added. Old labels stay as aliases so legacy stored values re-render.
   paid_vs_volunteer: [
     { id: 'all-volunteer', pt: 'Todas voluntárias', en: 'All volunteers', aliases: ['todos voluntários', 'all volunteer'] },
-    { id: 'mostly-volunteer', pt: 'Maioria voluntárias (1–2 pagas)', en: 'Mostly volunteers (1–2 paid)', aliases: ['maioria voluntárias', 'mostly volunteers'] },
+    { id: 'mostly-volunteer', pt: 'Maioria voluntárias', en: 'Mostly volunteers', aliases: ['maioria voluntárias (1–2 pagas)', 'mostly volunteers (1–2 paid)'] },
     { id: 'half-half', pt: 'Metade e metade', en: 'Half and half', aliases: ['metade', '50/50', 'half half'] },
     { id: 'mostly-paid', pt: 'Maioria pagas', en: 'Mostly paid', aliases: ['maioria remuneradas', 'mostly paid staff'] },
+    { id: 'all-paid', pt: 'Todas pagas', en: 'All paid', aliases: ['todas remuneradas', 'all paid staff'] },
+  ],
+  main_activities: [
+    { id: 'hortas-alimentar', pt: 'Hortas e segurança alimentar', en: 'Gardens and food security', aliases: ['hortas', 'segurança alimentar', 'food security', 'gardens'] },
+    { id: 'arborizacao', pt: 'Arborização e áreas verdes', en: 'Tree planting and green areas', aliases: ['arborização', 'áreas verdes', 'green areas', 'tree planting'] },
+    { id: 'resiliencia-climatica', pt: 'Resiliência climática (enchentes, calor)', en: 'Climate resilience (floods, heat)', aliases: ['resiliência climática', 'climate resilience'] },
+    { id: 'educacao-ambiental', pt: 'Educação ambiental', en: 'Environmental education', aliases: ['env education'] },
+    { id: 'cultura-comunitaria', pt: 'Cultura e organização comunitária', en: 'Culture and community organizing', aliases: ['cultura', 'organização comunitária', 'community organizing'] },
+  ],
+  has_cnpj: [
+    { id: 'yes', pt: 'Sim, temos CNPJ', en: 'Yes, we have a CNPJ', aliases: ['sim', 'yes', 'tem cnpj', 'com cnpj'] },
+    { id: 'no', pt: 'Ainda não', en: 'Not yet', aliases: ['não', 'nao', 'no', 'sem cnpj'] },
+    { id: 'not-sure', pt: 'Não temos certeza', en: 'Not sure', aliases: ['não sei', 'nao sei', 'not sure', 'não tenho certeza'] },
+  ],
+  funding_history: [
+    { id: 'yes', pt: 'Sim, já recebemos', en: 'Yes, we have', aliases: ['sim', 'yes', 'já recebemos', 'ja recebemos'] },
+    { id: 'no', pt: 'Ainda não', en: 'Not yet', aliases: ['não', 'nao', 'no', 'nunca recebemos'] },
+  ],
+  funded_project_count: [
+    { id: 'one', pt: '1 projeto', en: '1 project', aliases: ['um projeto', 'one project', '1'] },
+    { id: '2-5', pt: '2 a 5 projetos', en: '2–5 projects', aliases: ['2-5 projetos', '2 to 5 projects'] },
+    { id: 'gt-5', pt: 'Mais de 5 projetos', en: 'More than 5 projects', aliases: ['5+ projetos', '5+ projects', 'mais de 5'] },
+  ],
+  biggest_project_budget: [
+    { id: 'lt-10k', pt: 'Até R$ 10 mil', en: 'Up to R$ 10k', aliases: ['ate 10 mil', 'menos de 10 mil', 'up to 10k'] },
+    { id: '10-50k', pt: 'R$ 10 a 50 mil', en: 'R$ 10–50k', aliases: ['10 a 50 mil', '10-50k'] },
+    { id: '50-200k', pt: 'R$ 50 a 200 mil', en: 'R$ 50–200k', aliases: ['50 a 200 mil', '50-200k'] },
+    { id: 'gt-200k', pt: 'Mais de R$ 200 mil', en: 'More than R$ 200k', aliases: ['mais de 200 mil', '200k+'] },
   ],
   prior_project_scale: [
     { id: 'none', pt: 'Nenhum formal ainda', en: 'None formal yet', aliases: ['nenhum', 'none yet', 'no formal projects'] },
@@ -80,8 +124,14 @@ export const ORG_PROFILE_ENUMS: Record<string, CboEnumOption[]> = {
     { id: 'funded', pt: 'Projeto com financiamento', en: 'Funded project', aliases: ['projeto financiado', 'com financiamento'] },
     { id: 'partnership', pt: 'Parceria com órgão público / fundação', en: 'Partnership with public agency / foundation', aliases: ['parceria', 'partnership with public agency'] },
   ],
+  // Questionnaire v2: the chips are now Sim / Ainda não / Não temos certeza,
+  // with the specifics captured in the free-text follow-up
+  // (nbs_experience_detail). The old activity-flavored options stay so legacy
+  // sessions keep displaying — and they still read as a "yes" in the rubric.
   nbs_experience: [
-    { id: 'none', pt: 'Ainda não', en: 'Not yet', aliases: ['nenhuma', 'ainda nao'] },
+    { id: 'yes', pt: 'Sim', en: 'Yes', aliases: ['sim, já trabalhamos', 'ja trabalhamos'] },
+    { id: 'none', pt: 'Ainda não', en: 'Not yet', aliases: ['nenhuma', 'ainda nao', 'não', 'nao', 'no'] },
+    { id: 'not-sure', pt: 'Não temos certeza', en: 'Not sure', aliases: ['não tenho certeza', 'nao tenho certeza', 'not sure', 'não sei'] },
     { id: 'env-education', pt: 'Educação ambiental', en: 'Environmental education', aliases: ['env education', 'educação ambiental'] },
     { id: 'gardens-and-greening', pt: 'Hortas / arborização', en: 'Gardens and greening', aliases: ['hortas', 'arborização', 'hortas e arborização', 'gardens', 'greening'] },
     { id: 'implemented-nbs', pt: 'Já implementamos SbN', en: 'Already implemented NbS', aliases: ['já implementamos', 'implementamos', 'implemented nbs'] },
@@ -144,9 +194,10 @@ function matchOptionFuzzy(field: string, raw: string): CboEnumOption | null {
   return hits.length === 1 ? hits[0] : null;
 }
 
-/** groups_served is a multi-select stored as one string — split on the
- *  separators the agent/chips produce, map each item independently. */
-const MULTI_FIELDS = new Set(['groups_served']);
+/** groups_served / main_activities are multi-selects stored as one string —
+ *  split on the separators the agent/chips produce, map each item
+ *  independently. */
+const MULTI_FIELDS = new Set(['groups_served', 'main_activities']);
 const MULTI_SEPARATOR = /\s*[,;·|]\s*|\s+e\s+(?=[A-ZÀ-Ú])/;
 
 function mapValue(field: string, raw: string, pick: (opt: CboEnumOption) => string, fuzzy = false): string {


### PR DESCRIPTION
Implements exactly the `[ ]` items from the field-feedback Notion page. Every ✅ item — name/role, years of existence, team size, main audience, project status triage — is **untouched**.

## The six changes

| # | Feedback | Change |
|---|---|---|
| 1 | *"Did the mission question get cut?"* | It had — Batch A's activity chips were being **squashed into `mission_summary`**. Mission restored as the 2nd question (prose, before activities), stored in the org's own words. |
| 2 | *"make it a top 3 activities"* | New `main_activities` field — multi-select, max 3, same 5 options. List refinement with Vila Flores flagged as follow-up. |
| 3 | *"first ask if they have a CNPJ"* | New `has_cnpj` question before org type (Sim · Ainda não · Não temos certeza). |
| 4 | *"add all paid, erase (1–2 paid)"* | `Todas pagas` added; `(1–2 pagas)` dropped from the label (old label kept as alias so legacy values still render). |
| 5 | *"Have you ever received funding? → how many? → biggest budget?"* | Full restructure: `funding_history` (Sim/Não) → conditional `funded_project_count` (1 / 2–5 / 5+) + `biggest_project_budget` (4 bands). `prior_project_scale` no longer asked but kept everywhere legacy data needs it. |
| 6 | *"Yes / No / Not sure + open follow-ups"* | `nbs_experience` chips are now Sim · Ainda não · Não temos certeza, with per-answer free-text follow-up into `nbs_experience_detail`. |

Plus the smaller UX item: a one-time *"qualquer resposta dá pra ajustar depois"* line at the mission question.

## Compatibility
- Both maturity rubrics rewritten to read the new fields **with explicit legacy mappings** — pre-v2 sessions keep displaying and scoring.
- E1Cards panel groups + `cbo.fields` labels (pt + en) cover all 6 new fields; old fields stay listed.
- Follow-ups are the only conditional questions in E1 (skill text updated accordingly).

## Verification
- **Live model, full E1 run**: mission asked 2nd; Batch A = activities (multiSelect max 3) + CNPJ + type + years + team; Batch B shows `Todas pagas` and the new funding/NbS questions; conditional follow-ups fire only when applicable; `org_delivery_capacity=2` / `team_technical_experience=2` land exactly per the new rubric; path triage unchanged.
- Full e2e suite: **59 passed, 3 skipped**; `tsc` clean.

## Note for the cohort question on the Notion page
Recommend creating the **official cohort fresh after this merges** — orgs profiled before v2 carry the old enum values (they'll still display fine, but new sessions get the better questionnaire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iXQHNn6stMsr4BUAm416s