### PR TITLE
feat(site-explorer): add Flood Mechanism layer + fix categorical value decoding

### DIFF
--- a/client/public/sample-data/layer-legends.json
+++ b/client/public/sample-data/layer-legends.json
@@ -131,6 +131,43 @@
     "source": "sampled",
     "note": "colors recovered from tiles"
   },
+  "poa_flood_mechanism": {
+    "layerId": "poa_flood_mechanism",
+    "kind": "classes",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#e0e0e0",
+        "label": "None"
+      },
+      {
+        "value": 1,
+        "color": "#2166ac",
+        "label": "Riverine"
+      },
+      {
+        "value": 2,
+        "color": "#fdae61",
+        "label": "Pluvial"
+      },
+      {
+        "value": 3,
+        "color": "#abd9e9",
+        "label": "Low-lying"
+      },
+      {
+        "value": 4,
+        "color": "#7b3294",
+        "label": "Drainage constrained"
+      },
+      {
+        "value": 5,
+        "color": "#969696",
+        "label": "Mixed"
+      }
+    ],
+    "source": "classes"
+  },
   "poa_heat_hazard": {
     "layerId": "poa_heat_hazard",
     "kind": "gradient",

--- a/client/src/legacy/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/legacy/components/concept-note/ConceptNoteMap.tsx
@@ -4,7 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import { Button } from '@/core/components/ui/button';
 import { Badge } from '@/core/components/ui/badge';
 import { Check, MapPin, Layers, X, BarChart3, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, REFERENCE_LAYERS, type TileLayerDef } from '@shared/geospatial-layers';
+import { TILE_LAYERS, ALL_TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, REFERENCE_LAYERS, type TileLayerDef } from '@shared/geospatial-layers';
 import { riskBand, hazardPercentile, type HazardKey } from '@shared/risk-display';
 import ValueTooltip from '@/core/components/maps/ValueTooltip';
 import { buildSpatialQueryLayer } from '@/lib/spatialQueryBuilder';
@@ -119,9 +119,11 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
   const osmLayerRefs = useRef<Record<string, L.GeoJSON>>({});
   const spatialQueryRefs = useRef<Record<string, L.GeoJSON>>({});
 
-  // Enabled tile layer defs for ValueTooltip
+  // Enabled tile layer defs for ValueTooltip. ALL_TILE_LAYERS, not TILE_LAYERS —
+  // see the same note in site-explorer.tsx: the risk/index layers are merged in
+  // only by ALL_*, so filtering TILE_LAYERS silently dropped their hover values.
   const enabledTileLayerDefs = useMemo(
-    () => TILE_LAYERS.filter(l => enabledTileLayers.has(l.id)),
+    () => ALL_TILE_LAYERS.filter(l => enabledTileLayers.has(l.id)),
     [enabledTileLayers]
   );
 

--- a/client/src/legacy/pages/site-explorer.tsx
+++ b/client/src/legacy/pages/site-explorer.tsx
@@ -36,7 +36,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
 import { apiRequest } from '@/core/lib/queryClient';
-import { TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS, LANDSLIDE_INDEX_LAYERS } from '@shared/geospatial-layers';
+import { TILE_LAYERS, ALL_TILE_LAYERS, TILE_LAYER_GROUPS, OSM_LAYERS, SPATIAL_QUERIES, LOCAL_RISK_LAYERS, FLOOD_INDEX_LAYERS, HEAT_INDEX_LAYERS, LANDSLIDE_INDEX_LAYERS } from '@shared/geospatial-layers';
 import { riskBand, pct100, dominantPercentile, hazardPercentile, riskAnchor, TYPOLOGY_COLORS, type HazardKey } from '@shared/risk-display';
 import { LayerLegend } from '@/core/components/map/LayerLegend';
 import type { LegendIndex } from '@shared/legend-types';
@@ -308,9 +308,13 @@ export default function SiteExplorerPage() {
 
   const isSampleModeActive = isSampleMode || isSampleRoute;
 
-  // Enabled tile layers with value encodings for ValueTooltip
+  // Enabled tile layers with value encodings for ValueTooltip.
+  // Must be ALL_TILE_LAYERS, not TILE_LAYERS: the risk cards and the flood/heat/
+  // landslide index layers live in their own arrays and are only merged in ALL_*.
+  // Filtering TILE_LAYERS meant those layers advertised value tiles (green dot)
+  // but their hover tooltip could never fire.
   const enabledTileLayerDefs = useMemo(
-    () => TILE_LAYERS.filter(l => layers.some(ls => ls.id === l.id && ls.enabled)),
+    () => ALL_TILE_LAYERS.filter(l => layers.some(ls => ls.id === l.id && ls.enabled)),
     [layers]
   );
 

--- a/client/src/lib/valueTileUtils.ts
+++ b/client/src/lib/valueTileUtils.ts
@@ -1,23 +1,17 @@
 // Utilities for decoding OEF value tiles (RGB → numeric/categorical).
 // Ported from Bike-lanes-project-preparation/app/client/src/lib/valueTileUtils.ts
 
-// ── Value-tile encoding spec (matches geospatial-layers.ts) ─────────────────
-// Formula for numeric: value = (R + 256*G + 65536*B + offset) / scale
-// Formula for categorical: class_id = R (G=B=0)
-export interface ValueTileEncoding {
-  type: "numeric" | "categorical";
-  scale?: number;
-  offset?: number;
-  unit?: string;
-  urlTemplate?: string;
-  classes?: Record<number, string>;
-}
+// The encoding spec is owned by the catalog in @shared/geospatial-layers. It used
+// to be re-declared here by hand, which is how the two drifted apart.
+export type { ValueTileEncoding } from '@shared/geospatial-layers';
+import type { ValueTileEncoding } from '@shared/geospatial-layers';
 
 // ── Lat/lng → tile coordinate + pixel offset ─────────────────────────────────
 export function latLngToTilePixel(lat: number, lng: number, z: number) {
   const n = Math.pow(2, z);
   const latR = (lat * Math.PI) / 180;
-  const mercY = (1 - Math.log(Math.tan(latR) + 1 / Math.cos(latR)) / Math.PI) / 2;
+  const mercY =
+    (1 - Math.log(Math.tan(latR) + 1 / Math.cos(latR)) / Math.PI) / 2;
 
   const tileX = Math.floor(((lng + 180) / 360) * n);
   const tileY = Math.floor(mercY * n);
@@ -37,7 +31,9 @@ export function latLngToTilePixel(lat: number, lng: number, z: number) {
 const tileCache = new Map<string, ImageData | null>();
 const pendingTiles = new Map<string, Promise<ImageData | null>>();
 
-export async function fetchTilePixels(tileUrl: string): Promise<ImageData | null> {
+export async function fetchTilePixels(
+  tileUrl: string
+): Promise<ImageData | null> {
   if (tileCache.has(tileUrl)) return tileCache.get(tileUrl)!;
   if (pendingTiles.has(tileUrl)) return pendingTiles.get(tileUrl)!;
 
@@ -46,21 +42,28 @@ export async function fetchTilePixels(tileUrl: string): Promise<ImageData | null
     ? tileUrl
     : `/api/geospatial/proxy-tile?url=${encodeURIComponent(tileUrl)}`;
 
-  const promise = new Promise<ImageData | null>((resolve) => {
+  const promise = new Promise<ImageData | null>(resolve => {
     const img = new Image();
-    img.crossOrigin = "anonymous";
+    img.crossOrigin = 'anonymous';
     img.onload = () => {
-      const canvas = document.createElement("canvas");
+      const canvas = document.createElement('canvas');
       canvas.width = 256;
       canvas.height = 256;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) { tileCache.set(tileUrl, null); resolve(null); return; }
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        tileCache.set(tileUrl, null);
+        resolve(null);
+        return;
+      }
       ctx.drawImage(img, 0, 0, 256, 256);
       const data = ctx.getImageData(0, 0, 256, 256);
       tileCache.set(tileUrl, data);
       resolve(data);
     };
-    img.onerror = () => { tileCache.set(tileUrl, null); resolve(null); };
+    img.onerror = () => {
+      tileCache.set(tileUrl, null);
+      resolve(null);
+    };
     img.src = proxyUrl;
   });
 
@@ -71,38 +74,56 @@ export async function fetchTilePixels(tileUrl: string): Promise<ImageData | null
 }
 
 // ── Sample a single pixel from an ImageData ───────────────────────────────────
-export function samplePixel(imgData: ImageData, px: number, py: number): [number, number, number, number] {
+export function samplePixel(
+  imgData: ImageData,
+  px: number,
+  py: number
+): [number, number, number, number] {
   const i = (py * 256 + px) * 4;
-  return [imgData.data[i], imgData.data[i + 1], imgData.data[i + 2], imgData.data[i + 3]];
+  return [
+    imgData.data[i],
+    imgData.data[i + 1],
+    imgData.data[i + 2],
+    imgData.data[i + 3],
+  ];
 }
 
 // ── Decode OEF value tile pixel → number (or null for nodata) ─────────────────
 export function decodePixelNumeric(
-  r: number, g: number, b: number, alpha: number,
+  r: number,
+  g: number,
+  b: number,
+  alpha: number,
   encoding: ValueTileEncoding
 ): number | null {
   if (alpha < 10) return null;
 
-  if (encoding.type === "categorical") {
-    return r; // class id
+  const raw = r + 256 * g + 65536 * b;
+  if (encoding.nodata !== undefined && raw === encoding.nodata) return null;
+  const offset = encoding.offset ?? 0;
+
+  if (encoding.type === 'categorical') {
+    return raw + offset; // class id
   }
 
-  const raw = r + 256 * g + 65536 * b;
   const scale = encoding.scale ?? 100;
-  const offset = encoding.offset ?? 0;
   const value = (raw + offset) / scale;
   return isFinite(value) ? value : null;
 }
 
 // ── Decode pixel to human-readable string ─────────────────────────────────────
 export function decodePixelDisplay(
-  r: number, g: number, b: number, alpha: number,
+  r: number,
+  g: number,
+  b: number,
+  alpha: number,
   encoding: ValueTileEncoding
 ): string | null {
   if (alpha < 10) return null;
 
-  if (encoding.type === "categorical") {
-    const classId = r;
+  if (encoding.type === 'categorical') {
+    const classId = decodePixelNumeric(r, g, b, alpha, encoding);
+    if (classId === null) return null;
     const className = encoding.classes?.[classId];
     return className ?? `Class ${classId}`;
   }
@@ -110,8 +131,8 @@ export function decodePixelDisplay(
   const value = decodePixelNumeric(r, g, b, alpha, encoding);
   if (value === null) return null;
 
-  if (encoding.unit === "index 0–1") return value.toFixed(3);
-  if (encoding.unit?.includes("°C")) return value.toFixed(1);
+  if (encoding.unit === 'index 0–1') return value.toFixed(3);
+  if (encoding.unit?.includes('°C')) return value.toFixed(1);
   return value.toFixed(1);
 }
 
@@ -127,9 +148,9 @@ export async function sampleRasterAtPoint(
   const { tileX, tileY, px, py } = latLngToTilePixel(lat, lng, z);
 
   const tileUrl = encoding.urlTemplate
-    .replace("{z}", String(z))
-    .replace("{x}", String(tileX))
-    .replace("{y}", String(tileY));
+    .replace('{z}', String(z))
+    .replace('{x}', String(tileX))
+    .replace('{y}', String(tileY));
 
   try {
     const imgData = await fetchTilePixels(tileUrl);
@@ -150,22 +171,22 @@ export function geometryCentroid(geometry: any): [number, number] | null {
 
   const collect = (geom: any): void => {
     switch (geom.type) {
-      case "Point":
+      case 'Point':
         coords.push(geom.coordinates);
         break;
-      case "MultiPoint":
-      case "LineString":
+      case 'MultiPoint':
+      case 'LineString':
         coords.push(...geom.coordinates);
         break;
-      case "MultiLineString":
-      case "Polygon":
+      case 'MultiLineString':
+      case 'Polygon':
         for (const ring of geom.coordinates) coords.push(...ring);
         break;
-      case "MultiPolygon":
+      case 'MultiPolygon':
         for (const poly of geom.coordinates)
           for (const ring of poly) coords.push(...ring);
         break;
-      case "GeometryCollection":
+      case 'GeometryCollection':
         for (const g of geom.geometries) collect(g);
         break;
     }

--- a/scripts/generate-legends.ts
+++ b/scripts/generate-legends.ts
@@ -48,6 +48,9 @@ const COLOR_FILES: Record<string, { path: string; unit?: string }> = {
 // Categorical class colors from the catalog datasets.yaml (valueEncoding.classes has names only).
 const CLASS_COLORS: Record<string, Record<number, string>> = {
   oef_dynamic_world: { 0: '#62B0CC', 1: '#488C5F', 2: '#98B982', 3: '#A0AAC3', 4: '#D7A55F', 5: '#CDB982', 6: '#B45F55', 7: '#AFA89E', 8: '#B9CDE1' },
+  // Verified against the visual tiles: encoded 2/4/6 paint #2166ac/#abd9e9/#969696,
+  // which is class = encoded - 1 (riverine / low-lying / mixed).
+  poa_flood_mechanism: { 0: '#e0e0e0', 1: '#2166ac', 2: '#fdae61', 3: '#abd9e9', 4: '#7b3294', 5: '#969696' },
 };
 
 // Local risk ramps — mirror the colorFns in generate-risk-tiles.ts (value → color).

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -117,6 +117,8 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
   // (plural, like `floods`). ──
   poa_flood_risk:        { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_flood_hazard:      { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/hazard/tiles_visual/{z}/{x}/{y}.png" },
+  // NOTE the path segment is `flood_mechanism`, not the catalog dataset_id `poa_flood_mechanism_type`.
+  poa_flood_mechanism:   { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/flood_mechanism/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_risk:         { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_hazard:       { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/hazard/tiles_visual/{z}/{x}/{y}.png" },
   poa_landslide_risk:    { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/risk/tiles_visual/{z}/{x}/{y}.png" },

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -18,8 +18,13 @@ export type LayerGroup =
   | 'climate_projections'; // New: FRI, HWM projections
 
 // Value-tile encoding from OEF GitHub catalog (datasets.yaml).
-// Formula for numeric layers: value = (R + 256*G + 65536*B + offset) / scale
-// Formula for categorical layers: class_id = R  (G=B=0)
+// Both kinds read the same 24-bit value: raw = R + 256*G + 65536*B
+//   numeric:     value    = (raw + offset) / scale
+//   categorical: class_id = raw + offset
+// Most categorical layers encode the class directly (offset 0, G=B=0), but the
+// catalog's `class_lookup` layers reserve raw 0 for nodata and store class+1 —
+// those declare `offset: -1` and `nodata: 0`. Decoding those with the old
+// `class_id = R` rule silently shifted every label by one.
 export interface ValueTileEncoding {
   type: "numeric" | "categorical";
   scale?: number;
@@ -27,6 +32,8 @@ export interface ValueTileEncoding {
   unit?: string;
   urlTemplate?: string;
   classes?: Record<number, string>;
+  /** Raw 24-bit value meaning "no data". Decodes to null. */
+  nodata?: number;
 }
 
 export interface TileLayerDef {
@@ -99,6 +106,23 @@ export const FLOOD_INDEX_LAYERS: TileLayerDef[] = [
     id: 'poa_flood_hazard', name: 'Flood Hazard', group: 'flood_indices', color: '#2563eb',
     tileLayerId: 'poa_flood_hazard', available: true, hasValueTiles: true,
     valueEncoding: hazardIndexEncoding('floods', 'hazard'),
+  },
+  {
+    // Catalog dataset_id: poa_flood_mechanism_type (class_lookup, 250 m).
+    // Value tiles store class+1 so raw 0 can mean nodata — hence offset -1.
+    // Porto Alegre's raster only contains riverine, low-lying and mixed;
+    // pluvial and drainage_constrained never occur (drainage is a proxy until
+    // municipal drainage data exists).
+    id: 'poa_flood_mechanism', name: 'Flood Mechanism', group: 'flood_indices', color: '#7b3294',
+    tileLayerId: 'poa_flood_mechanism', available: true, hasValueTiles: true,
+    valueEncoding: {
+      type: 'categorical', offset: -1, nodata: 0,
+      urlTemplate: `${CLIMATE_HAZARDS_BASE}/floods/flood_mechanism/tiles_values/{z}/{x}/{y}.png`,
+      classes: {
+        0: 'None', 1: 'Riverine', 2: 'Pluvial',
+        3: 'Low-lying', 4: 'Drainage constrained', 5: 'Mixed',
+      },
+    },
   },
 ];
 


### PR DESCRIPTION
Adds the catalog dataset `poa_flood_mechanism_type` (250 m, `class_lookup`) to the **Flood Indices** row of Site Explorer — and fixes two bugs that would have made it silently wrong.

## The layer

Dominant flood mechanism per 250 m cell: riverine / pluvial / low-lying / drainage-constrained / mixed. It did not exist anywhere in this repo; the definition lives in `Open-Earth-Foundation/geospatial-data` at `catalog/datasets.yaml:461`.

## Bug 1 — categorical value tiles decoded wrong

`valueTileUtils.ts` decoded categorical tiles as `class_id = R`, ignoring G/B and ignoring `offset`. This layer stores `class + 1` in a 24-bit value so raw `0` can mean nodata. Every label would have been shifted by one.

I did not take the YAML's word for it. The raster only contains **even** encoded values (2, 4, 6) across every tile I sampled — which is equally consistent with `encoded - 1` and with `encoded / 2`. Pairing the value tiles against the **visual** tiles settles it at colour distance `0.0`:

| encoded | visual colour | class |
|---|---|---|
| 2 | `#2166ac` | Riverine (code 1) |
| 4 | `#abd9e9` | Low-lying (code 3) |
| 6 | `#969696` | Mixed (code 5) |

So `code = encoded - 1`. Under the old decoder those three would have read **"Pluvial"**, **"Drainage constrained"** and **"Class 6"**.

`decodePixelNumeric` now reads the full 24-bit value for both kinds and applies `offset`, with an explicit `nodata` raw value. Dynamic World (`offset` 0, G=B=0) decodes identically — verified.

## Bug 2 — risk/index layers never showed hover values

`enabledTileLayerDefs` filtered `TILE_LAYERS`, which excludes `LOCAL_RISK_LAYERS` and the flood/heat/landslide index arrays — those are only merged into `ALL_TILE_LAYERS`. So all seven of those layers rendered the green "has value tiles" dot while their hover tooltip could never fire.

Fixed in `site-explorer.tsx` and `ConceptNoteMap.tsx`. `MapMicroapp` already used `ALL_TILE_LAYERS` everywhere. **Flood Hazard now hovers as `0.450 index 0–1` for the first time.**

## Data note

Porto Alegre's raster only ever contains **riverine, low-lying and mixed**. Pluvial and drainage-constrained never occur — consistent with the catalog noting drainage is a proxy "until municipal drainage data exists." The legend still lists all six classes, since class 0 (`None`) is reachable at raw 1.

## Also

`valueTileUtils.ts` re-declared `ValueTileEncoding` by hand rather than importing it — which is exactly how the decoder and the catalog drifted apart. It now imports the shared type.

## Verification

Booted the app against a local Postgres and drove it in Chromium:

- Flood Mechanism toggle appears in the Flood Indices row, next to Flood Hazard.
- Visual tiles serve `200` through `/api/geospatial/tiles/poa_flood_mechanism/…` (the proxy registration is required; without it they 404).
- Legend renders all six classes with catalog colours.
- Hovering the raster yields **Riverine**, **Low-lying**, **Mixed** — exactly the three classes present in the data, and nothing else.
- `poa_flood_hazard` hover returns `0.450 index 0–1`.
- Decoder unit-checked against the real tile pixels; Dynamic World unchanged.

`npx tsc --noEmit` introduces no new errors (4 pre-existing, all in untouched files).

## Not verified

The legend generator (`scripts/generate-legends.ts`) re-samples every layer from S3. I ran it, then reverted an unrelated drift in `oef_chirps_rx5day_clim`'s sampled stops so this diff contains only the new `poa_flood_mechanism` key. Worth knowing that generator output is not byte-stable across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019V98vrBvgmUFdVJHroaPW7