### PR TITLE
fix(cbo): "Abrir o mapa" re-enters the agent's map, at the step the user left

### DIFF
--- a/client/src/core/components/maps/MapMicroapp.tsx
+++ b/client/src/core/components/maps/MapMicroapp.tsx
@@ -2107,6 +2107,11 @@ export default function MapMicroapp({
               variant='ghost'
               size='sm'
               className='h-7 text-xs'
+              data-testid={
+                isComposite && compositeStep === 'assets'
+                  ? 'map-back-to-zones'
+                  : 'map-cancel'
+              }
               onClick={
                 isComposite && compositeStep === 'assets'
                   ? backToZones

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -167,13 +167,20 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
   map: {
     tab: 'map',
     icon: MapIcon,
+    // LEGACY FALLBACK ONLY. Normal re-entry restores the agent's actual params
+    // from the persisted `open_map` composer row (see hydrateMessages), so the
+    // user gets back the map that was opened — guided hazard tour included.
+    // This reconstruction runs only for transcripts written before composer
+    // persistence, where no such row exists. Do not "improve" it into a second
+    // definition of the E2 map: that divergence (hazardTour:false, a different
+    // prompt) is exactly what made "Abrir o mapa" open the wrong map.
     defaultParams: (s) => s.phase === 2 ? {
       selectionMode: 'composite',
       zoneSource: 'neighborhood_zones',  // risk-scored bairros (typologyLabel/meanFlood…) — same as the orchestrator
       layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
       tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
       showLegendSimple: true,
-      hazardTour: false,        // re-entry skips the guided tour, straight to selection
+      hazardTour: false,        // no recorded tour position to resume → skip it
       allowDeferSite: true,
       prompt: 'Marque o bairro e o lugar onde vocês atuam.',
     } : null,
@@ -380,7 +387,12 @@ export default function CboProfilePage() {
   // another right-panel tab sets rightTab and unmounts the map, which would
   // otherwise reset the tour to Enchente 1/3 — and asking the agent a question
   // mid-tour makes leaving the map tab much more likely.
+  // Mirrors cbo_state.activeTool.tourIdx, which is the durable copy.
   const [tourIdx, setTourIdx] = useState(0);
+  // One-shot hydration latch. Without it, this effect and the write-through
+  // below trade the value back and forth on every commit (the persisted-state
+  // swap loop documented in useNavigationPersistence).
+  const tourIdxHydrated = useRef(false);
   const [interventionSelectorParams, setInterventionSelectorParams] = useState<OpenInterventionSelectorParams | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -396,25 +408,32 @@ export default function CboProfilePage() {
   // user back on the exact question instead of a dead transcript.
   const hydrateMessages = useCallback((msgs: CboChatMessage[]) => {
     setMessages(msgs);
-    // Right-panel tools (map / intervention selector) restore from ANY composer
-    // row in the TRAILING ASSISTANT RUN — everything after the last user
-    // message — because the agent routinely opens the tool and then asks a
-    // question in the same turn, so the tool row is rarely the very last
-    // message (RL-1). Restoring params (not just activeTool's {kind}) means
-    // the exact step re-renders: custom prompt, hazardTour, suggestedSite,
-    // recommended types. No forced tab switch — the tab chip + pulse are the
-    // affordance.
-    let runStart = msgs.length;
-    while (runStart > 0 && msgs[runStart - 1].role === 'assistant') runStart--;
-    for (let i = runStart; i < msgs.length; i++) {
+    // Right-panel tools (map / intervention selector) restore from the LAST
+    // matching composer row ANYWHERE in the transcript — not just the trailing
+    // assistant run. The trailing-run rule is right for *questions* ("pending"
+    // means nothing followed it) but wrong for an opened tool: `open_map` says
+    // "this is the map the agent opened", and that stays true until the tool's
+    // task is done. Scanning only the trailing run meant one chat turn after
+    // the map opened (e.g. a "how do I read this?" question) pushed the row out
+    // of the window, and re-entry silently fell back to the phase defaults —
+    // a DIFFERENT map, with the guided hazard tour switched off.
+    //
+    // Safe because the panel only renders the map when toolReached() says the
+    // step is live, and because we take the last row: a superseded open_map
+    // (site step after the tour) wins over the earlier one.
+    let mapRestored = false;
+    let interventionRestored = false;
+    for (let i = msgs.length - 1; i >= 0 && !(mapRestored && interventionRestored); i--) {
       const m = msgs[i];
       if (m.messageType !== 'composer') continue;
       let p: any = null;
       try { p = JSON.parse(m.content); } catch { continue; }
-      if (p?.kind === 'open_map' && p.params) {
+      if (p?.kind === 'open_map' && p.params && !mapRestored) {
+        mapRestored = true;
         setOpenMapParams(p.params);
         setMapRelevant(true);
-      } else if (p?.kind === 'open_intervention_selector' && p.params) {
+      } else if (p?.kind === 'open_intervention_selector' && p.params && !interventionRestored) {
+        interventionRestored = true;
         setInterventionSelectorParams(p.params);
       }
     }
@@ -1158,6 +1177,29 @@ export default function CboProfilePage() {
     setIsStreaming(false);
     setCompletedTurns(n => n + 1);
   }, [cboId, isStreaming, processEvent, lang]);
+
+  // Resume the hazard tour where the user left it, once, when state first lands.
+  useEffect(() => {
+    if (tourIdxHydrated.current || !state) return;
+    tourIdxHydrated.current = true;
+    const persisted = state.activeTool?.tourIdx;
+    if (typeof persisted === 'number') setTourIdx(persisted);
+  }, [state]);
+
+  // Advancing the tour is a UI gesture, not a chat turn — write it straight to
+  // cbo_state so a reload, a device switch, or "Abrir o mapa" all resume here.
+  // Fire-and-forget: a failed write costs the user a replayed tour, nothing more,
+  // so it must never block the tap or surface an error over the map.
+  const handleTourIdxChange = useCallback((next: number) => {
+    setTourIdx(next);
+    setState(prev => (prev?.activeTool ? { ...prev, activeTool: { ...prev.activeTool, tourIdx: next } } : prev));
+    if (!cboId) return;
+    fetch(`/api/cbo/${cboId}/tour-progress`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tourIdx: next }),
+    }).catch(err => console.warn('[cbo] tour-progress write failed', err));
+  }, [cboId]);
 
   // "Tenho outra dúvida" in the map's legend sheet. The sheet already answered
   // the common question in place; this is the escape hatch for a real one.
@@ -2292,7 +2334,7 @@ export default function CboProfilePage() {
                   <MapMicroapp
                     params={(openMapParams ?? RIGHT_PANEL_TOOLS.map.defaultParams(state!)) as OpenMapParams}
                     tourIdx={tourIdx}
-                    onTourIdxChange={setTourIdx}
+                    onTourIdxChange={handleTourIdxChange}
                     onAskMapHelp={handleAskMapHelp}
                     onConfirm={(result: MapSelectionResult) => {
                       const message = formatMapResult(result);
@@ -2341,8 +2383,12 @@ export default function CboProfilePage() {
                       setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
                     }}
                     onCancel={() => {
-                      setOpenMapParams(null);
-                      setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+                      // Leaving the map is navigation, not completion. Keep
+                      // openMapParams so "Abrir o mapa" re-enters THIS map at
+                      // the step the user left; nulling it here is what made
+                      // re-entry fall through to the phase defaults and drop
+                      // the guided hazard tour. Only onConfirm clears it.
+                      setRightTab('document'); setMobileActiveTab('chat');
                     }}
                   />
                 ) : (

--- a/docs/cbo-chat-composers.md
+++ b/docs/cbo-chat-composers.md
@@ -92,10 +92,25 @@ One structural pattern, in `cbo-profile.tsx`:
   `open_intervention_selector`, the server sets `cbo_state.activeTool = { kind }`
   (in `pushEvent`). It survives reload, so the panel is re-enterable. (Don't gate
   on the ephemeral `openMapParams` event — that's lost on reload.)
+- **Persist where the user is INSIDE the tool, next to `{kind}`.** The E2 hazard
+  tour's position rides on `activeTool.tourIdx` (0-2 = that hazard, 3 = done),
+  written by `POST /api/cbo/:id/tour-progress`. Advancing a tour is a UI gesture,
+  not a chat turn — the agent must not hear about it — but it still has to
+  survive a reload and a cross-device resume (Rule 5).
+- **Re-entry restores the agent's ACTUAL params, from the persisted `open_map`
+  composer row.** `hydrateMessages` scans the whole transcript backwards for the
+  last one. The trailing-assistant-run rule applies to *questions* ("pending"
+  means nothing followed it), never to an opened tool: one chat turn after the
+  map opened used to push the row out of the window. And leaving a tool
+  (`onCancel`) is navigation — only *completion* (`onConfirm`) may clear
+  `openMapParams`.
 - **Declare each tool in `RIGHT_PANEL_TOOLS`.** Each entry gives its `tab`, a
-  `defaultParams(state)` (the re-entry config when there's no live agent params —
-  e.g. the map's composite/site config with the tour OFF), an `isDone(state)`
-  check (reads the captured section field), a `nudge` label, and an `icon`.
+  `defaultParams(state)` — a **legacy fallback only**, for transcripts written
+  before composer persistence — an `isDone(state)` check (reads the captured
+  section field), a `nudge` label, and an `icon`. ⚠️ `defaultParams` must never
+  become a second definition of the step: its divergence from the agent's real
+  params (`hazardTour: false`, a different prompt) is what made "Abrir o mapa"
+  silently open a different map.
 - **The plumbing is generic over the registry.** `pendingTool(state)` (open +
   not done) drives a persistent chat **nudge chip** and the **tab pulse**;
   `toolReached(state, kind)` makes the tab render the live tool (`openMapParams ??

--- a/e2e/cougar-e2-map-reentry.spec.ts
+++ b/e2e/cougar-e2-map-reentry.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// "Abrir o mapa" used to open a DIFFERENT map than the one the agent opened.
+//
+// Cancelar nulled `openMapParams`, so re-entry fell through to
+// RIGHT_PANEL_TOOLS.map.defaultParams — a second, hardcoded definition of the
+// E2 map with `hazardTour: false` and its own prompt. The user lost the guided
+// flood → heat → landslide walk and landed straight on bairro selection.
+//
+// The same fallback fired on reload once ANY chat turn followed the map opening
+// (a "how do I read this?" question), because hydrateMessages only scanned the
+// trailing assistant run for the `open_map` composer row.
+//
+// Now: re-entry restores the agent's real params, and the tour position lives on
+// cbo_state.activeTool.tourIdx. The rules this pins:
+//   cancel mid-tour  → resume on that hazard
+//   cancel post-tour → no tour, straight to selection
+//   reload mid-tour  → resume on that hazard
+//   reload after a chat turn → still the agent's map, not the defaults
+
+const E2_TOUR = {
+  op: 'open_map' as const,
+  params: {
+    selectionMode: 'composite',
+    zoneSource: 'neighborhood_zones',
+    layers: ['osm_parks'],
+    tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
+    showLegendSimple: true,
+    hazardTour: true,
+    allowDeferSite: true,
+    prompt: 'Conheça os riscos e marque onde vocês atuam.',
+  },
+};
+
+/** The tour caption's "n/3" counter — language-agnostic, unlike the CTA label. */
+const step = (page: Page, n: number) => page.getByText(`${n}/3`);
+
+async function openTourMap(page: Page, api: TestApi): Promise<string> {
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+  await api.scriptCbo(cboId, [[{ op: 'set_phase', phase: 2 }, { op: 'say', text: 'Mapa.' }, E2_TOUR]]);
+  await page.getByTestId('cbo-chat-input').fill('mapa');
+  await page.getByTestId('cbo-chat-input').press('Enter');
+  await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+  await expect(step(page, 1)).toBeVisible();
+  return cboId;
+}
+
+test.describe('COUGAR — E2 map re-entry resumes the agent’s map', () => {
+  // There is no Cancelar while the tour is running — the action bar shows only
+  // the tour controls — so leaving mid-tour means switching right-panel tab.
+  test('leave mid-tour via the tab → "Abrir o mapa" resumes on the same hazard', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await openTourMap(page, api);
+
+    // Walk to hazard 2 of 3 (Calor), then leave the map.
+    await page.getByTestId('map-tour-next').click();
+    await expect(step(page, 2)).toBeVisible();
+    await page.getByTestId('cbo-tab-document').click();
+
+    const chip = page.getByTestId('cbo-open-tool-map');
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await chip.click();
+
+    // Resumed on Calor, still inside the guided tour — not the selection view.
+    await expect(step(page, 2)).toBeVisible();
+    await expect(page.getByTestId('map-tour-howto')).toBeVisible();
+  });
+
+  // The reported bug. Cancelar exists on the zone step (post-tour), and it used
+  // to null openMapParams, so re-entry rebuilt the map from defaultParams — a
+  // different prompt, and hazardTour off. The screenshot that reported this
+  // showed defaultParams' prompt verbatim.
+  test('Cancelar → "Abrir o mapa" re-enters the agent’s map, not the phase defaults', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await openTourMap(page, api);
+
+    // Finish all three hazards → zone step, where Cancelar lives.
+    for (let i = 0; i < 3; i++) await page.getByTestId('map-tour-next').click();
+    await expect(page.getByTestId('map-tour-next')).toHaveCount(0);
+    await page.getByTestId('map-cancel').click();
+
+    await page.getByTestId('cbo-open-tool-map').click();
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // The agent's prompt survived; the fallback map's did not appear.
+    await expect(page.getByText('Conheça os riscos e marque onde vocês atuam.')).toBeVisible();
+    await expect(page.getByText('Marque o bairro e o lugar onde vocês atuam.')).toHaveCount(0);
+    // A finished tour must not replay.
+    await expect(page.getByTestId('map-tour-next')).toHaveCount(0);
+    await expect(step(page, 1)).toHaveCount(0);
+  });
+
+  test('reload mid-tour resumes on the same hazard', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await openTourMap(page, api);
+
+    await page.getByTestId('map-tour-next').click();
+    await expect(step(page, 2)).toBeVisible();
+
+    // tourIdx is written to cbo_state.activeTool; debouncedPersist needs a beat.
+    await page.waitForTimeout(1200);
+    await page.reload();
+
+    // Reload deliberately does NOT force the map tab open — the chip and the tab
+    // pulse are the affordance (hydrateMessages). Take the chip, as a user would.
+    await page.getByTestId('cbo-open-tool-map').click();
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    await expect(step(page, 2)).toBeVisible();
+  });
+
+  test('a chat turn after the map opened does not lose the agent’s params on reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const cboId = await openTourMap(page, api);
+
+    // One ordinary chat turn, so the open_map composer row is no longer in the
+    // trailing assistant run. This is what used to strand re-entry on the
+    // phase defaults.
+    await api.scriptCbo(cboId, [[{ op: 'say', text: 'Claro, pode perguntar.' }]]);
+    await page.getByTestId('cbo-chat-input').fill('tenho uma dúvida');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.getByText('Claro, pode perguntar.')).toBeVisible({ timeout: 30_000 });
+
+    await page.waitForTimeout(1200);
+    await page.reload();
+    await page.getByTestId('cbo-open-tool-map').click();
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+
+    // Still the agent's map: the tour is live, and the header is the agent's
+    // prompt — not defaultParams' "Marque o bairro e o lugar onde vocês atuam."
+    await expect(step(page, 1)).toBeVisible();
+    await expect(page.getByText('Conheça os riscos e marque onde vocês atuam.')).toBeVisible();
+  });
+
+  test('tour-progress rejects a bogus index and a non-map tool', async ({ request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId } = await api.newSession();
+
+    const bad = await request.post(`/api/cbo/${cboId}/tour-progress`, { data: { tourIdx: 9 } });
+    expect(bad.status()).toBe(400);
+
+    // No map opened yet → activeTool isn't 'map'.
+    const wrongTool = await request.post(`/api/cbo/${cboId}/tour-progress`, { data: { tourIdx: 1 } });
+    expect(wrongTool.status()).toBe(409);
+  });
+});

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -324,6 +324,34 @@ export function registerCboRoutes(app: Express): void {
     res.json({ ok: true, phase: result.phase, state: getCboState(req.params.id) });
   });
 
+  // E2 hazard-tour position. The only client→state write that isn't a chat turn:
+  // advancing the tour is a UI gesture, not something the agent should hear about.
+  // Persisting it is what lets "Abrir o mapa" resume at the hazard the user left,
+  // and survives both a reload and a cross-device resume of the token link.
+  app.post("/api/cbo/:id/tour-progress", async (req: Request, res: Response) => {
+    if (!getCboState(req.params.id)) {
+      const persisted = await loadPersistedCboState(req.params.id);
+      if (persisted) setCboState(req.params.id, persisted.state);
+    }
+    const state = getCboState(req.params.id);
+    if (!state) return res.status(404).json({ error: "Not found" });
+
+    const tourIdx = Number(req.body?.tourIdx);
+    // 0-2 = touring that hazard; 3 = finished. Anything else is a client bug.
+    if (!Number.isInteger(tourIdx) || tourIdx < 0 || tourIdx > 3) {
+      return res.status(400).json({ error: "tourIdx must be an integer 0-3" });
+    }
+    // Only meaningful while the map is the open tool; refuse to invent one.
+    if (state.activeTool?.kind !== 'map') {
+      return res.status(409).json({ error: "map is not the active tool" });
+    }
+
+    state.activeTool = { ...state.activeTool, tourIdx };
+    setCboState(req.params.id, state);
+    debouncedPersist(req.params.id);
+    res.json({ ok: true, tourIdx });
+  });
+
   // User edit
   app.post("/api/cbo/:id/edit", async (req: Request, res: Response) => {
     const { sectionId, field, value } = req.body;

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1086,7 +1086,11 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
       // {kind}-only persistence dropped the params and left the resume chip
       // rendering over a pending map step.
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'open_map', params: (event as any).params }), messageType: 'composer', timestamp: new Date().toISOString() });
-      state.activeTool = { kind: 'map' };
+      // A fresh guided tour starts at hazard 0. Any other open_map (re-entry,
+      // site step) leaves the recorded position alone, so the user resumes.
+      state.activeTool = (event as any).params?.hazardTour
+        ? { kind: 'map', tourIdx: 0 }
+        : { kind: 'map', tourIdx: state.activeTool?.tourIdx };
       setCboState(cboId, state); debouncedPersist(cboId);
     } else if (event.type === 'open_intervention_selector') {
       addCboMessage(cboId, { role: 'assistant', content: JSON.stringify({ kind: 'open_intervention_selector', params: (event as any).params }), messageType: 'composer', timestamp: new Date().toISOString() });

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -150,7 +150,13 @@ export interface CboState {
   // The right-panel tool the agent has opened for this phase (map / type selector).
   // Persisted so the tool stays reachable across reloads — the panel isn't gated
   // behind a one-shot agent button. Cleared/superseded as the task completes.
-  activeTool?: { kind: 'map' | 'interventions' } | null;
+  //
+  // `tourIdx` is the E2 hazard tour's position (0=flood, 1=heat, 2=landslide,
+  // 3=done). It lives HERE, next to {kind}, because "where the user is inside
+  // the open tool" is one fact and needs one home: React state loses it on
+  // reload, and localStorage loses it on a device switch (the token link is
+  // meant to resume anywhere — see docs/cbo-chat-composers.md rule 5).
+  activeTool?: { kind: 'map' | 'interventions'; tourIdx?: number } | null;
   editLog: Array<{ timestamp: string; sectionId: string; field: string; oldValue: any; newValue: any; source: 'agent' | 'user' }>;
   uploadedFiles: Array<{ name: string; path: string; parsedAt: string; summary: string }>;
   metadata: {


### PR DESCRIPTION
Reported: closing the map and tapping **Abrir o mapa** opens a different map — no guided flood → heat → landslide tour, straight to bairro selection.

## What was happening

Re-entry didn't reopen the map the agent opened. It rebuilt one from `RIGHT_PANEL_TOOLS.map.defaultParams` — a second, hardcoded definition of the E2 step with `hazardTour: false` and its own prompt. The reporting screenshot is the tell: the header reads *"Marque o bairro e o lugar onde vocês atuam."*, which is `defaultParams.prompt` verbatim.

Three independent routes into that fallback:

| # | Cause | Symptom |
|---|---|---|
| 1 | `onCancel` nulled `openMapParams` | Cancelar → chip → wrong map |
| 2 | `hydrateMessages` scanned only the **trailing assistant run** for the `open_map` composer row | one chat turn after the map opened → reload loses the agent's params |
| 3 | `tourIdx` was React state | reload replayed the tour from Enchente |

Cause 2 is the subtle one. The trailing-run rule is correct for *question* composers — "pending" means nothing followed it — but wrong for an opened tool. `open_map` means "this is the map the agent opened," and that stays true until the tool's task is done. Ask the agent how to read the colors, and the row falls out of the window.

## The actual defect

Four representations of *"where is the user in the map step"*, disagreeing:

1. `openMapParams` — ephemeral, destroyed by Cancelar
2. the persisted `open_map` composer row — the real record, read in a narrow window
3. `tourIdx` — separate ephemeral state
4. `defaultParams` — a guess at what the agent *would have* sent

Now there is one. **The row says which map; `activeTool.tourIdx` says where in it.** `defaultParams` is demoted to a legacy fallback for pre-composer transcripts, and commented so nobody grows it back into a rival definition.

## Changes

- `onCancel` navigates away without clearing `openMapParams`; only `onConfirm` clears it.
- `hydrateMessages` takes the **last** `open_map` row anywhere in the transcript. Safe: the panel only renders the map when `toolReached()` says the step is live, and a later `open_map` supersedes an earlier one.
- `cbo_state.activeTool` gains `tourIdx` (`0-2` = that hazard, `3` = done), written by a new `POST /api/cbo/:id/tour-progress` — validated `0..3`, `409` unless the map is the active tool. Advancing the tour is a UI gesture the agent must not hear about, but it still has to survive a reload and a cross-device resume of the token link (`docs/cbo-chat-composers.md` rule 5). Client hydration uses a one-shot ref latch, per the swap-loop lesson in `useNavigationPersistence`.
- `pushEvent` resets `tourIdx: 0` when the agent opens a **fresh** guided tour, and leaves it alone otherwise.

## Behavior, pinned by e2e

| Scenario | Result |
|---|---|
| leave mid-tour via the tab | resume on that hazard |
| **Cancelar** (zone step) → chip | the agent's map, tour already finished |
| reload mid-tour | resume on that hazard |
| reload after a chat turn | still the agent's map, not the defaults |
| bogus `tourIdx`, or map not active | `400` / `409` |

## Verification

Each of the three fixes is **mutation-checked**: revert any one and exactly its own test fails, no other.

That mattered. My first mid-tour test passed against the *unfixed* code — it left the map via the right-panel tab, which never calls `onCancel`, and there is no Cancelar button while the tour is running (the action bar shows only the tour controls). I'd have shipped a test that guarded nothing. Rewrote it to press the real button, which meant adding `data-testid="map-cancel"`.

Full suite: **73 passed, 3 `@live` skipped**. `tsc --noEmit` unchanged at 4 pre-existing errors.

## Note

Post-tour re-entry now shows the agent's original prompt (*"Conheça os riscos e marque onde vocês atuam."*) rather than the selection-specific one. That's the correct map, but the prompt reads slightly stale once the tour is done — `MapMicroapp` renders a step-aware sub-line beneath it. Making the header follow the step rather than the params is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)