### PR TITLE
COUGAR quick fixes: pre-chat scroll on desktop, one-option ask_user → prose, free activity selection

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -767,7 +767,15 @@ export default function CboProfilePage() {
   // LOCK the document so only the inner message list scrolls — the page can't
   // scroll, so the chrome can't move and the bottom bar is pinned. Both are
   // scoped to this page and restored on unmount.
+  //
+  // Scoped to the CHAT shell only: the welcome/preamble screens have no inner
+  // scroller, so they need normal document scroll — locking during them
+  // stranded the CTA below the fold on short desktop viewports (field report
+  // 2026-07: "intro page is not scrolling so in the PC view you can not
+  // completely see the button to continue").
+  const preChatScreen = welcomeMode || preambleEncontro != null;
   useEffect(() => {
+    if (preChatScreen) return;
     const root = document.documentElement;
     const body = document.body;
     const mount = document.getElementById('root');
@@ -814,7 +822,7 @@ export default function CboProfilePage() {
       body.style.overscrollBehavior = prev.bodyOverscroll;
       if (mount) { mount.style.height = prev.mountHeight; mount.style.overflow = prev.mountOverflow; }
     };
-  }, []);
+  }, [preChatScreen]);
 
   // Auto-scroll to related sections when question changes
   useEffect(() => {

--- a/e2e/cougar-welcome-scroll.spec.ts
+++ b/e2e/cougar-welcome-scroll.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Field report 2026-07 — "Intro page (before entering the chat) is not
+// scrolling so in the PC view you can not completely see the button to
+// continue." Root cause: the chat shell's document scroll-lock (html/body
+// overflow:hidden, needed to pin the composer on mobile) ran unconditionally,
+// including while the welcome/preamble screens were up — and those screens
+// have no inner scroller of their own. The fix scopes the lock to the chat
+// shell. NOTE: we assert on computed styles + real scrolling, not on clicking
+// the CTA — Playwright's click auto-scrolls via scrollIntoView, which works
+// even inside overflow:hidden and would mask the bug.
+
+test.use({ viewport: { width: 1280, height: 420 } }); // short desktop window → CTA below the fold
+
+test.describe('COUGAR — pre-chat screens scroll on desktop', () => {
+  test('welcome screen scrolls; the lock re-engages once the chat shell shows', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const { cohort } = await api.createCohort('e2e welcome-scroll');
+    const invited = await api.inviteMember(cohort.id, { orgName: 'Org Rolagem' });
+
+    await page.goto(invited.inviteUrl);
+    const cta = page.getByTestId('button-cbo-welcome-cta');
+    await expect(cta).toBeAttached({ timeout: 30_000 });
+
+    // The document must NOT be scroll-locked while the welcome screen is up.
+    const overflows = () => page.evaluate(() => ({
+      html: getComputedStyle(document.documentElement).overflow,
+      body: getComputedStyle(document.body).overflow,
+    }));
+    expect(await overflows()).not.toMatchObject({ body: 'hidden' });
+
+    // And scrolling actually works — the welcome content overflows this short
+    // viewport, so a user-style scroll must move the page (reach the CTA).
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    expect(await page.evaluate(() => window.scrollY), 'welcome page must scroll on a short desktop viewport').toBeGreaterThan(0);
+    await expect(cta).toBeInViewport();
+
+    await cta.click();
+
+    // The preamble (if shown) is also pre-chat → still unlocked.
+    const pre = page.getByTestId('button-encontro-1-start');
+    if (await pre.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      expect((await overflows()).body, 'preamble must also keep document scroll').not.toBe('hidden');
+      await pre.click();
+    }
+
+    // Chat shell up → the mobile pin-the-composer lock re-engages.
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    await expect.poll(async () => (await overflows()).body, { timeout: 10_000 }).toBe('hidden');
+  });
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -98,7 +98,7 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 2. `contact_name` — who's talking with us
 3. `contact_role` — their role in the org — **capture only if volunteered.** Ask name+role together once (Step 0); if the answer brings only a name, take it and move on. Never spend a turn chasing the role — it gates nothing.
 4. `mission_summary` — the org's mission in one sentence, **in their words** — asked as the SECOND question of the encontro (free-text prose, right after Step 0), before the activity list. It matters for almost any funding application, and answering it first makes the org reflect before picking activities.
-5. `main_activities` — **multi-select, up to 3**: Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária. (Most orgs do more than one thing; the list itself is still being refined with Vila Flores.)
+5. `main_activities` — **multi-select, no cap**: Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária. (Most orgs do more than one thing — let them pick as many as apply; the list itself is still being refined with Vila Flores.)
 6. `has_cnpj` — enum: Sim, temos CNPJ · Ainda não · Não temos certeza. Asked BEFORE the org-type question — formalization is what actually gates fundraising.
 7. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
 8. `year_founded` — org-age **bucket**, captured as a chip (Começando agora / Menos de 2 anos / 2 a 5 anos / 5 a 10 anos / Mais de 10 anos) — a tap, not a typed year; works for informal groups too ("tempo que vocês fazem esse trabalho")
@@ -192,7 +192,7 @@ For everything still unknown, send **grouped `ask_user` calls** — one call car
 **Build each batch ONLY from questions whose fields are still empty in CURRENT STATE.** A document (or the invite) filling a field removes its question from the batch — the bulk-confirm in Step 1 already validated it. Re-asking something the panel already shows is the single most-reported field bug: after a link upload the org answered the same questions twice. If a batch would end up with zero questions, skip it entirely.
 
 **Batch A — quem são** (one `ask_user`):
-1. *O que vocês fazem? Pode escolher até 3.* (multi-select, max 3) — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária → `main_activities`
+1. *O que vocês fazem?* (multi-select, no cap — most orgs do several things; never tell the user to limit their picks) — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária → `main_activities`
 2. *Vocês têm CNPJ?* — Sim, temos CNPJ · Ainda não · Não temos certeza → `has_cnpj`
 3. *Que tipo de organização?* — ONG / Associação · Cooperativa · Coletivo informal · Empresa social · Empresa / estúdio / escritório técnico · Outra → `legal_form`
 4. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos → `year_founded`

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -529,10 +529,24 @@ Include showMap: true on a question only when the user genuinely needs the map t
       if (empty.length > 0) {
         return { content: [{ type: "text" as const, text: `NOT shown — ${empty.length} question(s) had no options. ask_user is only for chip questions (2-7 buckets). A question with no natural buckets (mission, name, story) must be asked as PLAIN TEXT in your message, with no tool call. Re-ask now: chip questions via ask_user, free-text ones as prose.` }], isError: true };
       }
+      // A ONE-option "list" is a free-text question wearing a chip costume —
+      // the user has to tap the lone chip (e.g. "Me conta") just to unlock the
+      // text input (field report 2026-07: "weird option, like a one-option
+      // list … a little bit confusing"). The skill forbids it but the model
+      // still does it, so convert server-side: deliver the question as plain
+      // chat prose instead of a composer. No isError — the question DID reach
+      // the user; an error retry would double-ask it.
+      let converted = 0;
       for (const q of args.questions || []) {
-        pushEvent({ type: 'ask_user', question: q.question, options: q.options || [], relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
+        if ((q.options?.length ?? 0) === 1) {
+          pushEvent({ type: 'chat', content: q.question, role: 'assistant' } as any);
+          converted++;
+        } else {
+          pushEvent({ type: 'ask_user', question: q.question, options: q.options || [], relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
+        }
       }
-      return { content: [{ type: "text" as const, text: `${(args.questions || []).length} question(s) shown. STOP and wait.` }] };
+      const note = converted > 0 ? ` (${converted} single-option question(s) delivered as plain text instead — a one-option list is a free-text question; next time ask it as prose with no tool call)` : '';
+      return { content: [{ type: "text" as const, text: `${(args.questions || []).length} question(s) shown.${note} STOP and wait.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );


### PR DESCRIPTION
Three quick items from Ana's Tech Space feedback page (refined with JVP 2026-07-13).

## 1. Welcome/preamble screens couldn't scroll on PC
> "Intro page (before entering the chat) is not scrolling so in the PC view you can not completely see the button to continue"

Root cause: the chat shell's document scroll-lock (`html/body overflow:hidden`, needed to pin the composer + tab bar on mobile) ran unconditionally on page mount — including while `CboWelcome`/`EncontroPreamble` were showing, and those screens have no inner scroller. Fix: the lock is now gated on `preChatScreen` (`welcomeMode || preambleEncontro != null`) and re-engages when the chat shell renders.

## 2. One-option "Me conta" chip list
> "there is this weird option, like a one-option list, which says 'Tell me about it'"

The `ask_user` guard only rejected *empty* option lists; a 1-option list passed and rendered a lone chip the user had to tap just to unlock the text input. The tool handler now delivers single-option questions as plain chat prose (persisted as a normal content message) and nudges the model in the tool result. Deliberate single-chip affordances (silent-turn "Continuar" recovery, E2 entry template) push their events directly and are intentionally unaffected — as are the ~9 e2e specs that script single-option turn-enders through the fake model (an event-level driver, same seam as the existing empty-options guard).

## 3. "Pode escolher até 3" on the activities question
> "Although it says is possible to select only three, it is possible to select all … just leave it free"

Removed the cap wording from the E1 skill (both the question script and the field notes). There was never any code enforcement — `mapValue` accepts any number of selections — so this is copy-only.

## Testing
- New `e2e/cougar-welcome-scroll.spec.ts`: short desktop viewport → asserts computed `overflow` + real `window.scrollY` movement on the welcome screen (NOT CTA clicks — Playwright auto-scroll works inside `overflow:hidden` and would mask the bug), preamble also unlocked, lock re-engaged once the chat shell shows. **Verified it fails on the unfixed code.**
- Regression battery passed: mobile-layout, mobile-no-hscroll, invite-session (welcome click-through), batched-questions, instant-kickoff.
- Known/safe vs assumed: the one-option conversion has no automated test path (repo has no unit runner; the real tool handler is only reachable via the live SDK) — verified by code-reading the persistence path (`chat` events persist as `messageType: 'content'`, same as the E2 entry template).

Also noted while refining: the "you can change any answer" hint Ana requested already shipped in E1 questionnaire v2 (`12f5a0e4`) — that Notion item can be ticked with no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)