### PR TITLE
Deployment backstop: demo/test seams are structurally dead inside Replit Deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,9 +113,12 @@ OVERPASS_API_URL=https://overpass-api.de/api/interpreter
 # □ No debug logs in production output
 # □ Session cookies use secure flag
 # □ All environment variables set correctly
-# ── Demo / test seams (NEVER set on the production Deployment) ───────────────
+# ── Demo / test seams ─────────────────────────────────────────────────────────
 # Makes the CBO progress-bar segments clickable jump buttons and lets the
 # server honor [SKIP TO phase:X], which pre-fills earlier sections with
 # CEA Bom Jesus sample data (overwrites real answers + renames the org).
-# Dev/local demos only.
+# Dev/local demos only. Replit shares App secrets with Deployments, so the
+# server ALSO refuses this (and ENABLE_TEST_ROUTES / CBO_FAKE_MODEL) whenever
+# it detects it is running inside a Replit Deployment (REPLIT_DEPLOYMENT=1) —
+# setting it here can never switch the demo tools on in prod.
 # ENABLE_PHASE_SKIP=1

--- a/docs/cougar-runbook.md
+++ b/docs/cougar-runbook.md
@@ -104,7 +104,10 @@ Log in at **`/coordinator-login`** → lands on **`/orchestrator`**.
 > **Never** set `ENABLE_TEST_ROUTES` / `CBO_FAKE_MODEL` / `TEST_API_SECRET` /
 > `ENABLE_PHASE_SKIP` on the prod Deployment. (`ENABLE_PHASE_SKIP` turns the
 > CBO progress bar into demo jump buttons that overwrite real answers with
-> sample data — dev demos only.)
+> sample data — dev demos only.) Since Replit shares App secrets with
+> Deployments, the server additionally refuses all of these seams whenever it
+> runs inside a Replit Deployment (`REPLIT_DEPLOYMENT=1`) — a shared secret
+> cannot switch them on in prod.
 
 ---
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,5 @@
 import type { Express } from 'express';
+import { isReplitDeployment } from "./services/runtimeEnv";
 import { createServer, type Server } from 'http';
 import { registerCboRoutes } from './routes/cboRoutes';
 import { registerCohortRoutes } from './routes/cohortRoutes';
@@ -110,7 +111,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Test-only seeding API — CONDITIONALLY registered so the routes literally do
   // not exist in production (the gate is registration, not a runtime check).
   // Never set ENABLE_TEST_ROUTES on the production Deployment. See testRoutes.ts.
-  if (process.env.ENABLE_TEST_ROUTES === '1') {
+  // Deployment backstop (see runtimeEnv.ts): a shared secret can't enable
+  // the test seams inside a Replit Deployment.
+  if (process.env.ENABLE_TEST_ROUTES === '1' && !isReplitDeployment()) {
     const { registerTestRoutes } = await import('./routes/testRoutes');
     registerTestRoutes(app);
   }

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -27,6 +27,7 @@ import {
   toDocumentMeta,
 } from "../services/documentPersistence";
 import { getCohortLanguageForCbo } from "../services/cohortLanguage";
+import { isPhaseSkipEnabled } from "../services/runtimeEnv";
 
 // Shim — pre-DB code called this synchronous-style. Routes now await DB.
 async function loadPersistedCboState(id: string): Promise<{ state: CboState; messages: any[] } | null> {
@@ -35,10 +36,10 @@ async function loadPersistedCboState(id: string): Promise<{ state: CboState; mes
 
 export function registerCboRoutes(app: Express): void {
   // Demo-only phase skipping (progress-bar segments become jump buttons and
-  // the server honors [SKIP TO phase:X]). Never set on the prod Deployment —
-  // the skip stamps sample data over real answers. Same family as
-  // ENABLE_TEST_ROUTES / CBO_FAKE_MODEL.
-  const phaseSkipEnabled = () => process.env.ENABLE_PHASE_SKIP === '1';
+  // the server honors [SKIP TO phase:X]) — the skip stamps sample data over
+  // real answers. isPhaseSkipEnabled requires the flag AND a non-deployment
+  // environment, so a secret shared with the Deployment can't enable it there.
+  const phaseSkipEnabled = () => isPhaseSkipEnabled();
 
   // Create new CBO session
   app.post("/api/cbo", async (req: Request, res: Response) => {

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -30,6 +30,7 @@ import { getOrgIdForCboState, listDocumentsByOrg, listDocumentSummariesByOrg, ge
 import { setMaturityTierForCboState, getMaturityTierForCboState } from "./orgPersistence";
 import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
+import { isPhaseSkipEnabled } from "./runtimeEnv";
 import { emitAssistantText } from "./agentOutput";
 import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, orgProfileLabelsForIds, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
 import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredForClose, type FieldReader, type QuestionnaireManifest } from "@shared/cbo-questionnaire";
@@ -1366,8 +1367,8 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   // it must be dead even for someone who TYPES the magic string: the message
   // is intercepted here and never reaches the model or the state.
   const skipMatch = userMessage.match(SKIP_PATTERN);
-  if (skipMatch && process.env.ENABLE_PHASE_SKIP !== '1') {
-    console.warn(`[cbo] blocked [SKIP TO phase:${skipMatch[1]}] for ${cboId} — ENABLE_PHASE_SKIP not set`);
+  if (skipMatch && !isPhaseSkipEnabled()) {
+    console.warn(`[cbo] blocked [SKIP TO phase:${skipMatch[1]}] for ${cboId} — phase skip disabled (flag unset or running in a deployment)`);
     pushEvent({ type: 'chat', content: lang === 'pt' ? 'Esse atalho de demonstração está desativado aqui.' : 'That demo shortcut is disabled here.', role: 'assistant' } as any);
     pushEvent({ type: 'done', summary: 'phase-skip blocked (flag off)' });
     res.end();

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -35,11 +35,14 @@ import {
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 import { emitAssistantText } from './agentOutput';
+import { isReplitDeployment } from './runtimeEnv';
 import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue } from '@shared/cbo-field-catalog';
 import { QUESTIONNAIRES, checkOptionRule } from '@shared/cbo-questionnaire';
 
 export function isFakeModelEnabled(): boolean {
-  return process.env.CBO_FAKE_MODEL === '1';
+  // Deployment backstop: Replit shares App secrets with Deployments by
+  // default, so the flag alone isn't a prod guarantee (see runtimeEnv.ts).
+  return process.env.CBO_FAKE_MODEL === '1' && !isReplitDeployment();
 }
 
 // ── Script shape ────────────────────────────────────────────────────────────

--- a/server/services/runtimeEnv.ts
+++ b/server/services/runtimeEnv.ts
@@ -1,0 +1,25 @@
+// ============================================================================
+// RUNTIME ENVIRONMENT DETECTION — the backstop for demo/test seams.
+// ============================================================================
+//
+// The demo/test flags (ENABLE_PHASE_SKIP, ENABLE_TEST_ROUTES, CBO_FAKE_MODEL)
+// were guarded only by "never set them on the prod Deployment". But Replit
+// shares App secrets with Deployments by default, so a flag set for a
+// workspace demo CAN ride into prod on the next republish. This module makes
+// the guard structural: Replit sets REPLIT_DEPLOYMENT=1 (and
+// REPLIT_DEPLOYMENT_ID) inside deployed apps and not in the workspace, so a
+// deployment refuses the seams REGARDLESS of which secrets it received.
+//
+// Local dev and the Playwright webServer have neither variable → seams work
+// exactly as before wherever a human is actually developing or testing.
+
+export function isReplitDeployment(): boolean {
+  return process.env.REPLIT_DEPLOYMENT === '1' || !!process.env.REPLIT_DEPLOYMENT_ID;
+}
+
+/** Demo-only phase skipping ([SKIP TO phase:X] + clickable progress
+ *  segments). Requires the explicit opt-in flag AND a non-deployment
+ *  environment — it overwrites real answers with sample data. */
+export function isPhaseSkipEnabled(): boolean {
+  return process.env.ENABLE_PHASE_SKIP === '1' && !isReplitDeployment();
+}


### PR DESCRIPTION
Follow-up to #399, from JVP's observation that **Replit shares App secrets with Deployments** — so "never set the flag on prod" isn't a guarantee: a workspace demo flag can ride into prod on the next republish.

## Approach
Rather than matching the prod hostname (goes stale if the domain changes, and depends on request headers), the server detects the environment itself: Replit sets `REPLIT_DEPLOYMENT=1` / `REPLIT_DEPLOYMENT_ID` inside deployed apps and not in the workspace. New `server/services/runtimeEnv.ts` exposes `isReplitDeployment()`, and every demo/test seam now requires **flag AND non-deployment**:

| Seam | Effect if it leaked into prod |
|---|---|
| `ENABLE_PHASE_SKIP` (#399) | progress bar overwrites real answers with sample data |
| `ENABLE_TEST_ROUTES` | open `/__test` API incl. data cleanup |
| `CBO_FAKE_MODEL` | real orgs would chat with the scripted fake model |

You can now safely set any of these in the shared secrets for a workspace demo — the deployment refuses them regardless.

## Verification
- Direct execution with `REPLIT_DEPLOYMENT=1` + both flags set: `isPhaseSkipEnabled()` → false, `isFakeModelEnabled()` → false.
- e2e (local, no deployment var): phase-skip-flag, golden-path, member-remove suites all green — dev behavior unchanged.
- Known vs assumed: `REPLIT_DEPLOYMENT=1` inside deployments is per Replit's documented deployment env vars; cheap to confirm on prod by hitting `/__test/ping` after this merges with `ENABLE_TEST_ROUTES` set in shared secrets — it must still 404. Until confirmed, keep NOT setting the flags in shared secrets (both layers then apply).

No DB change — pull + republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)