### PR TITLE
fix(cbo): one definition of the E2 map — presets, not five hand-typed copies

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -29,6 +29,7 @@ import {
 } from '@shared/cbo-schema';
 import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/concept-note-schema';
+import { e2SiteParams } from '@shared/cbo-map-presets';
 import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
   FileText, Files, Loader2, RotateCcw, Star, Leaf,
@@ -170,20 +171,15 @@ const RIGHT_PANEL_TOOLS: Record<ToolKind, RightPanelToolDef> = {
     // LEGACY FALLBACK ONLY. Normal re-entry restores the agent's actual params
     // from the persisted `open_map` composer row (see hydrateMessages), so the
     // user gets back the map that was opened — guided hazard tour included.
-    // This reconstruction runs only for transcripts written before composer
-    // persistence, where no such row exists. Do not "improve" it into a second
-    // definition of the E2 map: that divergence (hazardTour:false, a different
-    // prompt) is exactly what made "Abrir o mapa" open the wrong map.
-    defaultParams: (s) => s.phase === 2 ? {
-      selectionMode: 'composite',
-      zoneSource: 'neighborhood_zones',  // risk-scored bairros (typologyLabel/meanFlood…) — same as the orchestrator
-      layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
-      tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
-      showLegendSimple: true,
-      hazardTour: false,        // no recorded tour position to resume → skip it
-      allowDeferSite: true,
-      prompt: 'Marque o bairro e o lugar onde vocês atuam.',
-    } : null,
+    // This runs only for transcripts written before composer persistence.
+    //
+    // It is the `e2_site` preset itself, not a copy of it. The copy IS the bug:
+    // four hand-written definitions of this map disagreed on zoneSource,
+    // hazardTour and allowDeferSite, and whichever one won decided whether the
+    // bairros were even visible. See shared/cbo-map-presets.ts.
+    defaultParams: (s) => s.phase === 2
+      ? e2SiteParams(s.metadata?.language === 'en' ? 'en' : 'pt')
+      : null,
     isDone: (s) => fieldVal(s, 'intervention_site', 'bairro', 'site_name'),
     minPhase: 2,
     nudge: { pt: 'Abrir o mapa', en: 'Open the map' },

--- a/docs/cbo-ux-audit-backlog.md
+++ b/docs/cbo-ux-audit-backlog.md
@@ -222,7 +222,16 @@ The single structural fix is a **per-turn validate-before-flush normalization la
 - **Evidence:** MapMicroapp.tsx:135 showZones defined (only showAssets used at :807); zones effect :243-374 adds handlers regardless of tour; caption pointer-events:none :1025.
 - **Fix:** Gate the zone click handler on tour state (early-return when tourActive via a tourActiveRef) or don't enable the zones layer until the tour completes; remove the dead showZones or wire it to disable interactivity.
 
-#### [P2] `MAP-PARAM-DIVERGENCE` — Live-agent open vs re-entry param divergence: zone fill can be invisible (fillOpacity 0)  _(effort M)_
+#### ✅ FIXED [P2] `MAP-PARAM-DIVERGENCE` — Live-agent open vs re-entry param divergence: zone fill can be invisible (fillOpacity 0)  _(effort M)_
+> Resolved by `shared/cbo-map-presets.ts`: the E2 map is defined once and the agent
+> names a preset (`e2_risk_tour` / `e2_site` / `e2_browse`) instead of retyping params.
+> It was worse than recorded — **five** definitions, in `cboAgent.ts` (tool description
+> + phase map), `cbo-profile.tsx` (defaultParams) and `encontro-2.md` (three recipes,
+> two of which contradicted the file's own "NOT 'neighborhoods'" comment).
+> Pinned by `e2e/cougar-e2-map-presets.spec.ts`, which asserts the bairros actually
+> have nonzero fill; reverting the preset to the old params drops it to exactly 0.
+> The `minimum fillOpacity` half of the suggested fix was NOT done — invisible zones
+> are now impossible by construction, and a floor would mask the next divergence.
 - **Symptom:** Depending on whether the map was opened live by the agent vs restored from defaultParams, the zone step looks different: on the live path the choropleth may be missing and with zoneSource 'neighborhoods' (null priorityScore) zone fillOpacity computes to 0, so bairros look absent and only rasters show - feeding 'no clickable zones, just an overlay'.
 - **Root cause:** cboAgent.ts open_map examples pass showLegendSimple but omit allowDeferSite and hazardTour, whereas defaultParams sets allowDeferSite:true. Without allowDeferSite, getDefaultStyle takes the intervention-color branch where fillOpacity = priorityScore!=null ? ... : 0 -> 0 for raw-IBGE neighborhoods.
 - **Evidence:** cboAgent.ts:1300,1305 (no allowDeferSite/hazardTour); cbo-profile.tsx:125-134 sets them; MapMicroapp.tsx:289-292 fillOpacity 0 when priorityScore null.

--- a/e2e/cougar-e2-map-presets.spec.ts
+++ b/e2e/cougar-e2-map-presets.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The E2 map was described in five places, three of which disagreed. The two
+// copies the model was most likely to retype (the open_map tool description and
+// the phase map in the system prompt) said `zoneSource: "neighborhoods"` and
+// omitted `hazardTour` and `allowDeferSite`.
+//
+// That is not cosmetic. `neighborhoods` loads raw IBGE polygons, which carry no
+// `priorityScore`; without `allowDeferSite`, getDefaultStyle takes the branch
+//   fillOpacity = priorityScore != null ? … : 0
+// so every bairro renders with ZERO fill — an invisible map, and no hazard tour.
+//
+// Params now live once, in shared/cbo-map-presets.ts. The agent names a preset.
+// This spec pins what each preset actually renders.
+
+/** Fill opacity of the neighborhood choropleth, read off the SVG. */
+async function zoneFillOpacities(page: Page): Promise<number[]> {
+  return page.$$eval('.leaflet-overlay-pane path', paths =>
+    paths.map(p => Number((p as SVGPathElement).getAttribute('fill-opacity') ?? '0')),
+  );
+}
+
+async function boot(page: Page, api: TestApi): Promise<string> {
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  return (await marker.getAttribute('data-cbo-id'))!;
+}
+
+test.describe('COUGAR — E2 map presets are the single definition', () => {
+  test('e2_risk_tour opens the guided tour, with nothing but a preset name', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const cboId = await boot(page, api);
+
+    // The whole call. No selectionMode, no zoneSource, no prompt.
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 2 },
+      { op: 'say', text: 'Vamos ver os riscos.' },
+      { op: 'open_map', params: { preset: 'e2_risk_tour' } },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    // hazardTour: true
+    await expect(page.getByText('1/3')).toBeVisible();
+    await expect(page.getByTestId('map-tour-next')).toBeVisible();
+    // prompt came from the preset, localized
+    await expect(page.getByText(/Conheça os riscos|Get to know the risks/)).toBeVisible();
+  });
+
+  test('e2_site skips the tour and renders VISIBLE risk-coloured bairros', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const cboId = await boot(page, api);
+
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 2 },
+      { op: 'say', text: 'Marca teu bairro.' },
+      { op: 'open_map', params: { preset: 'e2_site' } },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId('map-tour-next')).toHaveCount(0);
+
+    // The regression that mattered: zoneSource 'neighborhoods' + no
+    // allowDeferSite gave every zone fill-opacity 0. Require real fill.
+    await expect
+      .poll(async () => (await zoneFillOpacities(page)).filter(o => o > 0.1).length, { timeout: 20_000 })
+      .toBeGreaterThan(10);
+  });
+
+  test('e2_browse opens exploration mode with the narration banner', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const cboId = await boot(page, api);
+
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 2 },
+      { op: 'say', text: 'Dá uma olhada.' },
+      { op: 'open_map', params: { preset: 'e2_browse' } },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    // browse-only → the single "back to chat" CTA, no commitment
+    await expect(page.getByTestId('map-back-to-chat')).toBeVisible();
+    await expect(page.getByText(/Azul = enchente|Blue = flood/)).toBeVisible();
+  });
+
+  test('an explicit arg narrows a preset instead of replacing it', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const cboId = await boot(page, api);
+
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 2 },
+      { op: 'say', text: 'Sem tour.' },
+      // "Já conheço os riscos" — the tour off, everything else from the preset.
+      { op: 'open_map', params: { preset: 'e2_risk_tour', hazardTour: false, prompt: 'Marque o terreno da proposta.' } },
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('mapa');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId('map-tour-next')).toHaveCount(0);       // override won
+    await expect(page.getByText('Marque o terreno da proposta.')).toBeVisible();
+    // …and the preset's allowDeferSite survived, so the zones are still visible.
+    await expect
+      .poll(async () => (await zoneFillOpacities(page)).filter(o => o > 0.1).length, { timeout: 20_000 })
+      .toBeGreaterThan(10);
+  });
+});

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -180,16 +180,15 @@ ask_user({
 On **"Abrir o mapa"** open with the guided tour ON; on **"Já conheço os riscos"** the same call with `hazardTour: false` (skips the tour, straight to neighborhood selection):
 
 ```
-open_map({
-  selectionMode: 'composite',
-  zoneSource: 'neighborhood_zones',  // risk-scored bairros (colored by risk like the orchestrator) — NOT 'neighborhoods' (raw IBGE, no risk colors)
-  layers: ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'],  // OSM sites to pick in step 2
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],  // HAZARD overlays (not H×E×V risk) — the tour teaches where each hazard is, one at a time, with the real color scale
-  showLegendSimple: true,
-  hazardTour: true,        // false if they tapped "Já conheço os riscos"
-  allowDeferSite: true,    // lets them tap "Usar o bairro todo" if no site yet
-  prompt: 'Conheça os riscos e marque onde vocês atuam.'
-})
+open_map({ preset: 'e2_risk_tour' })
+
+// The preset carries selectionMode, zoneSource, layers, hazard tiles, the
+// simplified legend, the guided tour, "usar o bairro todo", and the prompt.
+// It is defined ONCE in shared/cbo-map-presets.ts and imported by both the
+// server tool and the client — so it cannot drift from what actually renders.
+//
+// If they tapped "Já conheço os riscos": open_map({ preset: 'e2_site' })
+// If a doc named a place:               open_map({ preset: 'e2_risk_tour', suggestedSite: {…} })
 ```
 
 The map runs the **whole step itself** — you make ONE call, then wait for ONE result:
@@ -249,14 +248,7 @@ Never block on this — it's optional. Don't push if they don't have files.
 ### Old map recipe (reference)
 
 ```
-open_map({
-  selectionMode: 'composite',
-  zoneSource: 'neighborhoods',
-  layers: ['osm_parks', 'osm_schools', 'osm_wetlands'],
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
-  showLegendSimple: true,
-  prompt: 'Marca onde vocês querem atuar — primeiro o bairro, depois o lugar específico.'
-})
+open_map({ preset: 'e2_site' })
 ```
 
 ### `needs-help` flow — Beat 2a (browse-only)
@@ -264,13 +256,7 @@ open_map({
 First, exploration mode with a narration banner. The user can scroll the map, toggle layers, and read your overlay — but doesn't have to commit to a site yet.
 
 ```
-open_map({
-  selectionMode: 'browse-only',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
-  showLegendSimple: true,
-  prompt: 'Olha o seu bairro. As cores mostram os riscos.',
-  narrationOverlay: 'Azul = enchente. Vermelho = calor. Marrom = deslizamento. Toque "Voltar ao chat" quando quiser.'
-})
+open_map({ preset: 'e2_browse' })
 ```
 
 When the user clicks "Voltar ao chat", you receive an `onCancel`-equivalent (no map result message). Ask:
@@ -282,13 +268,7 @@ Listen for cues. If they name a spot, transition to Beat 2b. If they're still un
 ### `needs-help` flow — Beat 2b (site selection)
 
 ```
-open_map({
-  selectionMode: 'composite',
-  zoneSource: 'neighborhoods',
-  tileLayers: ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'],
-  showLegendSimple: true,
-  prompt: 'Agora marca o lugar específico onde vocês querem atuar.'
-})
+open_map({ preset: 'e2_site', prompt: 'Agora marca o lugar específico onde vocês querem atuar.' })
 ```
 
 After the user confirms a selection, you'll receive a message starting with `Map selection (composite mode):`. Parse it:
@@ -440,7 +420,7 @@ Active in this educational module:
 
 Wired but DEFERRED to the map step (do NOT call here):
 - `ask_priority_rank({prompt, minRanked?})`, `ask_community_anchoring({prompt})`
-- `open_map({selectionMode, zoneSource, layers, tileLayers, prompt, ...})`
+- `open_map({preset})` — `e2_risk_tour` | `e2_site` | `e2_browse`. Never retype the params.
 - `score_maturity`, `set_phase`
 - `read_knowledge(folder, file)` — exact-path KB read; `search_knowledge(query)` — search the KB by topic when you don't know the filename (prefer this)
 - `search_org_documents(query)`, `list_org_documents()`, `read_org_document([id])` — the org's uploaded files (see "Mine the org's documents before each beat" above)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -24,6 +24,7 @@ import {
 } from "./cboPersistence";
 import { db } from "../db";
 import { cohortMembers } from "@shared/cohort-schema";
+import { resolveOpenMapParams } from "@shared/cbo-map-presets";
 import { eq } from "drizzle-orm";
 import { getOrgIdForCboState, listDocumentsByOrg, listDocumentSummariesByOrg, getDocumentForOrg } from "./documentPersistence";
 import { setMaturityTierForCboState, getMaturityTierForCboState } from "./orgPersistence";
@@ -551,19 +552,27 @@ OSM (vector): osm_parks, osm_schools, osm_hospitals, osm_wetlands
 Tiles (raster): poa_flood_hazard (Flood Hazard), poa_heat_hazard (Heat Hazard), poa_landslide_hazard (Landslide Hazard), oef_dynamic_world (Land Use), oef_chirps_r90p_2024, oef_copernicus_dem, oef_ghsl_population, oef_merit_elv, +40 more
 Spatial queries: sq_parks_flood, sq_schools_flood, sq_hospitals_flood, sq_wetlands_flood, sq_schools_heat_250m, sq_schools_landslide_250m
 
-## Recipes
-- CBO Phase 2 (Where We Work): composite + zoneSource:"neighborhoods" + [osm_parks, osm_schools, osm_wetlands] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
+## Presets — ALWAYS use one for an Encontro-2 map. Never retype its params.
+- \`preset:"e2_risk_tour"\` — Beat 2, the guided entry: hazard tour (flood → heat → landslide), then bairro, then site.
+- \`preset:"e2_site"\` — the same map with the tour off ("Já conheço os riscos").
+- \`preset:"e2_browse"\` — needs-help Beat 2a: look around, commit to nothing.
+A preset supplies selectionMode, zoneSource, layers, tiles, legend, tour and prompt.
+Pass an extra field ONLY to narrow it — e.g. \`{preset:"e2_risk_tour", suggestedSite:{…}}\`
+or \`{preset:"e2_risk_tour", prompt:"…"}\` to frame it on the org's own words.
+
+## Recipes (non-CBO flows, which have no preset)
 - CBO Phase 3 (What We're Doing): assets + [osm_parks, osm_wetlands] + [oef_dynamic_world, poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
 - Concept Note Phase 2 (Territorial Scope): zones + [] + [poa_flood_hazard, poa_heat_hazard, poa_landslide_hazard]
 - Environmental analysis: sample + [] + [poa_flood_hazard, poa_heat_hazard, oef_copernicus_dem]
 
 STOP and wait for the user's map selection after calling this tool.`,
     {
+      preset: z.enum(["e2_risk_tour", "e2_site", "e2_browse"]).optional().describe("The canonical Encontro-2 map step. Supplies every param below. USE THIS for any E2 map — the params are defined once in shared/cbo-map-presets.ts, so a retyped copy can never drift from the one the client renders."),
       layers: z.array(z.string()).optional().describe("OSM layer IDs to show: osm_parks, osm_schools, osm_hospitals, osm_wetlands"),
       tileLayers: z.array(z.string()).optional().describe("Tile layer IDs as toggleable overlays (not auto-shown): poa_flood_hazard, poa_heat_hazard, etc."),
       spatialQueries: z.array(z.string()).optional().describe("Pre-filter features: sq_parks_flood, sq_schools_heatwave, etc."),
-      selectionMode: z.enum(["zones", "assets", "sample", "composite", "browse-only"]).describe("composite = zone first, then sites. assets = sites only. zones = zones only. sample = click-to-read-values. browse-only = exploration; no commitment (E2 needs-help)."),
-      prompt: z.string().describe("Clear instruction for the user, e.g. 'Select the zone where you work, then pick the parks and schools you are targeting'"),
+      selectionMode: z.enum(["zones", "assets", "sample", "composite", "browse-only"]).optional().describe("Required unless `preset` is given. composite = zone first, then sites. assets = sites only. zones = zones only. sample = click-to-read-values. browse-only = exploration; no commitment (E2 needs-help)."),
+      prompt: z.string().optional().describe("Required unless `preset` is given. Clear instruction for the user, e.g. 'Select the zone where you work, then pick the parks and schools you are targeting'"),
       sampleLayers: z.array(z.string()).optional().describe("For sample mode: which tile layers to sample on click"),
       zoneSource: z.enum(["neighborhood_zones", "intervention_zones", "neighborhoods"]).optional().describe("For composite mode step 1: 'neighborhood_zones' (default) shows bairros with risk scores + vulnerability-weighted priority. 'neighborhoods' shows raw IBGE census data. 'intervention_zones' uses legacy synthetic zones."),
       narrationOverlay: z.string().optional().describe("Translucent banner over the map for browse-only mode — agent narrates what colors mean. ~80 chars ideal."),
@@ -589,24 +598,32 @@ STOP and wait for the user's map selection after calling this tool.`,
       if ((mapState?.phase ?? 0) < 2) {
         return { content: [{ type: "text" as const, text: `BLOCKED: open_map is an Encontro 2+ tool and this org is still in phase ${mapState?.phase ?? 0}. Do NOT simulate Encontro 2 content or open the map. Tell the user the next encontro will appear as a green card here in the chat once their coordinator opens it, then END your turn.` }] };
       }
-      pushEvent({
-        type: 'open_map',
-        params: {
-          layers: args.layers,
-          tileLayers: args.tileLayers,
-          spatialQueries: args.spatialQueries,
-          selectionMode: args.selectionMode,
-          prompt: args.prompt,
-          sampleLayers: args.sampleLayers,
-          zoneSource: args.zoneSource,
-          narrationOverlay: args.narrationOverlay,
-          showLegendSimple: args.showLegendSimple,
-          hazardTour: args.hazardTour,
-          allowDeferSite: args.allowDeferSite,
-          suggestedSite: args.suggestedSite,
-        },
-      });
-      return { content: [{ type: "text" as const, text: `Map opened in "${args.selectionMode}" mode. STOP and wait for selection.` }] };
+      // A preset supplies the whole canonical step (shared/cbo-map-presets.ts);
+      // any explicit arg narrows it. Without a preset this is a passthrough, so
+      // the city / concept-note flows are untouched.
+      const lang = mapState?.metadata?.language === 'en' ? 'en' : 'pt';
+      const resolved = resolveOpenMapParams({
+        preset: args.preset,
+        layers: args.layers,
+        tileLayers: args.tileLayers,
+        spatialQueries: args.spatialQueries,
+        selectionMode: args.selectionMode,
+        prompt: args.prompt,
+        sampleLayers: args.sampleLayers,
+        zoneSource: args.zoneSource,
+        narrationOverlay: args.narrationOverlay,
+        showLegendSimple: args.showLegendSimple,
+        hazardTour: args.hazardTour,
+        allowDeferSite: args.allowDeferSite,
+        suggestedSite: args.suggestedSite,
+      }, lang);
+
+      if (!resolved.selectionMode) {
+        return { content: [{ type: "text" as const, text: `NOT opened — pass a \`preset\` (e2_risk_tour | e2_site | e2_browse) or an explicit \`selectionMode\`. Re-call open_map now.` }], isError: true };
+      }
+
+      pushEvent({ type: 'open_map', params: resolved });
+      return { content: [{ type: "text" as const, text: `Map opened in "${resolved.selectionMode}" mode${args.preset ? ` (preset ${args.preset})` : ''}. STOP and wait for selection.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -1779,12 +1796,12 @@ Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
     case 2:
       return isPt
         ? `**Fase 2: Onde Atuamos** (intervention_site)
-Abrir open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Selecione seu bairro, depois escolha os locais" }).
+Abrir open_map({ preset: "e2_risk_tour" }) — o preset já traz modo, camadas, tour de riscos e prompt.
 Após seleção: perguntar condições atuais, população, posse do terreno, engajamento comunitário.
 Se desenharem ponto/área customizada: perguntar "Esse local tem um nome?"
 Pedir fotos do local. Avaliar: Controle do Local (0-3), Ancoragem Comunitária (0-3).`
         : `**Phase 2: Where We Work** (intervention_site)
-Open open_map({ selectionMode: "composite", zoneSource: "neighborhoods", layers: ["osm_parks","osm_schools","osm_wetlands"], tileLayers: ["poa_flood_hazard","poa_heat_hazard","poa_landslide_hazard"], showLegendSimple: true, prompt: "Select your neighborhood, then pick sites" }).
+Open open_map({ preset: "e2_risk_tour" }) — the preset carries mode, layers, hazard tour and prompt.
 After selection: ask current conditions, population, land tenure, community engagement.
 If they draw custom point/area: ask "Does this site have a name?"
 Ask for site photos. Score: Site Control (0-3), Community Anchoring (0-3).`;

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -33,6 +33,7 @@ import {
   isValidSectionId,
 } from '@shared/cbo-schema';
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
+import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 import { emitAssistantText } from './agentOutput';
 import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue } from '@shared/cbo-field-catalog';
 
@@ -172,7 +173,12 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       break;
     }
     case 'open_map': {
-      pushEvent({ type: 'open_map', params: (op.params ?? {}) as any });
+      // Resolve presets exactly as the real MCP tool does, so a spec that
+      // scripts { preset: 'e2_risk_tour' } exercises the same params a live
+      // agent would produce. Without this the fake path would silently pass a
+      // bare {preset} straight through and the map would render nothing.
+      const resolved = resolveOpenMapParams((op.params ?? {}) as any, lang === 'en' ? 'en' : 'pt');
+      pushEvent({ type: 'open_map', params: resolved as any });
       break;
     }
     case 'show_types': {

--- a/shared/cbo-map-presets.ts
+++ b/shared/cbo-map-presets.ts
@@ -1,0 +1,132 @@
+// ============================================================================
+// CBO MAP PRESETS — the one definition of each canonical E2 map step
+// ============================================================================
+// The Encontro-2 map was described in FOUR places, three of which disagreed:
+//
+//   knowledge/_skills/encontro-2.md   zoneSource: 'neighborhood_zones'  ← correct
+//   cboAgent.ts (tool description)    zoneSource: 'neighborhoods'       ← wrong
+//   cboAgent.ts (phase map)           zoneSource: 'neighborhoods'       ← wrong
+//   cbo-profile.tsx (defaultParams)   zoneSource: 'neighborhood_zones'
+//
+// Both wrong copies also dropped `hazardTour` and `allowDeferSite`. That is not
+// cosmetic: `neighborhoods` loads raw IBGE census polygons, which carry no
+// `priorityScore`, and without `allowDeferSite` MapMicroapp's getDefaultStyle
+// takes the branch `fillOpacity = priorityScore != null ? … : 0` — so every
+// bairro renders INVISIBLE, and there is no guided hazard tour.
+//
+// Whichever copy the model happened to follow decided what the user saw. So the
+// params stop being prose the model retypes: it names a preset, and the config
+// lives here, in one place both the server tool and the client fallback import.
+//
+// Adding a step = add a preset. Never inline a rival param set.
+
+import type { OpenMapParams } from './concept-note-schema';
+
+export type CboMapPresetId = 'e2_risk_tour' | 'e2_site' | 'e2_browse';
+
+/** The OSM place types a CBO picks their intervention site from, in step 2. */
+const E2_OSM_LAYERS = ['osm_parks', 'osm_schools', 'osm_wetlands', 'osm_hospitals'];
+
+/** Hazard rasters, NOT the H×E×V risk cards — the tour teaches one hazard at a time. */
+const E2_HAZARD_TILES = ['poa_flood_hazard', 'poa_heat_hazard', 'poa_landslide_hazard'];
+
+interface PresetDef {
+  /** Everything except the prompt, which is copy and therefore localized. */
+  params: Omit<OpenMapParams, 'prompt'>;
+  prompt: { pt: string; en: string };
+  narrationOverlay?: { pt: string; en: string };
+}
+
+const PRESETS: Record<CboMapPresetId, PresetDef> = {
+  // Beat 2 — the guided entry. Hazard tour, then bairro, then site.
+  e2_risk_tour: {
+    params: {
+      selectionMode: 'composite',
+      zoneSource: 'neighborhood_zones',
+      layers: E2_OSM_LAYERS,
+      tileLayers: E2_HAZARD_TILES,
+      showLegendSimple: true,
+      hazardTour: true,
+      allowDeferSite: true,
+    },
+    prompt: {
+      pt: 'Conheça os riscos e marque onde vocês atuam.',
+      en: 'Get to know the risks, then mark where you work.',
+    },
+  },
+
+  // Same map with the tour off: "Já conheço os riscos", and every re-entry once
+  // the tour has been walked (activeTool.tourIdx === 3).
+  e2_site: {
+    params: {
+      selectionMode: 'composite',
+      zoneSource: 'neighborhood_zones',
+      layers: E2_OSM_LAYERS,
+      tileLayers: E2_HAZARD_TILES,
+      showLegendSimple: true,
+      hazardTour: false,
+      allowDeferSite: true,
+    },
+    prompt: {
+      pt: 'Marque o bairro e o lugar onde vocês atuam.',
+      en: 'Mark the neighborhood and the place where you work.',
+    },
+  },
+
+  // Beat 2a of the needs-help path: look around, commit to nothing.
+  e2_browse: {
+    params: {
+      selectionMode: 'browse-only',
+      tileLayers: E2_HAZARD_TILES,
+      showLegendSimple: true,
+    },
+    prompt: {
+      pt: 'Olha o seu bairro. As cores mostram os riscos.',
+      en: 'Look at your neighborhood. The colors show the risks.',
+    },
+    narrationOverlay: {
+      pt: 'Azul = enchente. Vermelho = calor. Marrom = deslizamento. Toque "Voltar ao chat" quando quiser.',
+      en: 'Blue = flood. Red = heat. Brown = landslide. Tap "Back to chat" whenever you like.',
+    },
+  },
+};
+
+export function isCboMapPresetId(v: unknown): v is CboMapPresetId {
+  return typeof v === 'string' && v in PRESETS;
+}
+
+/**
+ * Resolve a preset into concrete params, letting explicit args override.
+ *
+ * Overrides matter: the agent legitimately narrows a preset — `hazardTour:false`
+ * when the user taps "Já conheço os riscos", a `suggestedSite` lifted from an
+ * uploaded proposal, a `prompt` framed on the org's own words. Only keys the
+ * caller actually set win; `undefined` never clobbers a preset value.
+ *
+ * With no preset this is a passthrough, so pre-existing callers (the city and
+ * concept-note flows, which don't use presets) are unaffected.
+ */
+export function resolveOpenMapParams(
+  args: Partial<OpenMapParams> & { preset?: string },
+  lang: 'pt' | 'en' = 'pt',
+): OpenMapParams {
+  const { preset, ...explicit } = args;
+  const defined = Object.fromEntries(
+    Object.entries(explicit).filter(([, v]) => v !== undefined),
+  ) as Partial<OpenMapParams>;
+
+  if (!isCboMapPresetId(preset)) return defined as OpenMapParams;
+
+  const def = PRESETS[preset];
+  return {
+    ...def.params,
+    prompt: def.prompt[lang],
+    ...(def.narrationOverlay ? { narrationOverlay: def.narrationOverlay[lang] } : {}),
+    ...defined,
+  };
+}
+
+/** The E2 re-entry config, for the client's legacy fallback. Same object, no copy. */
+export function e2SiteParams(lang: 'pt' | 'en' = 'pt'): OpenMapParams {
+  return resolveOpenMapParams({ preset: 'e2_site' }, lang);
+}


### PR DESCRIPTION
From the same audit as #386. This is the larger of the two it surfaced.

## Five definitions, three of them wrong

The Encontro-2 map was hand-typed in five places:

| Where | `zoneSource` | tour / defer |
|---|---|---|
| `encontro-2.md` beat 2 | `neighborhood_zones` ✅ | tour on, defer on |
| `encontro-2.md` site step | `neighborhoods` ❌ | — |
| `encontro-2.md` needs-help | `neighborhoods` ❌ | — |
| `cboAgent.ts` tool description | `neighborhoods` ❌ | — |
| `cboAgent.ts` phase map | `neighborhoods` ❌ | — |
| `cbo-profile.tsx` defaultParams | `neighborhood_zones` ✅ | defer on |

The skill file even had the comment *"NOT 'neighborhoods' (raw IBGE, no risk colors)"* two paragraphs above a recipe that said `neighborhoods`.

## Why it's a real bug, not a style nit

`neighborhoods` loads raw IBGE census polygons, which carry no `priorityScore`. Without `allowDeferSite` — which every wrong copy also dropped — `getDefaultStyle` takes:

```
fillOpacity = priorityScore != null ? 0.05 + normalized * 0.65 : 0
```

`priorityScore` is `null`, so **every bairro renders at opacity 0 — an invisible map**, with no hazard tour. Whichever copy the model happened to follow that turn decided whether the user got a usable map. Logged in the UX backlog as `MAP-PARAM-DIVERGENCE`; this is the "single source of truth" fix it recommended.

## The fix

`shared/cbo-map-presets.ts` — the E2 map defined **once**, as three presets:

- `e2_risk_tour` — guided entry: hazard tour → bairro → site
- `e2_site` — same map, tour off (\"Já conheço os riscos\", and every re-entry)
- `e2_browse` — needs-help exploration, commit to nothing

The agent names a preset; `resolveOpenMapParams()` expands it. An explicit arg **narrows** a preset (`{preset:'e2_risk_tour', suggestedSite:{…}}`) — only defined keys win, so `undefined` never clobbers a preset value. Non-CBO callers (city, concept-note) pass no preset and are unaffected.

Both sides import it: the `open_map` tool (server) and the legacy `defaultParams` fallback (client), which **is** the `e2_site` preset now rather than a lookalike. The skill file's five recipes collapse to `open_map({ preset: '…' })`.

## Verification

`e2e/cougar-e2-map-presets.spec.ts` pins what each preset renders — the tour shows `1/3`; **`e2_site`'s bairros have nonzero fill-opacity**; browse shows the narration banner; an override wins while the rest of the preset survives.

Mutation-checked: revert the `e2_site` preset to the old `neighborhoods` / no-`allowDeferSite` params and the visible-zone count drops to **exactly 0** — the invisible map, reproduced.

The fake model resolves presets through the same `resolveOpenMapParams`, so the e2e path can't diverge from the live path.

I did **not** add the backlog's alternative "minimum fillOpacity floor" — invisible zones are now impossible by construction, and a floor would just mask the next divergence.

Full suite: **77 passed, 3 `@live` skipped**. `tsc --noEmit` unchanged at 4 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)