### PR TITLE
Cohort rename endpoint + per-org removal (keeps org data, reuses it on re-invite)

### DIFF
--- a/client/src/core/components/orchestrator/CohortDialogs.tsx
+++ b/client/src/core/components/orchestrator/CohortDialogs.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, Check, Copy, ExternalLink, Link as LinkIcon, MessageCircle, Plus, RotateCcw, Send, Users } from 'lucide-react';
+import { AlertTriangle, Check, Copy, ExternalLink, Link as LinkIcon, MessageCircle, Plus, RotateCcw, Send, Trash2, Users } from 'lucide-react';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter,
   DialogHeader, DialogTitle,
@@ -915,6 +915,55 @@ export function MemberResetConfirmDialog({
           >
             <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
             {busy ? t('common.working', { defaultValue: 'Working…' }) : t('orchestrator.memberReset.confirm', { defaultValue: 'Yes, reset this org' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MemberRemoveConfirmDialog — removes ONE org from the cohort entirely (unlike
+// reset, which keeps the member + invite link). The invite link stops working
+// and the card disappears from the roster; the org's uploaded documents are
+// kept server-side and relink if the same org name is invited again.
+// ---------------------------------------------------------------------------
+export function MemberRemoveConfirmDialog({
+  open, orgName, onOpenChange, onConfirm,
+}: {
+  open: boolean;
+  orgName: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}) {
+  const { t } = useTranslation();
+  const [busy, setBusy] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-destructive" />
+            {t('orchestrator.memberRemove.title', { defaultValue: 'Remove {{org}} from the cohort?', org: orgName })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('orchestrator.memberRemove.desc', {
+              defaultValue: 'Removes this organization from the cohort: the invite link stops working and its conversation and progress are erased. Uploaded documents are kept and come back if you invite the same organization name again. This can’t be undone.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => { setBusy(true); try { await onConfirm(); } finally { setBusy(false); } }}
+            disabled={busy}
+            data-testid="button-confirm-member-remove"
+          >
+            <Trash2 className="w-3.5 h-3.5 mr-1.5" />
+            {busy ? t('common.working', { defaultValue: 'Working…' }) : t('orchestrator.memberRemove.confirm', { defaultValue: 'Yes, remove this org' })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -48,6 +48,7 @@ export interface UseCohortResult {
   provisionCohort: (input: ProvisionInput) => Promise<{ ok: boolean; error?: string; coordinatorEmail?: string }>;
   resetCohort: () => Promise<void>;
   resetMember: (memberId: string) => Promise<boolean>;
+  removeMember: (memberId: string) => Promise<boolean>;
   invite: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
@@ -149,6 +150,15 @@ export function useCohort(): UseCohortResult {
     return r.ok;
   }, [refresh]);
 
+  // Remove ONE org from the cohort — the invite link dies and the card
+  // disappears. The org's documents survive server-side and relink if the
+  // same org name is re-invited later.
+  const removeMember = useCallback(async (memberId: string) => {
+    const r = await fetch(`/api/cohort/${slugRef.current}/member/${memberId}`, { method: 'DELETE' });
+    await refresh();
+    return r.ok;
+  }, [refresh]);
+
   const invite: UseCohortResult['invite'] = useCallback(async ({ orgName, neighborhood, orgType }) => {
     const r = await fetch(`/api/cohort/${slugRef.current}/invite`, {
       method: 'POST',
@@ -203,6 +213,6 @@ export function useCohort(): UseCohortResult {
   return {
     loading, cohort, members, isAdmin, allCohorts,
     refresh, refreshAllCohorts, switchCohort, provisionCohort,
-    resetCohort, resetMember, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
+    resetCohort, resetMember, removeMember, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
   };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -48,6 +48,7 @@ import {
   BulkInviteSummaryDialog,
   ResetConfirmDialog,
   MemberResetConfirmDialog,
+  MemberRemoveConfirmDialog,
   DeleteCohortConfirmDialog,
   ProvisionCohortDialog,
   type BulkInviteResult,
@@ -603,6 +604,7 @@ function ProjectCard({
   onOpenCbo,
   onSetTier,
   onResetProfile,
+  onRemove,
 }: {
   project: CboDemoProject;
   locale: 'en' | 'pt';
@@ -612,6 +614,7 @@ function ProjectCard({
   onOpenCbo: (p: CboDemoProject, tab: 'arquivos' | 'conversa' | 'perfil') => void;
   onSetTier: (p: CboDemoProject, tier: 'emerging' | 'developing' | 'advanced') => void;
   onResetProfile: (p: CboDemoProject) => void;
+  onRemove: (p: CboDemoProject) => void;
 }) {
   const { t } = useTranslation();
   const hasIntervention = project.interventionKey !== null;
@@ -764,6 +767,18 @@ function ProjectCard({
               <RotateCcw className="w-3 h-3" strokeWidth={2} />
               {t('orchestrator.memberReset.chip', { defaultValue: 'Reset' })}
             </button>
+            {/* Remove the org from the cohort entirely (invite link dies).
+                Opens a confirm dialog — unlike Reset, the member is gone. */}
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); onRemove(project); }}
+              className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full border border-foreground/15 text-foreground/70 hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
+              title={t('orchestrator.memberRemove.chipTooltip', { defaultValue: 'Remove this organization from the cohort' })}
+              data-testid={`button-cbo-remove-${project.id}`}
+            >
+              <Trash2 className="w-3 h-3" strokeWidth={2} />
+              {t('orchestrator.memberRemove.chip', { defaultValue: 'Remove' })}
+            </button>
             {hasIntervention ? (
               <span
                 className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${toneStyle.bubble} ${toneStyle.fg} border-foreground/10`}
@@ -892,7 +907,7 @@ export default function OrchestratorLandingPage() {
 
   const {
     cohort, members, isAdmin, allCohorts,
-    invite, unlockPhase, saveWorkshops, resetCohort, resetMember, saveLanguage, deleteCohort,
+    invite, unlockPhase, saveWorkshops, resetCohort, resetMember, removeMember, saveLanguage, deleteCohort,
     switchCohort, provisionCohort, refresh,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
@@ -960,6 +975,8 @@ export default function OrchestratorLandingPage() {
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   // Per-org reset: the card whose profile is about to be erased (null = closed).
   const [memberResetTarget, setMemberResetTarget] = useState<CboDemoProject | null>(null);
+  // Per-org remove: the card about to leave the cohort entirely (null = closed).
+  const [memberRemoveTarget, setMemberRemoveTarget] = useState<CboDemoProject | null>(null);
   const [provisionOpen, setProvisionOpen] = useState(false);
   const [supportInboxOpen, setSupportInboxOpen] = useState(false);
   // Mirrored from /support-requests?status=pending — drives the badge on
@@ -1039,6 +1056,18 @@ export default function OrchestratorLandingPage() {
       title: ok
         ? t('orchestrator.memberReset.done', { defaultValue: '{{org}} reset — the invite link starts fresh', org: target.name[locale] })
         : t('orchestrator.memberReset.failed', { defaultValue: 'Could not reset {{org}}', org: target.name[locale] }),
+    });
+  };
+
+  const handleMemberRemoveConfirm = async () => {
+    const target = memberRemoveTarget;
+    setMemberRemoveTarget(null);
+    if (!target) return;
+    const ok = await removeMember(target.id);
+    toast({
+      title: ok
+        ? t('orchestrator.memberRemove.done', { defaultValue: '{{org}} removed from the cohort', org: target.name[locale] })
+        : t('orchestrator.memberRemove.failed', { defaultValue: 'Could not remove {{org}}', org: target.name[locale] }),
     });
   };
 
@@ -1433,6 +1462,7 @@ export default function OrchestratorLandingPage() {
                     onOpenCbo={openCbo}
                     onSetTier={handleSetTier}
                     onResetProfile={setMemberResetTarget}
+                    onRemove={setMemberRemoveTarget}
                   />
                   {member && (
                     <div className="mt-1.5 flex items-center justify-between gap-2 px-1 text-[11px] text-muted-foreground">
@@ -1474,6 +1504,12 @@ export default function OrchestratorLandingPage() {
         orgName={memberResetTarget?.name[locale] ?? ''}
         onOpenChange={(open) => { if (!open) setMemberResetTarget(null); }}
         onConfirm={handleMemberResetConfirm}
+      />
+      <MemberRemoveConfirmDialog
+        open={memberRemoveTarget != null}
+        orgName={memberRemoveTarget?.name[locale] ?? ''}
+        onOpenChange={(open) => { if (!open) setMemberRemoveTarget(null); }}
+        onConfirm={handleMemberRemoveConfirm}
       />
       <DeleteCohortConfirmDialog
         open={deleteConfirmOpen}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -319,6 +319,15 @@
       "confirm": "Sim, resetar esta org",
       "done": "{{org}} resetada — o link de convite recomeça do zero",
       "failed": "Não foi possível resetar {{org}}"
+    },
+    "memberRemove": {
+      "chip": "Remover",
+      "chipTooltip": "Remover esta organização da coorte",
+      "title": "Remover {{org}} da coorte?",
+      "desc": "Remove esta organização da coorte: o link de convite deixa de funcionar e a conversa e o progresso são apagados. Os documentos enviados são mantidos e voltam se você convidar o mesmo nome de organização de novo. Não dá para desfazer.",
+      "confirm": "Sim, remover esta org",
+      "done": "{{org}} removida da coorte",
+      "failed": "Não foi possível remover {{org}}"
     }
   },
   "citySelection": {

--- a/docs/cougar-runbook.md
+++ b/docs/cougar-runbook.md
@@ -1,7 +1,8 @@
 # COUGAR / Vila Flores — Coordinator Runbook
 
 How to provision a coordinator, set up a cohort, invite community orgs (CBOs),
-re-issue links, and clean up. For the platform at `https://nbs-project-preparation.replit.app`.
+re-issue links, and clean up. For the platform at `https://cougar-nbs.replit.app`
+(the old `nbs-project-preparation.replit.app` URL is dead).
 
 > **Roles in one line.** *Coordinators* log in and manage a cohort. *CBOs never
 > log in* — their invite link (`?t=<token>`) is their sole credential.
@@ -71,6 +72,9 @@ Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 - **Workshops:** the cadence rail shows the 6 workshops as collapsible rows.
   Schedule a date, and click **Open for cohort** on the next-up workshop to
   unlock that phase for every org.
+- **Rename:** `PATCH /api/cohort/<coordinatorSlug>/name` with `{"name": "..."}`
+  (coordinator/admin cookie). Only the display name changes — invite links and
+  coordinator logins are untouched. No UI yet.
 
 ---
 
@@ -91,6 +95,8 @@ Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 
 | Action | What it does | Where |
 |---|---|---|
+| **Reset one org** | Erases the org's session + progress; the member row, invite link, and unlocks **stay**. | Card → **Reset** |
+| **Remove one org** | Deletes the member: invite link dies, card disappears. The org row + uploaded documents are **kept** and relink if the same org name is re-invited. | Card → **Remove** |
 | **Reset cohort** | Removes every invited CBO + clears workshop progress. The cohort row **stays** (same singleton, fresh state). | Header → **Reset** |
 | **Delete cohort** *(admin)* | Removes the cohort **and** its members entirely. The default cohort is re-created empty on next load. | Header → **Delete cohort** |
 | **Namespaced test data** | The e2e harness namespaces its data (`e2e-*` cohorts, `*@e2e.test` coordinators) and purges it via `POST /__test/cleanup` (gated by `ENABLE_TEST_ROUTES`). | test only |

--- a/e2e/cougar-member-remove.spec.ts
+++ b/e2e/cougar-member-remove.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Per-org REMOVAL (vs reset, which keeps the member): card chip → confirm
+// dialog → the member row is deleted, so the invite link dies and the card
+// leaves the board. The organization row survives on purpose — re-inviting
+// the same org name must relink to it (documents come back) instead of
+// minting a duplicate organizations row.
+
+test.describe('COUGAR — remove an organization from the cohort', () => {
+  test('remove chip deletes the member; re-inviting the same name reuses the org', async ({ page }) => {
+    const api = new TestApi(page.request);
+    const { cohort } = await api.createCohort('e2e member-remove');
+    await api.createCoordinator({ email: `coord-${randomUUID()}@e2e.test`, password: 'coord-pass-1', cohortId: cohort.id });
+
+    const invited = await api.inviteMember(cohort.id, { orgName: 'Org RemoveMe', neighborhood: 'Sarandi', withSession: true });
+    const stateId: string = invited.member.cboStateId;
+    const orgId: string = invited.member.orgId;
+    const token: string = invited.member.capabilityToken;
+    expect(stateId).toBeTruthy();
+    expect(orgId).toBeTruthy();
+
+    await page.goto('/orchestrator');
+    const card = page.getByTestId(`card-orchestrator-project-${invited.member.id}`);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+
+    // Remove chip → confirm dialog names the org → confirm.
+    await card.getByTestId(`button-cbo-remove-${invited.member.id}`).click();
+    await expect(page.getByText('Remove Org RemoveMe from the cohort?')).toBeVisible();
+    await page.getByTestId('button-confirm-member-remove').click();
+
+    // The member row is gone: card off the board, roster empty of it.
+    await expect(card).not.toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => {
+      const mine = await (await page.request.get('/api/cohort/mine')).json();
+      return (mine.members ?? []).some((x: any) => x.id === invited.member.id);
+    }, { timeout: 15_000 }).toBe(false);
+
+    // The invite link is dead and the working session deleted.
+    expect((await page.request.get(`/api/cbo-member/by-token/${token}`)).status()).toBe(404);
+    expect((await page.request.get(`/api/cbo/${stateId}`)).status()).toBe(404);
+
+    // Re-invite the SAME org name through the real coordinator invite: the
+    // kept organizations row is reused, not duplicated.
+    const reinvite = await (await page.request.post(`/api/cohort/${cohort.coordinatorSlug}/invite`, {
+      data: { orgName: 'Org RemoveMe', neighborhood: 'Sarandi' },
+    })).json();
+    expect(reinvite.member.id).not.toBe(invited.member.id);
+    expect(reinvite.member.orgId, 'same-name re-invite must relink the kept org').toBe(orgId);
+  });
+
+  test('cohort rename changes only the display name; invites keep working', async ({ page }) => {
+    const api = new TestApi(page.request);
+    const { cohort } = await api.createCohort('e2e rename-before');
+    await api.createCoordinator({ email: `coord-${randomUUID()}@e2e.test`, password: 'coord-pass-1', cohortId: cohort.id });
+    const invited = await api.inviteMember(cohort.id, { orgName: 'Org SurvivesRename' });
+
+    const r = await page.request.patch(`/api/cohort/${cohort.coordinatorSlug}/name`, {
+      data: { name: 'e2e rename-after' },
+    });
+    expect(r.ok()).toBe(true);
+
+    const mine = await (await page.request.get('/api/cohort/mine')).json();
+    expect(mine.cohort.name).toBe('e2e rename-after');
+    expect(mine.cohort.coordinatorSlug).toBe(cohort.coordinatorSlug);
+    // The member's invite token still resolves to the (renamed) cohort.
+    const byToken = await (await page.request.get(`/api/cbo-member/by-token/${invited.member.capabilityToken}`)).json();
+    expect(byToken.cohort?.name).toBe('e2e rename-after');
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -527,8 +527,24 @@ export function registerCohortRoutes(app: Express): void {
     // block the invite, so org_id just stays null and the backfill picks it up.
     let orgId: string | null = null;
     try {
-      const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: orgType === 'implementer' ? 'implementer' : 'community', cohortId: cohort.id });
-      orgId = org.id;
+      // Reuse an existing same-name org in this cohort (e.g. a previously
+      // removed member being re-invited): its identity, documents, and any
+      // profile the platform accumulated come back, instead of minting a
+      // duplicate organizations row (name has no unique constraint).
+      const [existingOrg] = await db.select().from(organizations)
+        .where(and(eq(organizations.name, String(orgName)), eq(organizations.cohortId, cohort.id)))
+        .limit(1);
+      if (existingOrg) {
+        orgId = existingOrg.id;
+        // The invite is where the coordinator declares the type (EF-5) — an
+        // explicit implementer re-invite upgrades a reused community/unknown row.
+        if (orgType === 'implementer' && existingOrg.type !== 'implementer') {
+          await db.update(organizations).set({ type: 'implementer' }).where(eq(organizations.id, existingOrg.id));
+        }
+      } else {
+        const org = await createOrganization({ name: orgName, city: 'porto-alegre', type: orgType === 'implementer' ? 'implementer' : 'community', cohortId: cohort.id });
+        orgId = org.id;
+      }
     } catch (e: any) {
       console.error('[cohort] org creation failed on invite (continuing, backfill will link):', e?.message || e);
     }
@@ -579,6 +595,19 @@ export function registerCohortRoutes(app: Express): void {
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), language };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true, language: language ?? null });
+  }));
+
+  // Rename the cohort. Only the display name changes — id, coordinatorSlug,
+  // coordinator scoping, and member invite tokens are untouched, so live
+  // invites keep working across a rename.
+  app.patch('/api/cohort/:coordinatorSlug/name', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const name = String(req.body?.name ?? '').trim();
+    if (!name) { res.status(400).json({ error: 'name required' }); return; }
+    await db.update(cohorts).set({ name }).where(eq(cohorts.id, cohort.id));
+    res.json({ ok: true, name });
   }));
 
   // Unlock a phase — for one member, multiple members, or 'all'
@@ -709,6 +738,30 @@ export function registerCohortRoutes(app: Express): void {
       snapshotUpdatedAt: new Date(),
     }).where(eq(cohortMembers.id, member.id));
 
+    res.json({ ok: true, memberId: member.id, orgName: member.orgName });
+  }));
+
+  // Remove ONE member from the cohort entirely — the invite link dies and the
+  // org disappears from the roster. Deletes the member row and its working
+  // session (state + transcript). The organization row and its uploaded
+  // documents are deliberately KEPT: re-inviting the same org name relinks to
+  // them (the invite endpoint reuses an existing same-name org in the cohort
+  // instead of minting a duplicate). Guarded by the :coordinatorSlug app.param
+  // ownership check like every cohort route.
+  app.delete('/api/cohort/:coordinatorSlug/member/:memberId', wrap(async (req, res) => {
+    const member = await memberInCohort(req);
+    if (!member) { res.status(404).json({ error: 'member not found' }); return; }
+
+    if (member.cboStateId) {
+      await deleteCboState(member.cboStateId);
+      setCboState(member.cboStateId, undefined as any);
+    }
+    // The tier was calibrated from the run being deleted — a future re-invite
+    // must not inherit it (same rationale as per-member reset).
+    if (member.orgId) {
+      await db.update(organizations).set({ maturityTier: null }).where(eq(organizations.id, member.orgId));
+    }
+    await db.delete(cohortMembers).where(eq(cohortMembers.id, member.id));
     res.json({ ok: true, memberId: member.id, orgName: member.orgName });
   }));
 


### PR DESCRIPTION
## Why

Provisioning **Rede SCbN POA**: the cohort currently named "Rede Learning Journey" (with its 4 scoped coordinators + 1 invited org) needs to become "Rede SCbN POA", and coordinators had no way to remove an invited org — only per-org reset (which keeps the member) or nuking the whole cohort.

## What

- **`PATCH /api/cohort/:coordinatorSlug/name`** — rename in place. Only the display name changes; `id`, `coordinatorSlug`, coordinator scoping, and member invite tokens are untouched, so live invites keep working.
- **`DELETE /api/cohort/:coordinatorSlug/member/:memberId`** — remove one org: invite link dies, member row + working session (state/transcript) deleted, card leaves the roster. The `organizations` row and its uploaded documents are **deliberately kept**.
- **Invite reuses a same-name org**: previously `organizations.name` had no uniqueness and every invite inserted a new row — re-inviting a removed org would duplicate it and orphan its documents. The invite now relinks an existing same-name org in the cohort; an explicit implementer re-invite upgrades a reused community/unknown row.
- **Console**: `Remove` chip on the CBO card next to `Reset`, with a confirm dialog spelling out the semantics (pt + en).
- **Docs**: `cougar-runbook.md` now shows the real prod URL (`cougar-nbs.replit.app` — the old `nbs-project-preparation.replit.app` is dead) and documents rename + remove-vs-reset.

## Safe vs assumed

- **Safe**: `ProjectCard` is file-local (single caller updated); `useCohort` consumers grepped — only `orchestrator-landing.tsx`. `tsc --noEmit` clean on touched files.
- **Assumed**: sharing one `organizations` row when a coordinator invites the same org name twice *while both are active* is intended (it's the same real-world org).

## Verification

Local Playwright e2e (local Postgres, fake model): new `e2e/cougar-member-remove.spec.ts` — remove → card gone, token 404, session 404, same-name re-invite returns the **same orgId**; rename → `/mine` shows new name, member token still resolves. Existing `cougar-member-reset.spec.ts` still passes.

## After merge

**Rebuild + republish the Repl**, then rename prod: `PATCH /api/cohort/50TkC-PsC2Ss-qTd_Mj49ri5/name {"name":"Rede SCbN POA"}` (admin cookie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)