### PR TITLE
feat(orchestrator): Mapa / Soluções / Casos tabs over the map region

### DIFF
--- a/client/src/core/components/cbo/NbsDesktopGrids.tsx
+++ b/client/src/core/components/cbo/NbsDesktopGrids.tsx
@@ -1,0 +1,76 @@
+// Desktop grid layouts for the orchestrator NBS tabs. These are thin LAYOUT
+// wrappers only — they arrange the same leaf cards the mobile CBO chat uses
+// (NbsTypeCard, NbsShowcaseCardItem), so a content edit reaches both surfaces.
+// The 3-col grid mirrors the participant grid on the same page for consistency.
+//
+// Design record: docs/nbs-type-content-model.md
+
+import { useState } from 'react';
+import type { NbsInterventionTypeId } from '@shared/cbo-schema';
+import { NBS_INTERVENTION_TYPES } from '@shared/cbo-schema';
+import { NBS_TYPE_CONTENT } from '@shared/nbs-type-content';
+import type { NbsShowcaseCard } from '@shared/nbs-showcase-cards';
+import { NbsTypeCard } from './NbsTypeCard';
+import { NbsTypeDialog } from './NbsTypeDialog';
+import { NbsShowcaseCardItem } from './NbsShowcaseCard';
+
+const GRID = 'grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3';
+
+/** "Soluções" tab — the six NBS type cards in a grid; a card opens the centered
+ *  detail dialog on that type (prev/next between the six). */
+export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
+  const [openTypeId, setOpenTypeId] = useState<NbsInterventionTypeId | null>(
+    null
+  );
+  const types = NBS_INTERVENTION_TYPES.filter(t => NBS_TYPE_CONTENT[t.id]);
+  const typeIds = types.map(t => t.id);
+
+  return (
+    <>
+      <div className={GRID}>
+        {types.map(type => (
+          <NbsTypeCard
+            key={type.id}
+            id={type.id}
+            lang={lang}
+            onOpen={setOpenTypeId}
+          />
+        ))}
+      </div>
+
+      <NbsTypeDialog
+        typeIds={typeIds}
+        openTypeId={openTypeId}
+        onOpenTypeId={setOpenTypeId}
+        onClose={() => setOpenTypeId(null)}
+        lang={lang}
+      />
+    </>
+  );
+}
+
+/** "Casos" tab — the Brazilian named-project case studies. Read-only: reuses the
+ *  showcase leaf in browse mode (no save toggle). Cards with a verified photo show
+ *  it; the rest render the gradient + emoji placeholder, same as the CBO chat. */
+export function NbsCasesGrid({
+  cards,
+  lang,
+}: {
+  cards: NbsShowcaseCard[];
+  lang: 'pt' | 'en';
+}) {
+  return (
+    <div className={GRID}>
+      {cards.map(card => (
+        <NbsShowcaseCardItem
+          key={card.id}
+          card={card}
+          lang={lang}
+          isSaved={false}
+          onToggleSave={() => {}}
+          mode='browse'
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/NbsTypeCard.tsx
+++ b/client/src/core/components/cbo/NbsTypeCard.tsx
@@ -1,0 +1,141 @@
+// NbsTypeCard — the leaf card for one NBS type: croqui + name + one benefit line
+// + three chips (two hazards, one delivery chip naming who can build it). It has
+// NO layout opinions and NO width of its own — it fills whatever cell the parent
+// gives it (a 240px snap item in the CBO chat strip, a grid track on the desktop
+// orchestrator). That's what keeps the two surfaces in lockstep: one card, two
+// containers, zero forks.
+//
+// Design record: docs/nbs-type-content-model.md
+
+import { ArrowRight } from 'lucide-react';
+import {
+  NBS_INTERVENTION_TYPES,
+  getLocalizedNbsType,
+} from '@shared/cbo-schema';
+import type { NbsInterventionTypeId } from '@shared/cbo-schema';
+import { getNbsTypeContent, nbsIllustration } from '@shared/nbs-type-content';
+import type { NbsDelivery } from '@shared/nbs-type-content';
+
+// Fallback wash behind the croqui — also what shows if an image fails to load.
+const GRADIENTS: Record<'flood' | 'heat' | 'biodiversity', string> = {
+  flood: 'linear-gradient(135deg, #cffafe 0%, #67e8f9 100%)',
+  heat: 'linear-gradient(135deg, #fef3c7 0%, #fcd34d 100%)',
+  biodiversity: 'linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%)',
+};
+
+// Which hazards each type primarily addresses. Derived from knowledge/_interventions/*.md.
+const TYPE_VISUAL: Record<
+  string,
+  {
+    gradient: 'flood' | 'heat' | 'biodiversity';
+    hazards: Array<'flood' | 'heat'>;
+  }
+> = {
+  'bioswales-rain-gardens': { gradient: 'flood', hazards: ['flood'] },
+  'flood-parks': { gradient: 'flood', hazards: ['flood'] },
+  'green-corridors': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
+  'green-roofs-walls': { gradient: 'heat', hazards: ['heat', 'flood'] },
+  'urban-forests': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
+  'wetland-restoration': { gradient: 'flood', hazards: ['flood'] },
+};
+
+const HAZARD_LABELS = {
+  pt: { flood: 'enchente', heat: 'calor' },
+  en: { flood: 'flood', heat: 'heat' },
+};
+
+const DELIVERY_LABELS: Record<'pt' | 'en', Record<NbsDelivery, string>> = {
+  pt: {
+    mutirao: 'mutirão',
+    parceria: 'parceria',
+    licenca: 'licença ambiental',
+  },
+  en: { mutirao: 'mutirão', parceria: 'partnership', licenca: 'env. licence' },
+};
+
+// The delivery chip is the honest one: at community scale all six are affordable,
+// so what actually gates a project is who has to say yes and who keeps it alive.
+const DELIVERY_CLASS: Record<NbsDelivery, string> = {
+  mutirao:
+    'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+  parceria: 'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300',
+  licenca: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+};
+
+const MORE_LABEL = { pt: 'Saber mais', en: 'Learn more' };
+
+export function NbsTypeCard({
+  id,
+  lang,
+  onOpen,
+}: {
+  id: NbsInterventionTypeId;
+  lang: 'pt' | 'en';
+  onOpen: (id: NbsInterventionTypeId) => void;
+}) {
+  const { copy, delivery } = getNbsTypeContent(id, lang);
+  const type = NBS_INTERVENTION_TYPES.find(t => t.id === id)!;
+  const loc = getLocalizedNbsType(type, lang);
+  const visual = TYPE_VISUAL[id] ?? {
+    gradient: 'biodiversity' as const,
+    hazards: [],
+  };
+
+  return (
+    <div
+      className='flex h-full w-full flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-emerald-500/60'
+      data-testid={`type-card-${id}`}
+    >
+      <div
+        className='h-[118px] w-full shrink-0 overflow-hidden'
+        style={{ background: GRADIENTS[visual.gradient] }}
+      >
+        <img
+          src={nbsIllustration(id, 'after')}
+          alt=''
+          aria-hidden='true'
+          width={1200}
+          height={896}
+          loading='lazy'
+          decoding='async'
+          className='h-full w-full object-cover'
+        />
+      </div>
+
+      <div className='flex flex-1 flex-col gap-1.5 p-3'>
+        <h4 className='text-sm font-semibold leading-tight tracking-tight'>
+          {loc.label}
+        </h4>
+        <p className='text-xs leading-snug text-muted-foreground'>
+          {copy.benefit}
+        </p>
+
+        <div className='mt-auto flex flex-wrap items-center gap-1 pt-1'>
+          {visual.hazards.map(h => (
+            <span
+              key={h}
+              className='rounded-[3px] bg-muted px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground'
+            >
+              {HAZARD_LABELS[lang][h]}
+            </span>
+          ))}
+          <span
+            className={`rounded-[3px] px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide ${DELIVERY_CLASS[delivery]}`}
+          >
+            {DELIVERY_LABELS[lang][delivery]}
+          </span>
+        </div>
+
+        <button
+          type='button'
+          onClick={() => onOpen(id)}
+          className='mt-1 inline-flex items-center justify-center gap-1.5 rounded-md bg-emerald-50 px-2.5 py-2 text-xs font-semibold text-emerald-800 transition-colors hover:bg-emerald-100 dark:bg-emerald-950/50 dark:text-emerald-300 dark:hover:bg-emerald-950'
+          data-testid={`type-expand-${id}`}
+        >
+          {MORE_LABEL[lang]}
+          <ArrowRight className='h-3 w-3' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/NbsTypeDetailContent.tsx
+++ b/client/src/core/components/cbo/NbsTypeDetailContent.tsx
@@ -1,0 +1,279 @@
+// NbsTypeDetailContent — one NBS type's full teaching content (gloss, before/
+// after with captions, o que muda, o que é preciso, custo, quando não funciona,
+// não é isso). This is the SHARED leaf: the mobile CBO drawer (NbsTypeSheet)
+// stacks all six of these, and the desktop orchestrator dialog (NbsTypeDialog)
+// renders one. Content lives here once so the two surfaces cannot drift.
+//
+// Design record: docs/nbs-type-content-model.md
+
+import {
+  getLocalizedNbsType,
+  type NbsInterventionTypeId,
+  NBS_INTERVENTION_TYPES,
+} from '@shared/cbo-schema';
+import { getNbsTypeContent, nbsIllustration } from '@shared/nbs-type-content';
+import type { NbsCostBand } from '@shared/nbs-type-content';
+
+export const NBS_DETAIL_STRINGS = {
+  pt: {
+    title: 'Tipos de soluções',
+    close: 'Fechar',
+    handle: 'Arraste para fechar',
+    prev: 'Anterior',
+    next: 'Próximo',
+    before: 'Antes',
+    after: 'Depois',
+    afterWork: 'Depois da obra',
+    changes: 'O que muda',
+    needs: 'O que é preciso',
+    cost: 'Custo e prazo',
+    failure: 'Quando não funciona',
+    notThis: 'Não confunda',
+    estimated: 'estimado',
+    bands: { baixo: 'baixo', medio: 'médio', alto: 'alto' },
+    drawings: {
+      cutaway: 'Corte esquemático',
+      'before-after': 'Antes e depois',
+      surface: 'Vista de superfície',
+    },
+  },
+  en: {
+    title: 'Types of solutions',
+    close: 'Close',
+    handle: 'Drag to close',
+    prev: 'Previous',
+    next: 'Next',
+    before: 'Before',
+    after: 'After',
+    afterWork: 'After the work',
+    changes: 'What changes',
+    needs: 'What it takes',
+    cost: 'Cost and time',
+    failure: 'When it fails',
+    notThis: "Don't confuse",
+    estimated: 'estimated',
+    bands: { baixo: 'low', medio: 'medium', alto: 'high' },
+    drawings: {
+      cutaway: 'Section perspective',
+      'before-after': 'Before and after',
+      surface: 'Surface view',
+    },
+  },
+} as const;
+
+export type NbsDetailStrings = (typeof NBS_DETAIL_STRINGS)['pt'];
+
+/** Canonical order for both surfaces — the strip, the grid, and prev/next in the
+ *  dialog all derive from this so no surface can re-sort independently. */
+export function orderedNbsTypeIds(typeIds: string[]): NbsInterventionTypeId[] {
+  const wanted = new Set(typeIds);
+  return NBS_INTERVENTION_TYPES.filter(t => wanted.has(t.id)).map(t => t.id);
+}
+
+const BAND_CLASS: Record<NbsCostBand, string> = {
+  baixo:
+    'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+  medio: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+  alto: 'bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300',
+};
+
+/** Marks a figure we could not source to a Brazilian reference. No unmarked
+ *  placeholder ships — see docs/nbs-type-content-model.md, open item 2. */
+function EstimatedMark({ label }: { label: string }) {
+  return (
+    <span className='ml-1 inline-block whitespace-nowrap rounded-[2px] bg-amber-100 px-1 align-middle text-[8px] font-medium uppercase leading-[1.5] tracking-wider text-amber-800 dark:bg-amber-950 dark:text-amber-300'>
+      {label}
+    </span>
+  );
+}
+
+function Panel({
+  src,
+  alt,
+  tag,
+  caption,
+}: {
+  src: string;
+  alt: string;
+  tag: string;
+  caption: string;
+}) {
+  return (
+    <figure className='m-0'>
+      <div className='relative overflow-hidden rounded-lg border border-border'>
+        {/* literal black/white, not bg-foreground/85: the theme colours are full
+            `var(--foreground)` values, so Tailwind's opacity modifier cannot apply
+            and the chip renders invisible. The croqui is light in both themes. */}
+        <span className='absolute left-2 top-2 z-10 rounded-[3px] bg-black/75 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.13em] text-white'>
+          {tag}
+        </span>
+        {/* width/height are load-bearing, not decoration: without them the lazy
+            images have zero height at mount, every section's offsetTop collapses,
+            and "open at type N" lands the sheet mid-way through type N-1. */}
+        <img
+          src={src}
+          alt={alt}
+          width={1200}
+          height={896}
+          loading='lazy'
+          decoding='async'
+          className='block h-auto w-full'
+        />
+      </div>
+      <figcaption className='px-0.5 pt-1.5 text-[13px] leading-snug text-foreground'>
+        {caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * One type's teaching content. `index` drives the `data-index` the mobile
+ * sheet's IntersectionObserver + scroll-to-target rely on; defaults to 0 for the
+ * single-type desktop dialog.
+ */
+export function NbsTypeDetailContent({
+  id,
+  lang,
+  index = 0,
+  hideTitle = false,
+}: {
+  id: NbsInterventionTypeId;
+  lang: 'pt' | 'en';
+  index?: number;
+  /** The desktop dialog already shows the type name in its header, so it hides
+   *  this H3 visually. Kept in the DOM (sr-only) so aria-labelledby stays valid. */
+  hideTitle?: boolean;
+}) {
+  const s = NBS_DETAIL_STRINGS[lang];
+  const { copy, costBand, drawing } = getNbsTypeContent(id, lang);
+  const type = NBS_INTERVENTION_TYPES.find(t => t.id === id)!;
+  const title = getLocalizedNbsType(type, lang).label;
+
+  return (
+    <section
+      aria-labelledby={`nbs-type-${id}`}
+      data-index={index}
+      data-testid={`type-section-${id}`}
+      className='border-b-8 border-muted px-4 py-5 last:border-b-0'
+    >
+      <div className='mx-auto w-full max-w-2xl'>
+        <h3
+          id={`nbs-type-${id}`}
+          className={
+            hideTitle
+              ? 'sr-only'
+              : 'm-0 text-[17.5px] font-semibold leading-tight tracking-tight'
+          }
+        >
+          {title}
+        </h3>
+        <p className='mb-2.5 mt-1 text-[9.5px] uppercase tracking-[0.12em] text-muted-foreground'>
+          {s.drawings[drawing]}
+        </p>
+
+        <p className='rounded-r-md border-l-[3px] border-emerald-700 bg-muted px-2.5 py-2 text-[12.5px] leading-relaxed text-foreground'>
+          {copy.gloss}
+        </p>
+
+        <div className='mt-3.5 flex flex-col gap-1' data-vaul-no-drag>
+          <Panel
+            src={nbsIllustration(id, 'before')}
+            alt={copy.altBefore}
+            tag={s.before}
+            caption={copy.antesCaption}
+          />
+          <div className='flex items-center justify-center gap-1.5 py-1.5 text-[9px] uppercase tracking-[0.13em] text-muted-foreground'>
+            <svg width='13' height='13' viewBox='0 0 14 14' aria-hidden='true'>
+              <path
+                d='M7 2v10M3.4 8.4 7 12l3.6-3.6'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth='1.3'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
+            </svg>
+            <span>{s.afterWork}</span>
+          </div>
+          <Panel
+            src={nbsIllustration(id, 'after')}
+            alt={copy.altAfter}
+            tag={s.after}
+            caption={copy.depoisCaption}
+          />
+        </div>
+
+        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
+          {s.changes}
+        </h4>
+        <ul className='m-0 flex list-none flex-col gap-1.5 p-0'>
+          {copy.changes.map(c => (
+            <li
+              key={c}
+              className='relative pl-4 text-[13px] leading-snug text-foreground'
+            >
+              <span className='absolute left-0 top-[7px] h-[7px] w-[7px] rounded-[2px] bg-emerald-700' />
+              {c}
+            </li>
+          ))}
+        </ul>
+
+        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
+          {s.needs}
+        </h4>
+        <dl className='m-0 flex flex-col'>
+          {copy.requirements.map((r, i) => (
+            <div
+              key={r.label}
+              className={`grid grid-cols-[88px_minmax(0,1fr)] gap-2.5 py-2 ${i > 0 ? 'border-t border-border' : ''}`}
+            >
+              <dt className='text-[11.5px] font-semibold leading-snug'>
+                {r.label}
+              </dt>
+              {/* overflow-wrap:anywhere — the wetland row carries a long SMAMUS
+                  email that otherwise overflows its column and is clipped. */}
+              <dd className='m-0 text-[12.5px] leading-snug text-muted-foreground [overflow-wrap:anywhere]'>
+                {r.value}
+                {r.estimated && <EstimatedMark label={s.estimated} />}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
+          {s.cost}
+        </h4>
+        <p className='m-0 text-[13px] leading-relaxed text-foreground'>
+          <span
+            className={`mr-2 inline-block rounded-[3px] px-1.5 py-0.5 align-[1px] text-[9.5px] font-bold uppercase tracking-wider ${BAND_CLASS[costBand]}`}
+          >
+            {s.bands[costBand]}
+          </span>
+          {copy.cost}
+          {copy.costEstimated && <EstimatedMark label={s.estimated} />}
+        </p>
+
+        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
+          {s.failure}
+        </h4>
+        <p className='m-0 rounded-r-md border-l-[3px] border-rose-400 bg-rose-50 px-2.5 py-2 text-[12.5px] leading-relaxed text-foreground dark:bg-rose-950/40'>
+          {copy.failure}
+        </p>
+
+        <div className='mt-3.5 rounded-md bg-muted px-2.5 py-2'>
+          <p className='m-0 mb-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground'>
+            {s.notThis}
+          </p>
+          <p className='m-0 text-[12.5px] leading-snug text-foreground'>
+            {copy.notThis}
+          </p>
+        </div>
+
+        <p className='mb-0 mt-3 text-[12px] italic leading-snug text-muted-foreground'>
+          {copy.example}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/client/src/core/components/cbo/NbsTypeDialog.tsx
+++ b/client/src/core/components/cbo/NbsTypeDialog.tsx
@@ -1,0 +1,115 @@
+// NbsTypeDialog — the desktop "Saber mais" surface for the orchestrator NBS tab.
+// Where the mobile CBO chat opens a bottom Drawer that scrolls through all six
+// types (NbsTypeSheet), the desktop grid already shows all six, so tapping a card
+// opens a centered dialog on the ONE tapped type, with prev/next to move between
+// them. The teaching content is the SAME NbsTypeDetailContent leaf both surfaces
+// render, so they cannot drift.
+//
+// The dialog portals to <body>, so it centers over the full viewport even though
+// the card that opened it lives inside the fixed-height, overflow-scrolled tab
+// panel. Design record: docs/nbs-type-content-model.md
+
+import { useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/core/components/ui/dialog';
+import {
+  getLocalizedNbsType,
+  NBS_INTERVENTION_TYPES,
+} from '@shared/cbo-schema';
+import type { NbsInterventionTypeId } from '@shared/cbo-schema';
+import {
+  NBS_DETAIL_STRINGS,
+  NbsTypeDetailContent,
+  orderedNbsTypeIds,
+} from './NbsTypeDetailContent';
+
+export function NbsTypeDialog({
+  typeIds,
+  openTypeId,
+  onOpenTypeId,
+  onClose,
+  lang,
+}: {
+  typeIds: string[];
+  /** Which type the dialog shows. `null` closes it. */
+  openTypeId: NbsInterventionTypeId | null;
+  /** Move to another type (prev/next) without closing. */
+  onOpenTypeId: (id: NbsInterventionTypeId) => void;
+  onClose: () => void;
+  lang: 'pt' | 'en';
+}) {
+  const s = NBS_DETAIL_STRINGS[lang];
+  const ordered = orderedNbsTypeIds(typeIds);
+  const index = openTypeId ? ordered.indexOf(openTypeId) : -1;
+  const isOpen = index >= 0;
+
+  // Reset the scroll to the top whenever the shown type changes.
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (bodyRef.current) bodyRef.current.scrollTop = 0;
+  }, [openTypeId]);
+
+  const go = (delta: number) => {
+    const next = ordered[index + delta];
+    if (next) onOpenTypeId(next);
+  };
+
+  if (ordered.length === 0) return null;
+
+  const currentId = isOpen ? ordered[index] : ordered[0];
+  const type = NBS_INTERVENTION_TYPES.find(t => t.id === currentId)!;
+  const label = getLocalizedNbsType(type, lang).label;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={next => !next && onClose()}>
+      <DialogContent
+        // Override the primitive's max-w-lg / p-6: the detail is a wider,
+        // internally-scrolled column with its own padding.
+        className='flex max-h-[88vh] w-[min(92vw,42rem)] max-w-none flex-col gap-0 overflow-hidden p-0'
+        data-testid='nbs-type-dialog'
+        aria-describedby={undefined}
+      >
+        {/* pr-12 leaves room for the primitive's built-in close button (top-4 right-4). */}
+        <div className='flex shrink-0 items-center gap-2 border-b border-border px-4 py-3 pr-12'>
+          <button
+            type='button'
+            onClick={() => go(-1)}
+            disabled={index <= 0}
+            aria-label={s.prev}
+            data-testid='nbs-type-dialog-prev'
+            className='flex h-7 w-7 items-center justify-center rounded-full bg-muted text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-30'
+          >
+            <ChevronLeft className='h-4 w-4' />
+          </button>
+          <button
+            type='button'
+            onClick={() => go(1)}
+            disabled={index >= ordered.length - 1}
+            aria-label={s.next}
+            data-testid='nbs-type-dialog-next'
+            className='flex h-7 w-7 items-center justify-center rounded-full bg-muted text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-30'
+          >
+            <ChevronRight className='h-4 w-4' />
+          </button>
+          <DialogTitle className='ml-1 truncate text-[15px] font-semibold tracking-tight'>
+            {label}
+          </DialogTitle>
+          <span className='ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground'>
+            {index + 1} / {ordered.length}
+          </span>
+        </div>
+
+        <div
+          ref={bodyRef}
+          className='min-h-0 flex-1 overflow-y-auto overscroll-contain'
+        >
+          <NbsTypeDetailContent id={currentId} lang={lang} hideTitle />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/components/cbo/NbsTypeSheet.tsx
+++ b/client/src/core/components/cbo/NbsTypeSheet.tsx
@@ -1,27 +1,26 @@
-// NbsTypeSheet — the "Saber mais" surface. Opens from any card in NbsTypeStrip
-// and holds ALL six NBS types, scrolled to the one that was tapped.
+// NbsTypeSheet — the mobile "Saber mais" surface for the CBO chat. Opens from a
+// card in NbsTypeStrip and holds ALL six NBS types, scrolled to the tapped one.
 //
 // Design record: docs/nbs-type-content-model.md
 //
-// Three interaction rules, each of them load-bearing:
+// Three interaction rules, each load-bearing:
 //
 //   1. Vertical scroll, not a horizontal carousel. A carousel hides types 2-6
 //      behind a gesture; NN/g puts the practical ceiling near five slides and we
 //      have six, dots are a weak cue on mobile, and horizontal swipe fights the
 //      iOS back-gesture.
 //
-//   2. The before/after pair is STACKED at full width, never a drag-divider
-//      wipe. A wipe shows half of each image at any instant, and a horizontal
-//      drag nested inside a vertically-draggable sheet gives two handlers
-//      fighting for one finger.
+//   2. The before/after pair is STACKED at full width, never a drag-divider wipe.
 //
-//   3. vaul `handleOnly` + `data-vaul-no-drag` on the figures. Without this the
-//      sheet dismisses when the user meant to scroll.
+//   3. vaul `handleOnly` + `data-vaul-no-drag` on the figures, or the sheet
+//      dismisses when the user meant to scroll.
 //
-// This is a scroll region with real headings, NOT an ARIA carousel — screen
-// reader users navigate the six types by heading. `lang` arrives as a prop, never
-// from i18n.language: see cbo-ux-audit-backlog.md:11 (NbsTypeStrip.tsx:111 could
-// render English to a PT cohort in a pre-fetch race).
+// A scroll region with real headings, NOT an ARIA carousel — screen readers
+// navigate the six types by heading. `lang` arrives as a prop (never i18n.language
+// read in the component — see cbo-ux-audit-backlog.md).
+//
+// The per-type teaching content lives in NbsTypeDetailContent, shared with the
+// desktop orchestrator dialog (NbsTypeDialog) so the two surfaces cannot drift.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
@@ -30,254 +29,12 @@ import {
   DrawerContent,
   DrawerHandle,
 } from '@/core/components/ui/drawer';
-import {
-  NBS_INTERVENTION_TYPES,
-  getLocalizedNbsType,
-} from '@shared/cbo-schema';
+import { NBS_INTERVENTION_TYPES } from '@shared/cbo-schema';
 import type { NbsInterventionTypeId } from '@shared/cbo-schema';
-import { getNbsTypeContent, nbsIllustration } from '@shared/nbs-type-content';
-import type { NbsCostBand, NbsTypeCopy } from '@shared/nbs-type-content';
-
-const STRINGS = {
-  pt: {
-    title: 'Tipos de soluções',
-    close: 'Fechar',
-    handle: 'Arraste para fechar',
-    before: 'Antes',
-    after: 'Depois',
-    afterWork: 'Depois da obra',
-    changes: 'O que muda',
-    needs: 'O que é preciso',
-    cost: 'Custo e prazo',
-    failure: 'Quando não funciona',
-    notThis: 'Não confunda',
-    estimated: 'estimado',
-    bands: { baixo: 'baixo', medio: 'médio', alto: 'alto' },
-    drawings: {
-      cutaway: 'Corte esquemático',
-      'before-after': 'Antes e depois',
-      surface: 'Vista de superfície',
-    },
-  },
-  en: {
-    title: 'Types of solutions',
-    close: 'Close',
-    handle: 'Drag to close',
-    before: 'Before',
-    after: 'After',
-    afterWork: 'After the work',
-    changes: 'What changes',
-    needs: 'What it takes',
-    cost: 'Cost and time',
-    failure: 'When it fails',
-    notThis: "Don't confuse",
-    estimated: 'estimated',
-    bands: { baixo: 'low', medio: 'medium', alto: 'high' },
-    drawings: {
-      cutaway: 'Section perspective',
-      'before-after': 'Before and after',
-      surface: 'Surface view',
-    },
-  },
-} as const;
-
-const BAND_CLASS: Record<NbsCostBand, string> = {
-  baixo:
-    'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
-  medio: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
-  alto: 'bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300',
-};
-
-/** Marks a figure we could not source to a Brazilian reference. No unmarked
- *  placeholder ships — see docs/nbs-type-content-model.md, open item 2. */
-function EstimatedMark({ label }: { label: string }) {
-  return (
-    <span className='ml-1 inline-block whitespace-nowrap rounded-[2px] bg-amber-100 px-1 align-middle text-[8px] font-medium uppercase leading-[1.5] tracking-wider text-amber-800 dark:bg-amber-950 dark:text-amber-300'>
-      {label}
-    </span>
-  );
-}
-
-function Panel({
-  src,
-  alt,
-  tag,
-  caption,
-}: {
-  src: string;
-  alt: string;
-  tag: string;
-  caption: string;
-}) {
-  return (
-    <figure className='m-0'>
-      <div className='relative overflow-hidden rounded-lg border border-border'>
-        {/* literal black/white, not bg-foreground/85: the theme colours are full
-            `var(--foreground)` values, so Tailwind's opacity modifier cannot apply
-            and the chip renders invisible. The croqui is light in both themes. */}
-        <span className='absolute left-2 top-2 z-10 rounded-[3px] bg-black/75 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.13em] text-white'>
-          {tag}
-        </span>
-        {/* width/height are load-bearing, not decoration: without them the lazy
-            images have zero height at mount, every section's offsetTop collapses,
-            and "open at type N" lands the sheet mid-way through type N-1. */}
-        <img
-          src={src}
-          alt={alt}
-          width={1200}
-          height={896}
-          loading='lazy'
-          decoding='async'
-          className='block h-auto w-full'
-        />
-      </div>
-      <figcaption className='px-0.5 pt-1.5 text-[13px] leading-snug text-foreground'>
-        {caption}
-      </figcaption>
-    </figure>
-  );
-}
-
-function TypeSection({
-  id,
-  title,
-  kicker,
-  copy,
-  costBand,
-  s,
-  index,
-}: {
-  id: NbsInterventionTypeId;
-  title: string;
-  kicker: string;
-  copy: NbsTypeCopy;
-  costBand: NbsCostBand;
-  s: (typeof STRINGS)['pt'] | (typeof STRINGS)['en'];
-  index: number;
-}) {
-  return (
-    <section
-      aria-labelledby={`nbs-type-${id}`}
-      data-index={index}
-      data-testid={`type-section-${id}`}
-      className='border-b-8 border-muted px-4 py-5 last:border-b-0'
-    >
-      <div className='mx-auto w-full max-w-2xl'>
-        <h3
-          id={`nbs-type-${id}`}
-          className='m-0 text-[17.5px] font-semibold leading-tight tracking-tight'
-        >
-          {title}
-        </h3>
-        <p className='mb-2.5 mt-1 text-[9.5px] uppercase tracking-[0.12em] text-muted-foreground'>
-          {kicker}
-        </p>
-
-        <p className='rounded-r-md border-l-[3px] border-emerald-700 bg-muted px-2.5 py-2 text-[12.5px] leading-relaxed text-foreground'>
-          {copy.gloss}
-        </p>
-
-        <div className='mt-3.5 flex flex-col gap-1' data-vaul-no-drag>
-          <Panel
-            src={nbsIllustration(id, 'before')}
-            alt={copy.altBefore}
-            tag={s.before}
-            caption={copy.antesCaption}
-          />
-          <div className='flex items-center justify-center gap-1.5 py-1.5 text-[9px] uppercase tracking-[0.13em] text-muted-foreground'>
-            <svg width='13' height='13' viewBox='0 0 14 14' aria-hidden='true'>
-              <path
-                d='M7 2v10M3.4 8.4 7 12l3.6-3.6'
-                fill='none'
-                stroke='currentColor'
-                strokeWidth='1.3'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-            <span>{s.afterWork}</span>
-          </div>
-          <Panel
-            src={nbsIllustration(id, 'after')}
-            alt={copy.altAfter}
-            tag={s.after}
-            caption={copy.depoisCaption}
-          />
-        </div>
-
-        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
-          {s.changes}
-        </h4>
-        <ul className='m-0 flex list-none flex-col gap-1.5 p-0'>
-          {copy.changes.map(c => (
-            <li
-              key={c}
-              className='relative pl-4 text-[13px] leading-snug text-foreground'
-            >
-              <span className='absolute left-0 top-[7px] h-[7px] w-[7px] rounded-[2px] bg-emerald-700' />
-              {c}
-            </li>
-          ))}
-        </ul>
-
-        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
-          {s.needs}
-        </h4>
-        <dl className='m-0 flex flex-col'>
-          {copy.requirements.map((r, i) => (
-            <div
-              key={r.label}
-              className={`grid grid-cols-[88px_minmax(0,1fr)] gap-2.5 py-2 ${i > 0 ? 'border-t border-border' : ''}`}
-            >
-              <dt className='text-[11.5px] font-semibold leading-snug'>
-                {r.label}
-              </dt>
-              {/* overflow-wrap:anywhere — the wetland row carries a long SMAMUS
-                  email that otherwise overflows its column and is clipped. */}
-              <dd className='m-0 text-[12.5px] leading-snug text-muted-foreground [overflow-wrap:anywhere]'>
-                {r.value}
-                {r.estimated && <EstimatedMark label={s.estimated} />}
-              </dd>
-            </div>
-          ))}
-        </dl>
-
-        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
-          {s.cost}
-        </h4>
-        <p className='m-0 text-[13px] leading-relaxed text-foreground'>
-          <span
-            className={`mr-2 inline-block rounded-[3px] px-1.5 py-0.5 align-[1px] text-[9.5px] font-bold uppercase tracking-wider ${BAND_CLASS[costBand]}`}
-          >
-            {s.bands[costBand]}
-          </span>
-          {copy.cost}
-          {copy.costEstimated && <EstimatedMark label={s.estimated} />}
-        </p>
-
-        <h4 className='mb-1.5 mt-5 text-[10px] uppercase tracking-[0.13em] text-muted-foreground'>
-          {s.failure}
-        </h4>
-        <p className='m-0 rounded-r-md border-l-[3px] border-rose-400 bg-rose-50 px-2.5 py-2 text-[12.5px] leading-relaxed text-foreground dark:bg-rose-950/40'>
-          {copy.failure}
-        </p>
-
-        <div className='mt-3.5 rounded-md bg-muted px-2.5 py-2'>
-          <p className='m-0 mb-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground'>
-            {s.notThis}
-          </p>
-          <p className='m-0 text-[12.5px] leading-snug text-foreground'>
-            {copy.notThis}
-          </p>
-        </div>
-
-        <p className='mb-0 mt-3 text-[12px] italic leading-snug text-muted-foreground'>
-          {copy.example}
-        </p>
-      </div>
-    </section>
-  );
-}
+import {
+  NBS_DETAIL_STRINGS,
+  NbsTypeDetailContent,
+} from './NbsTypeDetailContent';
 
 export function NbsTypeSheet({
   typeIds,
@@ -291,7 +48,7 @@ export function NbsTypeSheet({
   onClose: () => void;
   lang: 'pt' | 'en';
 }) {
-  const s = STRINGS[lang];
+  const s = NBS_DETAIL_STRINGS[lang];
   const bodyRef = useRef<HTMLDivElement>(null);
   const [active, setActive] = useState(0);
 
@@ -392,25 +149,14 @@ export function NbsTypeSheet({
           ref={bodyRef}
           className='min-h-0 flex-1 overflow-y-auto overscroll-contain'
         >
-          {types.map((type, i) => {
-            const { copy, costBand, drawing } = getNbsTypeContent(
-              type.id,
-              lang
-            );
-            const loc = getLocalizedNbsType(type, lang);
-            return (
-              <TypeSection
-                key={type.id}
-                id={type.id}
-                index={i}
-                title={loc.label}
-                kicker={s.drawings[drawing]}
-                copy={copy}
-                costBand={costBand}
-                s={s}
-              />
-            );
-          })}
+          {types.map((type, i) => (
+            <NbsTypeDetailContent
+              key={type.id}
+              id={type.id}
+              index={i}
+              lang={lang}
+            />
+          ))}
         </div>
       </DrawerContent>
     </Drawer>

--- a/client/src/core/components/cbo/NbsTypeStrip.tsx
+++ b/client/src/core/components/cbo/NbsTypeStrip.tsx
@@ -5,158 +5,20 @@
 //
 // Design record: docs/nbs-type-content-model.md
 //
-// The card TRIAGES; the sheet TEACHES. So the card carries the croqui, the type
-// name, one benefit line and three chips — two hazards and one delivery chip
-// naming who can actually build the thing. Cost, time, area and maintenance are
-// deliberation attributes and live in the sheet: people filter on one to three
-// salient attributes, then consult the rest only after narrowing.
-//
-// Source of truth for the types: NBS_INTERVENTION_TYPES in shared/cbo-schema.ts.
-// Copy + illustrations: shared/nbs-type-content.ts (croquis, not photographs —
-// see docs/photo-curation.md on the two registers).
+// The card TRIAGES; the sheet TEACHES. The card leaf (NbsTypeCard) is shared with
+// the desktop orchestrator grid; this strip is just the mobile-chat LAYOUT around
+// it — a horizontal snap-scroller. Keeping the card headless is what stops the
+// two surfaces from drifting.
 //
 // `lang` arrives as a prop. Reading i18n.language here loses a pre-fetch race and
 // renders English to a PT cohort — see cbo-ux-audit-backlog.md:11.
 
 import { useState } from 'react';
-import { ArrowRight } from 'lucide-react';
-import {
-  NBS_INTERVENTION_TYPES,
-  getLocalizedNbsType,
-} from '@shared/cbo-schema';
+import { NBS_INTERVENTION_TYPES } from '@shared/cbo-schema';
 import type { NbsInterventionTypeId } from '@shared/cbo-schema';
-import {
-  NBS_TYPE_CONTENT,
-  getNbsTypeContent,
-  nbsIllustration,
-} from '@shared/nbs-type-content';
-import type { NbsDelivery } from '@shared/nbs-type-content';
+import { NBS_TYPE_CONTENT } from '@shared/nbs-type-content';
+import { NbsTypeCard } from './NbsTypeCard';
 import { NbsTypeSheet } from './NbsTypeSheet';
-
-// Fallback wash behind the croqui — also what shows if an image fails to load.
-const GRADIENTS: Record<'flood' | 'heat' | 'biodiversity', string> = {
-  flood: 'linear-gradient(135deg, #cffafe 0%, #67e8f9 100%)',
-  heat: 'linear-gradient(135deg, #fef3c7 0%, #fcd34d 100%)',
-  biodiversity: 'linear-gradient(135deg, #d1fae5 0%, #6ee7b7 100%)',
-};
-
-// Which hazards each type primarily addresses. Derived from knowledge/_interventions/*.md.
-const TYPE_VISUAL: Record<
-  string,
-  {
-    gradient: 'flood' | 'heat' | 'biodiversity';
-    hazards: Array<'flood' | 'heat'>;
-  }
-> = {
-  'bioswales-rain-gardens': { gradient: 'flood', hazards: ['flood'] },
-  'flood-parks': { gradient: 'flood', hazards: ['flood'] },
-  'green-corridors': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
-  'green-roofs-walls': { gradient: 'heat', hazards: ['heat', 'flood'] },
-  'urban-forests': { gradient: 'biodiversity', hazards: ['heat', 'flood'] },
-  'wetland-restoration': { gradient: 'flood', hazards: ['flood'] },
-};
-
-const HAZARD_LABELS = {
-  pt: { flood: 'enchente', heat: 'calor' },
-  en: { flood: 'flood', heat: 'heat' },
-};
-
-const DELIVERY_LABELS: Record<'pt' | 'en', Record<NbsDelivery, string>> = {
-  pt: {
-    mutirao: 'mutirão',
-    parceria: 'parceria',
-    licenca: 'licença ambiental',
-  },
-  en: { mutirao: 'mutirão', parceria: 'partnership', licenca: 'env. licence' },
-};
-
-// The delivery chip is the honest one: at community scale all six are affordable,
-// so what actually gates a project is who has to say yes and who keeps it alive.
-const DELIVERY_CLASS: Record<NbsDelivery, string> = {
-  mutirao:
-    'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
-  parceria: 'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300',
-  licenca: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
-};
-
-const MORE_LABEL = { pt: 'Saber mais', en: 'Learn more' };
-
-type NbsType = (typeof NBS_INTERVENTION_TYPES)[number];
-
-function NbsTypeCardItem({
-  type,
-  lang,
-  onOpen,
-}: {
-  type: NbsType;
-  lang: 'pt' | 'en';
-  onOpen: (id: NbsInterventionTypeId) => void;
-}) {
-  const loc = getLocalizedNbsType(type, lang);
-  const { copy, delivery } = getNbsTypeContent(type.id, lang);
-  const visual = TYPE_VISUAL[type.id] ?? {
-    gradient: 'biodiversity' as const,
-    hazards: [],
-  };
-
-  return (
-    <div
-      className='flex h-full w-[240px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-emerald-500/60 md:w-full'
-      data-testid={`type-card-${type.id}`}
-    >
-      <div
-        className='h-[118px] w-full shrink-0 overflow-hidden'
-        style={{ background: GRADIENTS[visual.gradient] }}
-      >
-        <img
-          src={nbsIllustration(type.id, 'after')}
-          alt=''
-          aria-hidden='true'
-          width={1200}
-          height={896}
-          loading='lazy'
-          decoding='async'
-          className='h-full w-full object-cover'
-        />
-      </div>
-
-      <div className='flex flex-1 flex-col gap-1.5 p-3'>
-        <h4 className='text-sm font-semibold leading-tight tracking-tight'>
-          {loc.label}
-        </h4>
-        <p className='text-xs leading-snug text-muted-foreground'>
-          {copy.benefit}
-        </p>
-
-        <div className='mt-auto flex flex-wrap items-center gap-1 pt-1'>
-          {visual.hazards.map(h => (
-            <span
-              key={h}
-              className='rounded-[3px] bg-muted px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground'
-            >
-              {HAZARD_LABELS[lang][h]}
-            </span>
-          ))}
-          <span
-            className={`rounded-[3px] px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide ${DELIVERY_CLASS[delivery]}`}
-          >
-            {DELIVERY_LABELS[lang][delivery]}
-          </span>
-        </div>
-
-        <button
-          type='button'
-          onClick={() => onOpen(type.id)}
-          className='mt-1 inline-flex items-center justify-center gap-1.5 rounded-md bg-emerald-50 px-2.5 py-2 text-xs font-semibold text-emerald-800 transition-colors hover:bg-emerald-100 dark:bg-emerald-950/50 dark:text-emerald-300 dark:hover:bg-emerald-950'
-          data-testid={`type-expand-${type.id}`}
-        >
-          {MORE_LABEL[lang]}
-          <ArrowRight className='h-3 w-3' />
-        </button>
-      </div>
-    </div>
-  );
-}
 
 export function NbsTypeStrip({
   typeIds,
@@ -191,11 +53,12 @@ export function NbsTypeStrip({
         {types.map(type => (
           <div
             key={type.id}
+            // 240px snap item on mobile; a flex cell on md+. The card fills it.
             // scroll-snap-stop: always — an iOS momentum fling otherwise skips
             // several cards past their snap points.
-            className='flex snap-start [scroll-snap-stop:always] md:min-w-[220px] md:max-w-[320px] md:flex-1'
+            className='flex w-[240px] shrink-0 snap-start [scroll-snap-stop:always] md:w-auto md:min-w-[220px] md:max-w-[320px] md:flex-1'
           >
-            <NbsTypeCardItem type={type} lang={lang} onOpen={setOpenTypeId} />
+            <NbsTypeCard id={type.id} lang={lang} onOpen={setOpenTypeId} />
           </div>
         ))}
       </div>

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -19,11 +19,22 @@ import 'leaflet/dist/leaflet.css';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import {
-  ArrowLeft, Check, Clock, Compass, Copy, Droplets, Eye, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
-  Mountain, Network, Paperclip, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
+  ArrowLeft, BookOpen, Check, Clock, Compass, Copy, Droplets, Eye, Leaf, LifeBuoy, Lightbulb, MapPin, Target,
+  Map as MapIcon, Mountain, Network, Paperclip, Plus, RotateCcw, Sprout, Trash2, Trees, Unlock, Waves,
 } from 'lucide-react';
 import { Card, CardContent } from '@/core/components/ui/card';
 import { Button } from '@/core/components/ui/button';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/core/components/ui/tabs';
+import {
+  NbsSolutionsGrid,
+  NbsCasesGrid,
+} from '@/core/components/cbo/NbsDesktopGrids';
+import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useToast } from '@/core/hooks/use-toast';
 import { useResetRole } from '@/core/contexts/role-context';
@@ -835,6 +846,11 @@ export default function OrchestratorLandingPage() {
   const locale: 'en' | 'pt' = i18n.language?.startsWith('pt') ? 'pt' : 'en';
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Which view fills the map region: the bairro map, the six NBS type cards, or
+  // the Brazilian case studies. The map stays mounted underneath either panel.
+  const [regionTab, setRegionTab] = useState<'map' | 'solutions' | 'cases'>(
+    'map'
+  );
   // Active risk view on the coordinator map (one at a time). Defaults to flood —
   // the primary POA hazard — so the map lands on something meaningful.
   const [activeRisk, setActiveRisk] = useState<RiskView | null>('flood');
@@ -1334,28 +1350,68 @@ export default function OrchestratorLandingPage() {
           </BodySmall>
         </div>
 
-        {/* Map (full width) on top, participants list below. Presenting the map
-            this way keeps the orgs' states off-screen (below the fold). */}
+        {/* Tabs govern the map REGION only. The map stays mounted underneath —
+            the two card panels render as overlays over it — so switching tabs
+            never re-inits Leaflet, refetches the 2.5MB GeoJSON, or loses the
+            map's center/zoom (Leaflet greys out if init/resized while hidden).
+            The participants list below the tabs stays visible on every tab. */}
         <div className="flex flex-col gap-5">
-          {/* Map — full width */}
-          <div className="w-full">
+          <Tabs
+            value={regionTab}
+            onValueChange={v => setRegionTab(v as typeof regionTab)}
+            className="w-full"
+          >
+            <TabsList className="mb-3">
+              <TabsTrigger value="map" data-testid="region-tab-map">
+                <MapIcon className="w-3.5 h-3.5 mr-1.5" />
+                {t('orchestrator.regionTabs.map', { defaultValue: 'Mapa' })}
+              </TabsTrigger>
+              <TabsTrigger value="solutions" data-testid="region-tab-solutions">
+                <Sprout className="w-3.5 h-3.5 mr-1.5" />
+                {t('orchestrator.regionTabs.solutions', {
+                  defaultValue: 'Soluções',
+                })}
+              </TabsTrigger>
+              <TabsTrigger value="cases" data-testid="region-tab-cases">
+                <BookOpen className="w-3.5 h-3.5 mr-1.5" />
+                {t('orchestrator.regionTabs.cases', { defaultValue: 'Casos' })}
+              </TabsTrigger>
+            </TabsList>
+
             {/* `isolate`: MapLayerControls is z-400 and sits outside
                 .leaflet-container. Portalled Radix overlays are all z-50, so
                 without a local stacking context the legend paints over any
                 dialog opened from this page. */}
             <div className="relative isolate h-[56vh] md:h-[64vh] w-full">
-              <MapPanel
-                projects={projects}
-                selectedId={selectedId}
-                onSelect={setSelectedId}
-                activeRisk={activeRisk}
-                onBairroClick={handleBairroClick}
-              />
-              <MapLayerControls active={activeRisk} onChange={setActiveRisk} />
-            </div>
-          </div>
+              {/* Map is ALWAYS mounted, never in a TabsContent (which would
+                  display:none it). The overlays sit on top when active. */}
+              <div className="absolute inset-0" aria-label="Mapa" role="group">
+                <MapPanel
+                  projects={projects}
+                  selectedId={selectedId}
+                  onSelect={setSelectedId}
+                  activeRisk={activeRisk}
+                  onBairroClick={handleBairroClick}
+                />
+                <MapLayerControls active={activeRisk} onChange={setActiveRisk} />
+              </div>
 
-          {/* Participants — full-width list/grid below the map */}
+              <TabsContent
+                value="solutions"
+                className="absolute inset-0 z-[500] m-0 overflow-y-auto overscroll-contain rounded-xl border border-foreground/10 bg-background p-4 focus-visible:outline-none"
+              >
+                <NbsSolutionsGrid lang={locale} />
+              </TabsContent>
+              <TabsContent
+                value="cases"
+                className="absolute inset-0 z-[500] m-0 overflow-y-auto overscroll-contain rounded-xl border border-foreground/10 bg-background p-4 focus-visible:outline-none"
+              >
+                <NbsCasesGrid cards={NBS_SHOWCASE_CARDS} lang={locale} />
+              </TabsContent>
+            </div>
+          </Tabs>
+
+          {/* Participants — full-width list/grid below the tabs, always visible */}
           <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {projects.map((p, i) => {
               const member = memberById.get(p.id);

--- a/e2e/cougar-orchestrator-nbs-tabs.spec.ts
+++ b/e2e/cougar-orchestrator-nbs-tabs.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Orchestrator region tabs (Mapa / Soluções / Casos). The tabs govern the map
+// region only; the participant list stays visible below on every tab. Guards the
+// two things most likely to regress:
+//   1. The map is never unmounted — switching to Soluções and back keeps the
+//      SAME Leaflet instance (no re-init, no 2.5MB GeoJSON refetch, keeps view).
+//   2. The desktop detail opens as a centered dialog with prev/next, not a
+//      mobile bottom sheet, over the full viewport.
+
+test.describe('COUGAR — orchestrator NBS tabs', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('tabs swap the map region; map persists; solutions dialog navigates', async ({
+    page,
+    request,
+  }) => {
+    const api = new TestApi(page.request);
+    await api.createCoordinator({
+      email: `tabs-${randomUUID()}@e2e.test`,
+      password: 'tabs-pass-123',
+      name: 'Tabs',
+    });
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    const member = (
+      await new TestApi(request).inviteMember(mine.cohort.id, {
+        orgName: 'Org Tabs',
+        withSession: true,
+      })
+    ).member;
+
+    await page.goto('/orchestrator');
+    const mapBox = page.locator('.leaflet-container').first();
+    await expect(mapBox).toBeVisible({ timeout: 20_000 });
+
+    // Tag the live Leaflet container so we can prove it's the same node later.
+    await mapBox.evaluate(el => el.setAttribute('data-persist-probe', 'v1'));
+
+    const participant = page.getByTestId(
+      `card-orchestrator-project-${member.id}`
+    );
+    await expect(participant, 'participant list visible on Mapa').toBeVisible();
+
+    // → Soluções: the six type cards render; the map is hidden underneath.
+    await page.getByTestId('region-tab-solutions').click();
+    await expect(
+      page.locator('[data-testid^="type-card-"]').first()
+    ).toBeVisible();
+    expect(await page.locator('[data-testid^="type-card-"]').count()).toBe(6);
+    await expect(
+      participant,
+      'participant list stays visible on Soluções'
+    ).toBeVisible();
+
+    // Open the detail dialog on the 2nd type; it's a centered dialog, not a sheet.
+    await page.getByTestId('type-expand-flood-parks').click();
+    const dialog = page.getByTestId('nbs-type-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(page.getByTestId('nbs-type-sheet')).toHaveCount(0); // not the mobile drawer
+    await expect(dialog.locator('.tabular-nums')).toHaveText('2 / 6');
+
+    // prev/next walk the ordered six.
+    await page.getByTestId('nbs-type-dialog-prev').click();
+    await expect(dialog.locator('.tabular-nums')).toHaveText('1 / 6');
+    await expect(page.getByTestId('nbs-type-dialog-prev')).toBeDisabled(); // at the first
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+
+    // → Casos: the case-study cards render.
+    await page.getByTestId('region-tab-cases').click();
+    await expect(
+      page.locator('[data-testid^="showcase-card-"]').first()
+    ).toBeVisible();
+
+    // → back to Mapa: the SAME Leaflet instance is still there (our probe attr
+    // survived), proving it was never unmounted/re-initialized.
+    await page.getByTestId('region-tab-map').click();
+    await expect(mapBox).toBeVisible();
+    await expect(
+      page.locator('.leaflet-container[data-persist-probe="v1"]')
+    ).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
Adds a tab bar under the stats row (`LOCAIS MAPEADOS` / `PERFIS EM ANDAMENTO` / `PERFIS COMPLETOS`) that swaps the **map region only** between three views — the bairro **Mapa**, the six NBS **Soluções** cards, and the Brazilian **Casos** case studies. The participant list below the tabs stays visible on every tab.

Builds directly on the croquis + type cards from #390 (merged).

## Reuse, not fork — the CBO chat and the orchestrator stay in lockstep

The point of this PR is that a content edit reaches both surfaces automatically. To get there it extracts two shared leaves out of the mobile components:

- **`NbsTypeCard`** — the leaf card (croqui + name + one line + 3 chips), now headless with no width of its own, so it fills a 240px snap item in the chat *or* a grid track on desktop.
- **`NbsTypeDetailContent`** — one type's full teaching content (before/after, o que muda, o que é preciso, custo, quando não funciona, não é isso). Both surfaces render this exact node.

Only the **layout wrapper** and the **detail shell** differ per surface, which is the correct axis of difference:

| | Mobile CBO chat | Desktop orchestrator |
|---|---|---|
| Card layout | horizontal snap strip (`NbsTypeStrip`) | 3-col grid (`NbsDesktopGrids`) |
| Detail shell | vaul **Drawer**, scrolls all six (`NbsTypeSheet`) | centered Radix **Dialog** on the tapped type + prev/next (`NbsTypeDialog`) |

The desktop dialog portals to `<body>`, so it centers over the full viewport even though the card that opened it lives inside the fixed-height, overflow-scrolled tab panel. The mobile chat behaviour is unchanged — the sheet was just re-pointed at the shared content leaf.

**Casos** reuses `NbsShowcaseCardItem` in browse mode: the three named projects with a verified photo show it, the other three keep their gradient+emoji placeholder (same as the CBO chat renders today, per `photo-curation.md`).

## The map never unmounts

The Leaflet map is lifted **out** of the tab machinery — it stays permanently mounted as a plain child of the fixed-height box, and the two card panels render as opaque overlays over it. So switching tabs never unmounts or re-initializes the map, never refetches the 2.5MB GeoJSON, and never greys out (Leaflet renders a single grey tile if it's initialized or resized while `display:none`). No `invalidateSize()` juggling needed because the map's box never resizes on a tab flip.

Zero new dependencies — `Tabs`, `Dialog`, and `vaul` were already in the repo.

## Verification

Playwright at 1024px and 1440px, light and dark: the tabs swap, the map keeps the **same Leaflet instance** across a Soluções→Mapa round-trip (a probe attribute set on the live container survives), the desktop detail opens as a centered dialog (asserts the mobile `nbs-type-sheet` is *not* present) with working prev/next and a `2 / 6` counter, and the participant list stays visible on every tab. Mobile CBO chat re-checked for regression (strip + drawer still land on the tapped type, no horizontal overflow at 390px). New spec: `e2e/cougar-orchestrator-nbs-tabs.spec.ts`. `npx tsc --noEmit` adds no new errors (4 pre-existing on `main`, in untouched files); production `vite build` passes.

## Notes

- Components stay in `client/src/core/components/cbo/` (they're now shared with the orchestrator; a rename to a neutral folder was considered and deferred to avoid churn).
- The `NbsShowcaseCardStrip` still reads `i18n.language` internally (a known pre-fetch-race smell) — untouched here because this PR reuses the leaf `NbsShowcaseCardItem` directly with an explicit `lang`. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)