### PR TITLE
Mobile: chat shell follows the visual viewport (dead space below tab bar)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,10 +8,15 @@
          automatically (page is constrained above the URL bar / below the
          notch). Adding viewport-fit=cover would require us to manage all
          safe-area-inset offsets, which created empty space below the mobile
-         tab bar where Safari's URL bar was overlaying. -->
+         tab bar where Safari's URL bar was overlaying.
+         interactive-widget=resizes-content: Android Chrome 108+ resizes the
+         LAYOUT viewport when the keyboard opens (instead of overlaying it),
+         so 100dvh layouts stay correct with zero JS there. iOS ignores it —
+         the visualViewport follower in cbo-profile covers iOS. See
+         docs/mobile-viewport.md. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
     />
     <!-- Brand tint for Safari/Chrome toolbar. Light + dark variants match the
          emerald-50 page bg the CBO flow uses; falls back to single value for

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -794,6 +794,17 @@ export default function CboProfilePage() {
   // scroll, so the chrome can't move and the bottom bar is pinned. Both are
   // scoped to this page and restored on unmount.
   //
+  //  3. HEIGHT ALONE IS NOT ENOUGH (field report 2026-07-15, WhatsApp→Safari):
+  //     when the keyboard opens, iOS also SCROLLS the visual viewport down
+  //     (visualViewport.offsetTop > 0) to reveal the focused input. A shell
+  //     anchored at the layout-viewport top then pokes out of the visible
+  //     window: the tab bar rides up and dead space (= offsetTop) opens below
+  //     it, growing while typing. On dismiss iOS often fails to restore the
+  //     offset (long-standing bug, worse on iOS 26), leaving a permanent gap.
+  //     So the shell also FOLLOWS the viewport: translateY(offsetTop), plus a
+  //     scroll reset (nothing legitimate ever scrolls the locked document, so
+  //     any window scroll is Safari residue). See docs/mobile-viewport.md.
+  //
   // Scoped to the CHAT shell only: the welcome/preamble screens have no inner
   // scroller, so they need normal document scroll — locking during them
   // stranded the CTA below the fold on short desktop viewports (field report
@@ -805,9 +816,18 @@ export default function CboProfilePage() {
     const root = document.documentElement;
     const body = document.body;
     const mount = document.getElementById('root');
+    let raf = 0;
     const setVH = () => {
-      const h = window.visualViewport?.height ?? window.innerHeight;
-      root.style.setProperty('--cbo-vh', `${Math.round(h)}px`);
+      if (raf) return; // coalesce bursts (iOS fires resize+scroll together)
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const v = window.visualViewport;
+        const h = v?.height ?? window.innerHeight;
+        const top = v?.offsetTop ?? 0;
+        root.style.setProperty('--cbo-vh', `${Math.round(h)}px`);
+        root.style.setProperty('--cbo-vv-top', `${Math.round(top)}px`);
+        if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
+      });
     };
     setVH();
     const vv = window.visualViewport;
@@ -840,7 +860,9 @@ export default function CboProfilePage() {
       vv?.removeEventListener('scroll', setVH);
       window.removeEventListener('orientationchange', setVH);
       window.removeEventListener('resize', setVH);
+      if (raf) cancelAnimationFrame(raf);
       root.style.removeProperty('--cbo-vh');
+      root.style.removeProperty('--cbo-vv-top');
       root.style.overflow = prev.htmlOverflow;
       root.style.height = prev.htmlHeight;
       body.style.overflow = prev.bodyOverflow;
@@ -1572,7 +1594,7 @@ export default function CboProfilePage() {
   }
 
   return (
-    <div className="h-[100dvh] flex flex-col bg-background overflow-hidden" style={{ height: 'var(--cbo-vh, 100dvh)' }}>
+    <div data-testid="cbo-shell" className="h-[100dvh] flex flex-col bg-background overflow-hidden" style={{ height: 'var(--cbo-vh, 100dvh)', transform: 'translateY(var(--cbo-vv-top, 0px))' }}>
       {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
           waits on this hidden marker's attributes instead: data-streaming flips
           to 'false' when a turn ends, data-turns counts completed turns, and

--- a/docs/mobile-viewport.md
+++ b/docs/mobile-viewport.md
@@ -1,0 +1,83 @@
+# Mobile viewport — why the layout breaks, and the invariants that keep it fixed
+
+Audience: WhatsApp-invited community members on phones — **low-end Androids
+and iPhones, often inside in-app browsers**. This page exists because the
+"empty space at the bottom" bug has now been fixed twice (2026-07 desktop-pass
+era: height only; 2026-07-15: scroll offset). Read this before touching any
+full-height mobile layout so we never fix it a third time.
+
+## The three viewports (the whole problem in one table)
+
+| Thing | What it is | Keyboard opens → |
+|---|---|---|
+| **Layout viewport** (`100vh`, `window.innerHeight`-ish) | What CSS lays out against | iOS: UNCHANGED. Android (with `interactive-widget=resizes-content`): shrinks |
+| **Visual viewport** (`window.visualViewport`) | What's actually visible | Shrinks on both platforms |
+| **Visual-viewport OFFSET** (`visualViewport.offsetTop`) | Where the visible window sits inside the layout viewport | iOS SCROLLS it down to reveal the focused input — and often fails to scroll back on dismiss (long-standing bug, worse on iOS 26) |
+
+`100dvh` tracks browser-chrome show/hide but **does NOT shrink for the
+keyboard on iOS**. That's why a pure-CSS layout can't pin a composer above the
+iOS keyboard.
+
+## The failure we actually shipped (2026-07-15 field report)
+
+The chat shell height was driven from `visualViewport.height` (correct), but
+the shell stayed anchored at the layout-viewport top. iOS opened the keyboard
+and scrolled the visual viewport down: the visible window slid past the shell
+→ tab bar floated mid-screen, dead space (= `offsetTop`) below it, growing
+while typing, and a residual gap after dismiss because iOS didn't restore the
+offset. Screenshot in the PR.
+
+## The invariants (all live in `cbo-profile.tsx`'s viewport effect + `client/index.html`)
+
+1. **The chat shell is exactly `visualViewport.height` tall** — via
+   `--cbo-vh`, with `100dvh` as the no-JS fallback.
+2. **The shell FOLLOWS the visual viewport**: `translateY(var(--cbo-vv-top))`
+   where `--cbo-vv-top = visualViewport.offsetTop`. Height without offset is
+   half a fix.
+3. **The document is scroll-locked while the chat shell shows**
+   (`overflow:hidden` on html/body/#root — NOT `position:fixed` on body,
+   which makes iOS paint ghost copies of the composer during momentum
+   scroll). Only the message list scrolls.
+4. **Any window scroll is Safari residue** — nothing legitimate can scroll a
+   locked document, so the handler resets `scrollTo(0,0)`. This is what
+   clears the post-dismiss gap.
+5. **One rAF-coalesced listener** on `visualViewport` `resize`+`scroll` (+
+   window `resize`/`orientationchange`). Cheap enough for low-end Androids;
+   the transform is GPU-composited. Do not add per-frame work here.
+6. **`interactive-widget=resizes-content`** in the viewport meta: Android
+   Chrome 108+ then resizes the LAYOUT viewport for the keyboard, making
+   Android correct with zero JS. iOS ignores the flag — the follower covers it.
+7. **Inputs are ≥16px on mobile** (`text-base`, `md:text-sm`) — under 16px
+   iOS auto-zooms on focus, which changes `visualViewport.scale` and creates
+   a whole second family of offset bugs. Never "fix" a dense layout by
+   shrinking input font below 16px.
+8. **No `viewport-fit=cover`** — the system then handles safe areas; the tab
+   bar keeps only `env(safe-area-inset-bottom)` padding (`.safe-bottom`).
+9. **The lock is scoped to the chat shell** — welcome/preamble screens keep
+   normal document scroll (a locked welcome stranded the CTA below the fold
+   on short desktop viewports).
+
+## Do / Don't
+
+- ✅ New full-height mobile screen → `h-[100dvh]` + inner scroller; if it has
+  a keyboard-focused composer, reuse the shell's follower pattern.
+- ✅ Fixed-position UI → portal it to `body` (Radix does). The shell has a
+  `transform`, so it is the containing block for any `fixed` descendant.
+- ❌ Don't read `window.innerHeight` at one moment and cache it into a layout.
+- ❌ Don't add `maximum-scale=1` to the meta (accessibility) — the ≥16px rule
+  already prevents focus zoom.
+- ❌ Don't hand the document scroll back to the chat page "just for one
+  screen" — rubber-banding moves the browser chrome and reopens the gap.
+
+## Regression net
+
+- `e2e/cbo-mobile-viewport-follower.spec.ts` stubs `window.visualViewport`
+  (height/offsetTop + events) and asserts the shell height, translate, and
+  scroll reset react correctly — CI-checkable without real devices.
+- 5-minute manual device pass (before cohort-facing demos):
+  1. iPhone Safari via a WhatsApp invite link: open chat → focus composer →
+     type → send → dismiss keyboard. Tab bar must sit flush at the bottom at
+     every step; no dead space below it.
+  2. Same on a low-end Android (Chrome + WhatsApp in-app browser).
+  3. Rotate to landscape and back.
+  4. Background the browser mid-keyboard, return.

--- a/e2e/cbo-mobile-viewport-follower.spec.ts
+++ b/e2e/cbo-mobile-viewport-follower.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+// The chat shell must FOLLOW the visual viewport, not just match its height
+// (field report 2026-07-15: iOS scrolls the visual viewport down when the
+// keyboard opens — visualViewport.offsetTop > 0 — and a top-anchored shell
+// leaves dead space below the tab bar that grows while typing and survives
+// keyboard dismissal). Playwright can't summon a real keyboard, so this stubs
+// window.visualViewport before the app boots and drives it like iOS does,
+// asserting the two CSS variables and the shell's actual box react.
+// Mechanism + invariants: docs/mobile-viewport.md.
+
+test.describe('COUGAR — chat shell follows the visual viewport', () => {
+  test.use({ viewport: { width: 390, height: 844 }, locale: 'pt-BR' });
+
+  test('height + translate track a keyboard-style resize/offset and recover', async ({ page }) => {
+    await page.addInitScript(() => {
+      const listeners: Record<string, Set<() => void>> = {};
+      const vv = {
+        width: 390,
+        height: 844,
+        offsetTop: 0,
+        offsetLeft: 0,
+        pageTop: 0,
+        pageLeft: 0,
+        scale: 1,
+        addEventListener(t: string, fn: () => void) { (listeners[t] ??= new Set()).add(fn); },
+        removeEventListener(t: string, fn: () => void) { listeners[t]?.delete(fn); },
+        // Test seam: mutate + fire, the way an iOS keyboard open/close does.
+        __set(height: number, offsetTop: number) {
+          this.height = height;
+          this.offsetTop = offsetTop;
+          listeners['resize']?.forEach(fn => fn());
+          listeners['scroll']?.forEach(fn => fn());
+        },
+      };
+      Object.defineProperty(window, 'visualViewport', { value: vv, configurable: true });
+    });
+
+    await page.goto('/cbo-profile');
+    const shell = page.getByTestId('cbo-shell');
+    await expect(shell).toBeVisible();
+
+    // Baseline: shell fills the stubbed viewport, no translate.
+    await expect.poll(async () => (await shell.boundingBox())!.height).toBe(844);
+    expect((await shell.boundingBox())!.y).toBe(0);
+
+    // "Keyboard opens": visible area shrinks to 500px and iOS scrolls the
+    // visual viewport down by 300px. The shell must shrink AND move down —
+    // its box exactly covering [300, 800].
+    await page.evaluate(() => (window.visualViewport as any).__set(500, 300));
+    await expect.poll(async () => (await shell.boundingBox())!.height).toBe(500);
+    await expect.poll(async () => (await shell.boundingBox())!.y).toBe(300);
+
+    // "Keyboard closes" (iOS restores): shell recovers the full area with no
+    // residual offset — the dead-space-below-the-tab-bar regression.
+    await page.evaluate(() => (window.visualViewport as any).__set(844, 0));
+    await expect.poll(async () => (await shell.boundingBox())!.height).toBe(844);
+    await expect.poll(async () => (await shell.boundingBox())!.y).toBe(0);
+
+    // The variables the layout runs on are what the handler wrote.
+    const vars = await page.evaluate(() => ({
+      vh: document.documentElement.style.getPropertyValue('--cbo-vh'),
+      top: document.documentElement.style.getPropertyValue('--cbo-vv-top'),
+    }));
+    expect(vars.vh).toBe('844px');
+    expect(vars.top).toBe('0px');
+  });
+});


### PR DESCRIPTION
## The bug (with the why, since we 'fixed' this once already)
Screenshots from JVP (WhatsApp → Safari, iPhone): tab bar floating mid-screen, dead space below it that **grows while typing** and **survives keyboard dismissal**.

The earlier fix drove the shell **height** from `visualViewport.height` — that part was and is correct. What it missed: when the keyboard opens, iOS also **scrolls the visual viewport down** (`visualViewport.offsetTop > 0`) to reveal the focused input. A shell anchored at the layout-viewport top then pokes out of the visible window — the tab bar rides up and dead space exactly `offsetTop` tall opens beneath it. On dismiss, iOS frequently fails to restore the offset (long-standing, documented as worse on iOS 26 — [Apple forums thread](https://developer.apple.com/forums/thread/800125)), which is the residual gap with the keyboard closed.

## The fix (per current best practice — [visualViewport pattern](https://dev.to/franciscomoretti/fix-mobile-keyboard-overlap-with-visualviewport), [Safari resize-bug guide](https://medium.com/@krutilin.sergey.ks/fixing-the-safari-mobile-resizing-bug-a-developers-guide-6568f933cde0))
- The shell now **follows** the viewport: `translateY(--cbo-vv-top)` alongside the existing height var; the handler is rAF-coalesced (one cheap listener — fine on low-end Androids, no UX degradation anywhere) and resets residual window scroll (the document is scroll-locked, so any scroll is Safari residue).
- `interactive-widget=resizes-content` in the viewport meta: Android Chrome 108+ resizes the **layout** viewport for the keyboard, so Android is deterministic with zero JS. iOS ignores the flag and relies on the follower.
- Checked the transform side-effect: no `position:fixed` descendants inside the shell (dialogs portal to body).

## Documented so it stays fixed
**`docs/mobile-viewport.md`** — the three-viewports model, the 9 invariants (incl. the pre-existing ones: ≥16px inputs, no `viewport-fit=cover`, scroll lock scoped to the chat shell), do/don't list, and a 5-minute manual device checklist for pre-demo passes.

## Tests
- New `e2e/cbo-mobile-viewport-follower.spec.ts`: stubs `window.visualViewport` before boot and drives an iOS-style keyboard cycle (844→500 visible, offset 300 → restore), asserting the shell's real bounding box covers exactly the visible window at each step.
- Full chromium suite: **98 passed, 3 skipped (@live)**.

## Verify on device after deploy
iPhone Safari via a WhatsApp link: type in the composer → send → dismiss. The tab bar must stay flush at the bottom throughout. Same on a low-end Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)