### PR TITLE
fix(cbo): Cancelar on the NBS-type selector no longer strands the user

### DIFF
--- a/client/src/core/components/maps/InterventionSelector.tsx
+++ b/client/src/core/components/maps/InterventionSelector.tsx
@@ -396,7 +396,7 @@ export default function InterventionSelector({ params, onConfirm, onCancel }: Pr
 
       {/* Footer */}
       <div className="p-3 border-t bg-background flex items-center justify-between">
-        <Button variant="outline" size="sm" onClick={onCancel}>
+        <Button variant="outline" size="sm" onClick={onCancel} data-testid="intervention-cancel">
           {isPt ? 'Cancelar' : 'Cancel'}
         </Button>
         <div className="flex items-center gap-2">

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1052,7 +1052,14 @@ export default function CboProfilePage() {
         // Mirror the server-persisted activeTool locally so the chip/pulse/
         // re-entry reflect it immediately (the client's loaded state predates
         // this turn; without this they'd only update on reload).
-        setState(prev => prev ? { ...prev, activeTool: { kind: 'map' } } : prev);
+        // Mirror what pushEvent writes, tourIdx included: a fresh guided tour
+        // resets to 0, any other open_map keeps the recorded position. Writing
+        // a bare {kind:'map'} here silently dropped the position from the local
+        // mirror while the server still held it.
+        setState(prev => prev ? {
+          ...prev,
+          activeTool: { kind: 'map', tourIdx: event.params?.hazardTour ? 0 : prev.activeTool?.tourIdx },
+        } : prev);
         setRightTab('map');
         setMapRelevant(true);
         setMobileActiveTab('panel');
@@ -2415,7 +2422,12 @@ export default function CboProfilePage() {
                       setRightTab('document'); setMobileActiveTab('chat');
                     }}
                     onCancel={() => {
-                      setInterventionSelectorParams(null);
+                      // Same rule as the map: leaving is navigation, not
+                      // completion. Nulling params here stranded the user —
+                      // the nudge chip still said "Escolher o tipo de SbN",
+                      // but the tab it opened showed the "not yet" placeholder,
+                      // because `interventions` has no defaultParams to fall
+                      // back to. Only onConfirm may clear it.
                       setRightTab('document'); setMobileActiveTab('chat');
                     }}
                   />
@@ -2479,6 +2491,12 @@ export default function CboProfilePage() {
         {(() => {
           // Compose the tabs available right now. Chat + Perfil are permanent.
           // Mapa / Intervenções appear only while the agent has those microapps active.
+          //
+          // Deliberately keyed on the LIVE params, not on pendingTool(): the tool
+          // stays "pending" between onConfirm and the agent persisting the section
+          // field, so a registry-derived gate would pop the tab back up seconds
+          // after the user finished with it. Cancelar no longer nulls the params,
+          // so the tab now survives leaving the panel — which is what was broken.
           const showMap = openMapParams != null || mapRelevant;
           const showInterv = interventionSelectorParams != null;
           const tabs: Array<{

--- a/e2e/cougar-e3-selector-reentry.spec.ts
+++ b/e2e/cougar-e3-selector-reentry.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The NBS-type selector had the map's re-entry bug, without the map's safety net.
+//
+// `onCancel` nulled `interventionSelectorParams`, and unlike the map there is no
+// `defaultParams` to fall through to (the registry returns null). So Cancelar
+// left the chat still nudging "Escolher o tipo de SbN" while the tab it opens
+// showed the "will open here" placeholder — and on a phone the Intervenções tab
+// disappeared from the bottom nav entirely, because it was gated on the same
+// ephemeral params. A reload was the only way back.
+
+const OPEN_SELECTOR = {
+  op: 'open_intervention_selector' as const,
+  params: { multiSelect: true, maxRecommendations: 2 },
+};
+
+test.describe('COUGAR — E3 NBS-type selector re-entry', () => {
+  test('Cancelar keeps the selector re-enterable via the nudge chip', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Phase 3 is the selector's minPhase — below it, pendingTool refuses to fire.
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 3 },
+      { op: 'say', text: 'Escolhe o tipo de SbN.' },
+      OPEN_SELECTOR,
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('tipos');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    const cancel = page.getByTestId('intervention-cancel');
+    await expect(cancel).toBeVisible({ timeout: 30_000 });
+
+    // Leave via the selector's own Cancelar.
+    await cancel.click();
+
+    // The chat still says the step is pending…
+    const chip = page.getByTestId('cbo-open-tool-interventions');
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    // …and tapping it must land on the SELECTOR, not the "not yet" placeholder.
+    await chip.click();
+    await expect(page.getByTestId('intervention-cancel')).toBeVisible();
+    await expect(page.getByText(/will open here|abre aqui/i)).toHaveCount(0);
+  });
+
+  test('the mobile Intervenções tab survives Cancelar', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 3 },
+      { op: 'say', text: 'Escolhe o tipo de SbN.' },
+      OPEN_SELECTOR,
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('tipos');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await expect(page.getByTestId('intervention-cancel')).toBeVisible({ timeout: 30_000 });
+
+    const tab = page.getByRole('button', { name: /Intervenções|Interventions/i });
+    await expect(tab).toBeVisible();
+
+    await page.getByTestId('intervention-cancel').click();
+
+    // The tab is the phone's only route back into the panel. It used to vanish.
+    await expect(tab).toBeVisible();
+    await tab.click();
+    await expect(page.getByTestId('intervention-cancel')).toBeVisible();
+  });
+});

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -52,6 +52,7 @@ export type FakeOp =
   | { op: 'set_phase'; phase: number }
   | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
   | { op: 'open_map'; params?: Record<string, unknown> }
+  | { op: 'open_intervention_selector'; params?: Record<string, unknown> }
   | { op: 'show_types'; typeIds?: string[]; intro?: string }
   | { op: 'show_examples'; cardIds?: string[]; mode?: 'browse' | 'favorites'; intro?: string };
 
@@ -173,6 +174,10 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
     }
     case 'open_map': {
       pushEvent({ type: 'open_map', params: (op.params ?? {}) as any });
+      break;
+    }
+    case 'open_intervention_selector': {
+      pushEvent({ type: 'open_intervention_selector', params: (op.params ?? {}) as any });
       break;
     }
     case 'show_types': {


### PR DESCRIPTION
Follow-up to #385. Same bug class, found by auditing for it: the NBS-type selector had the map's re-entry bug **without the map's safety net**.

## The dead end

`onCancel` nulled `interventionSelectorParams` (`cbo-profile.tsx:2417`) — but unlike the map, `RIGHT_PANEL_TOOLS.interventions.defaultParams` returns `null`, so there is nothing to fall through to.

Result, once a cohort reaches Phase 3:

- Tap **Cancelar** in the selector.
- The chat still shows the nudge chip *"Escolher o tipo de SbN"*, and the tab still pulses.
- Tapping either lands on the placeholder: *"The NBS Type Selector will open here when the agent asks you to choose…"*
- On a phone the **Intervenções tab disappears from the bottom nav** entirely (`showInterv = interventionSelectorParams != null`), so there is no route back at all.

Only a full reload recovered it, because `hydrateMessages` restores the params from the persisted composer row.

Also fixed: the client's `open_map` handler mirrored `activeTool = {kind:'map'}` and silently dropped the `tourIdx` that `pushEvent` had just preserved, so the local mirror disagreed with the server until the next reload.

## What I deliberately did *not* ship

My first version also derived the mobile tab's visibility from `pendingTool()` rather than the live params — it reads like the more principled gate.

The mutation test killed it. `pendingTool()` stays truthy between `onConfirm` and the agent persisting the section field, so the tab would **pop back up seconds after the user finished with it** — and on the map, tapping it would render the legacy `defaultParams` fallback, which is exactly the rival-definition path #385 just closed. Keeping the params on cancel is the fix at the right level. The extra gate was belt-and-braces that reintroduced a worse bug.

That's in the diff as a comment, so the next person doesn't re-derive it.

## Coverage

`open_intervention_selector` had **no fake-model op**, so this whole path had zero e2e coverage. Added one (`fakeCboModel.ts`) plus `e2e/cougar-e3-selector-reentry.spec.ts`, which pins both the chip route and the mobile-tab route.

Mutation-checked: revert `onCancel` and both specs fail — the chip lands on the placeholder, and the mobile tab vanishes.

Full suite: **75 passed, 3 `@live` skipped**. `tsc --noEmit` unchanged at 4 pre-existing errors.

## Still open, from the same audit

Two larger ones, each getting its own PR:

1. **The E2 map is defined in four places, three of which disagree.** The agent's own recipes (`cboAgent.ts:555`, `:1782`, `:1787`) say `zoneSource:"neighborhoods"` and omit `hazardTour` and `allowDeferSite` — while `knowledge/_skills/encontro-2.md:185` says `neighborhood_zones` with an explicit comment *"NOT 'neighborhoods' (raw IBGE, no risk colors)"*, and `encontro-2.md:252` then contradicts itself. Without `allowDeferSite`, `getDefaultStyle` takes the branch where `fillOpacity = priorityScore != null ? … : 0`, and raw IBGE polygons have no `priorityScore` — **the bairros render invisible**, with no hazard tour.
2. **`filledCount` uses a predicate the codebase already deemed wrong.** The CBO's own "X/7 seções" (`cbo-profile.tsx:1413`) counts a section if it has *any field key*; the server and the shared `phaseComplete()` require a filled, non-`invite` field. Every invited org starts with `org_profile` prefilled from the invite, so the CBO sees **1/7** while the coordinator's roster derives **0/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)