### PR TITLE
Default member sessions to Portuguese (cohort force still wins)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -664,8 +664,13 @@ export default function CboProfilePage() {
       if (typeof data.supportPendingCount === 'number') setSupportPendingCount(data.supportPendingCount);
       if (Array.isArray(data.inspirationPicks)) setInspirationPicks(data.inspirationPicks);
       if (data.cohort?.name) setCohortName(data.cohort.name);
-      // Coordinator-forced cohort language overrides browser detection.
-      const cohortLang = data.cohort?.language;
+      // Coordinator-forced cohort language overrides browser detection. When
+      // the coordinator never picked one, members still default to Portuguese:
+      // this is a POA community tool opened from WhatsApp invite links, and an
+      // English-configured phone/laptop must not flip the whole session
+      // (questions, chips, the agent itself) into English. Coordinators can
+      // force EN from the orchestrator view for the exceptions.
+      const cohortLang = data.cohort ? (data.cohort.language ?? 'pt') : undefined;
       if ((cohortLang === 'pt' || cohortLang === 'en') && i18n.resolvedLanguage !== cohortLang) {
         i18n.changeLanguage(cohortLang);
       }

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -10,7 +10,14 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: 'en',
+    // The platform's audience is Porto Alegre community organizations — an
+    // unrecognized/unsupported browser language must land on Portuguese, not
+    // English (COUGAR Perfect Demo 2026-07-14: a whole E1 session ran in
+    // English because detection resolved 'en'). English must NOT fall back to
+    // pt though: some patterns (workshopHelpers' by-position names) rely on
+    // keys being absent from en.json so `defaultValue` (the stored English
+    // string) wins — a global pt fallback would surface Portuguese there.
+    fallbackLng: { en: ['en'], default: ['pt'] },
     supportedLngs: ['en', 'pt'],
     // Map region locales to the base language — without this, a `pt-BR` browser
     // (every Brazilian user + Playwright's pt-BR locale) doesn't match the

--- a/e2e/cougar-default-language-pt.spec.ts
+++ b/e2e/cougar-default-language-pt.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// COUGAR Perfect Demo (2026-07-14): a member session ran entirely in English —
+// questions, chips, "Question 1 of 2 · Tab to cycle" — because the browser was
+// English and the cohort had no forced language, so detection won. The platform
+// serves Porto Alegre community orgs: a member arriving via invite link must
+// default to Portuguese unless the coordinator explicitly forces English
+// (cougar-cohort-language.spec.ts covers the forced cases).
+
+test.use({ locale: 'en-US' });
+
+test.describe('COUGAR — members default to Portuguese', () => {
+  test('an en-US browser on an invite from a language-less cohort gets PT', async ({ page, request }) => {
+    const ext = new TestApi(request);
+    const { cohort } = await ext.createCohort('e2e default lang');
+    const invite = (await ext.inviteMember(cohort.id, { orgName: 'Org Padrão' })).inviteUrl as string;
+
+    await page.goto(invite);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'pt', { timeout: 20_000 });
+    // The focus-workshop card renders the localized (PT) workshop name.
+    await expect(page.getByText('Encontro 1 — Quem somos')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Workshop 1 — Who We Are')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Why
In the COUGAR Perfect Demo prep (2026-07-14), an entire E1 session ran in **English** — the questions, the chips, "Question 1 of 2 · Tab to cycle", "recommended", and the agent's own prose. Every one of those strings is translated; the session simply resolved `lang=en` because the browser was English-configured and the test cohort had no forced language. For a Porto Alegre community tool opened from WhatsApp invite links, that default is wrong.

## What
- **Invite-link members now default to Portuguese** when the cohort has no forced language. The coordinator's explicit EN/PT force (orchestrator view) still overrides everything, and the server-side language authority is untouched (cohort force → client lang → stored) — the client just sends `pt` now.
- **`fallbackLng` is language-scoped** (`{ en: ['en'], default: ['pt'] }`): a Spanish/French browser lands on pt instead of en, but an English session does **not** fall back to pt. A naive global `fallbackLng: 'pt'` broke the by-position workshop-name pattern (keys deliberately absent from en.json must fall through to `defaultValue`) — caught live by `cougar-cohort-language.spec.ts` showing "Encontro 1 — Quem somos" inside a forced-EN cohort.

## Tests
- New `e2e/cougar-default-language-pt.spec.ts`: en-US browser + language-less cohort ⇒ `html lang=pt` + PT workshop card.
- `cougar-cohort-language.spec.ts` (both force directions) passes.
- Full chromium e2e suite run reported in PR comments.

## Safe vs assumed
- Verified: both language specs green locally; standalone `/cbo-profile` (no invite) keeps browser detection.
- Assumed: no coordinator-view flow depends on unsupported-language browsers resolving to en (they now get pt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)