### PR TITLE
Desktop chat-first: right panel collapsed by default

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -35,6 +35,7 @@ import {
   Send, Download, ChevronDown, ChevronRight, AlertTriangle, ArrowLeft, Paperclip,
   FileText, Files, Loader2, RotateCcw, Star, Leaf,
   Check, Circle, AlertCircle, Pencil, Mic, Square, Map as MapIcon, Layers,
+  ChevronsRight, ClipboardList, BarChart3,
   type LucideIcon,
 } from 'lucide-react';
 import { useVoiceRecorder, type RecorderError } from '@/core/hooks/useVoiceRecorder';
@@ -360,6 +361,12 @@ export default function CboProfilePage() {
   // Mobile-only: which top-level pane is visible. On `md+` both panels render
   // side-by-side and this state is ignored.
   const [mobileActiveTab, setMobileActiveTab] = useState<'chat' | 'panel'>('chat');
+  // Desktop chat-first (Perfect Demo decision, 2026-07-14): on md+ the right
+  // panel starts COLLAPSED — chat takes the full width, mirroring the mobile
+  // pattern — and opens when the agent activates a microapp or the user taps
+  // the edge strip. Form + map side-by-side read as "a system" to
+  // low-digital-literacy users; the conversation must be the whole screen.
+  const [desktopPanelOpen, setDesktopPanelOpen] = useState(false);
   // Unread indicator on the Chat tab when the agent posts while the user is on
   // another mobile tab. Cleared on switch-to-chat.
   const [mobileChatUnread, setMobileChatUnread] = useState(false);
@@ -1069,7 +1076,7 @@ export default function CboProfilePage() {
         }]);
         setSelectedOptionIdx(0);
         setIsStreaming(false);
-        if (hasMap) { setMapRelevant(true); setRightTab('map'); setMobileActiveTab('panel'); }
+        if (hasMap) { setMapRelevant(true); setRightTab('map'); setMobileActiveTab('panel'); setDesktopPanelOpen(true); }
         break;
       }
       case 'open_map':
@@ -1091,6 +1098,7 @@ export default function CboProfilePage() {
         setRightTab('map');
         setMapRelevant(true);
         setMobileActiveTab('panel');
+        setDesktopPanelOpen(true);
         setIsStreaming(false);
         break;
       case 'open_intervention_selector':
@@ -1098,6 +1106,7 @@ export default function CboProfilePage() {
         setState(prev => prev ? { ...prev, activeTool: { kind: 'interventions' } } : prev);
         setRightTab('interventions');
         setMobileActiveTab('panel');
+        setDesktopPanelOpen(true);
         setIsStreaming(false);
         break;
       case 'show_types':
@@ -1321,7 +1330,7 @@ export default function CboProfilePage() {
   const handleRestart = useCallback(async () => {
     abortActiveStream();
     if (cboId) { try { await fetch(`/api/cbo/${cboId}`, { method: 'DELETE' }); } catch {} }
-    clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setStreamDraft(''); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+    clearId(); setOpenMapParams(null); setInterventionSelectorParams(null); setStreamDraft(''); setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
     setMessages([]); setActiveQuestions([]); setState(null); setCboId(null);
     // The server just cleared cohort_members.path — mirror it locally so the
     // UI doesn't keep showing the old run's E1 triage answer.
@@ -1592,11 +1601,13 @@ export default function CboProfilePage() {
       )}
       <CboFilesSheet cboId={cboId} open={filesSheetOpen} onOpenChange={setFilesSheetOpen} />
       <div className="flex flex-1 min-h-0">
-        {/* LEFT: Chat — full width on mobile (when Chat tab active), half on md+ */}
+        {/* LEFT: Chat — full width on mobile (when Chat tab active); on md+
+            full width while the panel is collapsed (chat-first), half when
+            the panel is open. */}
         <div
-          className={`w-full md:w-1/2 min-w-0 md:border-r md:flex flex-col relative ${
-            mobileActiveTab === 'chat' ? 'flex' : 'hidden'
-          }`}
+          className={`w-full min-w-0 md:flex flex-col relative ${
+            desktopPanelOpen ? 'md:w-1/2 md:border-r' : 'md:w-full'
+          } ${mobileActiveTab === 'chat' ? 'flex' : 'hidden'}`}
           {...dragHandlers}
         >
           {isDragging && (
@@ -2141,7 +2152,7 @@ export default function CboProfilePage() {
                   <Button
                     size="sm"
                     className="h-8 text-xs gap-1.5 bg-emerald-600 hover:bg-emerald-700"
-                    onClick={() => { setRightTab(pend.def.tab); setMapRelevant(true); setMobileActiveTab('panel'); }}
+                    onClick={() => { setRightTab(pend.def.tab); setMapRelevant(true); setMobileActiveTab('panel'); setDesktopPanelOpen(true); }}
                     data-testid={`cbo-open-tool-${pend.kind}`}
                   >
                     <Icon className="w-3.5 h-3.5" /> {lang === 'pt' ? pend.def.nudge.pt : pend.def.nudge.en}
@@ -2267,15 +2278,28 @@ export default function CboProfilePage() {
 
         {/* RIGHT: Document / Map / Scorecard / Interventions
             On mobile: visible only when mobileActiveTab === 'panel' (the user
-            tapped a non-Chat tab, or the agent invoked a microapp). */}
+            tapped a non-Chat tab, or the agent invoked a microapp).
+            On md+: only while desktopPanelOpen — collapsed is the default. */}
         <div
-          className={`w-full md:w-1/2 min-w-0 md:flex flex-col bg-muted/30 ${
-            mobileActiveTab === 'panel' ? 'flex' : 'hidden'
-          }`}
+          className={`w-full min-w-0 flex-col bg-muted/30 ${
+            desktopPanelOpen ? 'md:flex md:w-1/2' : 'md:hidden'
+          } ${mobileActiveTab === 'panel' ? 'flex' : 'hidden'}`}
         >
           <div className="border-b bg-background">
             <div className="px-4 pt-3 pb-0">
-              <h2 className="text-base font-semibold">{state.orgName || t('cbo.interventionProfile')}</h2>
+              <div className="flex items-start justify-between gap-2">
+                <h2 className="text-base font-semibold">{state.orgName || t('cbo.interventionProfile')}</h2>
+                <button
+                  type="button"
+                  onClick={() => setDesktopPanelOpen(false)}
+                  className="hidden md:inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+                  title={lang === 'pt' ? 'Recolher painel' : 'Collapse panel'}
+                  aria-label={lang === 'pt' ? 'Recolher painel' : 'Collapse panel'}
+                  data-testid="cbo-panel-collapse"
+                >
+                  <ChevronsRight className="w-4 h-4" />
+                </button>
+              </div>
               <div className="flex items-center gap-3 mt-1.5 mb-2">
                 <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden"><div className="h-full bg-green-500 rounded-full transition-all duration-500" style={{ width: `${(filledCount / 7) * 100}%` }} /></div>
                 <span className="text-xs text-muted-foreground shrink-0">{filledCount}/7</span>
@@ -2429,7 +2453,7 @@ export default function CboProfilePage() {
                       if (currentQuestion) setActiveQuestions([]);
                       sendMessage(message, false, false, summary, 'map');
                       setOpenMapParams(null);
-                      setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat');
+                      setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
                     }}
                     onCancel={() => {
                       // Leaving the map is navigation, not completion. Keep
@@ -2437,7 +2461,7 @@ export default function CboProfilePage() {
                       // the step the user left; nulling it here is what made
                       // re-entry fall through to the phase defaults and drop
                       // the guided hazard tour. Only onConfirm clears it.
-                      setRightTab('document'); setMobileActiveTab('chat');
+                      setRightTab('document'); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
                     }}
                   />
                 ) : (
@@ -2461,7 +2485,7 @@ export default function CboProfilePage() {
                         : result.label; // "I don't know — help me decide"
                       if (currentQuestion) handleSelectOption(message); else sendMessage(message);
                       setInterventionSelectorParams(null);
-                      setRightTab('document'); setMobileActiveTab('chat');
+                      setRightTab('document'); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
                     }}
                     onCancel={() => {
                       // Same rule as the map: leaving is navigation, not
@@ -2470,7 +2494,7 @@ export default function CboProfilePage() {
                       // but the tab it opened showed the "not yet" placeholder,
                       // because `interventions` has no defaultParams to fall
                       // back to. Only onConfirm may clear it.
-                      setRightTab('document'); setMobileActiveTab('chat');
+                      setRightTab('document'); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
                     }}
                   />
                 ) : (
@@ -2524,6 +2548,41 @@ export default function CboProfilePage() {
             </div>
           )}
         </div>
+
+        {/* DESKTOP EDGE STRIP — md+ only, rendered while the panel is
+            collapsed (chat-first default). Mirrors the mobile tab bar's
+            availability rules: Perfil + Scorecard always; Mapa /
+            Intervenções only while those microapps are live. */}
+        {!desktopPanelOpen && (
+          <div className="hidden md:flex w-14 shrink-0 border-l bg-background flex-col items-stretch pt-2 gap-1" data-testid="cbo-panel-strip">
+            {(() => {
+              const stripTabs: Array<{ tab: 'document' | 'map' | 'interventions' | 'scorecard'; Icon: LucideIcon; label: string; pulse?: boolean }> = [
+                { tab: 'document', Icon: ClipboardList, label: t('cbo.mobileTab.perfil', { defaultValue: 'Perfil' }), pulse: pendingTool(state)?.def.tab === 'document' },
+                ...(openMapParams != null || mapRelevant
+                  ? [{ tab: 'map' as const, Icon: MapIcon, label: t('cbo.mobileTab.map', { defaultValue: 'Mapa' }), pulse: mapRelevant || pendingTool(state)?.def.tab === 'map' }]
+                  : []),
+                ...(interventionSelectorParams != null
+                  ? [{ tab: 'interventions' as const, Icon: Leaf, label: t('cbo.tabs.interventions', 'NBS'), pulse: true }]
+                  : []),
+                { tab: 'scorecard', Icon: BarChart3, label: t('cbo.tabs.scorecard') },
+              ];
+              return stripTabs.map(({ tab, Icon, label, pulse }) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => { setRightTab(tab); setDesktopPanelOpen(true); }}
+                  className="relative flex flex-col items-center gap-0.5 py-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors rounded-md mx-1"
+                  data-testid={`cbo-strip-${tab}`}
+                  title={label}
+                >
+                  <Icon className="w-4 h-4" />
+                  <span className="text-[9px] leading-tight text-center px-0.5 truncate max-w-full">{label}</span>
+                  {pulse && <span className="absolute top-1 right-1.5 w-2 h-2 rounded-full bg-green-500 animate-pulse" />}
+                </button>
+              ));
+            })()}
+          </div>
+        )}
       </div>
 
       {/* MOBILE TAB BAR — visible only below md. Drives `mobileActiveTab` +

--- a/e2e/cougar-activetool-cold-load.spec.ts
+++ b/e2e/cougar-activetool-cold-load.spec.ts
@@ -86,9 +86,12 @@ test.describe('COUGAR — activeTool survives a cold load', () => {
     await page.reload();
     await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
 
-    // Leave to the document tab: the nudge chip (pendingTool → activeTool.kind)
-    // must still be there. Before the column, activeTool was null cold → no chip.
-    await page.getByTestId('cbo-tab-document').click();
+    // Chat-first desktop: a cold load lands on the chat with the panel
+    // collapsed, and the nudge chip (pendingTool → activeTool.kind) is the
+    // re-entry affordance. Before the column, activeTool was null cold → no
+    // chip; before chat-first this needed a click over to the document tab.
     await expect(page.getByTestId('cbo-open-tool-map')).toBeVisible({ timeout: 10_000 });
+    // The map-relevant strip button pulses too — the second way back in.
+    await expect(page.getByTestId('cbo-strip-map')).toBeVisible();
   });
 });

--- a/e2e/cougar-desktop-chat-first.spec.ts
+++ b/e2e/cougar-desktop-chat-first.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Desktop chat-first (Perfect Demo decision, 2026-07-14): on md+ the right
+// panel (Documento/Mapa/…) starts COLLAPSED so the conversation is the whole
+// screen — the mobile pattern applied to desktop. A slim edge strip re-opens
+// it; the agent's microapps (open_map, …) auto-open it; a collapse control
+// closes it again.
+
+test.describe('COUGAR — desktop is chat-first (right panel collapsed)', () => {
+  test.use({ locale: 'pt-BR', viewport: { width: 1280, height: 800 } });
+
+  test('collapsed by default; strip opens; collapse closes; open_map auto-opens', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Default: chat full-width, panel closed, edge strip present.
+    await expect(page.getByTestId('cbo-panel-strip')).toBeVisible();
+    await expect(page.getByTestId('cbo-tab-document')).not.toBeVisible();
+    await expect(page.getByTestId('cbo-chat-input')).toBeVisible();
+
+    // The strip opens the panel on the chosen tab; the strip goes away.
+    await page.getByTestId('cbo-strip-document').click();
+    await expect(page.getByTestId('cbo-tab-document')).toBeVisible();
+    await expect(page.getByTestId('cbo-panel-strip')).not.toBeVisible();
+    // Chat stays visible next to it (split view, not a swap).
+    await expect(page.getByTestId('cbo-chat-input')).toBeVisible();
+
+    // The collapse control closes it again.
+    await page.getByTestId('cbo-panel-collapse').click();
+    await expect(page.getByTestId('cbo-panel-strip')).toBeVisible();
+    await expect(page.getByTestId('cbo-tab-document')).not.toBeVisible();
+
+    // An agent microapp auto-opens the panel (the user must never have to
+    // find the map themselves).
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Vamos olhar o mapa.' },
+        { op: 'open_map' },
+      ],
+    ]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('bora');
+    await input.press('Enter');
+    await expect(page.getByTestId('cbo-tab-map')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('cbo-panel-strip')).not.toBeVisible();
+  });
+});

--- a/e2e/cougar-desktop-strip-grid.spec.ts
+++ b/e2e/cougar-desktop-strip-grid.spec.ts
@@ -33,11 +33,18 @@ test.describe('COUGAR — showcase strip wraps into a grid on desktop', () => {
     expect(n).toBeGreaterThanOrEqual(3);
 
     // Every card sits fully inside the chat column — none clipped at an edge.
-    const vw = await page.evaluate(() => document.documentElement.clientWidth);
+    // Chat-first desktop: the column ends at the collapsed panel's edge strip
+    // (or, with the panel open, at the half-viewport split) — not at a
+    // hardcoded vw/2.
+    const chatRight = await page.evaluate(() => {
+      const strip = document.querySelector('[data-testid="cbo-panel-strip"]');
+      if (strip) return strip.getBoundingClientRect().left;
+      return document.documentElement.clientWidth / 2;
+    });
     for (let i = 0; i < n; i++) {
       const box = (await cards.nth(i).boundingBox())!;
       expect(box.x).toBeGreaterThanOrEqual(-1);
-      expect(box.x + box.width).toBeLessThanOrEqual(vw / 2 + 2);
+      expect(box.x + box.width).toBeLessThanOrEqual(chatRight + 2);
     }
 
     // The strip container itself has nothing to scroll (it wrapped instead).

--- a/e2e/cougar-e1-enum-labels.spec.ts
+++ b/e2e/cougar-e1-enum-labels.spec.ts
@@ -40,6 +40,8 @@ test.describe('COUGAR — E1 enum fields render human labels, never machine ids'
     await input.press('Enter');
     await expect(marker).toHaveAttribute('data-streaming', 'false');
 
+    // Chat-first desktop: the document panel starts collapsed — open it.
+    await page.getByTestId('cbo-strip-document').click();
     // Histórico card shows the Portuguese chip labels…
     await expect(page.getByText('Projeto com financiamento', { exact: false })).toBeVisible();
     await expect(page.getByText('Hortas / arborização', { exact: false })).toBeVisible();
@@ -78,6 +80,8 @@ test.describe('COUGAR — E1 enum fields render human labels, never machine ids'
     await input.press('Enter');
     await expect(marker).toHaveAttribute('data-streaming', 'false');
 
+    // Chat-first desktop: the document panel starts collapsed — open it.
+    await page.getByTestId('cbo-strip-document').click();
     // Fuzzy hit: the paraphrase landed on the canonical chip label.
     await expect(page.getByText('ONG / Associação', { exact: false }).first()).toBeVisible();
     await expect(page.getByText('Associação comunitária de moradores', { exact: false })).toHaveCount(0);

--- a/e2e/cougar-filled-count.spec.ts
+++ b/e2e/cougar-filled-count.spec.ts
@@ -35,6 +35,8 @@ test.describe('COUGAR — CBO progress count matches the server predicate', () =
     await page.reload();
     await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
 
+    // Chat-first desktop: the count lives in the collapsed panel — open it.
+    await page.getByTestId('cbo-strip-document').click();
     await expect(page.getByText('0/7').first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText('1/7')).toHaveCount(0);
   });
@@ -56,6 +58,8 @@ test.describe('COUGAR — CBO progress count matches the server predicate', () =
     await page.reload();
     await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
 
+    // Chat-first desktop: the count lives in the collapsed panel — open it.
+    await page.getByTestId('cbo-strip-document').click();
     await expect(page.getByText('1/7').first()).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Why
Perfect Demo decision (2026-07-14, Ana + JVP): the desktop view shows chat + form/map side-by-side, which reads as "a system" and overloads low-digital-literacy users. Decision: apply the mobile pattern to desktop — the conversation is the whole screen; the panel appears when needed.

## What
- **md+ starts with the right panel collapsed** and the chat full-width (`desktopPanelOpen`, default false). Mobile behavior unchanged.
- **Slim edge strip** on the right (Perfil / Mapa / Intervenções / Scorecard) re-opens the panel; availability mirrors the mobile tab bar (Mapa/Intervenções only while those microapps are live) with pulse dots for pending tools.
- **Auto-open**: the agent's microapps open the panel themselves — `open_map`, the intervention selector, map-relevant questions, and the pending-tool nudge chip. Confirm/cancel on the map/selector and a restart collapse it again.
- **Collapse control** (chevron) in the panel header.
- **Cold load stays chat-first**: reloading mid-map lands on chat with the nudge chip + a pulsing Mapa strip button as re-entry paths (`cougar-activetool-cold-load.spec.ts` updated accordingly — the old flow clicked a tab that no longer renders while collapsed).

## Tests
- New `e2e/cougar-desktop-chat-first.spec.ts`: collapsed default, strip opens, collapse closes, `open_map` auto-opens.
- `cougar-activetool-cold-load`, `cougar-e2-map-help`, `cougar-e2-map-reentry` green.
- Full chromium suite run reported in comments.

## Safe vs assumed
- Verified: welcome screen early-returns before the split, so no strip pre-chat; all panel auto-open/close call sites audited (grep of every setMobileActiveTab/setRightTab site).
- Assumed: no coordinator flow embeds this page (it's the member view only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)