### PR TITLE
Live-test fixes: duplicate question, skipped docs offer, answered-chip overflow

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -2658,8 +2658,12 @@ function CboQuestionCard({
           {isMulti && <span className="text-[10px] text-muted-foreground ml-1">{t('cbo.selectAllThatApply', { defaultValue: '(select all that apply)' })}</span>}
         </div>
         {answeredValue && (
-          <span className="shrink-0 inline-flex items-center gap-1 text-xs text-green-700 bg-green-100 px-2 py-1 rounded">
-            <Check className="w-3 h-3" /> {answeredValue}
+          // max-w + wrapping: a long multi-select answer ("Arborização e áreas
+          // verdes, Hortas e segurança alimentar, …") used to be shrink-0 and
+          // squeezed the question title into a one-word column (live test
+          // 2026-07-13). The badge now wraps within half the card instead.
+          <span className="max-w-[50%] inline-flex items-start gap-1 text-xs text-green-700 bg-green-100 px-2 py-1 rounded break-words [overflow-wrap:anywhere]">
+            <Check className="w-3 h-3 shrink-0 mt-0.5" /> <span className="min-w-0">{answeredValue}</span>
           </span>
         )}
       </div>

--- a/e2e/cbo-duplicate-text-guard.spec.ts
+++ b/e2e/cbo-duplicate-text-guard.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Live test 2026-07-13: the model asked the proud-moment question, ran tools,
+// then re-emitted the same question slightly extended in its final round —
+// the client concatenates consecutive assistant blocks, so the user read the
+// question twice in one bubble. The stream layer now drops a chat block that
+// is a repeat or prefix-extension of one already emitted THIS turn (≥40 chars
+// normalized). A later TURN may still legitimately re-ask.
+
+const QUESTION = 'Algum momento que vocês se sentiram orgulhosos com esse trabalho? Pode ser uma história rápida.';
+
+test('a near-duplicate chat block in the same turn is dropped', async ({ page, request }) => {
+  const api = new TestApi(request);
+  test.skip(!(await api.ping()).fakeModel, 'CBO_FAKE_MODEL not enabled on target.');
+
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+  await api.scriptCbo(cboId, [
+    [
+      { op: 'say', text: 'Anotado.' },
+      { op: 'say', text: QUESTION },
+      { op: 'say', text: `${QUESTION.slice(0, -1)} — dessa arborização ou de outro projeto.` },
+    ],
+    // A later turn may re-ask the same thing — per-turn scope, not per-session.
+    [
+      { op: 'say', text: QUESTION },
+    ],
+  ]);
+
+  const input = page.getByTestId('cbo-chat-input');
+  await input.fill('plantamos 200 árvores');
+  await input.press('Enter');
+  await expect(marker).toHaveAttribute('data-turns', '1');
+
+  const countQuestion = async () => {
+    const msgs = await (await page.request.get(`/api/cbo/${cboId}/messages`)).json();
+    return msgs.filter((m: any) => m.role === 'assistant' && m.messageType === 'content' && m.content.includes('orgulhosos')).length;
+  };
+  expect(await countQuestion(), 'the extended re-emission must be dropped').toBe(1);
+  // The short ack ("Anotado.") is under the 40-char floor and untouched.
+  await expect(page.getByText('Anotado.')).toBeVisible();
+
+  // Next turn: asking the same question again is allowed.
+  await input.fill('foi ótimo');
+  await input.press('Enter');
+  await expect(marker).toHaveAttribute('data-turns', '2');
+  expect(await countQuestion(), 'a later turn may legitimately repeat').toBe(2);
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -97,7 +97,7 @@ Per the spec, these fields land in the CBO profile (`state.sections.org_profile`
 1. `org_name` — the organization's name
 2. `contact_name` — who's talking with us
 3. `contact_role` — their role in the org — **capture only if volunteered.** Ask name+role together once (Step 0); if the answer brings only a name, take it and move on. Never spend a turn chasing the role — it gates nothing.
-4. `mission_summary` — the org's mission in one sentence, **in their words** — asked as the SECOND question of the encontro (free-text prose, right after Step 0), before the activity list. It matters for almost any funding application, and answering it first makes the org reflect before picking activities.
+4. `mission_summary` — the org's mission in one sentence, **in their words** — asked as the FIRST org question (free-text prose, right after the Step-0.5 choice), before the activity list. It matters for almost any funding application, and answering it first makes the org reflect before picking activities.
 5. `main_activities` — **multi-select, no cap**: Hortas e segurança alimentar · Arborização e áreas verdes · Resiliência climática (enchentes, calor) · Educação ambiental · Cultura e organização comunitária. (Most orgs do more than one thing — let them pick as many as apply; the list itself is still being refined with Vila Flores.)
 6. `has_cnpj` — enum: Sim, temos CNPJ · Ainda não · Não temos certeza. Asked BEFORE the org-type question — formalization is what actually gates fundraising.
 7. `legal_form` — enum: ngo, associação, cooperativa, informal, implementer (empresa/estúdio/escritório técnico), social-enterprise, other
@@ -145,9 +145,9 @@ The question set branches **only at declared points** within E1 — everyone ans
   - Invite pre-fill: *"Conferindo: vocês são a {orgName}, atuando no {bairro}, certo? Me corrige se eu errei."*
   - In the same opening, ask the one human thing as plain prose: *"E com quem eu tô falando — seu nome e seu papel por aí?"*
 
-### Step 0.5 — The org-questions announcement + docs/site choice
+### Step 0.5 — The org-questions announcement + docs/site choice (MANDATORY — never skip)
 
-Right after the person introduces themselves (persist `contact_name` / `contact_role` first, same turn), announce what comes next and offer the shortcut — one short message plus ONE `ask_user`:
+Right after the person introduces themselves (persist `contact_name` / `contact_role` first, same turn), announce what comes next and offer the shortcut — one short message plus ONE `ask_user`. **This step is not optional: NEVER ask the mission (or any other org question) in the same turn the user introduces themselves.** The one exception: a document or link ALREADY arrived — then go straight to Step 1 (the docs offer would be redundant). Live test 2026-07-13: the agent jumped from the introduction straight to the mission question and the org never learned it could just send its website — that is exactly the failure this step exists to prevent.
 
 > *"Prazer, {nome}! Agora vou fazer umas perguntas sobre a {orgName} — quem são vocês, o que fazem. Coisa rápida. Se preferir, vocês podem me mandar o site ou algum material sobre a organização que eu leio e já preencho o que der."*
 
@@ -192,9 +192,9 @@ Then confirm what you wrote **all at once**, concisely — and say **where you r
 
 A document never replaces the user's confirmation — extracted fields stay low-confidence (`source: 'document'`) until they validate.
 
-### Step 1.5 — The mission question (SECOND question of the encontro)
+### Step 1.5 — The mission question (first org question)
 
-Right after the Step-0 answer lands (name/role — or the document bulk-confirm), ask the **mission** as plain prose, before any batch:
+After the Step-0.5 choice is answered with "Responder às perguntas" (or after the document bulk-confirm, when they sent material instead), ask the **mission** as plain prose, before any batch. Never before Step 0.5 was offered:
 
 > *"E me conta: qual é a missão de vocês — em uma frase, o que a organização busca fazer?"*
 
@@ -229,7 +229,7 @@ The server enforces this mapping: chips outside the subset are dropped before th
 - If `funding_history` = **Sim** → one grouped `ask_user` with both:
   1. *Quantos projetos financiados vocês já executaram?* — 1 projeto · 2 a 5 projetos · Mais de 5 projetos → `funded_project_count`
   2. *Qual foi o orçamento do maior projeto?* — Até R$ 10 mil · R$ 10 a 50 mil · R$ 50 a 200 mil · Mais de R$ 200 mil → `biggest_project_budget`
-- If `nbs_experience` = **Sim** → prose: *"Que tipo de solução baseada na natureza vocês já trabalharam?"* → `nbs_experience_detail`
+- If `nbs_experience` = **Sim** → prose: *"Que tipo de solução baseada na natureza vocês já trabalharam?"* → `nbs_experience_detail`. **Prose means NO ask_user at all** — do not invent a chip list of NbS types for it (live test 2026-07-13: the agent fabricated "Hortas e jardins comunitários · Arborização e plantio de árvores · …" chips; those buckets exist nowhere and flatten the org's real answer).
 - If `nbs_experience` = **Não temos certeza** → prose: *"Me conta um pouco da iniciativa que vocês acham que pode ser SbN."* → `nbs_experience_detail`
 (Funding follow-up batch first, then the NbS prose question — each in its own turn.)
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1222,8 +1222,29 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   // (persisted on phase boundaries); we just stop writing to nobody.
   let clientGone = false;
 
+  // Near-duplicate guard for this turn's chat text. Live test 2026-07-13: the
+  // model asked the proud-moment question, ran tools, then re-emitted the same
+  // question slightly extended in its final round — the client concatenates
+  // consecutive assistant blocks, so the user read the question twice in one
+  // bubble. If a later block is a prefix-extension (or repeat) of an earlier
+  // one this turn, drop it. 40-char floor so short legit repeats ("Anotado.")
+  // are never touched; per-turn scope so re-asking in a LATER turn still works.
+  const turnChatTexts: string[] = [];
+  const normChat = (s: string) => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, ' ').trim();
+  const isTurnDuplicate = (content: string): boolean => {
+    const n = normChat(content);
+    return turnChatTexts.some(p => Math.min(p.length, n.length) >= 40 && (n.startsWith(p) || p.startsWith(n)));
+  };
+
   const pushEvent = (event: CboEvent) => {
     if (clientGone || res.writableEnded) return;
+    if (event.type === 'chat') {
+      if (isTurnDuplicate(event.content)) {
+        console.log(`[cbo] dropped near-duplicate chat block for ${cboId} (${event.content.length} chars)`);
+        return;
+      }
+      turnChatTexts.push(normChat(event.content));
+    }
     res.write(`data: ${JSON.stringify(event)}\n\n`);
     if (event.type === 'chat') {
       // ALL chat events store as messageType: 'content'. The previous


### PR DESCRIPTION
Three findings from JVP's live run right after the #393–#397 merges, plus one hardening spotted in the same screenshots.

## 1. Duplicate question in one bubble
Log showed `rounds=4 … text | update_section | ask_user | text` — the model asked the proud-moment question, ran tools, then re-emitted it slightly reworded in its final round, and the client concatenates consecutive assistant blocks into one bubble. **Fix**: the stream layer drops a chat block that repeats or prefix-extends one already emitted in the same turn (normalized comparison, 40-char floor so short acks like "Anotado." are never touched, per-turn scope so a later turn can legitimately re-ask). Lives in the `pushEvent` wrapper, so display AND transcript stay clean, and the fake model shares the path — covered by `e2e/cbo-duplicate-text-guard.spec.ts` (drop within turn + allow across turns, both asserted).

## 2. The docs/site offer never appeared
Root cause was a **contradiction inside the E1 skill**: Step 1.5 still said *"right after the Step-0 answer lands (name/role), ask the mission"* — routing straight past the new Step 0.5 choice, which is exactly what happened live. Both stale lines now route through Step 0.5, and Step 0.5 is marked **MANDATORY** with the failure documented inline (exception: a doc/link already arrived). Prompt-level fix — worth one more live pass to confirm compliance.

## 3. Answered-chip overflow
The green answered badge was `shrink-0` with no max width, so a long multi-select answer squeezed the question title into a one-word column. It now wraps within half the card width.

## Also hardened
The screenshots showed the agent inventing a chip list ("Hortas e jardins comunitários · Arborização e plantio de árvores · …") for `nbs_experience_detail`, which must be free prose — the skill now forbids it explicitly at the follow-up definition.

## Testing
New dedupe spec + batched-questions, golden-path, tool-activity-label all green; `tsc --noEmit` clean for touched files. The Step 0.5 and prose-detail fixes are prompt-level (not deterministically testable) — flagging for the next live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)