### PR TITLE
E1 polish: agent knows today's date; empty-option ask_user rejected

### DIFF
--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -76,6 +76,7 @@ This is an **explicit exception** to "every turn ends with a tool call." A plain
 
 **NEVER do this for a free-text question:**
 - ❌ Calling `ask_user` with a single option like *"I'll type it below"* / *"Type my name"* / *"Outra coisa"*. That forces the user to click a button **and then** type — two steps for one answer. It is the most common pace-killer in this flow. Just ask the question in prose.
+- ❌ Calling `ask_user` with an **empty options array** (the mission question kept getting wrapped this way). A question with no chips IS a prose question — the server rejects the call and you lose a round-trip. Put it in your message text.
 - ❌ Adding chips to a name/year question. There are no buckets; chips only add friction.
 
 Right: *"E você, com quem estou conversando?"* → (user types "Marina") → next question.
@@ -152,6 +153,8 @@ When a document, link, or article arrives (now or later), read it and `update_se
 **A pasted URL must be FETCHED with `WebFetch` before you extract anything.** You cannot know what a page says from its address — extracting "from a link" without fetching is inventing data about someone's organization. If the fetch fails or the page is empty/irrelevant, say so honestly (*"Não consegui abrir o link — pode mandar o arquivo ou colar o texto aqui?"*) and continue the normal question flow. Never fill a single field from an unfetched URL.
 
 **Enum fields extracted from a document must land EXACTLY on a chip label from the question lists below** (e.g. `legal_form` gets "ONG / Associação", never "Associação de moradores"; `groups_served` picks from the eight listed groups, never the article's own category names). If the document's phrasing doesn't map cleanly onto one of the options, do **not** store an approximation — leave the field empty and ask that one question with its normal chips, **leading with your best guess**: *"Pelo material, vocês parecem ser uma associação — confere?"*. The server rejects off-list document values, so an approximation would silently not save and the panel and your recap would disagree.
+
+**`year_founded` from a founding YEAR is arithmetic, not vibes.** When a document says the org was founded in a specific year, compute the age against TODAY (given at the top of CURRENT STATE) and pick the bucket that contains it: founded 2013 with TODAY in 2026 is 13 years → 'Mais de 10 anos', not '5 a 10 anos'. If your recap states an age ("12 anos de atuação"), the stored bucket MUST contain that number — a recap that contradicts the panel makes the user distrust both.
 
 **These fields are NEVER filled from a document:**
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -518,6 +518,16 @@ Include showMap: true on a question only when the user genuinely needs the map t
       })),
     },
     async (args: any) => {
+      // A question with no chips is a PROSE question, not an ask_user — the
+      // model kept wrapping free-text questions (the mission) in empty-option
+      // ask_user calls, rendering a bare question card instead of plain chat
+      // text (live E1 run, 2026-07-08). Reject the whole call so the model
+      // re-asks correctly; rendering the valid subset would double-ask the
+      // rest on the retry.
+      const empty = (args.questions || []).filter((q: any) => !(q.options?.length > 0));
+      if (empty.length > 0) {
+        return { content: [{ type: "text" as const, text: `NOT shown — ${empty.length} question(s) had no options. ask_user is only for chip questions (2-7 buckets). A question with no natural buckets (mission, name, story) must be asked as PLAIN TEXT in your message, with no tool call. Re-ask now: chip questions via ask_user, free-text ones as prose.` }], isError: true };
+      }
       for (const q of args.questions || []) {
         pushEvent({ type: 'ask_user', question: q.question, options: q.options || [], relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
       }
@@ -1290,7 +1300,12 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   // "check CURRENT STATE first" keep working; the blocks just arrive in the
   // conversation instead of the system message.
   const systemPrompt = sysCtx;
-  const turnContext = `## CURRENT STATE\n${stateSummary}${documentsBlock}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}\n\n## NEW MESSAGE FROM THE USER\n`;
+  // TODAY rides in the volatile block (never the cached system prompt): the
+  // model has no other way to know the date, so age arithmetic silently
+  // drifted — a site saying "fundada em 2013" got bucketed '5 a 10 anos'
+  // instead of 'Mais de 10 anos' (live E1 run, 2026-07-08).
+  const todayLine = `TODAY: ${new Date().toISOString().slice(0, 10)}\n`;
+  const turnContext = `## CURRENT STATE\n${todayLine}${stateSummary}${documentsBlock}\n\n## RECENT CONVERSATION\n${decisionLog}${accessPolicy}\n\n## NEW MESSAGE FROM THE USER\n`;
 
   console.log(`[cbo] Turn for ${cboId} (phase ${state.phase}, model ${model}, ${Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length}/7 sections)`);
 


### PR DESCRIPTION
Fixes the two defects spotted during the live verification of #372/#373.

## 1. Wrong year bucket ("fundada em 2013" → '5 a 10 anos')

The model **had no access to the current date**, so any age computed from a founding year was a guess. Now:
- `TODAY: <date>` rides at the top of the volatile `CURRENT STATE` block — **not** the system prompt, so the LT-1 prompt-cache split stays intact.
- Skill rule: a founding year is **arithmetic against TODAY**, and the stored bucket must contain the age the recap states (recap/panel disagreement is what erodes trust).

## 2. Mission question rendered as a bare question card

The model kept wrapping the free-text mission question in an `ask_user` with an **empty options array**. The tool now rejects any call containing a zero-option question with a teaching error (the whole call is rejected so the retry can't double-ask the valid subset), and the skill's free-text anti-pattern list names the failure explicitly.

## Verification
- Live model: mission now arrives as plain chat prose; vilaflores.org (founded 2013) stores **'Mais de 10 anos'**, matching its own recap.
- CBO e2e subset 8/8 green (fake-model scripts always author options — no fake-path change needed); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iXQHNn6stMsr4BUAm416s