### PR TITLE
Gate skip-to-phase demo tool behind ENABLE_PHASE_SKIP (dead on prod)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,3 +113,9 @@ OVERPASS_API_URL=https://overpass-api.de/api/interpreter
 # □ No debug logs in production output
 # □ Session cookies use secure flag
 # □ All environment variables set correctly
+# ── Demo / test seams (NEVER set on the production Deployment) ───────────────
+# Makes the CBO progress-bar segments clickable jump buttons and lets the
+# server honor [SKIP TO phase:X], which pre-fills earlier sections with
+# CEA Bom Jesus sample data (overwrites real answers + renames the org).
+# Dev/local demos only.
+# ENABLE_PHASE_SKIP=1

--- a/client/src/core/components/cbo/CboProgress.tsx
+++ b/client/src/core/components/cbo/CboProgress.tsx
@@ -34,8 +34,11 @@ export function CboProgress({
   currentPhase: number;
   unlockedPhases: number[];
   workshops: WorkshopConfig[];
-  /** Called when the user taps an unlocked phase segment to navigate there. */
-  onJumpToPhase: (phaseNum: number) => void;
+  /** Called when the user taps an unlocked phase segment to navigate there.
+   *  DEMO-ONLY (ENABLE_PHASE_SKIP): the jump overwrites earlier sections with
+   *  sample data. Omit it (the default in prod) and the segments render as
+   *  plain, non-interactive progress indicators. */
+  onJumpToPhase?: (phaseNum: number) => void;
 }) {
   const { t, i18n } = useTranslation();
   const isPt = i18n.language?.startsWith('pt');
@@ -123,6 +126,22 @@ export function CboProgress({
             );
           }
 
+          if (!onJumpToPhase) {
+            // Plain indicator — no tap target at all when phase-skipping is
+            // off (the prod default): a progress bar must never be one
+            // accidental thumb-tap away from rewriting the profile.
+            return (
+              <div
+                key={p.num}
+                className={`flex-1 h-1.5 rounded-full ${bg} ${isCompleted ? 'flex items-center justify-center' : ''}`}
+                aria-label={`Phase ${p.num} (${segmentLabel})`}
+                data-testid={`cbo-progress-unlocked-${p.num}`}
+                title={segmentLabel}
+              >
+                {isCompleted && <Check className="w-2 h-2 text-white" strokeWidth={3} />}
+              </div>
+            );
+          }
           return (
             <button
               key={p.num}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -501,6 +501,11 @@ export default function CboProfilePage() {
   // inline-options normalizer) REPLACES it, so persistence and conversion
   // still operate on whole blocks. Never persisted, cleared on any finalizer.
   const [streamDraft, setStreamDraft] = useState('');
+  // Demo-only phase skipping — reported by the server (ENABLE_PHASE_SKIP,
+  // never set on prod). When false the progress segments are plain
+  // indicators; when true they become jump buttons that trigger the
+  // sample-data skip. Server-enforced too — this only controls affordance.
+  const [phaseSkipEnabled, setPhaseSkipEnabled] = useState(false);
   // Live per-tool activity label ("Lendo o site…", "Atualizando a ficha…")
   // emitted as 'thinking_step' events while the agent runs tools. Replaces the
   // generic "Processando…" in the working indicator; ephemeral — cleared as
@@ -613,6 +618,7 @@ export default function CboProfilePage() {
           const data = await res.json();
           setCboId(candidate);
           setState(migrateCboState(data.state));
+          setPhaseSkipEnabled(!!data.phaseSkipEnabled);
           const msgRes = await fetch(`/api/cbo/${candidate}/messages`);
           if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) hydrateMessages(msgs); }
           saveId(candidate); // converge the same-device cache onto the server id
@@ -627,6 +633,7 @@ export default function CboProfilePage() {
     const data = await res.json();
     setCboId(data.cboId);
     setState(data.state);
+    setPhaseSkipEnabled(!!data.phaseSkipEnabled);
     saveId(data.cboId);
   }, []);
 
@@ -870,6 +877,7 @@ export default function CboProfilePage() {
             const data = await res.json();
             setCboId(saved);
             setState(migrateCboState(data.state));
+            setPhaseSkipEnabled(!!data.phaseSkipEnabled);
             const msgRes = await fetch(`/api/cbo/${saved}/messages`);
             if (msgRes.ok) { const msgs = await msgRes.json(); if (msgs.length) hydrateMessages(msgs); }
             return;
@@ -1715,11 +1723,15 @@ export default function CboProfilePage() {
               currentPhase={Math.max(1, Math.min(5, state.phase || 1))}
               unlockedPhases={unlockedPhases}
               workshops={workshops}
-              onJumpToPhase={(p) => {
+              // Demo-only: without the flag the segments are plain progress
+              // indicators. The jump overwrites earlier sections with sample
+              // data, so it must never be one accidental tap away for a real
+              // org (server blocks it independently).
+              onJumpToPhase={phaseSkipEnabled ? (p) => {
                 if (isStreaming) return;
                 const skip = p === 3 ? '3a' : String(p);
                 sendMessage(`[SKIP TO phase:${skip}]`, false, false, undefined, 'system');
-              }}
+              } : undefined}
             />
           </div>
 

--- a/docs/cougar-runbook.md
+++ b/docs/cougar-runbook.md
@@ -101,8 +101,10 @@ Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 | **Delete cohort** *(admin)* | Removes the cohort **and** its members entirely. The default cohort is re-created empty on next load. | Header → **Delete cohort** |
 | **Namespaced test data** | The e2e harness namespaces its data (`e2e-*` cohorts, `*@e2e.test` coordinators) and purges it via `POST /__test/cleanup` (gated by `ENABLE_TEST_ROUTES`). | test only |
 
-> **Never** set `ENABLE_TEST_ROUTES` / `CBO_FAKE_MODEL` / `TEST_API_SECRET` on
-> the prod Deployment.
+> **Never** set `ENABLE_TEST_ROUTES` / `CBO_FAKE_MODEL` / `TEST_API_SECRET` /
+> `ENABLE_PHASE_SKIP` on the prod Deployment. (`ENABLE_PHASE_SKIP` turns the
+> CBO progress bar into demo jump buttons that overwrite real answers with
+> sample data — dev demos only.)
 
 ---
 

--- a/e2e/cbo-phase-skip-flag.spec.ts
+++ b/e2e/cbo-phase-skip-flag.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// The skip-to-phase demo tool ([SKIP TO phase:X] via clickable progress-bar
+// segments) overwrites earlier sections with CEA Bom Jesus sample data and
+// renames the org — it must be dead unless ENABLE_PHASE_SKIP=1 (a flag the
+// prod Deployment never sets, same family as ENABLE_TEST_ROUTES). The e2e
+// dev server does NOT set it, so this suite runs in the prod-default shape:
+// segments are inert indicators and even TYPING the magic string is blocked
+// server-side before it can touch the model or the state.
+
+test.describe('COUGAR — phase skipping is dead without ENABLE_PHASE_SKIP', () => {
+  test('segments are not buttons; a typed [SKIP TO] is blocked server-side', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'CBO_FAKE_MODEL not enabled on target.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // The server reports the flag off, and the unlocked segment renders as a
+    // plain indicator (a DIV), not a tap target.
+    const info = await (await page.request.get(`/api/cbo/${cboId}`)).json();
+    expect(info.phaseSkipEnabled).toBe(false);
+    const seg = page.getByTestId('cbo-progress-unlocked-1');
+    await expect(seg).toBeVisible();
+    expect(await seg.evaluate(el => el.tagName)).toBe('DIV');
+
+    // Even typing the magic string is intercepted before model/state: the org
+    // name is not replaced by the sample org and the phase does not jump.
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('[SKIP TO phase:4]');
+    await input.press('Enter');
+    await expect(page.getByText(/atalho de demonstração está desativado|demo shortcut is disabled/)).toBeVisible({ timeout: 15_000 });
+
+    const after = (await (await page.request.get(`/api/cbo/${cboId}`)).json()).state;
+    expect(after.orgName, 'sample org must never be stamped in').not.toBe('CEA Bom Jesus');
+    expect(after.phase, 'phase must not jump').toBeLessThanOrEqual(1);
+    const fields = after.sections?.org_profile?.fields ?? {};
+    expect(fields.contact_name?.value ?? '').not.toBe('Maria Santos');
+  });
+});

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -34,13 +34,19 @@ async function loadPersistedCboState(id: string): Promise<{ state: CboState; mes
 }
 
 export function registerCboRoutes(app: Express): void {
+  // Demo-only phase skipping (progress-bar segments become jump buttons and
+  // the server honors [SKIP TO phase:X]). Never set on the prod Deployment —
+  // the skip stamps sample data over real answers. Same family as
+  // ENABLE_TEST_ROUTES / CBO_FAKE_MODEL.
+  const phaseSkipEnabled = () => process.env.ENABLE_PHASE_SKIP === '1';
+
   // Create new CBO session
   app.post("/api/cbo", async (req: Request, res: Response) => {
     const { city } = req.body;
     const state = createEmptyCboState(city || "porto-alegre");
     setCboState(state.id, state);
     debouncedPersist(state.id);
-    res.json({ cboId: state.id, state });
+    res.json({ cboId: state.id, state, phaseSkipEnabled: phaseSkipEnabled() });
   });
 
   // Get CBO state
@@ -66,7 +72,7 @@ export function registerCboRoutes(app: Express): void {
       debouncedPersist(req.params.id);
       console.log(`[cbo] lifted ${req.params.id} from stranded phase 0 to phase 1 (read path)`);
     }
-    res.json({ state, cboId: req.params.id });
+    res.json({ state, cboId: req.params.id, phaseSkipEnabled: phaseSkipEnabled() });
   });
 
   // Get messages

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1360,8 +1360,19 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
     }
   }
 
-  // Handle [SKIP TO phase:X] magic prefix
+  // Handle [SKIP TO phase:X] magic prefix — DEMO TOOL, env-gated. It stamps
+  // fictitious CEA Bom Jesus sample data over earlier sections and renames the
+  // org, so on prod (flag never set there, same family as ENABLE_TEST_ROUTES)
+  // it must be dead even for someone who TYPES the magic string: the message
+  // is intercepted here and never reaches the model or the state.
   const skipMatch = userMessage.match(SKIP_PATTERN);
+  if (skipMatch && process.env.ENABLE_PHASE_SKIP !== '1') {
+    console.warn(`[cbo] blocked [SKIP TO phase:${skipMatch[1]}] for ${cboId} — ENABLE_PHASE_SKIP not set`);
+    pushEvent({ type: 'chat', content: lang === 'pt' ? 'Esse atalho de demonstração está desativado aqui.' : 'That demo shortcut is disabled here.', role: 'assistant' } as any);
+    pushEvent({ type: 'done', summary: 'phase-skip blocked (flag off)' });
+    res.end();
+    return;
+  }
   if (skipMatch) {
     const targetPhase = skipMatch[1];
     const { phase, agentMessage } = applySkipData(state, targetPhase);


### PR DESCRIPTION
Refined with JVP: env flag over removal (keeps the demo tool for dev), and prod never sets the flag (no prod demos needed).

## Why this mattered more than it looked
- The **progress bar segments were the skip buttons** — every unlocked segment was a live tap target on a phone.
- The server handler **overwrote real answers unconditionally**: it stamps fictitious *CEA Bom Jesus* sample data over earlier sections and renames the org (`state.orgName = 'CEA Bom Jesus'`).
- There was **no server-side gate**: anyone could trigger it by typing `[SKIP TO phase:4]` in the chat.
- This is the "legacy-demo escape path" class the system-complexity audit flagged.

## What this does
- **Server**: `[SKIP TO phase:X]` is honored only when `ENABLE_PHASE_SKIP=1` — same never-on-prod family as `ENABLE_TEST_ROUTES`/`CBO_FAKE_MODEL`. When off, the message is intercepted before the model/state, logged, and answered with a one-line "demo shortcut disabled".
- **Client**: `/api/cbo` responses report the flag; without it the segments render as plain `div` indicators — no tap target at all (`CboProgress.onJumpToPhase` is now optional).
- **Docs**: `.env.example` and the runbook's never-set-on-prod list.

To demo later phases in the workspace/dev: set `ENABLE_PHASE_SKIP=1` in the **Workspace** secrets (not Deployment) — behavior when enabled is unchanged.

## Testing
- New `e2e/cbo-phase-skip-flag.spec.ts` runs in the prod-default shape (the test env doesn't set the flag): flag reported false, segment is a DIV, typed `[SKIP TO phase:4]` yields the blocked message and leaves org name/phase/fields untouched.
- phase1-walkthrough + golden-path unaffected; `tsc --noEmit` clean for touched files.
- Known vs assumed: the enabled path is code-unchanged but not e2e-covered (the suite can't restart the server with a different env) — verified by reading; a quick dev-workspace tap test after setting the flag confirms it.

## Deploy
No DB change — just pull + republish. Do **not** set the flag on the Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)