### PR TITLE
fix(cbo): first-turn heavy-model guard must count USER messages, not all

### DIFF
--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1220,7 +1220,9 @@ const DEFAULT_CBO_MODEL = 'claude-sonnet-4-6';
 // prompts). Kill switch: CBO_ADAPTIVE_MODEL=0 (no redeploy needed).
 const LIGHT_CBO_MODEL = process.env.CBO_LIGHT_MODEL || 'claude-haiku-4-5';
 
-function resolveTurnModel(
+// Exported for testability — the first-turn guard interacts with the kickoff
+// route's persisted greeting, and that interaction is exactly what regressed.
+export function resolveTurnModel(
   cboId: string,
   state: CboState,
   userMessage: string,
@@ -1247,7 +1249,14 @@ function resolveTurnModel(
   if (turnKind === 'system') return heavy('system-turn');
   if (/(?:vamos\s+(?:começar|comecar)|let'?s\s+start)\s+(?:o\s+)?encontro/i.test(raw)) return heavy('phase-start');
   // First user message of the session = the intro turn (set_phase + framing).
-  if (getCboMessages(cboId).filter(m => m.messageType === 'content').length < 2) return heavy('first-turn');
+  // Count USER messages only. The old check counted all 'content' messages,
+  // and the instant-kickoff route persists one ASSISTANT content message before
+  // the user ever types — so by the first real turn the count was already 2 and
+  // this guard never fired: the session's most important turn fell through to
+  // light('short-text') → the fast model (audit §2.3, a regression: guard
+  // c9a00d5e 2026-07-02, kickoff fa647505 2026-07-07). The current user message
+  // is persisted before we run, so first turn ⇒ exactly 1 user message.
+  if (getCboMessages(cboId).filter(m => m.messageType === 'content' && m.role === 'user').length < 2) return heavy('first-turn');
 
   // Trivial conversational turns in the interview phases → fast model.
   if (turnKind === 'chip') return light('chip-answer');


### PR DESCRIPTION
Fixes root cause **2.3** of `docs/audit-e1-first-turn-2026-07-10.md` (PR #379) — the session's first turn running on the fast model.

## Problem

`resolveTurnModel` routes the first turn heavy (the intro turn sets phase, frames the interview, persists the first fields). It counted **all** `content` messages — and the instant-kickoff route (`fa647505`, 2026-07-07) persists one **assistant** content message before the user ever types. So by the first real turn the count was already 2, the guard never fired, and the turn fell through to `light('short-text')` → **claude-haiku-4-5**. Confirmed verbatim in the production log:

```
[cbo] turn routing …: light (short-text) kind=text model=claude-haiku-4-5
```

This is a **regression**: the guard landed `c9a00d5e` (2026-07-02); the kickoff five days later silently defeated it. Two latency optimizations, each fine alone.

## Change

Count only **user** content messages. The current user message is persisted before `resolveTurnModel` runs, so first turn ⇒ exactly 1 user message — with or without a kickoff greeting.

## Verified — replaying the production sequence through the real `resolveTurnModel`

```
turn 1 after kickoff : heavy (first-turn) model=claude-sonnet-4-6   <- was light
turn 2 short text    : light (short-text) model=claude-haiku-4-5    <- optimization preserved
later chip turn      : light (chip-answer) model=claude-haiku-4-5   <- optimization preserved
turn 1, no kickoff   : heavy (first-turn) model=claude-sonnet-4-6   <- unchanged
```

The hole is closed; the fast-model optimization for trivial turns is untouched. `resolveTurnModel` is exported for that test; nothing else calls it.

64/64 deterministic Playwright specs pass; `tsc` introduces no new errors (4 pre-existing).

## Siblings

Independent PRs for the other two audit findings: #380 (decision-log truncation, the double-ask) and the Encontro-1 banner predicate (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019V98vrBvgmUFdVJHroaPW7