### PR TITLE
Path section updates live on set_path (no refresh)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1053,6 +1053,12 @@ export default function CboProfilePage() {
         // cboStateId-link effect and the unlock clamp still use it.
         setState(prev => prev ? { ...prev, phase: event.phase } : prev);
         break;
+      case 'path_set':
+        // The E1 closing set_path writes cohort_members.path — mirror it
+        // locally so the panel's Path section flips from "not yet chosen"
+        // without needing a page refresh (Perfect Demo 2026-07-14).
+        setMemberPath(event.path);
+        break;
       case 'maturity_update':
         setState(prev => prev ? { ...prev, maturityScores: event.scores, totalMaturityScore: event.total, priorityFlags: event.flags } : prev);
         break;

--- a/e2e/cbo-path-live-update.spec.ts
+++ b/e2e/cbo-path-live-update.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Perfect Demo (2026-07-14): after the E1 closing set_path, the panel's Path
+// section kept saying "Caminho ainda não escolhido" until a full page refresh
+// — the value lands on cohort_members.path, which the client only refetches
+// on load. set_path now emits a path_set event so the panel flips live.
+
+test.describe('COUGAR — the Path section updates live on set_path', () => {
+  test.use({ locale: 'pt-BR', viewport: { width: 1280, height: 800 } });
+
+  test('the panel flips from "not chosen" to the chosen path without a reload', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Chat-first desktop: open the document panel to watch the Path section.
+    await page.getByTestId('cbo-strip-document').click();
+    await expect(page.getByText('Caminho ainda não escolhido')).toBeVisible({ timeout: 10_000 });
+
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'say', text: 'Fechando o diagnóstico.' },
+        { op: 'set_path', path: 'has-project' },
+      ],
+    ]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('já temos um projeto definido');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // No reload — the chip appears and the placeholder goes away.
+    await expect(page.getByText('Já tem um projeto NBS definido')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Caminho ainda não escolhido')).toHaveCount(0);
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -483,6 +483,10 @@ function createCboMcpTools(cboId: string) {
         if (result.length === 0) {
           return { content: [{ type: "text" as const, text: `No cohort member linked to this CBO; path '${args.path}' not persisted (standalone session).` }] };
         }
+        // Without this event the panel's Path section says "not yet chosen"
+        // until a full page refresh (Perfect Demo 2026-07-14) — the value
+        // lives on the member row, which the client only refetches on load.
+        pushEvent({ type: 'path_set', path: args.path });
         return { content: [{ type: "text" as const, text: `Path set to '${args.path}' for ${result[0].orgName}.` }] };
       } catch (err: any) {
         return { content: [{ type: "text" as const, text: `Error setting path: ${err.message}` }], isError: true };

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -57,6 +57,7 @@ export type FakeOp =
   | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean; allowReask?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
   | { op: 'set_phase'; phase: number }
+  | { op: 'set_path'; path: 'has-project' | 'has-idea' | 'needs-help' } // emits path_set (display mirror; standalone sessions have no member row)
   | { op: 'priority_flag'; flag: string; met: boolean; notes?: string }
   | { op: 'open_map'; params?: Record<string, unknown> }
   | { op: 'open_intervention_selector'; params?: Record<string, unknown> }
@@ -224,6 +225,12 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       state.phase = phase;
       deps.setCboState(cboId, state);
       pushEvent({ type: 'phase_change', phase });
+      break;
+    }
+    case 'set_path': {
+      // Display mirror of the real set_path's path_set event (the DB write to
+      // cohort_members is skipped — standalone e2e sessions have no member).
+      pushEvent({ type: 'path_set', path: op.path });
       break;
     }
     case 'priority_flag': {

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -329,6 +329,10 @@ export type CboEvent =
   | { type: 'field_update'; sectionId: string; field: string; value: string; confidence: Confidence; source?: string }
   | { type: 'gap'; sectionId: string; field: string; reason: string; severity: string }
   | { type: 'phase_change'; phase: number }
+  // set_path persists to cohort_members and used to be silent — the panel's
+  // Path section kept saying "not yet chosen" until a full page refresh
+  // (Perfect Demo 2026-07-14). This event lets the client update live.
+  | { type: 'path_set'; path: 'has-project' | 'has-idea' | 'needs-help' }
   | { type: 'maturity_update'; scores: MaturityScore[]; total: number; flags: PriorityFlag[] }
   // options[].action 'upload': the chip renders as a prominent attach banner
   // (paperclip icon) and opens the file picker instead of answering — the


### PR DESCRIPTION
Last Perfect Demo transcript item: after the E1 closing `set_path`, the panel's Path section kept saying **"Caminho ainda não escolhido"** until a full page refresh (you both hit this live — "no tiene que actualizar la página"). The value lands on `cohort_members.path`, which the client only refetches on page load; the tool emitted no event.

- `set_path` now pushes a `path_set` SSE event after the DB write; the client mirrors it into `memberPath`, so the panel chip appears the moment the diagnostic closes.
- Fake model gets a `set_path` op (event mirror only — standalone e2e sessions have no member row).
- New spec `e2e/cbo-path-live-update.spec.ts`: placeholder → chip, no reload.

Verified on prod data earlier today that the underlying persistence was always fine (Ana's test member has `path: has-project` stored) — this is purely the live-display gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)