### PR TITLE
Rede SCbN POA branding: welcome screen + coordinator view (colors, no logo)

### DIFF
--- a/client/src/core/components/RedeMark.tsx
+++ b/client/src/core/components/RedeMark.tsx
@@ -1,0 +1,22 @@
+// Rede SCbN POA brand motif — the logo's four organic color tiles reduced to
+// a quiet 2×2 mark. Decision (COUGAR Perfect Demo, 2026-07-14): the platform
+// carries the network's visual identity (colors), never the logo itself —
+// it serves the whole Rede, not one organization.
+//
+// Palette sampled from the official logo PDF:
+//   terracotta #8A4C38 · ochre #8F7041 · blue #4B5C8A · teal #7D9AA6
+//   cream (backgrounds) #EFE9DC · slate (text/CTAs) #3F4A46
+
+const TILES = ['bg-[#8A4C38]', 'bg-[#8F7041]', 'bg-[#4B5C8A]', 'bg-[#7D9AA6]'];
+
+export function RedeMark({ size = 'sm' }: { size?: 'sm' | 'md' }) {
+  const tile = size === 'md' ? 'w-3.5 h-3.5 rounded-[5px]' : 'w-2 h-2 rounded-[3px]';
+  const gap = size === 'md' ? 'gap-1' : 'gap-0.5';
+  return (
+    <div className={`grid grid-cols-2 ${gap} shrink-0`} aria-hidden data-testid="rede-mark">
+      {TILES.map(c => (
+        <span key={c} className={`${tile} ${c}`} />
+      ))}
+    </div>
+  );
+}

--- a/client/src/core/components/cbo/CboWelcome.tsx
+++ b/client/src/core/components/cbo/CboWelcome.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
-import { Calendar, Clock, Leaf, Sprout } from 'lucide-react';
+import { Calendar, Clock, Sprout } from 'lucide-react';
 import { Button } from '@/core/components/ui/button';
+import { RedeMark } from '@/core/components/RedeMark';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { formatCalendarDate } from '@/lib/dateHelpers';
 import { localizedWorkshopName } from '@/lib/workshopHelpers';
@@ -51,12 +52,12 @@ export function CboWelcome({
     : null;
 
   return (
-    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-emerald-50/60 via-white to-emerald-50/40 dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
-      {/* Top bar — quiet brand mark, no other chrome */}
-      <header className="px-5 sm:px-8 py-5 flex items-center gap-2 text-emerald-700 dark:text-emerald-400">
-        <Leaf className="w-4 h-4" strokeWidth={1.75} />
+    <div className="min-h-[100dvh] flex flex-col bg-gradient-to-b from-[#EFE9DA] via-[#F8F4EB] to-[#ECE5D3] dark:from-emerald-950/30 dark:via-background dark:to-emerald-950/20">
+      {/* Top bar — quiet brand mark (Rede palette, no logo), no other chrome */}
+      <header className="px-5 sm:px-8 py-5 flex items-center gap-2.5 text-[#3F4A46] dark:text-emerald-400">
+        <RedeMark />
         <span className="text-xs font-medium uppercase tracking-[0.18em]">
-          {t('cbo.welcome.brand', { defaultValue: 'COUGAR · Vila Flores' })}
+          {t('cbo.welcome.brand', { defaultValue: 'COUGAR · Rede SCbN POA' })}
         </span>
       </header>
 
@@ -70,10 +71,10 @@ export function CboWelcome({
         >
           {/* Greeting */}
           <div className="space-y-2">
-            <p className="text-sm text-emerald-700/80 dark:text-emerald-300/80 font-medium">
+            <p className="text-sm text-[#8A4C38] dark:text-emerald-300/80 font-medium">
               {t('cbo.welcome.greeting', { defaultValue: 'Olá,' })}
             </p>
-            <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight text-foreground">
+            <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight text-[#3F4A46] dark:text-foreground">
               {orgName}
             </h1>
             {neighborhood && (
@@ -106,9 +107,9 @@ export function CboWelcome({
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.15 }}
-              className="rounded-xl border border-emerald-200/60 bg-white/70 dark:border-emerald-900/40 dark:bg-emerald-950/30 px-4 py-3 backdrop-blur-sm"
+              className="rounded-xl border border-[#3F4A46]/15 bg-white/75 dark:border-emerald-900/40 dark:bg-emerald-950/30 px-4 py-3 backdrop-blur-sm"
             >
-              <p className="text-[10px] uppercase tracking-wider text-emerald-700/70 dark:text-emerald-400/70 font-semibold mb-1.5">
+              <p className="text-[10px] uppercase tracking-wider text-[#4B5C8A] dark:text-emerald-400/70 font-semibold mb-1.5">
                 {focusWorkshopIsCurrent
                   ? t('cbo.welcome.currentWorkshopLabel', { defaultValue: 'Current workshop' })
                   : t('cbo.welcome.nextWorkshopLabel', { defaultValue: 'Next workshop' })}
@@ -137,12 +138,16 @@ export function CboWelcome({
                 { label: t('cbo.welcome.step3', { defaultValue: 'What you build' }), unlocked: unlockedPhases.includes(3) },
                 { label: t('cbo.welcome.step4', { defaultValue: 'What you need' }), unlocked: unlockedPhases.includes(4) },
                 { label: t('cbo.welcome.step5', { defaultValue: 'Results & evidence' }), unlocked: unlockedPhases.includes(5) },
-              ].map((s, i) => (
-                <li key={i} className="flex items-center gap-2.5 text-sm">
-                  <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${s.unlocked ? 'bg-emerald-500' : 'bg-foreground/15'}`} />
-                  <span className={s.unlocked ? 'text-foreground/85' : 'text-muted-foreground/60'}>{s.label}</span>
-                </li>
-              ))}
+              ].map((s, i) => {
+                // Unlocked steps carry the Rede tile colors, in logo order.
+                const tone = ['bg-[#8A4C38]', 'bg-[#8F7041]', 'bg-[#4B5C8A]', 'bg-[#7D9AA6]', 'bg-[#3F4A46]'][i];
+                return (
+                  <li key={i} className="flex items-center gap-2.5 text-sm">
+                    <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${s.unlocked ? tone : 'bg-foreground/15'}`} />
+                    <span className={s.unlocked ? 'text-foreground/85' : 'text-muted-foreground/60'}>{s.label}</span>
+                  </li>
+                );
+              })}
             </ol>
           </div>
 
@@ -150,7 +155,7 @@ export function CboWelcome({
           <div className="pt-2 space-y-2">
             <Button
               size="lg"
-              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white rounded-full h-12 text-base font-medium shadow-sm"
+              className="w-full bg-[#3F4A46] hover:bg-[#33403B] dark:bg-emerald-600 dark:hover:bg-emerald-700 text-white rounded-full h-12 text-base font-medium shadow-sm"
               onClick={hasExistingProgress ? onResume : onStart}
               data-testid="button-cbo-welcome-cta"
             >

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -37,6 +37,7 @@ import {
 import { NBS_SHOWCASE_CARDS } from '@shared/nbs-showcase-cards';
 import { TitleLarge, BodyMedium, BodySmall } from '@oef/components';
 import { useToast } from '@/core/hooks/use-toast';
+import { RedeMark } from '@/core/components/RedeMark';
 import { useResetRole } from '@/core/contexts/role-context';
 import { useCohort } from '@/core/hooks/useCohort';
 import { useLocation } from 'wouter';
@@ -1143,13 +1144,14 @@ export default function OrchestratorLandingPage() {
   }
 
   return (
-    <div className="min-h-screen relative bg-gradient-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-background dark:to-slate-950">
-      {/* Header */}
-      <header className="relative z-10 px-6 sm:px-10 py-6 border-b border-foreground/5 bg-background/40 backdrop-blur-sm">
+    <div className="min-h-screen relative bg-gradient-to-b from-[#F2EDE0] via-white to-[#F2EDE0] dark:from-slate-950 dark:via-background dark:to-slate-950">
+      {/* Header — carries the Rede SCbN POA palette (colors only, no logo:
+          the platform serves the whole network, not one org). */}
+      <header className="relative z-10 px-6 sm:px-10 py-6 border-b border-[#3F4A46]/10 dark:border-foreground/5 bg-background/40 backdrop-blur-sm">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-lg bg-amber-50 dark:bg-amber-950/40 text-amber-600 dark:text-amber-300 flex items-center justify-center">
-              <Compass className="w-5 h-5" strokeWidth={1.75} />
+            <div className="w-10 h-10 rounded-lg bg-white/80 border border-[#3F4A46]/10 dark:bg-amber-950/40 dark:border-transparent flex items-center justify-center">
+              <RedeMark size="md" />
             </div>
             <div>
               <BodySmall className="text-muted-foreground uppercase tracking-wide text-[11px]">

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1846,7 +1846,7 @@
       "results_evidence": "5. Results & Evidence"
     },
     "welcome": {
-      "brand": "COUGAR · Vila Flores",
+      "brand": "COUGAR · Rede SCbN POA",
       "greeting": "Hi,",
       "neighborhood": "from {{n}}",
       "invitationLead": "You've been invited to the {{cohort}} platform — a quiet space to share what your organization does, where you work, and what you need to move your project forward.",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -2026,7 +2026,7 @@
       "results_evidence": "5. Resultados e Evidências"
     },
     "welcome": {
-      "brand": "COUGAR · Vila Flores",
+      "brand": "COUGAR · Rede SCbN POA",
       "greeting": "Olá,",
       "neighborhood": "de {{n}}",
       "invitationLead": "Você foi convidado(a) para a plataforma do {{cohort}} — um espaço tranquilo para contar o que a sua organização faz, onde trabalha, e do que precisa para tirar o seu projeto do papel.",


### PR DESCRIPTION
## Why
Perfect Demo decision (2026-07-14): apply the Rede SCbN POA visual identity to the platform — **colors only, never the logo** (the platform serves the whole network, so full Vila Flores/Rede logos would misalign with the network-building goal), and label the platform as the **Rede**, not Vila Flores.

## What
- **`RedeMark`** — the logo's four organic tiles reduced to a quiet 2×2 mark. Palette sampled from the official logo PDF: terracotta `#8A4C38`, ochre `#8F7041`, blue `#4B5C8A`, teal `#7D9AA6`, cream `#EFE9DC`, slate `#3F4A46`.
- **Welcome screen** (the WhatsApp-invite landing): cream gradient background, slate headline + CTA button, terracotta greeting, blue workshop-card eyebrow, journey-step dots in the tile colors, RedeMark in the header. Brand line is now **"COUGAR · Rede SCbN POA"** (pt + en). Dark mode keeps the existing emerald look.
- **Coordinator view**: cream page tint + RedeMark header tile replacing the amber compass. Functional colors (risk tones, statuses, progress) untouched.
- Chat UI untouched — its green semantics (answered chips, streaming) stay.

## Verified
Screenshot pass on mobile (390px) + desktop welcome and the orchestrator — reviewed before commit. Specs: cougar-welcome-scroll, cbo-instant-kickoff, cougar-cohort-language, cougar-admin-cohort-panel green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)