### PR TITLE
Intake opening: two-stage greeting + prominent "send docs/site" upload banner

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1915,6 +1915,7 @@ export default function CboProfilePage() {
                   multiSelected={multiSelectedOptions}
                   onMultiToggle={(label) => setMultiSelectedOptions(prev => { const next = new Set(prev); next.has(label) ? next.delete(label) : next.add(label); return next; })}
                   onMultiConfirm={() => { handleSelectOption(Array.from(multiSelectedOptions).join(', ')); setMultiSelectedOptions(new Set()); }}
+                  onUploadAction={() => fileInputRef.current?.click()}
                 />
               </div>
             )}
@@ -2587,6 +2588,7 @@ function CboQuestionCard({
   onMultiToggle,
   onMultiConfirm,
   readOnly,
+  onUploadAction,
 }: {
   question: { question: string; options: any[]; multiSelect?: boolean };
   selectedIdx: number;
@@ -2599,6 +2601,8 @@ function CboQuestionCard({
   onMultiConfirm?: () => void;
   /** Transcript mode: the question was already answered. Options are inert. */
   readOnly?: boolean;
+  /** Opens the file picker — for options with action 'upload'. */
+  onUploadAction?: () => void;
 }) {
   const { t } = useTranslation();
   const isMulti = question.multiSelect;
@@ -2637,6 +2641,29 @@ function CboQuestionCard({
       </div>
       <div className="space-y-1.5">
         {question.options.map((opt: any, i: number) => {
+          // Upload-action option (intake opening's "send your site or
+          // documents"): a deliberately prominent attach banner — dashed
+          // border + paperclip badge — that opens the file picker instead of
+          // sending an answer (field report 2026-07: the docs path needed to
+          // be "a bit more noticeable"). Inert in transcript mode.
+          if (opt.action === 'upload') {
+            return (
+              <button key={i} type="button"
+                onClick={() => { if (!disabled && !readOnly) onUploadAction?.(); }}
+                disabled={readOnly}
+                data-testid={readOnly ? `cbo-answered-option-${i}` : 'cbo-option-upload'}
+                data-option-label={opt.label}
+                className={`w-full text-left px-3 py-3 rounded-md border-2 border-dashed text-sm transition-all flex items-center gap-3 ${
+                  readOnly ? 'opacity-45 cursor-default border-muted' : disabled ? 'opacity-50 border-green-300' : 'border-green-500 bg-green-50/60 hover:bg-green-50 cursor-pointer'
+                }`}>
+                <span className="inline-flex items-center justify-center w-9 h-9 rounded-full bg-green-600 text-white shrink-0"><Paperclip className="w-4 h-4" /></span>
+                <div className="flex-1">
+                  <span className="font-semibold">{opt.label}</span>
+                  {opt.description && <div className="text-muted-foreground text-xs mt-0.5">{opt.description}</div>}
+                </div>
+              </button>
+            );
+          }
           const letter = String.fromCharCode(65 + i);
           // In readOnly (transcript) mode the highlight tracks the recorded
           // answer, not the keyboard cursor - there is no cursor.

--- a/e2e/cbo-intake-upload-banner.spec.ts
+++ b/e2e/cbo-intake-upload-banner.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Intake opening redesign (field report 2026-07): the docs/site offer is no
+// longer a prose line in the greeting — it's a Step-0.5 choice whose upload
+// option renders as a prominent attach banner (action: 'upload') and opens
+// the file picker directly. This spec proves the banner renders, opens the
+// chooser, and a picked file flows through the existing upload path into a
+// user message + the next agent turn.
+
+test('the upload-action option renders as a banner and drives a real upload', async ({ page, request }) => {
+  const api = new TestApi(request);
+  test.skip(!(await api.ping()).fakeModel, 'CBO_FAKE_MODEL not enabled on target.');
+
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+  await api.scriptCbo(cboId, [
+    // Turn 1 — the Step-0.5 choice: a normal chip + the upload banner.
+    [
+      { op: 'say', text: 'Prazer, Marina! Agora vou fazer umas perguntas sobre a organização.' },
+      {
+        op: 'ask_user',
+        question: 'Como você prefere?',
+        options: [
+          { label: 'Responder às perguntas', description: 'A gente conversa rapidinho' },
+          { label: 'Enviar site ou documentos', description: 'Toca pra anexar proposta, relatório…', action: 'upload' },
+        ],
+      },
+    ],
+    // Turn 2 — the agent's reaction to the uploaded document.
+    [
+      { op: 'say', text: 'Li o documento, obrigado!' },
+      { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }, { label: 'Quero ajustar' }] },
+    ],
+  ]);
+
+  const input = page.getByTestId('cbo-chat-input');
+  await input.fill('sou a Marina, coordenadora');
+  await input.press('Enter');
+  await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+  // The banner renders distinctly (its own testid, not a lettered chip)…
+  const banner = page.getByTestId('cbo-option-upload');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText('Enviar site ou documentos');
+  // …and the normal chip is still a normal chip.
+  await expect(page.getByTestId('cbo-option-0')).toContainText('Responder às perguntas');
+
+  // Clicking the banner opens the file picker (NOT sending a chip answer).
+  const [chooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    banner.click(),
+  ]);
+  await chooser.setFiles({
+    name: 'proposta.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('Nossa horta comunitária na Rua Cascata reduziu alagamentos.'),
+  });
+
+  // The upload flows through the existing path: a file bubble appears and the
+  // scripted next turn answers it.
+  await expect(page.getByText('proposta.txt')).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText('Li o documento, obrigado!')).toBeVisible({ timeout: 20_000 });
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -138,13 +138,26 @@ The question set **barely branches** within E1 — everyone answers the same bat
 
 ### Step 0 — Open, and use what you already know
 
-**The opening greeting is usually already posted for you.** The platform serves the standard Step-0 message (greeting + doc invite + invite confirmation + the name/role question) instantly, before you're ever called. If RECENT CONVERSATION starts with that assistant greeting: do NOT re-greet or re-ask — the user's first message IS the answer to it. Persist what they gave (name, role, org correction) and go straight to the mission question (Step 1.5). Only produce the opening yourself if the transcript has no greeting.
+**The opening greeting is usually already posted for you.** The platform serves the standard Step-0 message (greeting + invite confirmation + the name/role question — nothing else; the docs offer comes NEXT, in Step 0.5) instantly, before you're ever called. If RECENT CONVERSATION starts with that assistant greeting: do NOT re-greet or re-ask — the user's first message IS the answer to it. Persist what they gave (name, role, org correction) and go to Step 0.5. Only produce the opening yourself if the transcript has no greeting.
 
-- One short greeting line, then invite a document (it can do most of the work):
-  > *"Se vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho."*
+- One short greeting line, then straight to who's talking — the opening asks ONLY for the person. Do NOT mention documents or material here: this step is about the human, and the old "material about a project" line confused orgs (this intake is about the ORG, not a project).
 - **Check CURRENT STATE and any uploaded document FIRST.** Anything already known (org name + bairro from the invite; anything a document gives you) is a **confirmation, never a question.**
   - Invite pre-fill: *"Conferindo: vocês são a {orgName}, atuando no {bairro}, certo? Me corrige se eu errei."*
   - In the same opening, ask the one human thing as plain prose: *"E com quem eu tô falando — seu nome e seu papel por aí?"*
+
+### Step 0.5 — The org-questions announcement + docs/site choice
+
+Right after the person introduces themselves (persist `contact_name` / `contact_role` first, same turn), announce what comes next and offer the shortcut — one short message plus ONE `ask_user`:
+
+> *"Prazer, {nome}! Agora vou fazer umas perguntas sobre a {orgName} — quem são vocês, o que fazem. Coisa rápida. Se preferir, vocês podem me mandar o site ou algum material sobre a organização que eu leio e já preencho o que der."*
+
+`ask_user` with exactly these two options:
+1. `{ label: "Responder às perguntas", description: "A gente conversa rapidinho" }`
+2. `{ label: "Enviar site ou documentos", description: "Manda o link do site aqui no chat, ou toca pra anexar proposta, relatório, estatuto…", action: "upload" }`
+
+The `action: "upload"` option renders as a prominent attach banner (paperclip icon) and opens the file picker directly — that's the point: the docs path must be visible, not buried in prose. If they tap it and upload, or paste a link, run Step 1. If they pick "Responder às perguntas" (or just start typing an answer), go to the mission question (Step 1.5). If they answer the choice in free text mentioning a site, treat it as a link offer and ask for the URL.
+
+When a website is shared, aim your reading at the org-description pages: fetch the given URL and prefer following/fetching an *about* page («Sobre nós», «Quem somos», «/sobre», «/about») when one is apparent — that's where mission, activities and legal form live, not on a news or landing page.
 
 ### Step 1 — If a document was shared: pre-fill DESCRIPTIVE fields, then BULK-confirm (don't re-ask)
 

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -234,12 +234,12 @@ export function registerCboRoutes(app: Express): void {
       const confirm = org
         ? `Conferindo: vocês são a **${org}**${bairro ? `, atuando no ${bairro}` : ''}, certo? Me corrige se eu errei. E com quem eu tô falando — seu nome e seu papel por aí?`
         : `Pra começar: qual é o nome da organização de vocês, e com quem eu tô falando — seu nome e seu papel por aí?`;
-      content = `Oi! 👋 Eu vou te ajudar a montar o perfil da ${org || 'organização de vocês'} — leva uns 20 minutinhos, no seu ritmo.\n\nSe vocês já têm algum material — proposta, relatório, até fotos de um projeto — pode arrastar aqui que eu leio e já preencho o que der. Senão a gente conversa rapidinho.\n\n${confirm}`;
+      content = `Oi! 👋 Eu vou te ajudar a montar o perfil da ${org || 'organização de vocês'} — leva uns 20 minutinhos, no seu ritmo.\n\n${confirm}`;
     } else {
       const confirm = org
         ? `Checking: you are **${org}**${bairro ? `, working in ${bairro}` : ''}, right? Correct me if I got it wrong. And who am I talking to — your name and your role?`
         : `To start: what is your organization's name, and who am I talking to — your name and your role?`;
-      content = `Hi! 👋 I'll help you build ${org ? `${org}'s` : 'your organization\u2019s'} profile — about 20 minutes, at your pace.\n\nIf you already have any material — a proposal, a report, even photos of a project — drop it here and I'll read it and pre-fill what I can. Otherwise we'll just have a quick chat.\n\n${confirm}`;
+      content = `Hi! 👋 I'll help you build ${org ? `${org}'s` : 'your organization\u2019s'} profile — about 20 minutes, at your pace.\n\n${confirm}`;
     }
 
     const msg = { role: 'assistant' as const, content, messageType: 'content' as const, timestamp: new Date().toISOString() };

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -512,7 +512,10 @@ Include showMap: true on a question only when the user genuinely needs the map t
     {
       questions: z.array(z.object({
         question: z.string(),
-        options: z.array(z.object({ label: z.string(), description: z.string().optional(), recommended: z.boolean().optional() })),
+        // action 'upload': renders as a prominent attach banner (paperclip
+        // icon) that opens the file picker instead of sending an answer. Use
+        // ONLY on the intake-opening "send your site or documents" option.
+        options: z.array(z.object({ label: z.string(), description: z.string().optional(), recommended: z.boolean().optional(), action: z.enum(['upload']).optional() })),
         relatedSections: z.array(z.string()).optional(),
         showMap: z.boolean().optional(),
         multiSelect: z.boolean().optional(),

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -48,7 +48,7 @@ export type FakeOp =
   | { op: 'say'; text: string }
   | { op: 'wait'; ms: number } // test seam: simulate SDK thinking time (capped 25s)
   | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
-  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean }[]; multiSelect?: boolean; showMap?: boolean }
+  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
   | { op: 'set_phase'; phase: number }
   | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
@@ -144,7 +144,7 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       break;
     }
     case 'ask_user': {
-      const options = (op.options ?? []).map(o => ({ label: o.label, description: o.description ?? '', recommended: o.recommended }));
+      const options = (op.options ?? []).map(o => ({ label: o.label, description: o.description ?? '', recommended: o.recommended, action: o.action }));
       pushEvent({ type: 'ask_user', question: op.question, options, showMap: op.showMap, multiSelect: op.multiSelect });
       break;
     }

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -323,7 +323,10 @@ export type CboEvent =
   | { type: 'gap'; sectionId: string; field: string; reason: string; severity: string }
   | { type: 'phase_change'; phase: number }
   | { type: 'maturity_update'; scores: MaturityScore[]; total: number; flags: PriorityFlag[] }
-  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  // options[].action 'upload': the chip renders as a prominent attach banner
+  // (paperclip icon) and opens the file picker instead of answering — the
+  // intake opening's "send your site or documents" affordance.
+  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string; action?: 'upload' }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }


### PR DESCRIPTION
Ana's intake-opening feedback (refined with JVP 2026-07-13, two-stage flow + banner affordance chosen explicitly):

> the intro text refers to docs about a *project* and not the org, can be confusing. I suggest that this intro text asks only for the name and position … then an option "answer the questions manually" or "send docs/links" … add a button for uploading files directly, with some icon … a bit more noticeable … when asking for data from a website should try to point to the about us / sobre nós

## Changes
- **Kickoff template** (`cboRoutes.ts`, PT+EN): the greeting now asks only who's talking — greeting + invite confirmation + name/role. The "se vocês já têm algum material…" paragraph is gone.
- **Skill Step 0.5** (`encontro-1.md`): after the person introduces themselves, the agent announces the org questions and offers the explicit choice — "Responder às perguntas" (normal chip) / "Enviar site ou documentos" (upload banner). Link-pasting stays chat-native; the skill also directs website reads at *Sobre nós / about* pages.
- **`action: 'upload'` ask_user option** (schema + tool + client): renders as a dashed-border banner with a paperclip badge — deliberately more prominent than a chip — and opens the file picker directly instead of sending an answer. Persists/reloads like any ask_user composer (PERSIST-PROMPTS); inert in transcript mode. The composer's always-visible paperclip already existed and is untouched.

## Testing
- New `e2e/cbo-intake-upload-banner.spec.ts`: banner renders with its own testid (normal chip unaffected) → click opens the file chooser (not a chip answer) → picked file flows through the real `/api/upload/cbo/:id` path into a file bubble + the next agent turn.
- `cbo-instant-kickoff` (greeting contract) and `cbo-upload` suites pass; `tsc --noEmit` clean for touched files.
- Known vs assumed: keyboard-selecting the banner option with Enter sends its label as a text answer (the model then asks for the doc) — graceful fallback, not wired to the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)