### PR TITLE
CBO chat: live tool-activity labels instead of generic "Processando…"

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -501,6 +501,13 @@ export default function CboProfilePage() {
   // inline-options normalizer) REPLACES it, so persistence and conversion
   // still operate on whole blocks. Never persisted, cleared on any finalizer.
   const [streamDraft, setStreamDraft] = useState('');
+  // Live per-tool activity label ("Lendo o site…", "Atualizando a ficha…")
+  // emitted as 'thinking_step' events while the agent runs tools. Replaces the
+  // generic "Processando…" in the working indicator; ephemeral — cleared as
+  // soon as text starts streaming or the turn ends, never persisted. (Field
+  // report 2026-07: users only ever saw "processando" and couldn't tell the
+  // agent was e.g. reading their website.)
+  const [activeToolLabel, setActiveToolLabel] = useState<string | null>(null);
   // Live mirror of cboId + the in-flight stream's handle. Restart/unmount
   // abort the stream DELIBERATELY; the catch below must distinguish that (and
   // an abort belonging to an already-replaced session) from a genuine drop —
@@ -943,7 +950,14 @@ export default function CboProfilePage() {
         // Transient draft text — replaced wholesale when the finalizing
         // 'chat' arrives. Mobile unread flag matches the 'chat' behavior.
         if (mobileActiveTabRef.current !== 'chat') setMobileChatUnread(true);
+        setActiveToolLabel(null); // text is flowing — the tool step is over
         setStreamDraft(prev => prev + (event as any).content);
+        break;
+      }
+      case 'thinking_step': {
+        // Per-tool activity label while the agent works. 'active' shows it in
+        // the working indicator; anything else clears it.
+        setActiveToolLabel(event.step.status === 'active' ? event.step.label : null);
         break;
       }
       case 'chat': {
@@ -961,6 +975,7 @@ export default function CboProfilePage() {
           setMobileChatUnread(true);
         }
         setStreamDraft(''); // finalizer replaces the live draft
+        setActiveToolLabel(null);
         setMessages(prev => {
           const last = prev[prev.length - 1];
           // Concatenate consecutive assistant chat chunks into one bubble
@@ -1092,9 +1107,9 @@ export default function CboProfilePage() {
         setIsStreaming(false);
         break;
       case 'done':
-        setStreamDraft(''); setIsStreaming(false); break;
+        setStreamDraft(''); setActiveToolLabel(null); setIsStreaming(false); break;
       case 'error':
-        setStreamDraft(''); setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `${i18n.resolvedLanguage === 'pt' ? 'Erro' : 'Error'}: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
+        setStreamDraft(''); setActiveToolLabel(null); setIsStreaming(false); setMessages(prev => [...prev, { role: 'assistant', content: `${i18n.resolvedLanguage === 'pt' ? 'Erro' : 'Error'}: ${event.message}`, messageType: 'content', timestamp: new Date().toISOString() }]); break;
     }
   }, []);
 
@@ -1128,6 +1143,7 @@ export default function CboProfilePage() {
       setMessages(prev => [...prev, { role: 'user', content: JSON.stringify({ kind: 'answers', pairs: chipAnswers }), messageType: 'composer', timestamp: new Date().toISOString() }]);
     }
     setIsStreaming(true);
+    setActiveToolLabel(null); // never carry a stale tool label into a new turn
     // Inactivity watchdog. On patchy mobile data the SSE socket can stall
     // silently — reader.read() then hangs forever, isStreaming stays true, and
     // the user faces a frozen "Processando…" with no way out. If no chunk
@@ -1930,7 +1946,7 @@ export default function CboProfilePage() {
                 </div>
               </div>
             )}
-            {isStreaming && !streamDraft && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1">{t('cbo.working')}</span></div>}
+            {isStreaming && !streamDraft && <div className="flex items-center gap-2 py-2"><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} /><span className="w-2 h-2 bg-green-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} /><span className="text-xs text-muted-foreground ml-1" data-testid="cbo-working-label">{activeToolLabel ?? t('cbo.working')}</span></div>}
 
             {/* Start Next Workshop banner.
                 When the coordinator opens a workshop higher than the user's

--- a/e2e/cbo-tool-activity-label.spec.ts
+++ b/e2e/cbo-tool-activity-label.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Field report 2026-07 — while the agent works, users only ever saw a generic
+// "Processando…" and couldn't tell it was e.g. reading their website. The
+// agent now emits 'thinking_step' events when a tool starts and the working
+// indicator shows that label live. Ephemeral by design: the label must vanish
+// as soon as text streams / the turn ends, and never leak into the next turn.
+
+test('working indicator shows the live tool label, then falls back to generic', async ({ page, request }) => {
+  const api = new TestApi(request);
+  test.skip(!(await api.ping()).fakeModel, 'CBO_FAKE_MODEL not enabled on target.');
+
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+  await api.scriptCbo(cboId, [
+    // Turn 1: a tool label held visible by a thinking gap, then a reply.
+    [
+      { op: 'thinking_step', label: 'Lendo vilaflores.org…' },
+      { op: 'wait', ms: 2000 },
+      { op: 'say', text: 'Li o site, ficou ótimo.' },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }, { label: 'Ainda não' }] },
+    ],
+    // Turn 2: no tool step — the indicator must be back to the generic label.
+    [
+      { op: 'wait', ms: 2000 },
+      { op: 'say', text: 'Beleza.' },
+    ],
+  ]);
+
+  const input = page.getByTestId('cbo-chat-input');
+  const workingLabel = page.getByTestId('cbo-working-label');
+
+  await input.fill('manda ver');
+  await input.press('Enter');
+  // While the (fake) tool runs, the indicator narrates it…
+  await expect(workingLabel).toHaveText('Lendo vilaflores.org…', { timeout: 10_000 });
+  // …and once the turn lands, the reply is there and the indicator is gone.
+  await expect(page.getByText('Li o site, ficou ótimo.')).toBeVisible({ timeout: 10_000 });
+  await expect(workingLabel).not.toBeVisible();
+
+  // Next turn: the old tool label must NOT leak into the generic indicator.
+  await input.fill('e agora?');
+  await input.press('Enter');
+  await expect(workingLabel).toBeVisible({ timeout: 10_000 });
+  await expect(workingLabel).not.toHaveText('Lendo vilaflores.org…');
+  await expect(page.getByText('Beleza.')).toBeVisible({ timeout: 10_000 });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1292,6 +1292,35 @@ export function resolveTurnModel(
   return heavy('default');
 }
 
+/** Human label for the working indicator while a tool executes. Server-side
+ *  (not i18n keys) because the WebFetch label embeds the fetched hostname and
+ *  the kickoff/recovery copy already follows this server-picks-language
+ *  pattern. Returns null for instant / user-facing tools (ask_user, chips,
+ *  composers, phase bookkeeping) — a label that flashes for 50ms is noise. */
+function formatCboToolLabel(tool: string, input: any, lang: string): string | null {
+  const pt = lang === 'pt';
+  switch (tool) {
+    case 'WebFetch': {
+      let host = '';
+      try { host = new URL(String(input?.url ?? '')).hostname.replace(/^www\./, ''); } catch { /* no host in label */ }
+      return host ? (pt ? `Lendo ${host}…` : `Reading ${host}…`) : (pt ? 'Lendo o site…' : 'Reading the website…');
+    }
+    case 'update_section':
+      return pt ? 'Atualizando a ficha…' : 'Updating the profile…';
+    case 'read_org_document':
+    case 'search_org_documents':
+    case 'list_org_documents':
+      return pt ? 'Lendo seus documentos…' : 'Reading your documents…';
+    case 'read_knowledge':
+    case 'search_knowledge':
+      return pt ? 'Consultando o material de apoio…' : 'Checking the reference material…';
+    case 'score_maturity':
+      return pt ? 'Avaliando o perfil…' : 'Assessing the profile…';
+    default:
+      return null;
+  }
+}
+
 async function streamWithSdk(cboId: string, userMessage: string, state: CboState, pushEvent: EventPusher, lang: string = 'en', turnKind?: string) {
   const mcpServer = getMcpServer(cboId);
   // Independent reads — run concurrently instead of serially. Together with
@@ -1450,7 +1479,15 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           } else if (block.type === "tool_use" && block.name) {
             // MCP tools come through namespaced as "mcp__cbo__<name>"; strip
             // the prefix so the guard below can match against canonical names.
-            calledTools.add(String(block.name).replace(/^mcp__cbo__/, ''));
+            const toolName = String(block.name).replace(/^mcp__cbo__/, '');
+            calledTools.add(toolName);
+            // Live activity label (field report 2026-07: users only ever saw
+            // "Processando…" and couldn't tell the agent was e.g. reading
+            // their website). The tool_use block lands right BEFORE the tool
+            // executes — exactly the wait this label narrates. Ephemeral:
+            // the client clears it on the next text delta / composer / done.
+            const label = formatCboToolLabel(toolName, (block as any).input, lang);
+            if (label) pushEvent({ type: 'thinking_step', step: { id: String((block as any).id || toolName), label, status: 'active' } });
           }
         }
       }

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -47,6 +47,7 @@ export function isFakeModelEnabled(): boolean {
 export type FakeOp =
   | { op: 'say'; text: string }
   | { op: 'wait'; ms: number } // test seam: simulate SDK thinking time (capped 25s)
+  | { op: 'thinking_step'; label: string; status?: 'active' | 'complete' } // live tool-activity label (pair with 'wait' to hold it visible)
   | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
   | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean }[]; multiSelect?: boolean; showMap?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
@@ -111,6 +112,10 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
   switch (op.op) {
     case 'say': {
       emitAssistantText(op.text, pushEvent);
+      break;
+    }
+    case 'thinking_step': {
+      pushEvent({ type: 'thinking_step', step: { id: 'fake-step', label: op.label, status: op.status ?? 'active' } });
       break;
     }
     case 'update_section': {


### PR DESCRIPTION
Field report follow-up: while the agent works, the chat only ever showed a generic **"Processando…"** — users couldn't tell the agent was e.g. reading their website. The per-tool activity indicator everyone remembered *was* built, but only for the concept-note agent (`formatToolStepLabel` + `thinking_step` in `conceptNoteAgent.ts`); the CBO stack reserved the event/message types and never emitted or rendered them.

## What this does
- **Server** (`cboAgent.ts`): when a `tool_use` block lands in the SDK stream (right before the tool executes — exactly the wait worth narrating), emit a `thinking_step` event with a human label, language-matched to the session (`Lendo vilaflores.org…", "Atualizando a ficha…", "Lendo seus documentos…", "Consultando o material de apoio…", "Avaliando o perfil…"). Instant/user-facing tools (ask_user, composers, set_phase…) get **no** label — a 50ms flash is noise.
- **Client** (`cbo-profile.tsx`): the working indicator shows the live label when present, falling back to `t('cbo.working')`. Ephemeral: cleared on first text delta, chat finalizer, done/error, and at the start of every new turn — never persisted, transcript stays clean (per refine decision: live label, not persisted `tool_status` bubbles).
- **Fake model**: new `thinking_step` op (pair with `wait` to hold it visible) so the flow is deterministically testable.

## Testing
- New `e2e/cbo-tool-activity-label.spec.ts`: label visible while the (scripted) tool runs → reply lands and indicator disappears → next turn does NOT leak the old label.
- `thinking_step` was already in the `CboEvent` union — no schema change; `npx tsc --noEmit` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)