### PR TITLE
Mobile: infer keyboard state from focus (iOS reports stale viewport after dismissal)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -817,22 +817,50 @@ export default function CboProfilePage() {
     const body = document.body;
     const mount = document.getElementById('root');
     let raf = 0;
+    let settle: ReturnType<typeof setTimeout> | undefined;
     const setVH = () => {
       if (raf) return; // coalesce bursts (iOS fires resize+scroll together)
       raf = requestAnimationFrame(() => {
         raf = 0;
         const v = window.visualViewport;
-        const h = v?.height ?? window.innerHeight;
-        const top = v?.offsetTop ?? 0;
+        let h = v?.height ?? window.innerHeight;
+        let top = v?.offsetTop ?? 0;
+        // KEYBOARD STATE IS INFERRED FROM FOCUS, NOT FROM THE VIEWPORT. After
+        // the keyboard dismisses, iOS keeps REPORTING the stale smaller
+        // height/offset and often never fires another vv event (field report
+        // 2026-07-15 round 2: fine at session start, short shell + dead space
+        // after the first typed turn; known iOS 26 regression). No editable
+        // element focused ⇒ the keyboard cannot be open ⇒ trust the layout
+        // viewport. Skipped while pinch-zoomed (scale ≠ 1), where
+        // vv.height < innerHeight is legitimate.
+        const ae = document.activeElement as HTMLElement | null;
+        const editableFocused = !!ae && (
+          ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable
+        );
+        if (!editableFocused && (v?.scale ?? 1) === 1) {
+          h = Math.max(h, window.innerHeight);
+          top = 0;
+        }
         root.style.setProperty('--cbo-vh', `${Math.round(h)}px`);
         root.style.setProperty('--cbo-vv-top', `${Math.round(top)}px`);
         if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
       });
     };
+    // Focus changes are the reliable keyboard signal, but they land BEFORE the
+    // keyboard animation finishes and — in the stale case above — without any
+    // vv event at all. Measure immediately and again after the animation
+    // settles (~300ms on iOS; 400 leaves margin for low-end Androids).
+    const onFocusChange = () => {
+      setVH();
+      clearTimeout(settle);
+      settle = setTimeout(setVH, 400);
+    };
     setVH();
     const vv = window.visualViewport;
     vv?.addEventListener('resize', setVH);
     vv?.addEventListener('scroll', setVH);
+    document.addEventListener('focusin', onFocusChange);
+    document.addEventListener('focusout', onFocusChange);
     window.addEventListener('orientationchange', setVH);
     window.addEventListener('resize', setVH);
 
@@ -858,9 +886,12 @@ export default function CboProfilePage() {
     return () => {
       vv?.removeEventListener('resize', setVH);
       vv?.removeEventListener('scroll', setVH);
+      document.removeEventListener('focusin', onFocusChange);
+      document.removeEventListener('focusout', onFocusChange);
       window.removeEventListener('orientationchange', setVH);
       window.removeEventListener('resize', setVH);
       if (raf) cancelAnimationFrame(raf);
+      clearTimeout(settle);
       root.style.removeProperty('--cbo-vh');
       root.style.removeProperty('--cbo-vv-top');
       root.style.overflow = prev.htmlOverflow;

--- a/docs/mobile-viewport.md
+++ b/docs/mobile-viewport.md
@@ -42,8 +42,17 @@ offset. Screenshot in the PR.
    locked document, so the handler resets `scrollTo(0,0)`. This is what
    clears the post-dismiss gap.
 5. **One rAF-coalesced listener** on `visualViewport` `resize`+`scroll` (+
-   window `resize`/`orientationchange`). Cheap enough for low-end Androids;
-   the transform is GPU-composited. Do not add per-frame work here.
+   window `resize`/`orientationchange`, + document `focusin`/`focusout` with a
+   400ms settle re-measure). Cheap enough for low-end Androids; the transform
+   is GPU-composited. Do not add per-frame work here.
+5b. **Keyboard state is inferred from FOCUS, never from the viewport.** After
+   a dismissal, iOS keeps reporting the stale keyboard-sized
+   `visualViewport.height`/`offsetTop` and often fires no further event
+   (iOS 26 regression — this shipped as "fixed" once and came back through
+   exactly this hole: fine at session start, short shell after the first
+   typed turn). When no editable element is focused, the keyboard cannot be
+   open: clamp to `max(vv.height, innerHeight)`, offset 0. Skipped while
+   pinch-zoomed (`vv.scale ≠ 1`), where a small vv is legitimate.
 6. **`interactive-widget=resizes-content`** in the viewport meta: Android
    Chrome 108+ then resizes the LAYOUT viewport for the keyboard, making
    Android correct with zero JS. iOS ignores the flag — the follower covers it.

--- a/e2e/cbo-mobile-viewport-follower.spec.ts
+++ b/e2e/cbo-mobile-viewport-follower.spec.ts
@@ -44,15 +44,18 @@ test.describe('COUGAR — chat shell follows the visual viewport', () => {
     await expect.poll(async () => (await shell.boundingBox())!.height).toBe(844);
     expect((await shell.boundingBox())!.y).toBe(0);
 
-    // "Keyboard opens": visible area shrinks to 500px and iOS scrolls the
-    // visual viewport down by 300px. The shell must shrink AND move down —
-    // its box exactly covering [300, 800].
+    // "Keyboard opens": the composer is FOCUSED (the only way a keyboard
+    // opens), the visible area shrinks to 500px and iOS scrolls the visual
+    // viewport down by 300px. The shell must shrink AND move down — its box
+    // exactly covering [300, 800]. (Focus matters: an unfocused page with a
+    // small vv is treated as a stale report and clamped, below.)
+    await page.getByTestId('cbo-chat-input').focus();
     await page.evaluate(() => (window.visualViewport as any).__set(500, 300));
     await expect.poll(async () => (await shell.boundingBox())!.height).toBe(500);
     await expect.poll(async () => (await shell.boundingBox())!.y).toBe(300);
 
-    // "Keyboard closes" (iOS restores): shell recovers the full area with no
-    // residual offset — the dead-space-below-the-tab-bar regression.
+    // "Keyboard closes" the honest way (iOS restores the values): shell
+    // recovers the full area with no residual offset.
     await page.evaluate(() => (window.visualViewport as any).__set(844, 0));
     await expect.poll(async () => (await shell.boundingBox())!.height).toBe(844);
     await expect.poll(async () => (await shell.boundingBox())!.y).toBe(0);
@@ -64,5 +67,52 @@ test.describe('COUGAR — chat shell follows the visual viewport', () => {
     }));
     expect(vars.vh).toBe('844px');
     expect(vars.top).toBe('0px');
+  });
+
+  test('a STALE keyboard dismissal (no vv event, values stuck small) still recovers on blur', async ({ page }) => {
+    // Field report 2026-07-15 round 2: fine at session start, short shell +
+    // dead space after the first typed turn. iOS dismissed the keyboard but
+    // visualViewport kept reporting the keyboard-sized height and fired NO
+    // further event (iOS 26 regression). The recovery signal is focus: no
+    // editable element focused ⇒ keyboard cannot be open ⇒ clamp to the
+    // layout viewport.
+    await page.addInitScript(() => {
+      const listeners: Record<string, Set<() => void>> = {};
+      const vv = {
+        width: 390, height: 844, offsetTop: 0, offsetLeft: 0, pageTop: 0, pageLeft: 0, scale: 1,
+        addEventListener(t: string, fn: () => void) { (listeners[t] ??= new Set()).add(fn); },
+        removeEventListener(t: string, fn: () => void) { listeners[t]?.delete(fn); },
+        __set(height: number, offsetTop: number) {
+          this.height = height;
+          this.offsetTop = offsetTop;
+          listeners['resize']?.forEach(fn => fn());
+          listeners['scroll']?.forEach(fn => fn());
+        },
+        // Mutate WITHOUT firing events — how the stale bug actually behaves.
+        __setSilently(height: number, offsetTop: number) {
+          this.height = height;
+          this.offsetTop = offsetTop;
+        },
+      };
+      Object.defineProperty(window, 'visualViewport', { value: vv, configurable: true });
+    });
+
+    await page.goto('/cbo-profile');
+    const shell = page.getByTestId('cbo-shell');
+    await expect(shell).toBeVisible();
+
+    // Keyboard opens while the composer is focused.
+    await page.getByTestId('cbo-chat-input').focus();
+    await page.evaluate(() => (window.visualViewport as any).__set(500, 300));
+    await expect.poll(async () => (await shell.boundingBox())!.height).toBe(500);
+
+    // Keyboard dismisses but iOS lies: values stay small, NO event fires.
+    // The blur alone must bring the shell back (focusout + settle timer).
+    await page.evaluate(() => {
+      (window.visualViewport as any).__setSilently(500, 300);
+      (document.activeElement as HTMLElement | null)?.blur();
+    });
+    await expect.poll(async () => (await shell.boundingBox())!.height, { timeout: 3_000 }).toBe(844);
+    await expect.poll(async () => (await shell.boundingBox())!.y).toBe(0);
   });
 });


### PR DESCRIPTION
## What you saw (and why #407 wasn't enough)
Post-#407 field test: layout is perfect when the session starts, but the dead space returns **after the agent responds** to a typed turn. The follower was live and doing its job — the problem is upstream: after the keyboard dismisses, **iOS keeps reporting the stale keyboard-sized `visualViewport.height`/`offsetTop` and often never fires another viewport event** ([Apple forums, iOS 26 regression](https://developer.apple.com/forums/thread/800125)). The follower faithfully rendered what iOS reported: a short shell. Nothing re-measured because nothing fired.

The trigger sequence is exactly "after the agent responds": you type (keyboard open) → send → the composer input disables for streaming → focus is lost → keyboard dismisses → stale report, zero events.

## Fix: focus is the source of truth for the keyboard, never the viewport
- When **no editable element is focused, the keyboard cannot be open** → clamp to `max(vv.height, innerHeight)`, offset 0. Skipped while pinch-zoomed (`vv.scale ≠ 1`), where a small visual viewport is legitimate.
- `focusin`/`focusout` (which fire reliably — including when the input is disabled on send) re-measure immediately **and** after a 400ms settle, covering the case where iOS emits no viewport events at all.
- Android unaffected: with `interactive-widget=resizes-content` its layout viewport shrinks too, so the clamp is a no-op there.

## Tests
- Follower spec updated: the keyboard-open simulation now focuses the composer (matching how keyboards actually open, and the clamp).
- **New stale-dismissal spec**: visualViewport values stuck small, zero events fired, blur alone must recover the shell to full height — the literal reported bug, now CI-checked.
- Full chromium suite: **100 passed, 3 skipped (@live)**.
- `docs/mobile-viewport.md` gains invariant 5b so the third fix is the last.

## Device verification after merge + workspace pull
Same one-minute pass: WhatsApp link → type in the composer → send → keyboard dismisses → tab bar must sit flush at the bottom while "Processando…" streams and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)