### PR TITLE
fix(maps): map overlays painted over every dialog — isolate their stacking context

### DIFF
--- a/client/src/core/components/maps/MapMicroapp.tsx
+++ b/client/src/core/components/maps/MapMicroapp.tsx
@@ -1468,7 +1468,14 @@ export default function MapMicroapp({
         : t('mapMicroapp.clickZones');
 
   return (
-    <div className='relative flex flex-col h-full w-full bg-background overflow-hidden'>
+    // `isolate` is load-bearing. The overlays below (tour caption z-900, legend
+    // sheet z-1001, loading veil z-1000) sit OUTSIDE .leaflet-container, so
+    // without a stacking context here their z-indices compete in the root
+    // context and beat every portalled Radix overlay — all of which are z-50.
+    // The ⓘ "De onde vêm estes dados" dialog opened *underneath* the hazard
+    // legend because of this. Leaflet solves it for its own panes the same way
+    // (.leaflet-container is z-index:0); we just do it for ours.
+    <div className='relative isolate flex flex-col h-full w-full bg-background overflow-hidden'>
       {/* Header */}
       <div className='px-3 py-2 border-b bg-muted/30 shrink-0 flex items-start gap-2'>
         <div className='min-w-0 flex-1'>

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -1339,7 +1339,11 @@ export default function OrchestratorLandingPage() {
         <div className="flex flex-col gap-5">
           {/* Map — full width */}
           <div className="w-full">
-            <div className="relative h-[56vh] md:h-[64vh] w-full">
+            {/* `isolate`: MapLayerControls is z-400 and sits outside
+                .leaflet-container. Portalled Radix overlays are all z-50, so
+                without a local stacking context the legend paints over any
+                dialog opened from this page. */}
+            <div className="relative isolate h-[56vh] md:h-[64vh] w-full">
               <MapPanel
                 projects={projects}
                 selectedId={selectedId}

--- a/client/src/legacy/components/concept-note/ConceptNoteMap.tsx
+++ b/client/src/legacy/components/concept-note/ConceptNoteMap.tsx
@@ -431,7 +431,12 @@ export default function ConceptNoteMap({ onConfirm, isActive }: ConceptNoteMapPr
   };
 
   return (
-    <div className="flex flex-col h-full">
+    // `isolate` traps the hover-info overlay's z-1000 in a local stacking
+    // context. Without it that z-index competes at the root and paints over
+    // every portalled dialog/popover/select, all of which are z-50.
+    // `isolation` creates the context without touching layout, so the
+    // absolutely-positioned overlay keeps its containing block.
+    <div className="flex flex-col h-full isolate">
       {/* Controls */}
       <div className="flex items-center justify-end gap-1.5 p-2 border-b bg-background">
         {(() => {

--- a/client/src/legacy/pages/site-explorer.tsx
+++ b/client/src/legacy/pages/site-explorer.tsx
@@ -1891,7 +1891,11 @@ export default function SiteExplorerPage() {
             )}
           </div>
         </div>
-        <div className="flex-1 relative">
+        {/* `isolate`: the zone panel / evidence drawer / zone card below are
+            z-1001 and live outside .leaflet-container, so without a local
+            stacking context they paint over every portalled Radix overlay
+            (all z-50) — including the ⓘ data-provenance dialog. */}
+        <div className="flex-1 relative isolate">
           {/* Map container - leaves room for right panel and bottom drawer */}
           <div
             ref={mapContainerRef}

--- a/e2e/cougar-map-overlay-stacking.spec.ts
+++ b/e2e/cougar-map-overlay-stacking.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The ⓘ "De onde vêm estes dados" dialog opened UNDERNEATH the hazard legend.
+//
+// Every portalled Radix overlay in this app is z-50 (dialog, popover, select,
+// tooltip, dropdown-menu, sheet, alert-dialog). MapMicroapp's own overlays are
+// z-900 (tour caption, narration banner, zone explainer, basemap toggle) and
+// z-1000/1001 (loading veil, HazardLegendSheet), and they live OUTSIDE
+// .leaflet-container. With no stacking context between them and <html>, those
+// z-indices compete in the root stacking context and win.
+//
+// Leaflet already solves this for its own panes (z-400/800/999) by giving
+// .leaflet-container `z-index: 0`. MapMicroapp's root now does the same via
+// Tailwind's `isolate`.
+//
+// This CANNOT be asserted with elementFromPoint: the tour caption is
+// pointer-events-none, so hit-testing happily reports the dialog on top while
+// the caption paints over it. Assert the structural invariant instead.
+
+const OPEN_TOUR = {
+  op: 'open_map' as const,
+  params: {
+    selectionMode: 'composite',
+    zoneSource: 'neighborhood_zones',
+    layers: ['osm_parks'],
+    tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+    showLegendSimple: true,
+    hazardTour: true,
+    allowDeferSite: true,
+    prompt: 'Conheça os riscos e marque onde vocês atuam.',
+  },
+};
+
+/**
+ * Walk el → body. Report the first ancestor that creates a stacking context,
+ * or null if the element's z-index escapes into the root context.
+ */
+const STACKING_ANCESTOR = (selector: string) => {
+  const start = document.querySelector(selector) as HTMLElement | null;
+  if (!start) return 'ELEMENT_MISSING';
+  for (let el = start.parentElement; el && el !== document.body; el = el.parentElement) {
+    const s = getComputedStyle(el);
+    if (s.isolation === 'isolate') return `isolation:isolate on .${el.className.toString().slice(0, 40)}`;
+    if (s.zIndex !== 'auto' && s.position !== 'static') return `z-index:${s.zIndex} on .${el.className.toString().slice(0, 40)}`;
+    if (s.transform !== 'none' || s.filter !== 'none' || s.opacity !== '1') return `transform/filter/opacity on .${el.className.toString().slice(0, 40)}`;
+    if (s.contain !== 'none' || s.willChange !== 'auto') return `contain/will-change on .${el.className.toString().slice(0, 40)}`;
+  }
+  return null; // escapes to the root stacking context — the bug
+};
+
+test.describe('COUGAR — map overlays never paint over a dialog', () => {
+  test('MapMicroapp overlays are trapped in a local stacking context', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[{ op: 'say', text: 'riscos' }, OPEN_TOUR]]);
+    await page.getByTestId('cbo-chat-input').fill('Mostra o mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // The tour caption (z-900) must not reach the root stacking context.
+    const caption = await page.evaluate(STACKING_ANCESTOR, '.z-\\[900\\]');
+    expect(caption, 'tour caption z-900 escapes to the root stacking context').not.toBeNull();
+    expect(caption).toContain('isolation:isolate');
+
+    // Same for the legend sheet (z-1001), which is rendered at the microapp root.
+    await page.getByTestId('map-tour-howto').click();
+    await expect(page.getByTestId('map-help-sheet')).toBeVisible();
+    const sheet = await page.evaluate(STACKING_ANCESTOR, '[data-testid="map-help-sheet"]');
+    expect(sheet, 'legend sheet z-1001 escapes to the root stacking context').not.toBeNull();
+    expect(sheet).toContain('isolation:isolate');
+    await page.getByTestId('map-help-understood').click();
+
+    // And the invariant that makes all of the above matter: every portalled
+    // Radix overlay is z-50, so anything outside a stacking context with a
+    // bigger z-index wins. Open the ⓘ dialog and pin its z-index.
+    await page.getByRole('button', { name: /about this data|sobre estes dados/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveCSS('z-index', '50');
+
+    // The dialog's own stacking ancestor is the body-level portal, i.e. none.
+    // If someone "fixes" a future occlusion by bumping a map overlay past 50
+    // again, the two assertions above fail first.
+  });
+});


### PR DESCRIPTION
Reported: opening the ⓘ **De onde vêm estes dados** dialog leaves the hazard legend painted on top of it.

## Root cause

Not the dialog. Measured in the browser:

| Element | z-index | In a stacking context? |
|---|---|---|
| Radix dialog / popover / select / tooltip / dropdown / sheet | `50` | body portal |
| `.leaflet-pane` | `400` | ✅ yes — `.leaflet-container` is `z-index: 0` |
| `.leaflet-control-zoom` | `800` | ✅ yes |
| `.leaflet-top` / `.leaflet-bottom` | `999` | ✅ yes |
| MapMicroapp tour caption, narration, zone explainer, basemap toggle | `900` | ❌ **no** |
| MapMicroapp loading veil, `HazardLegendSheet` | `1000` / `1001` | ❌ **no** |
| site-explorer zone panel, evidence drawer, zone card | `1001` | ❌ **no** |
| ConceptNoteMap hover info | `1000` | ❌ **no** |
| orchestrator `MapLayerControls` | `400` | ❌ **no** |

Our overlays live *outside* `.leaflet-container`, and no ancestor creates a stacking context, so their z-indices compete in the **root** context and beat every portalled overlay. Leaflet's own panes are fine precisely because `.leaflet-container` has `z-index: 0` — which is why the tiles and zoom controls dim correctly while the legend does not.

## Fix

Give each map surface a local stacking context with Tailwind's `isolate` — the same thing Leaflet does. One line each, no layout change (`isolation` creates the context without affecting containing blocks), and it fixes **all** portalled overlays at once instead of bumping `z-50` upward and starting a new race with the toast layer (`z-[100]`).

## Yes, it happened elsewhere

Anywhere a dialog, popover, select or tooltip overlapped a map: **`site-explorer`**, **`ConceptNoteMap`**, and the **orchestrator landing** map. All four fixed. The ⓘ dialog is shared between the CBO and orchestrator views, so it was reachable on more than one page.

## Verification

`elementFromPoint` is **blind to this bug** — the tour caption is `pointer-events-none`, so hit-testing cheerfully reports the dialog on top while the caption paints over it. My first probe "passed" and was wrong.

So the regression spec (`e2e/cougar-map-overlay-stacking.spec.ts`) asserts the structural invariant: walk up from each overlay and require a stacking-context ancestor, and pin the dialog at `z-50` so a future "fix" that raises a map overlay past it trips the first two assertions.

Mutation-checked — removing `isolate` fails it with `tour caption z-900 escapes to the root stacking context`; restoring it passes.

Full suite: **68 passed, 3 `@live` skipped**. `tsc --noEmit` unchanged at 4 pre-existing errors.

## Not covered

The spec exercises the CBO map only. `site-explorer`, `ConceptNoteMap` and the orchestrator map are fixed by inspection of the same measured pattern, not by their own test — they have no fake-model harness to open a dialog over them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)