### PR TITLE
fix(cbo): Encontro 1 completes on its maturity scores, not on one filled field

### DIFF
--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -43,17 +43,34 @@ export function cboFieldIsFilled(f?: CboFieldState): boolean {
 }
 
 /**
+ * Phases whose skill GUARANTEES its maturity scores at the encontro's close.
+ * For these, the scores ARE the completion signal and the section-fill
+ * fallback below must not apply — it is far too weak. Phase 1 has exactly one
+ * section (org_profile), so the fallback's every() collapsed to some(): the
+ * agent's very first update_section (contact_name) marked Encontro 1 complete
+ * and fired the "Começar Encontro 2" banner one exchange into the interview
+ * (docs/audit-e1-first-turn-2026-07-10.md §3). encontro-1.md:220 mandates both
+ * score_maturity calls at the E1 close, and the score_maturity validator
+ * already tells the model "the next-workshop banner only appears when the
+ * phase's metrics are scored" — this makes that sentence true.
+ *
+ * NOT in the set: phase 2 (encontro-2.md:81 explicitly DEFERS scoring — the
+ * fallback exists for it) and phases 3-5 (no skill files yet; their scoring
+ * behavior is unverified, so their gate is left untouched).
+ */
+const PHASES_SCORED_AT_CLOSE = new Set([1]);
+
+/**
  * Whether a phase's work is done — the single forward-progress predicate used by
  * the next-workshop advance banner (and available to the server phase gate).
  * A phase is complete when EITHER signal holds:
  *   (a) every maturity metric for the phase is scored (the legacy signal — still
  *       true for phases that DO score), OR
- *   (b) every section belonging to the phase has at least one filled field.
+ *   (b) every section belonging to the phase has at least one filled field —
+ *       UNLESS the phase is in PHASES_SCORED_AT_CLOSE, where (a) is the contract.
  * (b) is what unblocks Encontro 2, whose skill intentionally DEFERS its two
  * maturity scores (site_control / community_anchoring) — so (a) is never
  * satisfiable there and the advance banner used to dead-end with no way forward.
- * Being an OR of the two, this is strictly more permissive than the old
- * metrics-only gate: it can never hide a banner that previously showed.
  */
 export function phaseComplete(
   state: Pick<CboState, 'sections' | 'maturityScores'>,
@@ -66,6 +83,9 @@ export function phaseComplete(
   if (required.length > 0) {
     const scored = new Set((state.maturityScores ?? []).map(s => s.metric));
     if (required.every(m => scored.has(m))) return true;
+    // The skill scores these at the encontro's close — until it does, the
+    // phase is not complete, no matter how many fields are filled.
+    if (PHASES_SCORED_AT_CLOSE.has(phase)) return false;
   }
 
   return sections.every(sec => {


### PR DESCRIPTION
Fixes root cause **3** of `docs/audit-e1-first-turn-2026-07-10.md` (PR #379) — the "Começar Encontro 2" banner appearing one exchange into the interview.

## Problem

`phaseComplete`'s section-fill fallback requires every phase section to have *some* non-invite filled field. Phase 1 has **exactly one** section (`org_profile`), so `every()` collapses to `some()`: the agent's very first `update_section` (writing `contact_name: Joaquim`) marked Encontro 1 complete and fired the banner at `1/7` sections filled. The `source !== 'invite'` guard had fixed this same banner for prefilled orgs — and left the general hole open.

## Change

The completion contract for E1 already exists in three places: `encontro-1.md:220` mandates both `score_maturity` calls at the E1 close; the `score_maturity` validator literally tells the model *"the next-workshop banner only appears when the phase's metrics are scored"* (`cboAgent.ts:629`); and `PHASE_COMPLETION_METRICS` derives the two metrics from `CBO_SECTIONS`. This PR makes that sentence true: for phases in `PHASES_SCORED_AT_CLOSE` (= `{1}`), the scores are the **only** completion signal.

**Deliberately scoped.** Phase 2 keeps the fallback — `encontro-2.md:81` explicitly *defers* scoring ("do NOT … call `score_maturity`"), which is why the fallback exists. Phases 3–5 have no skill files yet, so their gates are untouched.

## Verified — against the real predicate

```
turn-1 state (the bug)          -> phaseComplete(1) = false  (was true)
all fields filled, no scores    -> phaseComplete(1) = false
E1 close (both metrics scored)  -> phaseComplete(1) = true
only one metric scored          -> phaseComplete(1) = false
E2, deferred scores, one field  -> phaseComplete(2) = true   (unchanged)
E5 (no metrics), one field      -> phaseComplete(5) = true   (unchanged)
```

Sole caller is the banner gate (`cbo-profile.tsx:1885`). The server's `advanceCboPhase` gates on coordinator unlocks only — coordinator flow and phase jumps unaffected.

**Known accepted risk:** a model that finishes E1 without calling `score_maturity` keeps the banner hidden until it does. Recovery exists (phase-jump chips), the validator nags the model with exact metric ids, and the alternative — one field = done — is the bug.

64/64 deterministic Playwright specs pass (`cbo-phase1-walkthrough` already scripts both `score_maturity` calls, so the legitimate close still banners). `tsc`: no new errors.

## Siblings

#380 (decision-log truncation → the double-ask) and #381 (first-turn model routing) — all three independent, all off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019V98vrBvgmUFdVJHroaPW7