### PR TITLE
Croquis visible everywhere: beside variants, sheet banner, lightbox + wide ficha dialog

### DIFF
--- a/client/src/core/components/cbo/CroquiLightbox.tsx
+++ b/client/src/core/components/cbo/CroquiLightbox.tsx
@@ -1,0 +1,56 @@
+// CroquiLightbox — the large view of a família croqui. Every surface that
+// shows a croqui small (strip card, sheet banner, coordinator section) opens
+// this on tap. It also carries the Register-2 disclosure caption required by
+// docs/photo-curation.md condition 4: a croqui is a schematic illustration of
+// a CATEGORY, not a photo of a real place — the lightbox is where that is
+// said in the viewer's language.
+
+import { Dialog, DialogContent } from '@/core/components/ui/dialog';
+
+const CAPTION = {
+  pt: 'Ilustração esquemática — representa um tipo de intervenção, não um local específico.',
+  en: 'Schematic illustration — it represents a type of intervention, not a specific place.',
+};
+
+export function CroquiLightbox({
+  src,
+  title,
+  lang,
+  onClose,
+}: {
+  /** Croqui image path; `null` closes the lightbox. */
+  src: string | null;
+  title?: string;
+  lang: 'pt' | 'en';
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={!!src} onOpenChange={open => { if (!open) onClose(); }}>
+      <DialogContent
+        className='max-w-4xl p-3'
+        data-testid='croqui-lightbox'
+        aria-label={title}
+      >
+        {src && (
+          <figure className='m-0 space-y-2'>
+            <img
+              src={src}
+              alt={title ?? ''}
+              className='max-h-[75vh] w-full rounded-md object-contain'
+            />
+            <figcaption className='flex flex-wrap items-baseline justify-between gap-2 px-1'>
+              {title && (
+                <span className='text-sm font-semibold tracking-tight'>
+                  {title}
+                </span>
+              )}
+              <span className='text-[11px] italic text-muted-foreground'>
+                {CAPTION[lang]}
+              </span>
+            </figcaption>
+          </figure>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/components/cbo/NbsDesktopGrids.tsx
+++ b/client/src/core/components/cbo/NbsDesktopGrids.tsx
@@ -16,8 +16,10 @@ import { NbsTypeDialog } from './NbsTypeDialog';
 import { NbsSolutionCard } from './NbsSolutionCard';
 import { NbsSolutionDetail } from './NbsSolutionDetail';
 import { NbsShowcaseCardItem } from './NbsShowcaseCard';
+import { CroquiLightbox } from './CroquiLightbox';
 
 const GRID = 'grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3';
+const CROQUI_CAPTION = { pt: 'Ilustração esquemática — toque para ampliar', en: 'Schematic illustration — click to enlarge' };
 
 /** "Soluções" tab — the full Rede SCbN POA catalog: five família sections, each
  *  with its solution variants. Every variant opens its own ficha técnica
@@ -28,6 +30,7 @@ export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
     null
   );
   const [openSolutionId, setOpenSolutionId] = useState<string | null>(null);
+  const [croqui, setCroqui] = useState<{ src: string; title: string } | null>(null);
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
   const typeIds = NBS_INTERVENTION_TYPES.filter(
     t => NBS_TYPE_CONTENT[t.id]
@@ -58,19 +61,53 @@ export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
                 — {familia[lang].description}
               </span>
             </div>
-            <div className={GRID}>
-              {solutions.map(solution => (
-                <NbsSolutionCard
-                  key={solution.id}
-                  solution={solution}
-                  lang={lang}
-                  onOpenFicha={setOpenSolutionId}
-                />
-              ))}
+            {/* The croqui sits BESIDE its variants — the category drawing and
+                the concrete options read together (field ask, 2026-07-15). */}
+            <div className='flex flex-col gap-5 lg:flex-row'>
+              <figure className='m-0 shrink-0 lg:w-1/3'>
+                <button
+                  type='button'
+                  className='block w-full overflow-hidden rounded-xl border border-border transition-colors hover:border-emerald-500/60'
+                  onClick={() =>
+                    setCroqui({ src: familia.croqui, title: familia[lang].label })
+                  }
+                  data-testid={`familia-croqui-${familia.id}`}
+                >
+                  <img
+                    src={familia.croqui}
+                    alt={familia[lang].label}
+                    loading='lazy'
+                    decoding='async'
+                    className='aspect-[4/3] w-full object-cover'
+                  />
+                </button>
+                <figcaption className='mt-1 px-1 text-[10px] italic text-muted-foreground'>
+                  {CROQUI_CAPTION[lang]}
+                </figcaption>
+              </figure>
+              <div className='min-w-0 flex-1'>
+                <div className='grid grid-cols-1 gap-5 sm:grid-cols-2'>
+                  {solutions.map(solution => (
+                    <NbsSolutionCard
+                      key={solution.id}
+                      solution={solution}
+                      lang={lang}
+                      onOpenFicha={setOpenSolutionId}
+                    />
+                  ))}
+                </div>
+              </div>
             </div>
           </section>
         );
       })}
+
+      <CroquiLightbox
+        src={croqui?.src ?? null}
+        title={croqui?.title}
+        lang={lang}
+        onClose={() => setCroqui(null)}
+      />
 
       {/* Per-solution ficha técnica dialog; "ver conteúdo do tipo" swaps to the
           croqui/knowledge dialog below (never both open at once). */}
@@ -79,13 +116,14 @@ export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
         onOpenChange={open => { if (!open) setOpenSolutionId(null); }}
       >
         <DialogContent
-          className='max-h-[85vh] max-w-lg overflow-y-auto'
+          className='max-h-[85vh] max-w-3xl overflow-y-auto'
           data-testid='nbs-solution-dialog'
         >
           {openSolution && (
             <NbsSolutionDetail
               solution={openSolution}
               lang={lang}
+              wide
               onOpenTypeContent={typeId => {
                 setOpenSolutionId(null);
                 setOpenTypeId(typeId);

--- a/client/src/core/components/cbo/NbsFamiliaCard.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaCard.tsx
@@ -27,36 +27,57 @@ export function NbsFamiliaCard({
   id,
   lang,
   onOpen,
+  onOpenCroqui,
 }: {
   id: NbsFamiliaId;
   lang: 'pt' | 'en';
   onOpen: (id: NbsFamiliaId) => void;
+  /** Tap on the cover enlarges the croqui (the 104px crop hides most of it). */
+  onOpenCroqui?: (id: NbsFamiliaId) => void;
 }) {
   const familia = getFamilia(id);
   if (!familia) return null;
   const loc = familia[lang];
   const count = solutionsForFamilia(id).length;
 
+  const cover = (
+    <>
+      <img
+        src={familia.croqui}
+        alt=''
+        aria-hidden='true'
+        loading='lazy'
+        decoding='async'
+        className='h-full w-full object-cover'
+      />
+      <div
+        aria-hidden='true'
+        className='absolute inset-x-0 bottom-0 h-1'
+        style={{ background: familia.color }}
+      />
+    </>
+  );
+
   return (
     <div
       className='flex h-full w-full flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-emerald-500/60'
       data-testid={`familia-card-${id}`}
     >
-      <div className='relative h-[104px] w-full shrink-0 overflow-hidden bg-muted'>
-        <img
-          src={familia.croqui}
-          alt=''
-          aria-hidden='true'
-          loading='lazy'
-          decoding='async'
-          className='h-full w-full object-cover'
-        />
-        <div
-          aria-hidden='true'
-          className='absolute inset-x-0 bottom-0 h-1'
-          style={{ background: familia.color }}
-        />
-      </div>
+      {onOpenCroqui ? (
+        <button
+          type='button'
+          onClick={() => onOpenCroqui(id)}
+          className='relative h-[104px] w-full shrink-0 overflow-hidden bg-muted'
+          aria-label={loc.label}
+          data-testid={`familia-cover-croqui-${id}`}
+        >
+          {cover}
+        </button>
+      ) : (
+        <div className='relative h-[104px] w-full shrink-0 overflow-hidden bg-muted'>
+          {cover}
+        </div>
+      )}
 
       <div className='flex flex-1 flex-col gap-1.5 p-3'>
         <h4 className='text-sm font-semibold leading-tight tracking-tight'>

--- a/client/src/core/components/cbo/NbsFamiliaSheet.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaSheet.tsx
@@ -21,6 +21,7 @@ import type { NbsFamiliaId } from '@shared/nbs-catalog';
 import { getFamilia, getSolution, solutionsForFamilia } from '@shared/nbs-catalog';
 import { NbsSolutionCard } from './NbsSolutionCard';
 import { NbsSolutionDetail } from './NbsSolutionDetail';
+import { CroquiLightbox } from './CroquiLightbox';
 
 const STRINGS = {
   pt: {
@@ -29,6 +30,7 @@ const STRINGS = {
     handle: 'Arraste para fechar',
     credit: 'Fotos: cartas da Rede SCbN de POA (fontes MMA, GIZ e CNM)',
     estNote: '* classificação estimada, em verificação',
+    croquiHint: 'Ilustração esquemática — toque para ampliar',
   },
   en: {
     close: 'Close',
@@ -36,6 +38,7 @@ const STRINGS = {
     handle: 'Drag to close',
     credit: 'Photos: Rede SCbN de POA card deck (MMA, GIZ and CNM sources)',
     estNote: '* estimated classification, under verification',
+    croquiHint: 'Schematic illustration — tap to enlarge',
   },
 };
 
@@ -52,6 +55,7 @@ export function NbsFamiliaSheet({
   const s = STRINGS[lang];
   const bodyRef = useRef<HTMLDivElement>(null);
   const [openSolutionId, setOpenSolutionId] = useState<string | null>(null);
+  const [croquiOpen, setCroquiOpen] = useState(false);
   const familia = openFamiliaId ? getFamilia(openFamiliaId) : undefined;
   const solutions = openFamiliaId ? solutionsForFamilia(openFamiliaId) : [];
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
@@ -135,6 +139,30 @@ export function NbsFamiliaSheet({
                   {familia[lang].description}
                 </p>
               )}
+              {/* The família croqui reads WITH its variants — banner above the
+                  list, tap to see it large (the strip card crops it to 104px). */}
+              {familia && (
+                <figure className='m-0'>
+                  <button
+                    type='button'
+                    className='block w-full overflow-hidden rounded-lg border border-border'
+                    onClick={() => setCroquiOpen(true)}
+                    data-testid='familia-sheet-croqui'
+                    data-vaul-no-drag
+                  >
+                    <img
+                      src={familia.croqui}
+                      alt={familia[lang].label}
+                      loading='lazy'
+                      decoding='async'
+                      className='max-h-44 w-full object-cover'
+                    />
+                  </button>
+                  <figcaption className='mt-1 px-1 text-[10px] italic text-muted-foreground'>
+                    {s.croquiHint}
+                  </figcaption>
+                </figure>
+              )}
               {solutions.map(solution => (
                 <NbsSolutionCard
                   key={solution.id}
@@ -149,6 +177,13 @@ export function NbsFamiliaSheet({
             </>
           )}
         </div>
+
+        <CroquiLightbox
+          src={croquiOpen && familia ? familia.croqui : null}
+          title={familia?.[lang].label}
+          lang={lang}
+          onClose={() => setCroquiOpen(false)}
+        />
       </DrawerContent>
     </Drawer>
   );

--- a/client/src/core/components/cbo/NbsFamiliaStrip.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaStrip.tsx
@@ -11,9 +11,10 @@
 
 import { useState } from 'react';
 import type { NbsFamiliaId } from '@shared/nbs-catalog';
-import { NBS_FAMILIAS } from '@shared/nbs-catalog';
+import { NBS_FAMILIAS, getFamilia } from '@shared/nbs-catalog';
 import { NbsFamiliaCard } from './NbsFamiliaCard';
 import { NbsFamiliaSheet } from './NbsFamiliaSheet';
+import { CroquiLightbox } from './CroquiLightbox';
 
 export function NbsFamiliaStrip({
   familiaIds,
@@ -26,6 +27,8 @@ export function NbsFamiliaStrip({
   lang: 'pt' | 'en';
 }) {
   const [openFamiliaId, setOpenFamiliaId] = useState<NbsFamiliaId | null>(null);
+  const [croquiFamiliaId, setCroquiFamiliaId] = useState<NbsFamiliaId | null>(null);
+  const croquiFamilia = croquiFamiliaId ? getFamilia(croquiFamiliaId) : undefined;
 
   const ids = new Set(familiaIds && familiaIds.length > 0 ? familiaIds : NBS_FAMILIAS.map(f => f.id));
   const familias = NBS_FAMILIAS.filter(f => ids.has(f.id));
@@ -49,6 +52,7 @@ export function NbsFamiliaStrip({
               id={familia.id}
               lang={lang}
               onOpen={setOpenFamiliaId}
+              onOpenCroqui={setCroquiFamiliaId}
             />
           </div>
         ))}
@@ -58,6 +62,13 @@ export function NbsFamiliaStrip({
         openFamiliaId={openFamiliaId}
         onClose={() => setOpenFamiliaId(null)}
         lang={lang}
+      />
+
+      <CroquiLightbox
+        src={croquiFamilia?.croqui ?? null}
+        title={croquiFamilia?.[lang].label}
+        lang={lang}
+        onClose={() => setCroquiFamiliaId(null)}
       />
     </div>
   );

--- a/client/src/core/components/cbo/NbsSolutionDetail.tsx
+++ b/client/src/core/components/cbo/NbsSolutionDetail.tsx
@@ -76,12 +76,16 @@ export function NbsSolutionDetail({
   solution,
   lang,
   onOpenTypeContent,
+  wide,
 }: {
   solution: NbsSolution;
   lang: 'pt' | 'en';
   /** When set and the solution maps to a deep-content type, renders the
    *  complementary "see croqui/technical content" button. */
   onOpenTypeContent?: (id: NbsInterventionTypeId) => void;
+  /** Desktop dialog layout: photo + identity on the left, the four ficha
+   *  sections on the right (collapses back to one column under md). */
+  wide?: boolean;
 }) {
   const s = STRINGS[lang];
   const ficha = getSolutionFicha(solution.id);
@@ -91,10 +95,10 @@ export function NbsSolutionDetail({
     ? NBS_INTERVENTION_TYPES.find(t => t.id === solution.legacyTypeId)
     : undefined;
 
-  return (
-    <div className='space-y-4' data-testid={`solution-detail-${solution.id}`}>
+  const identity = (
+    <div className='space-y-4'>
       <div className='overflow-hidden rounded-lg'>
-        <div className='h-36 w-full overflow-hidden bg-muted'>
+        <div className={`${wide ? 'h-44' : 'h-36'} w-full overflow-hidden bg-muted`}>
           <img
             src={nbsSolutionPhoto(solution.id)}
             alt=''
@@ -124,7 +128,11 @@ export function NbsSolutionDetail({
       </div>
 
       <Section title={s.oQueE} body={solution[lang].whatItIs} estimadoLabel={s.estimado} />
+    </div>
+  );
 
+  const fichaBody = (
+    <div className='space-y-4'>
       {copy ? (
         <>
           <Section title={s.comoFunciona} body={copy.comoFunciona} estimadoLabel={s.estimado} />
@@ -163,6 +171,20 @@ export function NbsSolutionDetail({
           {s.fontes}: {ficha.sources.join(' · ')}
         </p>
       )}
+    </div>
+  );
+
+  return (
+    <div
+      className={
+        wide
+          ? 'space-y-4 md:grid md:grid-cols-[2fr_3fr] md:gap-6 md:space-y-0'
+          : 'space-y-4'
+      }
+      data-testid={`solution-detail-${solution.id}`}
+    >
+      {identity}
+      {fichaBody}
     </div>
   );
 }

--- a/e2e/cougar-e2-instant-entry.spec.ts
+++ b/e2e/cougar-e2-instant-entry.spec.ts
@@ -37,11 +37,20 @@ test.describe('COUGAR — instant E2 entry', () => {
     expect(Date.now() - t0).toBeLessThan(8_000); // UI-time, not model-time
     await expect(page.getByText('Vamos continuar', { exact: false })).toHaveCount(0); // model never ran
 
-    // Two-level: opening a família shows its variants (deck-card leaves).
+    // Two-level: opening a família shows its croqui banner + variants.
     await page.getByTestId('familia-expand-aguas-pluviais').click();
     const sheet = page.getByTestId('nbs-familia-sheet');
     await expect(sheet).toBeVisible();
     expect(await sheet.locator('[data-testid^="solution-card-"]').count()).toBe(11);
+
+    // The croqui reads WITH the variants: banner above the list, tap → large
+    // view carrying the Register-2 "ilustração esquemática" disclosure.
+    await sheet.getByTestId('familia-sheet-croqui').click();
+    const lightbox = page.getByTestId('croqui-lightbox');
+    await expect(lightbox).toBeVisible();
+    await expect(lightbox.getByText('Ilustração esquemática', { exact: false })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(lightbox).toBeHidden();
 
     // Third level: a variant's ficha técnica opens INSIDE the sheet (list ⇄
     // detail with a back affordance), with the five CBO-first sections.

--- a/e2e/cougar-orchestrator-nbs-tabs.spec.ts
+++ b/e2e/cougar-orchestrator-nbs-tabs.spec.ts
@@ -51,6 +51,16 @@ test.describe('COUGAR — orchestrator NBS tabs', () => {
     ).toBeVisible();
     expect(await page.locator('[data-testid^="familia-section-"]').count()).toBe(5);
     expect(await page.locator('[data-testid^="solution-card-"]').count()).toBe(27);
+
+    // Each família shows its croqui BESIDE the variants; clicking enlarges it
+    // in the lightbox (with the ilustração-esquemática disclosure).
+    expect(await page.locator('[data-testid^="familia-croqui-"]').count()).toBe(5);
+    await page.getByTestId('familia-croqui-encostas-e-solo').click();
+    const lightbox = page.getByTestId('croqui-lightbox');
+    await expect(lightbox).toBeVisible();
+    await expect(lightbox.getByText(/Ilustração esquemática|Schematic illustration/)).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(lightbox).toBeHidden();
     await expect(
       participant,
       'participant list stays visible on Soluções'


### PR DESCRIPTION
Follow-up to #410 from today's review: *the croquis aren't visible in the new famílias, the coordinator modal is too small, and the croqui should show together with the solution types.*

## What
- **Coordinator Soluções tab**: each família section now shows its **croqui large (~1/3 width) beside that família's variant cards** — the category drawing and the concrete options read together. Clicking it opens the lightbox.
- **`CroquiLightbox`** (new): large view of any croqui, carrying the Register-2 disclosure caption *"Ilustração esquemática — representa um tipo de intervenção, não um local específico"* — which `docs/photo-curation.md` condition 4 required and no surface delivered until now.
- **Mobile**: the família sheet opens with the croqui as a **banner above the variant list** (tap → lightbox); the strip card's cover image is also tappable.
- **Ficha dialog**: `max-w-lg` → `max-w-3xl` with a **two-column layout** (photo + identity + o-que-é left, the four ficha sections right; collapses to one column under md). Same `NbsSolutionDetail` component via a `wide` prop — sheet and selector keep the single column.

## Verification
- Screenshotted the coordinator section (croqui beside Grade viva/Muro de arrimo cards), the wide ficha dialog, and the lightbox at 1440px — layouts read correctly.
- Affected specs green on this branch: instant-entry (sheet banner → lightbox + disclosure caption), orchestrator-tabs (5 croquis beside sections → lightbox → ficha → type dialog chain), two-level selector.
- `tsc` clean.

After merge: pull main in Replit + republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)