### PR TITLE
fix(cbo): truncate decision-log messages from the middle, not the end

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1536,8 +1536,23 @@ function buildDecisionLog(cboId: string): string {
       return null;
     }
     const who = m.role === 'user' ? 'User' : 'You (agent)';
-    return `- ${who}: ${m.content.slice(0, 300)}`;
+    return `- ${who}: ${clipKeepingTail(m.content, 300)}`;
   }).filter(Boolean).join('\n');
+}
+
+// Truncate from the MIDDLE, never the end. Agent messages put their question
+// LAST, so the old head-only `slice(0, 300)` deleted the question from the
+// agent's own memory of any message over 300 chars. The guaranteed victim was
+// the templated kickoff greeting (404 chars, every language/prefill variant):
+// the model never saw that it had already asked for the contact's name+role,
+// so it re-asked on turn 1 of every session. See
+// docs/audit-e1-first-turn-2026-07-10.md §2.1. Exported for the proof test.
+export function clipKeepingTail(text: string, max = 300): string {
+  if (text.length <= max) return text;
+  const marker = ' […] ';
+  const head = Math.ceil((max - marker.length) * 0.55);
+  const tail = max - marker.length - head;
+  return `${text.slice(0, head)}${marker}${text.slice(-tail)}`;
 }
 
 // Knowledge cache (cleared on server restart)


### PR DESCRIPTION
Fixes root cause **2.1** of `docs/audit-e1-first-turn-2026-07-10.md` (PR #379) — the double-ask of the contact's name on every session's first turn.

## Problem

`buildDecisionLog` cut every RECENT CONVERSATION message to its **first 300 chars**. Agent messages put their question **last**, so any message over 300 chars lost its question from the agent's own memory. The guaranteed victim: the templated kickoff greeting (404–424 chars in every language/prefill variant), whose final sentence is the name/role question. The model's view of its own greeting ended mid-word at `Conferindo: vocês são a **C` — it never saw that it had already asked, so it re-asked. The E1 skill's "do NOT re-greet or re-ask" rule (`encontro-1.md:140`) was correct and starved of evidence.

## Change

One function: `clipKeepingTail()` keeps ~55% head + ~45% tail around a `[…]` marker. **Same 300-char budget** — the prompt does not grow.

## Verified

Ran all five kickoff variants through the exported function:

```
PT, invite org, no bairro    len=404 -> clipped=300  question visible: YES
PT, invite org + bairro      len=424 -> clipped=300  question visible: YES
PT, no org (standalone)      len=385 -> clipped=300  question visible: YES
EN, invite org               len=394 -> clipped=300  question visible: YES
EN, no org (standalone)      len=364 -> clipped=300  question visible: YES
short message untouched: true
```

What the model now sees (vs. ending mid-word before):

```
Oi! 👋 Eu vou te ajudar a montar o perfil da Comunidad feliz — … até fot […]
Conferindo: vocês são a **Comunidad feliz**, certo? Me corrige se eu errei.
E com quem eu tô falando — seu nome e seu papel por aí?
```

64/64 deterministic Playwright specs pass; `tsc` introduces no new errors (4 pre-existing).

## Not in this PR

The two sibling root causes ship as their own independent PRs: the first-turn model-routing regression (audit §2.3) and the one-field-completes-Encontro-1 banner (§3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019V98vrBvgmUFdVJHroaPW7