### PR TITLE
Re-ask guard: answered chip questions can't be asked twice

### DIFF
--- a/docs/cbo-questionnaire-guards.md
+++ b/docs/cbo-questionnaire-guards.md
@@ -1,0 +1,84 @@
+# CBO questionnaire guards — the deterministic net under the encontro skills
+
+The encontro skills (`knowledge/_skills/encontro-N.md`) are prose the model
+follows — and prose rules leak, especially on the light (haiku) turns that
+answer chip taps. Every guard below exists because a rule leaked **live**.
+This doc is the inventory, and — because Encontros 2–6 will hit the same
+failure classes — the recipe for extending each guard beyond E1.
+
+The principle: **the skill teaches, the server enforces.** Any behavior that
+would embarrass the platform when the model ignores it needs a code chokepoint,
+not another ALL-CAPS prompt line. The fake model (`fakeCboModel.ts`) mirrors
+every guard through the same shared helpers, so each one is e2e-testable
+without a live model.
+
+## Guard inventory
+
+| Guard | Where | Live incident it answers |
+|---|---|---|
+| Enum canonicalization (any label/alias/id → canonical label) | `shared/cbo-field-catalog.ts` → `update_section` | Machine ids stored raw, English labels in a PT doc (2026-07-07) |
+| Off-list doc values rejected (exact match, fuzzy only for docs) | same | Crawler stored "categories related to ours but not exactly them" (2026-07-08) |
+| Conditional option rules (`optionRules`, by stable option id) | `shared/cbo-questionnaire.ts` → ask_user filter + update_section | CNPJ-less org offered "ONG" (2026-07) |
+| Required-to-close (`requiredToClose`, `requiresPath`) | same → score_maturity close gate | E1 closed without the project-status triage |
+| Crawl-trust staging (doc free-text staged until user confirms; `confirm_doc_fields` refuses until the user has replied) | `cboAgent.ts` + `staged_doc_fields` column | Doc extractions silently overwrote profile fields (2026-07-13) |
+| **Re-ask guard** (chip question whose labels resolve to already-answered enum field(s) is dropped; `allowReask: true` = deliberate change flow) | `enumFieldsMatchingOptions` in the catalog → ask_user (real + fake) | "How is your team structured?" asked twice in a row (Perfect Demo, 2026-07-14) |
+| Single-option ask_user → prose conversion | `cboAgent.ts` ask_user | One-chip "lists" forcing tap-then-type (2026-07) |
+| Per-turn near-duplicate chat-text guard (normalized prefix match, 40-char floor) | `cboAgent.ts` pushEvent wrapper | Model re-emitted its question in the final round (2026-07-13) |
+| Silent-turn fallback (turn may not end without a user prompt) | `cboAgent.ts` | Users stranded on a blank screen |
+
+## What's generic vs E1-only today
+
+Generic already (nothing to do per encontro): staging/confirm, single-option
+conversion, duplicate chat-text guard, silent-turn fallback.
+
+E1-only today, because they read `ORG_PROFILE_ENUMS` / `QUESTIONNAIRES` and
+both currently only describe `org_profile`:
+
+- canonicalization + off-list rejection
+- conditional option rules + required-to-close
+- **the re-ask guard**
+
+## Recipe — giving Encontro N the same net
+
+When an encontro starts capturing structured fields (E2 site fields, E3
+intervention fields…), do these in order:
+
+1. **Catalog the enums.** Add the section's closed-list fields to the field
+   catalog with stable ids + pt/en labels + aliases (today that means either a
+   new `SECTION_ENUMS[sectionId]` map generalizing `ORG_PROFILE_ENUMS`, or a
+   sibling per-section catalog — prefer generalizing so `matchOption`,
+   `canonicalizeOrgProfileValue` and `enumFieldsMatchingOptions` become
+   section-aware instead of forked). Every downstream guard keys off this.
+2. **Declare the manifest.** Add a `QUESTIONNAIRES` entry for the section:
+   `optionRules` for any option list that depends on an earlier answer,
+   `requiredToClose` for what must exist before the encontro's closing scores,
+   `requiresPath` where relevant. Rules use option **ids**, never labels. The
+   three chokepoints (ask_user filter, update_section reject, close gate) pick
+   the manifest up with no new code.
+3. **Point the re-ask guard at the section.** `enumFieldsMatchingOptions` +
+   the "every candidate field already filled" check in ask_user must read the
+   new section's fields (today they read `sections.org_profile` — generalize
+   the lookup to iterate the sections that have catalogs).
+4. **Skill prose stays.** Keep the "never re-ask, check CURRENT STATE"
+   paragraph in the encontro skill (E1 + E2 both carry it) — the guard is the
+   net, not the flow. Mention `allowReask: true` as the user-requested-change
+   escape hatch.
+5. **Fake model = free.** If steps 1–3 live in shared helpers, the fake model
+   mirrors automatically. Verify its `ask_user` / `update_section` ops route
+   through the same functions.
+6. **One spec per guard.** Copy the shape of `e2e/cbo-reask-guard.spec.ts` /
+   `e2e/cougar-e1-conditional-org-type.spec.ts`: script the misbehaving turn,
+   assert the guard ate it, assert the legit path still works.
+
+## Design constraints worth keeping
+
+- **Stable option ids in rules, labels only at the edges.** Copy edits and
+  language switching must never break a rule.
+- **Ambiguity is resolved toward showing the question.** Generic chip sets
+  ("Sim" / "Ainda não") match several fields; the re-ask guard only blocks
+  when *every* candidate field is answered. False negatives (a duplicate slips
+  through) are recoverable; false positives (a needed question suppressed) are
+  not.
+- **Guards teach, not just block.** Every rejection returns a tool message
+  naming the field, the stored value, and what to do instead — the model's
+  next round should succeed, invisibly to the user.

--- a/e2e/cbo-reask-guard.spec.ts
+++ b/e2e/cbo-reask-guard.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Re-ask guard (COUGAR Perfect Demo, 2026-07-14): the live model asked "How is
+// your team structured?" again immediately after the user had answered it —
+// ask_user carries no field id, so nothing stopped a duplicate. The guard
+// infers the target enum field from the chip labels and drops the question
+// when that field is already answered; `allowReask: true` (reserved for a
+// user-requested change) bypasses it. The fake model mirrors the real guard's
+// logic (shared enumFieldsMatchingOptions + the same filled check).
+
+test.describe('COUGAR — answered chip questions are not re-asked', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('a duplicate of an answered field is dropped; allowReask shows it', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    const teamChips = [
+      { label: 'Todas voluntárias' },
+      { label: 'Maioria voluntárias' },
+      { label: 'Metade e metade' },
+      { label: 'Maioria pagas' },
+      { label: 'Todas pagas' },
+    ];
+
+    await api.scriptCbo(cboId, [
+      // Turn 1 — the answer is stored, then the (misbehaving) agent re-asks the
+      // exact same field: the duplicate must be dropped, and only the follow-up
+      // question about an UNANSWERED field (year_founded) may render.
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'paid_vs_volunteer', value: 'Maioria pagas' },
+        { op: 'say', text: 'Anotei a estrutura da equipe.' },
+        { op: 'ask_user', question: 'Como é a estrutura da equipe?', options: teamChips },
+        { op: 'ask_user', question: 'Há quanto tempo a organização existe?', options: [{ label: '2 a 5 anos' }, { label: 'Mais de 10 anos' }] },
+      ],
+      // Turn 2 — the user asked to CHANGE the answer: allowReask renders the
+      // same chips again.
+      [
+        { op: 'say', text: 'Claro, vamos ajustar.' },
+        { op: 'ask_user', question: 'Como é a estrutura da equipe?', options: teamChips, allowReask: true },
+      ],
+    ]);
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('maioria pagas');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // The unanswered follow-up shows; the duplicate never renders.
+    await expect(page.getByText('Há quanto tempo a organização existe?')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Como é a estrutura da equipe?')).toHaveCount(0);
+
+    // Answer the visible question so the composer clears, then request a change.
+    await page.getByText('2 a 5 anos', { exact: false }).first().click();
+    await expect(marker).toHaveAttribute('data-turns', '2');
+
+    // allowReask (the deliberate change flow) does render the answered field.
+    await expect(page.getByText('Como é a estrutura da equipe?')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Todas voluntárias').first()).toBeVisible();
+  });
+});

--- a/knowledge/_skills/encontro-1.md
+++ b/knowledge/_skills/encontro-1.md
@@ -130,6 +130,8 @@ The orchestrator collected the org name (and often the neighborhood) at invite t
 
 Treat pre-filled values as **starting points the user can edit**, never as final answers.
 
+**NEVER re-ask a field that already holds a value — from ANY source** (the user's earlier answer, a document, the invite). Before every `ask_user`, check CURRENT STATE for the field you're about to ask; if it's filled, skip to the next unanswered one. This happened live (2026-07-14): the team-structure question was asked again immediately after being answered, and it reads as the platform not listening. The server now BLOCKS duplicate chip questions (the tool result will tell you), but don't rely on the net — don't ask. The only exception is the user explicitly asking to change an answer this turn: then either write the new value directly with `update_section`, or re-ask with `allowReask: true`.
+
 ## Flow — resolve what's known, batch the rest, think once
 
 Phase 1 is almost entirely **information capture**. Only two things need real reasoning, and both happen **once, at the very end**: the two maturity scores and the path triage. So do **not** take a full turn per question — that makes the user wait for the model after every tap. **Capture in batches; reason once.**

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -395,8 +395,8 @@ The P-8 gate will refuse `set_phase(3)` until Workshop 3 is opened — don't try
 
 ## Important behavior rules
 
-### Don't re-ask E1 questions
-The CURRENT STATE has `org_name`, `mission_summary`, `bairro_of_operation`, `path`, etc. Reference them naturally; never ask again.
+### Don't re-ask E1 questions — or anything already answered
+The CURRENT STATE has `org_name`, `mission_summary`, `bairro_of_operation`, `path`, etc. Reference them naturally; never ask again. The same applies within this encontro: before every `ask_user`, check CURRENT STATE for the field you're about to ask — if it's filled, skip to the next unanswered one. The server blocks duplicate chip questions for cataloged enum fields (see `docs/cbo-questionnaire-guards.md`), but don't rely on the net. If the user explicitly asks to change an answer, write the new value with `update_section` directly, or re-ask with `allowReask: true`.
 
 ### Path is in state.metadata or member.path
 The CURRENT STATE prompt block includes the path. Branch your opening accordingly.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -32,7 +32,7 @@ import { queryTerms, scoreText, extractExcerpt } from "./textSearch";
 import { isFakeModelEnabled, streamWithFakeModel } from "./fakeCboModel";
 import { isPhaseSkipEnabled } from "./runtimeEnv";
 import { emitAssistantText } from "./agentOutput";
-import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, orgProfileLabelsForIds, ORG_PROFILE_FIELDS } from "@shared/cbo-field-catalog";
+import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, orgProfileLabelsForIds, ORG_PROFILE_FIELDS, enumFieldsMatchingOptions } from "@shared/cbo-field-catalog";
 import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredForClose, type FieldReader, type QuestionnaireManifest } from "@shared/cbo-questionnaire";
 
 /** Manifests whose rules govern this section (today: E1 ↔ org_profile). */
@@ -624,6 +624,9 @@ Include showMap: true on a question only when the user genuinely needs the map t
         relatedSections: z.array(z.string()).optional(),
         showMap: z.boolean().optional(),
         multiSelect: z.boolean().optional(),
+        // Escape hatch for the re-ask guard below: set it ONLY when the user
+        // explicitly asked, this turn, to change an answer they already gave.
+        allowReask: z.boolean().optional(),
       })),
     },
     async (args: any) => {
@@ -646,11 +649,35 @@ Include showMap: true on a question only when the user genuinely needs the map t
       // the user; an error retry would double-ask it.
       let converted = 0;
       const filteredNotes: string[] = [];
+      const blockedNotes: string[] = [];
+      let shown = 0;
       for (const q of args.questions || []) {
         if ((q.options?.length ?? 0) === 1) {
           pushEvent({ type: 'chat', content: q.question, role: 'assistant' } as any);
           converted++;
           continue;
+        }
+        // Re-ask guard (COUGAR Perfect Demo 2026-07-14): the model re-asked
+        // already-answered questions ("How is your team structured?" twice in
+        // a row). ask_user carries no field id, so infer the target field(s)
+        // by resolving the chip labels against the enum catalog; when every
+        // plausible field already holds an answer, this is a duplicate — drop
+        // it and teach the model instead of rendering it. `allowReask: true`
+        // (a deliberate act, reserved for a user-requested change) bypasses.
+        if (!q.allowReask) {
+          const chipLabels = (q.options || []).filter((o: any) => !o.action).map((o: any) => o.label);
+          const fieldsHit = enumFieldsMatchingOptions(chipLabels);
+          if (fieldsHit.length > 0) {
+            const orgSection = getCboState(cboId)?.sections?.org_profile;
+            if (orgSection) {
+              const read = sectionFieldReader(orgSection);
+              const answered = fieldsHit.map(f => ({ field: f, value: read(f) })).filter(x => (x.value ?? '').trim().length > 0);
+              if (answered.length === fieldsHit.length) {
+                blockedNotes.push(`"${q.question}" — ${answered.map(a => `${a.field} is already answered ("${a.value}")`).join(' and ')}`);
+                continue;
+              }
+            }
+          }
         }
         // Manifest rule: when this is recognizably a rule-governed enum
         // question (e.g. legal_form), drop the options the stored dependency
@@ -669,10 +696,18 @@ Include showMap: true on a question only when the user genuinely needs the map t
           }
         }
         pushEvent({ type: 'ask_user', question: q.question, options, relatedSections: q.relatedSections, showMap: q.showMap, multiSelect: q.multiSelect });
+        shown++;
+      }
+      // Everything was a blocked duplicate and nothing reached the user →
+      // error so the model retries with the NEXT unanswered question (a plain
+      // success here would strand the user on a promptless turn).
+      if (shown === 0 && converted === 0 && blockedNotes.length > 0) {
+        return { content: [{ type: "text" as const, text: `NOT shown — duplicate question(s): ${blockedNotes.join('; ')}. Do NOT re-ask answered fields. Move on to the next UNANSWERED field now (check the CURRENT STATE). If the user explicitly asked to change one of these answers, call update_section with the new value directly, or re-ask with allowReask: true.` }], isError: true };
       }
       const note = converted > 0 ? ` (${converted} single-option question(s) delivered as plain text instead — a one-option list is a free-text question; next time ask it as prose with no tool call)` : '';
       const filterNote = filteredNotes.length > 0 ? ` (${filteredNotes.join('; ')} — the user only saw the valid chips)` : '';
-      return { content: [{ type: "text" as const, text: `${(args.questions || []).length} question(s) shown.${note}${filterNote} STOP and wait.` }] };
+      const blockedNote = blockedNotes.length > 0 ? ` (${blockedNotes.length} duplicate question(s) NOT shown: ${blockedNotes.join('; ')} — never re-ask answered fields)` : '';
+      return { content: [{ type: "text" as const, text: `${shown + converted} question(s) shown.${note}${filterNote}${blockedNote} STOP and wait.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -36,7 +36,7 @@ import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 import { emitAssistantText } from './agentOutput';
 import { isReplitDeployment } from './runtimeEnv';
-import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue } from '@shared/cbo-field-catalog';
+import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, enumFieldsMatchingOptions } from '@shared/cbo-field-catalog';
 import { QUESTIONNAIRES, checkOptionRule } from '@shared/cbo-questionnaire';
 
 export function isFakeModelEnabled(): boolean {
@@ -54,7 +54,7 @@ export type FakeOp =
   | { op: 'thinking_step'; label: string; status?: 'active' | 'complete' } // live tool-activity label (pair with 'wait' to hold it visible)
   | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
   | { op: 'confirm_doc_fields'; fields?: string[] } // commit values staged by doc-sourced free-text update_section
-  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean }
+  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean; allowReask?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
   | { op: 'set_phase'; phase: number }
   | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
@@ -191,6 +191,20 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
     }
     case 'ask_user': {
       const options = (op.options ?? []).map(o => ({ label: o.label, description: o.description ?? '', recommended: o.recommended, action: o.action }));
+      // Mirror of the real ask_user re-ask guard (cboAgent.ts): a chip list
+      // that resolves to enum field(s) the state already answers is a
+      // duplicate and is dropped instead of rendered. `allowReask` bypasses,
+      // same as the real tool.
+      if (!op.allowReask) {
+        const fieldsHit = enumFieldsMatchingOptions(options.filter(o => !o.action).map(o => o.label));
+        const fields = state.sections.org_profile?.fields ?? {};
+        if (
+          fieldsHit.length > 0 &&
+          fieldsHit.every(f => String(fields[f]?.value ?? '').trim().length > 0)
+        ) {
+          break;
+        }
+      }
       pushEvent({ type: 'ask_user', question: op.question, options, showMap: op.showMap, multiSelect: op.multiSelect });
       break;
     }

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -256,6 +256,25 @@ export function resolveOrgProfileOptionId(field: string, raw: string): string | 
   return matchOption(field, raw)?.id ?? null;
 }
 
+/** Re-ask guard support (COUGAR Perfect Demo 2026-07-14: the model re-asked
+ *  "How is your team structured?" right after it was answered). ask_user
+ *  carries no field id, so the guard infers which enum field(s) a chip list
+ *  plausibly targets: a field qualifies when at least 2 of the labels — and at
+ *  least 70% of them — resolve to its options. Generic yes/no chip sets match
+ *  several fields (has_cnpj / nbs_experience share "Sim"/"Ainda não"); the
+ *  caller must treat the result as a duplicate only when EVERY returned field
+ *  is already answered. */
+export function enumFieldsMatchingOptions(labels: string[]): string[] {
+  const real = labels.filter(l => typeof l === 'string' && l.trim().length > 0);
+  if (real.length < 2) return [];
+  const fields: string[] = [];
+  for (const field of Object.keys(ORG_PROFILE_ENUMS)) {
+    const hits = real.filter(l => matchOption(field, l) !== null).length;
+    if (hits >= 2 && hits >= Math.ceil(real.length * 0.7)) fields.push(field);
+  }
+  return fields;
+}
+
 /** Labels (in `lang`) for a subset of an enum field's option ids — for guard
  *  messages that must name the allowed chips exactly. */
 export function orgProfileLabelsForIds(field: string, ids: string[], lang: 'pt' | 'en' = 'pt'): string[] {


### PR DESCRIPTION
## Why
In the Perfect Demo prep session (2026-07-14), the agent re-asked **"How is your team structured?"** immediately after the user answered it (and "Who else does your organization serve" re-appeared with groups_served already filled). Ana flagged questions appearing twice. `ask_user` carries no field id, so the server had no way to catch a duplicate — and these turns route to haiku, which ignores prompt-level rules more often.

## What
- **`enumFieldsMatchingOptions()`** (shared catalog): infers which enum field(s) a chip list targets — ≥2 labels and ≥70% of them must resolve to one field's options. Generic `Sim / Ainda não` sets match several fields (has_cnpj, nbs_experience…), so a question is only a duplicate when **every** candidate field is already answered — an ambiguous match with any unfilled candidate still renders.
- **`ask_user` guard**: duplicate questions are dropped; the tool result names the field and its stored value so the model moves to the next unanswered field. If the whole call was duplicates, it returns `isError` → the model retries invisibly (user never sees a promptless turn; the silent-turn fallback still backstops).
- **`allowReask: true`** — deliberate escape hatch, documented as reserved for a user-requested answer change ("quero mudar a resposta").
- **Fake model mirrors the guard** (same shared helper + filled check), so it's deterministically testable.
- **Skill hardening** in `encontro-1.md`: never-re-ask rule + the live incident as the example.

## Tests
- New `e2e/cbo-reask-guard.spec.ts`: duplicate dropped, unanswered follow-up renders, `allowReask` renders.
- Adjacent specs green: cbo-batched-questions, cougar-e1-conditional-org-type, cbo-golden-path.
- Verified existing scripted specs can't false-positive: 'Seguimos?' [Sim / Quero ajustar] hits only 1 option per field (< 2 floor).

## Safe vs assumed
- Verified: 4 specs green locally; tsc clean on touched files.
- Assumed: the guard covers org_profile (E1) enums only — the observed failures were all E1. E2+ fields get coverage when their catalogs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)