### PR TITLE
fix(cbo): the CBO's "X/7 seções" count matched neither the server nor reality

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -17,6 +17,7 @@ import { useFileDrop } from '@/core/hooks/useFileDrop';
 import {
   CBO_SECTIONS,
   phaseComplete,
+  cboSectionsFilledCount,
   type CboState,
   type CboEvent,
   type CboChatMessage,
@@ -1410,7 +1411,11 @@ export default function CboProfilePage() {
   // Clear a stale voice error once the user starts a new recording.
   useEffect(() => { if (voice.status === 'recording') setVoiceError(null); }, [voice.status]);
 
-  const filledCount = useMemo(() => state ? Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length : 0, [state]);
+  // Was: sections with ANY field key, which counted invite-prefilled org_profile
+  // (and empty-valued fields) — so the CBO read 1/7 at turn 0 while the
+  // coordinator's roster derived 0/7. Use the shared predicate the server and
+  // phaseComplete() already use.
+  const filledCount = useMemo(() => state ? cboSectionsFilledCount(state) : 0, [state]);
 
   if (!state) {
     // Invite link failed to resolve — never leave the user on a bare spinner.

--- a/e2e/cougar-filled-count.spec.ts
+++ b/e2e/cougar-filled-count.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The CBO's own "X/7 seções preenchidas" over-counted. It counted a section if
+// it had ANY field key — so an invite-prefilled org_profile (source:'invite',
+// the org name the ORCHESTRATOR typed at invite) read as 1/7 at turn 0, while
+// the coordinator roster derived 0/7 with the stricter server predicate. Now
+// both use the shared cboSectionsFilledCount (filled AND non-invite).
+
+/** Open a fresh CBO session and return its auto-created id. */
+async function freshCbo(page: Page): Promise<string> {
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  return (await marker.getAttribute('data-cbo-id'))!;
+}
+
+test.describe('COUGAR — CBO progress count matches the server predicate', () => {
+  test('invite-prefilled fields do not inflate the seções count', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    const cboId = await freshCbo(page);
+    // The invite fills org_name + bairro (source:'invite'), plus an empty-valued
+    // user field to prove empties don't count either. No real work yet → 0/7.
+    await api.seedState(cboId, {
+      phase: 1,
+      language: 'pt',
+      sections: [
+        { sectionId: 'org_profile', field: 'org_name', value: 'Comunidade X', source: 'invite' },
+        { sectionId: 'org_profile', field: 'bairro_of_operation', value: 'Centro', source: 'invite' },
+        { sectionId: 'org_profile', field: 'mission', value: '', source: 'user' },
+      ],
+    });
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+
+    await expect(page.getByText('0/7').first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('1/7')).toHaveCount(0);
+  });
+
+  test('a real org-provided field counts', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    const cboId = await freshCbo(page);
+    await api.seedState(cboId, {
+      phase: 1,
+      language: 'pt',
+      sections: [
+        { sectionId: 'org_profile', field: 'org_name', value: 'Comunidade X', source: 'invite' },
+        // The org actually answered → the section now counts.
+        { sectionId: 'org_profile', field: 'mission', value: 'Reflorestar encostas', source: 'user' },
+      ],
+    });
+    await page.reload();
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+
+    await expect(page.getByText('1/7').first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -21,7 +21,7 @@ import {
 } from '@shared/cohort-schema';
 import { createOrganization, linkCboStateToOrg, setMaturityTierForCboState } from '../services/orgPersistence';
 import { cboStates } from '@shared/cbo-db-schema';
-import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
+import { cboSectionsFilledCount, type CboState } from '@shared/cbo-schema';
 import { getCboMessages, getCboState, setCboState, loadCboFromDb } from '../services/cboAgent';
 import { deleteCboState } from '../services/cboPersistence';
 import {
@@ -218,14 +218,7 @@ async function attachDerivedSections<
       .from(cboStates)
       .where(inArray(cboStates.id, ids));
     for (const row of rows) {
-      const sections = (row.sections ?? {}) as Record<
-        string,
-        { fields?: Record<string, CboFieldState> } | undefined
-      >;
-      const n = CBO_SECTIONS.filter(sec => {
-        const fields = sections[sec.id]?.fields ?? {};
-        return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
-      }).length;
+      const n = cboSectionsFilledCount({ sections: (row.sections ?? {}) as CboState['sections'] });
       byState.set(row.id, n);
     }
   }

--- a/server/services/cboPersistence.ts
+++ b/server/services/cboPersistence.ts
@@ -14,7 +14,7 @@
 import { db } from '../db';
 import { cboStates, cboMessages } from '@shared/cbo-db-schema';
 import { cohortMembers } from '@shared/cohort-schema';
-import { CBO_SECTIONS, cboFieldIsFilled, type CboFieldState } from '@shared/cbo-schema';
+import { cboSectionsFilledCount } from '@shared/cbo-schema';
 import { eq, asc } from 'drizzle-orm';
 import type { CboState, CboChatMessage } from '@shared/cbo-schema';
 
@@ -204,10 +204,7 @@ export async function flushCbo(
 /** Derived roster snapshot from the live state — single source of truth for
  *  what the coordinator cards show between workshops. */
 async function syncMemberSnapshot(state: CboState): Promise<void> {
-  const sectionsComplete = CBO_SECTIONS.filter(sec => {
-    const fields = (state.sections as Record<string, { fields?: Record<string, CboFieldState> } | undefined>)?.[sec.id]?.fields ?? {};
-    return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
-  }).length;
+  const sectionsComplete = cboSectionsFilledCount(state);
   const interventionRaw = (state.sections as any)?.intervention_type?.fields;
   const intervention = (interventionRaw?.intervention_type?.value ?? interventionRaw?.nbs_type?.value ?? null) as string | null;
   await db.update(cohortMembers).set({

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -43,6 +43,33 @@ export function cboFieldIsFilled(f?: CboFieldState): boolean {
 }
 
 /**
+ * Whether a section has real work in it: at least one filled field the ORG
+ * provided. Invite-prefilled values (source:'invite' — the org name / bairro the
+ * ORCHESTRATOR typed at invite time) don't count; they aren't the org's work.
+ *
+ * This is THE definition of "filled" for a section. The server's snapshot
+ * (syncMemberSnapshot) and the shared phaseComplete() both use it; the client's
+ * "X/7 seções" progress readout must too, or the CBO's count and the
+ * coordinator's roster disagree — the CBO saw 1/7 at turn 0 (org_profile,
+ * invite-prefilled) while the coordinator derived 0/7.
+ */
+export function cboSectionIsFilled(
+  section?: { fields?: Record<string, CboFieldState> },
+): boolean {
+  const fields = section?.fields ?? {};
+  return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
+}
+
+/** How many of the 7 sections have real (non-invite) work. One source of truth. */
+export function cboSectionsFilledCount(
+  state: Pick<CboState, 'sections'>,
+): number {
+  return CBO_SECTIONS.filter(sec =>
+    cboSectionIsFilled(state.sections?.[sec.id as keyof CboState['sections']]),
+  ).length;
+}
+
+/**
  * Phases whose skill GUARANTEES its maturity scores at the encontro's close.
  * For these, the scores ARE the completion signal and the section-fill
  * fallback below must not apply — it is far too weak. Phase 1 has exactly one
@@ -88,14 +115,12 @@ export function phaseComplete(
     if (PHASES_SCORED_AT_CLOSE.has(phase)) return false;
   }
 
-  return sections.every(sec => {
-    const fields = state.sections?.[sec.id]?.fields ?? {};
-    // Invite-prefilled values (org name / neighborhood the ORCHESTRATOR typed at
-    // invite time, source:'invite') are not work the org did — counting them
-    // made phase 1 "complete" at turn 0 for every invited org, so the green
-    // "Começar Encontro 2" banner appeared mid-interview once WS2 was unlocked.
-    return Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite');
-  });
+  // Invite-prefilled values don't count — see cboSectionIsFilled. Counting them
+  // made phase 1 "complete" at turn 0 for every invited org, firing the green
+  // "Começar Encontro 2" banner mid-interview.
+  return sections.every(sec =>
+    cboSectionIsFilled(state.sections?.[sec.id as keyof CboState['sections']]),
+  );
 }
 
 // Maturity scores (0-3 per COUGAR NBS Mapping Criteria)


### PR DESCRIPTION
Third finding from the audit behind #386 / #387.

## The divergence

The CBO's own progress readout — *"X/7 seções preenchidas"*, the ring, the phase label — counted a section as filled if it had **any field key**:

```js
Object.values(state.sections).filter(s => Object.keys(s.fields).length > 0).length
```

The server (`syncMemberSnapshot`) and the shared `phaseComplete()` require a **filled, non-`invite`** field:

```js
Object.values(fields).some(f => cboFieldIsFilled(f) && f?.source !== 'invite')
```

Every invited org starts with `org_profile` prefilled from the invite (`source:'invite'` — the org name and bairro the *orchestrator* typed). So at turn 0:

- the **CBO** sees **1/7** on their own screen,
- the **coordinator** sees **0/7** for that same org on the roster.

Empty-valued fields inflated the client number too.

It's the same class as the phase-1-banner fix (#324): the strict predicate was applied to `phaseComplete` but the loose count was left in place — and inconsistently *within one component*, since the advance banner already called `phaseComplete` while the header two lines up used the loose count.

## Fix

`cboSectionsFilledCount()` / `cboSectionIsFilled()` in `shared/cbo-schema.ts` — one definition. All four call-sites now route through it:

- the client count (`cbo-profile.tsx`)
- `phaseComplete()`'s own per-section check
- `syncMemberSnapshot` (server snapshot)
- `attachDerivedSections` (roster read)

No second definition remains to drift.

## Verification

`e2e/cougar-filled-count.spec.ts` seeds an invite-only org plus an empty user field and asserts **0/7**; a real org-provided field → **1/7**. Mutation-checked: revert the client to the old key-count predicate and the first assertion flips to 1/7 and fails.

Full suite: **75 passed, 3 `@live` skipped**. The phase-1-banner and E2-dead-end specs (which exercise `phaseComplete`) stay green — its behavior is unchanged; only its inner predicate is now the shared one. `tsc --noEmit` unchanged at 4 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)