### PR TITLE
Questionnaire manifest: CNPJ-conditional org type + required-fields close gate

### DIFF
--- a/e2e/cougar-e1-conditional-org-type.spec.ts
+++ b/e2e/cougar-e1-conditional-org-type.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Questionnaire manifest (shared/cbo-questionnaire.ts), Ana 2026-07: "is kinda
+// weird to say they have a CNPJ and then have 'Coletivo informal' as an
+// option" — the org-type list must follow the CNPJ answer, and a value the
+// answer excludes must never be stored. The fake model shares the same
+// checkOptionRule call as the real update_section, so this exercises the real
+// write-path rule deterministically.
+
+test.describe('COUGAR — org type is conditional on the CNPJ answer', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('a legal_form the CNPJ answer excludes is rejected; an allowed one stores', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Turn 1 — the org has NO CNPJ, and the (misbehaving) agent then tries to
+    // store "ONG / Associação": the rule must reject it, and the batch order
+    // must not matter (has_cnpj is written first even when sent together in
+    // the real tool; here they arrive as sequential ops).
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'has_cnpj', value: 'Ainda não' },
+        { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'ONG / Associação' },
+        { op: 'say', text: 'Anotei sobre o CNPJ.' },
+        { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }, { label: 'Quero ajustar' }] },
+      ],
+      // Turn 2 — the allowed option for a CNPJ-less org stores normally.
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'Coletivo informal' },
+        { op: 'say', text: 'Fechou.' },
+        { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }, { label: 'Quero ajustar' }] },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('não temos cnpj ainda');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The excluded value never reached the state.
+    const stateAfterReject = await (await page.request.get(`/api/cbo/${cboId}`)).json();
+    const fields1 = stateAfterReject.state?.sections?.org_profile?.fields ?? stateAfterReject.sections?.org_profile?.fields;
+    expect(fields1.has_cnpj?.value).toBe('Ainda não');
+    expect(fields1.legal_form, 'legal_form "ONG" must be rejected for a CNPJ-less org').toBeUndefined();
+
+    // Turn 2: the consistent value stores.
+    await input.fill('somos um coletivo');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-turns', '2');
+    const stateAfterAccept = await (await page.request.get(`/api/cbo/${cboId}`)).json();
+    const fields2 = stateAfterAccept.state?.sections?.org_profile?.fields ?? stateAfterAccept.sections?.org_profile?.fields;
+    expect(fields2.legal_form?.value).toBe('Coletivo informal');
+  });
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -134,7 +134,7 @@ Treat pre-filled values as **starting points the user can edit**, never as final
 
 Phase 1 is almost entirely **information capture**. Only two things need real reasoning, and both happen **once, at the very end**: the two maturity scores and the path triage. So do **not** take a full turn per question — that makes the user wait for the model after every tap. **Capture in batches; reason once.**
 
-The question set **barely branches** within E1 — everyone answers the same batches; org type and maturity tier change only your *tone*, never *which* questions you ask. The ONLY conditional questions are the post-Batch-B follow-ups (funding count/budget when funding_history = Sim; the NbS detail when nbs_experience ≠ Ainda não). Because nothing inside a batch depends on an earlier answer, you can safely put several questions on one screen.
+The question set branches **only at declared points** within E1 — everyone answers the same batches; org type and maturity tier change only your *tone*, never *which* questions you ask. The conditional questions are: the org-type follow-up after Batch A (its option list depends on `has_cnpj` — see the mapping there) and the post-Batch-B follow-ups (funding count/budget when funding_history = Sim; the NbS detail when nbs_experience ≠ Ainda não). Because nothing inside a single batch depends on an answer from that same batch, you can safely put several questions on one screen. These rules are also enforced in code (shared/cbo-questionnaire.ts): inconsistent chips are filtered, inconsistent values rejected, and the closing scores refuse while required fields are missing.
 
 ### Step 0 — Open, and use what you already know
 
@@ -207,9 +207,15 @@ For everything still unknown, send **grouped `ask_user` calls** — one call car
 **Batch A — quem são** (one `ask_user`):
 1. *O que vocês fazem?* (multi-select, no cap — most orgs do several things; never tell the user to limit their picks) — Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária → `main_activities`
 2. *Vocês têm CNPJ?* — Sim, temos CNPJ · Ainda não · Não temos certeza → `has_cnpj`
-3. *Que tipo de organização?* — ONG / Associação · Cooperativa · Coletivo informal · Empresa social · Empresa / estúdio / escritório técnico · Outra → `legal_form`
-4. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos → `year_founded`
-5. *Quantas pessoas na equipe?* — 1–2 · 3–5 · 6–15 · 16+ → `team_size`
+3. *Há quanto tempo vocês existem?* — Começando agora · Menos de 2 anos · 2 a 5 anos · 5 a 10 anos · Mais de 10 anos → `year_founded`
+4. *Quantas pessoas na equipe?* — 1–2 · 3–5 · 6–15 · 16+ → `team_size`
+
+**Follow-up — org type (right after Batch A returns, its options depend on the CNPJ answer):**
+*Que tipo de organização?* → `legal_form`, offering ONLY the subset the `has_cnpj` answer allows:
+- **Sim, temos CNPJ** → ONG / Associação · Cooperativa · Empresa social · Empresa / estúdio / escritório técnico · Outra (no "Coletivo informal" — an org with a CNPJ isn't informal)
+- **Ainda não** → Coletivo informal · Outra (without a CNPJ they can't be an empresa or formal NGO)
+- **Não temos certeza** → ONG / Associação · Cooperativa · Coletivo informal · Outra
+The server enforces this mapping: chips outside the subset are dropped before the user sees them, and an inconsistent `legal_form` value is rejected at `update_section`. You can batch this follow-up together with Batch B in one grouped `ask_user`.
 
 **Batch B — experiência e alcance** (one `ask_user`):
 1. *Como é a equipe?* — Todas voluntárias · Maioria voluntárias · Metade e metade · Maioria pagas · Todas pagas → `paid_vs_volunteer`
@@ -217,7 +223,7 @@ For everything still unknown, send **grouped `ask_user` calls** — one call car
 3. *Já trabalharam com soluções baseadas na natureza?* — Sim · Ainda não · Não temos certeza → `nbs_experience`
 4. *Quem vocês atendem?* (multi-select) — Mulheres · Idosos · Pessoas com deficiência · Comunidades tradicionais · Jovens · Pessoas negras · Povos indígenas · Comunidade do bairro → `groups_served`
 
-**Follow-ups — the ONLY conditional questions in E1** (send after Batch B returns, skip entirely when they don't apply):
+**Follow-ups after Batch B** (send after Batch B returns, skip entirely when they don't apply):
 - If `funding_history` = **Sim** → one grouped `ask_user` with both:
   1. *Quantos projetos financiados vocês já executaram?* — 1 projeto · 2 a 5 projetos · Mais de 5 projetos → `funded_project_count`
   2. *Qual foi o orçamento do maior projeto?* — Até R$ 10 mil · R$ 10 a 50 mil · R$ 50 a 200 mil · Mais de R$ 200 mil → `biggest_project_budget`
@@ -356,7 +362,7 @@ A doc-sourced value is still **confirmed with the user, not asserted** (keep `so
 After both batches are answered (Step 2) and the path triage is done:
 
 1. Call `update_section('org_profile', ...)` with any consolidated fields not yet persisted
-2. Call `score_maturity` for both Phase-1 metrics (`org_delivery_capacity`, `team_technical_experience`) — REQUIRED. Without both scores, the green "next workshop" banner will not appear for the user.
+2. Call `score_maturity` for both Phase-1 metrics (`org_delivery_capacity`, `team_technical_experience`) — REQUIRED. Without both scores, the green "next workshop" banner will not appear for the user. The server refuses these calls while any required E1 field (or the path triage) is still missing — the refusal names exactly what's left; ask those questions first, even if the user edited an earlier answer late in the flow, then re-run the closing calls.
 3. Render the completion message (one final chat text — this is the only allowed long message in E1):
 
 > "✓ **Diagnóstico concluído** — obrigado pelas respostas, [contact_name]. Esse perfil já está salvo.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -31,7 +31,21 @@ import { setMaturityTierForCboState, getMaturityTierForCboState } from "./orgPer
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { emitAssistantText } from "./agentOutput";
-import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
+import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, orgProfileLabelsForIds, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
+import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredForClose, type FieldReader, type QuestionnaireManifest } from "@shared/cbo-questionnaire";
+
+/** Manifests whose rules govern this section (today: E1 ↔ org_profile). */
+function manifestsForSection(sectionId: string): QuestionnaireManifest[] {
+  return Object.values(QUESTIONNAIRES).filter(m => m.sectionId === sectionId);
+}
+
+/** FieldReader over a live section's fields. */
+function sectionFieldReader(section: { fields: Record<string, { value: unknown } | undefined> }): FieldReader {
+  return (field: string) => {
+    const v = section.fields[field]?.value;
+    return v == null ? undefined : String(v);
+  };
+}
 
 // ============================================================================
 // SDK LOADING — shared with conceptNoteAgent (lazy load)
@@ -286,7 +300,14 @@ function createCboMcpTools(cboId: string) {
       // exact-match-or-pass-through: never destroy what the human said.
       const isDocSource = String(args.source ?? '').toLowerCase() === 'document';
       const offList: string[] = [];
+      const ruleBlocked: { field: string; dependsOn: string; allowedIds: string[] }[] = [];
       const updated: string[] = [];
+      // Conditional-option rules (manifest): write dependency fields first so
+      // a batch carrying { has_cnpj, legal_form } validates legal_form against
+      // the has_cnpj value from THIS batch, not a stale one.
+      const manifests = manifestsForSection(args.sectionId);
+      const dependencyFields = new Set(manifests.flatMap(m => Object.values(m.optionRules).map(r => r.dependsOn)));
+      writable = [...writable.filter(([k]) => dependencyFields.has(k)), ...writable.filter(([k]) => !dependencyFields.has(k))];
       for (const [fieldName, rawValue] of writable) {
         const finalValue = args.sectionId === 'org_profile'
           ? canonicalizeOrgProfileValue(fieldName, rawValue, getActiveCboLang(cboId), isDocSource)
@@ -296,6 +317,17 @@ function createCboMcpTools(cboId: string) {
           isEnumOrgProfileField(fieldName) && !isCanonicalOrgProfileValue(fieldName, finalValue)
         ) {
           offList.push(fieldName);
+          continue;
+        }
+        // Manifest rule: a KNOWN option that the stored dependency answer
+        // excludes (e.g. legal_form "ONG" after has_cnpj "Ainda não") is
+        // rejected for every source — user chips included, since a wrong
+        // stored combination is wrong no matter who produced it.
+        const ruleHit = manifests
+          .map(m => checkOptionRule(m, fieldName, finalValue, sectionFieldReader(section)))
+          .find(r => !r.ok) as { ok: false; dependsOn: string; allowedIds: string[] } | undefined;
+        if (ruleHit) {
+          ruleBlocked.push({ field: fieldName, dependsOn: ruleHit.dependsOn, allowedIds: ruleHit.allowedIds });
           continue;
         }
         const oldValue = section.fields[fieldName]?.value ?? null;
@@ -315,8 +347,11 @@ function createCboMcpTools(cboId: string) {
       const offListNote = offList.length > 0
         ? ` NOT STORED (off-list value from document): ${offList.map(f => `${f} — allowed values are exactly: ${orgProfileOptionLabels(f, getActiveCboLang(cboId)).join(' · ')}`).join('; ')}. Either resend with one of those exact labels, or leave the field empty and ask the user that question with the normal chips, leading with your best guess from the document.`
         : '';
+      const ruleNote = ruleBlocked.length > 0
+        ? ` NOT STORED (inconsistent with an earlier answer): ${ruleBlocked.map(b => `${b.field} — given the stored ${b.dependsOn} answer, the only valid options are: ${orgProfileLabelsForIds(b.field, b.allowedIds, getActiveCboLang(cboId)).join(' · ')}`).join('; ')}. Re-ask the user with exactly those chips.`
+        : '';
       const summary = updated.length > 0 ? `Updated ${args.sectionId}: ${updated.join(', ')}.` : `Nothing stored in ${args.sectionId}.`;
-      return { content: [{ type: "text" as const, text: `${summary}${note}${offListNote}` }] };
+      return { content: [{ type: "text" as const, text: `${summary}${note}${offListNote}${ruleNote}` }] };
     },
     { annotations: { readOnlyHint: false } }
   );
@@ -540,16 +575,34 @@ Include showMap: true on a question only when the user genuinely needs the map t
       // chat prose instead of a composer. No isError — the question DID reach
       // the user; an error retry would double-ask it.
       let converted = 0;
+      const filteredNotes: string[] = [];
       for (const q of args.questions || []) {
         if ((q.options?.length ?? 0) === 1) {
           pushEvent({ type: 'chat', content: q.question, role: 'assistant' } as any);
           converted++;
-        } else {
-          pushEvent({ type: 'ask_user', question: q.question, options: q.options || [], relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
+          continue;
         }
+        // Manifest rule: when this is recognizably a rule-governed enum
+        // question (e.g. legal_form), drop the options the stored dependency
+        // answer excludes — a CNPJ-less org must never see "ONG" as a chip.
+        // Only applied when ≥2 options survive; otherwise the original list
+        // renders and the write-path rule still backstops the answer.
+        let options = q.options || [];
+        const qState = getCboState(cboId);
+        for (const m of Object.values(QUESTIONNAIRES)) {
+          const qSection = qState?.sections[m.sectionId as keyof typeof qState.sections];
+          if (!qSection) continue;
+          const filtered = filterRuledOptions(m, options, sectionFieldReader(qSection));
+          if (filtered && filtered.droppedLabels.length > 0 && filtered.kept.length >= 2) {
+            options = filtered.kept as typeof options;
+            filteredNotes.push(`dropped ${filtered.droppedLabels.length} ${filtered.field} option(s) inconsistent with the stored ${m.optionRules[filtered.field].dependsOn} answer: ${filtered.droppedLabels.join(' · ')}`);
+          }
+        }
+        pushEvent({ type: 'ask_user', question: q.question, options, relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
       }
       const note = converted > 0 ? ` (${converted} single-option question(s) delivered as plain text instead — a one-option list is a free-text question; next time ask it as prose with no tool call)` : '';
-      return { content: [{ type: "text" as const, text: `${(args.questions || []).length} question(s) shown.${note} STOP and wait.` }] };
+      const filterNote = filteredNotes.length > 0 ? ` (${filteredNotes.join('; ')} — the user only saw the valid chips)` : '';
+      return { content: [{ type: "text" as const, text: `${(args.questions || []).length} question(s) shown.${note}${filterNote} STOP and wait.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -664,6 +717,33 @@ STOP and wait for the user's map selection after calling this tool.`,
           }],
           isError: true,
         };
+      }
+      // CLOSE GATE (manifest): for phases scored at close (E1), scoring IS the
+      // closing signal — so refuse it while required questionnaire fields (or
+      // the set_path triage) are missing, naming exactly what's left. This is
+      // what makes "edit an earlier answer near the end → the model jumps to
+      // the closing and skips the project-status question" structurally
+      // impossible (field report 2026-07).
+      const closeManifest = QUESTIONNAIRES[state.phase];
+      if (closeManifest) {
+        const gateSection = state.sections[closeManifest.sectionId as keyof typeof state.sections];
+        let hasPath: boolean | null = null; // null = standalone session, path not persistable
+        if (closeManifest.requiresPath) {
+          try {
+            const rows = await db.select({ path: cohortMembers.path }).from(cohortMembers).where(eq(cohortMembers.cboStateId, cboId)).limit(1);
+            hasPath = rows.length === 0 ? null : rows[0].path != null;
+          } catch { hasPath = null; }
+        }
+        const missing = gateSection ? missingRequiredForClose(closeManifest, sectionFieldReader(gateSection), hasPath) : [];
+        if (missing.length > 0) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `NOT scored — Encontro ${state.phase} can't close yet, these are still missing: ${missing.join(', ')}. Ask the user for each of them (chips for enum fields, prose for free-text), store the answers, and only then re-run the closing calls.`,
+            }],
+            isError: true,
+          };
+        }
       }
       state.maturityScores = state.maturityScores.filter(s => s.metric !== args.metric);
       state.maturityScores.push({ metric: args.metric, score: args.score, justification: args.justification });

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -36,6 +36,7 @@ import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 import { emitAssistantText } from './agentOutput';
 import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue } from '@shared/cbo-field-catalog';
+import { QUESTIONNAIRES, checkOptionRule } from '@shared/cbo-questionnaire';
 
 export function isFakeModelEnabled(): boolean {
   return process.env.CBO_FAKE_MODEL === '1';
@@ -134,6 +135,17 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
         isDocSource && op.sectionId === 'org_profile' &&
         isEnumOrgProfileField(op.field) && !isCanonicalOrgProfileValue(op.field, value)
       ) break;
+      // Same conditional-option rule as the real tool (manifest): a known
+      // option excluded by the stored dependency answer is not stored.
+      if (op.sectionId === 'org_profile') {
+        const blocked = Object.values(QUESTIONNAIRES)
+          .filter(m => m.sectionId === op.sectionId)
+          .some(m => !checkOptionRule(m, op.field, value, (f) => {
+            const v = section.fields[f]?.value;
+            return v == null ? undefined : String(v);
+          }).ok);
+        if (blocked) break;
+      }
       section.fields[op.field] = {
         value,
         confidence: (op.confidence ?? 'high') as Confidence,

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -248,6 +248,22 @@ export function orgProfileOptionLabels(field: string, lang: 'pt' | 'en' = 'pt'):
   return (ORG_PROFILE_ENUMS[field] ?? []).map(o => (lang === 'pt' ? o.pt : o.en));
 }
 
+/** Resolve any form of an enum value (stable id, pt/en label, alias) to its
+ *  stable option id — the representation the questionnaire manifest rules use.
+ *  Null when the field isn't an enum or the value doesn't sit on the list. */
+export function resolveOrgProfileOptionId(field: string, raw: string): string | null {
+  if (typeof raw !== 'string' || !ORG_PROFILE_ENUMS[field]) return null;
+  return matchOption(field, raw)?.id ?? null;
+}
+
+/** Labels (in `lang`) for a subset of an enum field's option ids — for guard
+ *  messages that must name the allowed chips exactly. */
+export function orgProfileLabelsForIds(field: string, ids: string[], lang: 'pt' | 'en' = 'pt'): string[] {
+  return (ORG_PROFILE_ENUMS[field] ?? [])
+    .filter(o => ids.includes(o.id))
+    .map(o => (lang === 'pt' ? o.pt : o.en));
+}
+
 /** Read path: render any stored form (including legacy machine ids already in
  *  the database) as the viewer-language label. */
 export function orgProfileDisplayValue(field: string, stored: string, lang: 'pt' | 'en'): string {

--- a/shared/cbo-questionnaire.ts
+++ b/shared/cbo-questionnaire.ts
@@ -1,0 +1,205 @@
+// ============================================================================
+// QUESTIONNAIRE MANIFESTS — the enforceable contract layer per workshop.
+// ============================================================================
+//
+// The encontro skills (knowledge/_skills/encontro-N.md) are prose the model
+// follows; shared/cbo-field-catalog.ts holds the enum options code can
+// canonicalize against. What neither expressed was questionnaire STRUCTURE:
+// which option lists depend on an earlier answer, and which fields must be
+// captured before an encontro may close. Both used to be prompt-level rules —
+// and prompt-level rules leak (field report 2026-07: a CNPJ-less org was
+// offered "ONG"; editing a late answer let the model close E1 without ever
+// asking the project-status triage).
+//
+// A manifest declares that structure once, and three existing chokepoints in
+// cboAgent.ts enforce it deterministically:
+//   1. ask_user       — options inconsistent with a stored dependency answer
+//                       are filtered out before the composer renders.
+//   2. update_section — a value outside the currently-allowed subset is
+//                       rejected (same contract as the off-list document rule).
+//   3. score_maturity — the closing scores refuse while required fields (or
+//                       the set_path triage) are missing, returning the list
+//                       so the model asks exactly those.
+//
+// E2–E6 opt in by adding a manifest to QUESTIONNAIRES — no new code. All
+// values in rules are stable option IDS from ORG_PROFILE_ENUMS, never labels,
+// so label copy edits and language never break a rule.
+
+import { ORG_PROFILE_ENUMS, resolveOrgProfileOptionId } from './cbo-field-catalog';
+
+/** The option list for `field` is a function of an earlier answer:
+ *  allow[<dependency option id>] = the option ids offerable for `field`. */
+export interface OptionRule {
+  dependsOn: string;
+  allow: Record<string, string[]>;
+}
+
+/** A field that must be filled before the encontro closes. `requiredIf` makes
+ *  it conditional on another field's answer (by option id); `orField` accepts
+ *  a legacy/alternate field as satisfying the requirement. */
+export interface RequiredEntry {
+  field: string;
+  orField?: string;
+  requiredIf?: { field: string; isAnyOf?: string[]; isNoneOf?: string[] };
+}
+
+export interface QuestionnaireManifest {
+  workshop: string;
+  /** The phase whose close this manifest gates. */
+  phase: number;
+  sectionId: string;
+  optionRules: Record<string, OptionRule>;
+  requiredToClose: (string | RequiredEntry)[];
+  /** The E1 triage (set_path) must have run before closing. */
+  requiresPath?: boolean;
+}
+
+export const E1_QUESTIONNAIRE: QuestionnaireManifest = {
+  workshop: 'e1',
+  phase: 1,
+  sectionId: 'org_profile',
+  optionRules: {
+    // Ana's mapping (field report 2026-07): "is kinda weird to say they have
+    // a CNPJ and then have 'Coletivo informal' as an option" — and an org
+    // without one can't be an empresa or formal NGO.
+    legal_form: {
+      dependsOn: 'has_cnpj',
+      allow: {
+        'yes': ['ngo', 'cooperativa', 'social-enterprise', 'implementer', 'other'],
+        'no': ['informal', 'other'],
+        'not-sure': ['ngo', 'cooperativa', 'informal', 'other'],
+      },
+    },
+  },
+  requiredToClose: [
+    'org_name', 'contact_name', 'contact_role', 'mission_summary',
+    'main_activities', 'has_cnpj', 'legal_form', 'year_founded', 'team_size',
+    'paid_vs_volunteer', 'nbs_experience', 'groups_served',
+    // Legacy sessions captured prior_project_scale instead of the v2
+    // funding_history split — either satisfies.
+    { field: 'funding_history', orField: 'prior_project_scale' },
+    { field: 'funded_project_count', requiredIf: { field: 'funding_history', isAnyOf: ['yes'] } },
+    { field: 'biggest_project_budget', requiredIf: { field: 'funding_history', isAnyOf: ['yes'] } },
+    // Detail is asked for "Sim" AND "Não temos certeza" (and the legacy
+    // yes-flavored ids) — only a clean "Ainda não" skips it.
+    { field: 'nbs_experience_detail', requiredIf: { field: 'nbs_experience', isNoneOf: ['none'] } },
+  ],
+  requiresPath: true,
+};
+
+/** Manifests by the phase they close. E2+ get entries as their skills gain
+ *  enforceable structure. */
+export const QUESTIONNAIRES: Record<number, QuestionnaireManifest> = {
+  1: E1_QUESTIONNAIRE,
+};
+
+/** Raw stored value of a field, or undefined — the caller adapts its state shape. */
+export type FieldReader = (field: string) => string | undefined;
+
+function storedId(read: FieldReader, field: string): string | null {
+  const raw = read(field);
+  if (raw == null || String(raw).trim() === '') return null;
+  return resolveOrgProfileOptionId(field, String(raw));
+}
+
+/** The option ids currently offerable for `field`, or null when unconstrained
+ *  (no rule, or the dependency hasn't been answered / doesn't resolve). */
+export function allowedOptionIds(
+  manifest: QuestionnaireManifest,
+  field: string,
+  read: FieldReader,
+): string[] | null {
+  const rule = manifest.optionRules[field];
+  if (!rule) return null;
+  const dep = storedId(read, rule.dependsOn);
+  if (!dep) return null;
+  return rule.allow[dep] ?? null;
+}
+
+/** Write-path check: is `value` (any form — id, label, alias) allowed for
+ *  `field` given the stored dependency answer? */
+export function checkOptionRule(
+  manifest: QuestionnaireManifest,
+  field: string,
+  value: string,
+  read: FieldReader,
+): { ok: true } | { ok: false; dependsOn: string; allowedIds: string[] } {
+  const allowed = allowedOptionIds(manifest, field, read);
+  if (!allowed) return { ok: true };
+  const id = resolveOrgProfileOptionId(field, value);
+  // Unresolvable values are someone else's problem (the canonicalization /
+  // off-list rules) — this rule only rejects a KNOWN option that the
+  // dependency answer excludes.
+  if (!id || allowed.includes(id)) return { ok: true };
+  return { ok: false, dependsOn: manifest.optionRules[field].dependsOn, allowedIds: allowed };
+}
+
+/** ask_user guard: if this option list is recognizably a rule-governed enum
+ *  question (≥2 options resolve to the same ruled field), drop the options the
+ *  dependency answer excludes. Returns null when no rule applies. */
+export function filterRuledOptions(
+  manifest: QuestionnaireManifest,
+  options: { label: string }[],
+  read: FieldReader,
+): { field: string; kept: { label: string }[]; droppedLabels: string[] } | null {
+  for (const field of Object.keys(manifest.optionRules)) {
+    const resolved = options.map(o => resolveOrgProfileOptionId(field, o.label));
+    if (resolved.filter(Boolean).length < 2) continue;
+    const allowed = allowedOptionIds(manifest, field, read);
+    if (!allowed) return null; // it IS the ruled question, but nothing to filter by
+    const kept: { label: string }[] = [];
+    const droppedLabels: string[] = [];
+    options.forEach((o, i) => {
+      const id = resolved[i];
+      if (id && !allowed.includes(id)) droppedLabels.push(o.label);
+      else kept.push(o);
+    });
+    return { field, kept, droppedLabels };
+  }
+  return null;
+}
+
+/** The fields still blocking the encontro's close (plus the path triage when
+ *  required). Field names are returned as-is so the caller can name them to
+ *  the model. `hasPath` = the set_path triage already ran; pass null when the
+ *  session has no cohort member (standalone) — the path requirement is then
+ *  skipped, since set_path can't persist there. */
+export function missingRequiredForClose(
+  manifest: QuestionnaireManifest,
+  read: FieldReader,
+  hasPath: boolean | null,
+): string[] {
+  const filled = (field: string) => {
+    const v = read(field);
+    return v != null && String(v).trim() !== '';
+  };
+  const missing: string[] = [];
+  for (const entry of manifest.requiredToClose) {
+    const req: RequiredEntry = typeof entry === 'string' ? { field: entry } : entry;
+    if (req.requiredIf) {
+      const dep = storedId(read, req.requiredIf.field);
+      if (!dep) continue; // dependency itself unanswered → reported on its own line
+      if (req.requiredIf.isAnyOf && !req.requiredIf.isAnyOf.includes(dep)) continue;
+      if (req.requiredIf.isNoneOf && req.requiredIf.isNoneOf.includes(dep)) continue;
+    }
+    if (filled(req.field) || (req.orField && filled(req.orField))) continue;
+    if (!missing.includes(req.field)) missing.push(req.field);
+  }
+  if (manifest.requiresPath && hasPath === false) missing.push('path triage (ask the project-status question, then set_path)');
+  return missing;
+}
+
+// Sanity: every id referenced by a rule must exist in the catalog — a typo'd
+// id would silently never match. Fails fast at module load in dev/tests.
+for (const m of Object.values(QUESTIONNAIRES)) {
+  for (const [field, rule] of Object.entries(m.optionRules)) {
+    const ids = new Set((ORG_PROFILE_ENUMS[field] ?? []).map(o => o.id));
+    const depIds = new Set((ORG_PROFILE_ENUMS[rule.dependsOn] ?? []).map(o => o.id));
+    for (const [dep, allowed] of Object.entries(rule.allow)) {
+      if (!depIds.has(dep)) throw new Error(`cbo-questionnaire: ${m.workshop}.${field} rule keys unknown ${rule.dependsOn} id "${dep}"`);
+      for (const id of allowed) {
+        if (!ids.has(id)) throw new Error(`cbo-questionnaire: ${m.workshop}.${field} allow-list has unknown ${field} id "${id}"`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two Tech Space items (refined with JVP 2026-07-13), solved with one structural mechanism instead of ad-hoc patches — JVP explicitly asked for something extensible to the other workshops.

## The mechanism
`shared/cbo-questionnaire.ts` — a declarative per-workshop manifest:
- **`optionRules`**: which option lists depend on an earlier answer (`legal_form` ← `has_cnpj`, with Ana's exact mapping). Rules reference stable option **ids**, never labels, so copy edits and language can't break them; ids are validated against the catalog at module load (typo → immediate throw).
- **`requiredToClose`**: fields that must be captured before the encontro closes — plain, conditional (`requiredIf` by option id), legacy alternates (`orField: 'prior_project_scale'`), plus the `set_path` triage.

Enforced at the **three chokepoints that already exist** — no new flow machinery:
1. **`ask_user`** filters chips the stored dependency answer excludes (only when ≥2 survive; the write-path rule backstops otherwise).
2. **`update_section`** rejects an inconsistent known option for *every* source, returning the allowed chip labels; dependency fields write first within a batch so `{has_cnpj, legal_form}` in one call validates against the fresh value.
3. **`score_maturity`** (the E1 closing signal — `PHASES_SCORED_AT_CLOSE`) refuses while required fields/triage are missing, naming them. This makes Ana's bug — *"edit an earlier answer near the end → the status-of-NbS question is skipped"* — structurally impossible: the close is gated on the answer existing, however the model got there. Standalone sessions (no cohort member) skip the path requirement since `set_path` can't persist there.

**E2–E6 opt in by adding a manifest entry — zero new code.**

## Skill changes (`encontro-1.md`)
`legal_form` moves out of Batch A into a conditional follow-up with the CNPJ mapping spelled out (it can batch with Batch B); the closing section documents the gate so the model understands refusals.

## Testing
- New `e2e/cougar-e1-conditional-org-type.spec.ts`: `has_cnpj = 'Ainda não'` → storing `'ONG / Associação'` is rejected (field stays empty), `'Coletivo informal'` stores. The fake model shares `checkOptionRule`, so this exercises the real write-path rule.
- Regression: enum-labels ×3, golden-path, batched-questions all pass. `npx tsc --noEmit` clean for touched files.
- Known vs assumed: the ask_user chip filter and the close gate live on the real-SDK path only (same seam as the existing empty-options guard) — verified by code-reading; the deterministic suite can't reach them by design.

## Risk noted
Sessions already mid-E1 that predate this PR close only once all required fields are present — the gate will make the model ask what's missing instead of silently closing. That's the intended completeness behavior, but it means older half-done sessions get a couple of extra questions at close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)