### PR TITLE
Add heat + landslide mechanism-type layers (and refresh flood mechanism)

### DIFF
--- a/client/public/sample-data/layer-legends.json
+++ b/client/public/sample-data/layer-legends.json
@@ -207,6 +207,48 @@
     "source": "sampled",
     "note": "colors recovered from tiles"
   },
+  "poa_heat_mechanism": {
+    "layerId": "poa_heat_mechanism",
+    "kind": "classes",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#e0e0e0",
+        "label": "Without clear dominant"
+      },
+      {
+        "value": 1,
+        "color": "#d73027",
+        "label": "UHI built-up"
+      },
+      {
+        "value": 2,
+        "color": "#fee08b",
+        "label": "Shade deficit"
+      },
+      {
+        "value": 3,
+        "color": "#fc8d59",
+        "label": "High daytime LST"
+      },
+      {
+        "value": 4,
+        "color": "#9970ab",
+        "label": "Limited nocturnal cooling"
+      },
+      {
+        "value": 5,
+        "color": "#636363",
+        "label": "High social exposure"
+      },
+      {
+        "value": 6,
+        "color": "#969696",
+        "label": "Mixed"
+      }
+    ],
+    "source": "classes"
+  },
   "poa_landslide_hazard": {
     "layerId": "poa_landslide_hazard",
     "kind": "gradient",
@@ -245,6 +287,63 @@
     "max": 0.393,
     "source": "sampled",
     "note": "colors recovered from tiles"
+  },
+  "poa_landslide_mechanism": {
+    "layerId": "poa_landslide_mechanism",
+    "kind": "classes",
+    "stops": [
+      {
+        "value": 0,
+        "color": "#e0e0e0",
+        "label": "Without clear dominant"
+      },
+      {
+        "value": 1,
+        "color": "#b2182b",
+        "label": "Steep activatable slope"
+      },
+      {
+        "value": 2,
+        "color": "#2166ac",
+        "label": "Rainfall trigger"
+      },
+      {
+        "value": 3,
+        "color": "#8c510a",
+        "label": "Low cohesion wet"
+      },
+      {
+        "value": 4,
+        "color": "#d8b365",
+        "label": "Vegetation deficit"
+      },
+      {
+        "value": 5,
+        "color": "#4393c3",
+        "label": "Drainage saturation"
+      },
+      {
+        "value": 6,
+        "color": "#a6611a",
+        "label": "Disturbed bare slope"
+      },
+      {
+        "value": 7,
+        "color": "#5e3c99",
+        "label": "Upslope convergence"
+      },
+      {
+        "value": 8,
+        "color": "#636363",
+        "label": "High social exposure"
+      },
+      {
+        "value": 9,
+        "color": "#969696",
+        "label": "Mixed"
+      }
+    ],
+    "source": "classes"
   },
   "oef_dynamic_world": {
     "layerId": "oef_dynamic_world",

--- a/scripts/generate-legends.ts
+++ b/scripts/generate-legends.ts
@@ -48,9 +48,11 @@ const COLOR_FILES: Record<string, { path: string; unit?: string }> = {
 // Categorical class colors from the catalog datasets.yaml (valueEncoding.classes has names only).
 const CLASS_COLORS: Record<string, Record<number, string>> = {
   oef_dynamic_world: { 0: '#62B0CC', 1: '#488C5F', 2: '#98B982', 3: '#A0AAC3', 4: '#D7A55F', 5: '#CDB982', 6: '#B45F55', 7: '#AFA89E', 8: '#B9CDE1' },
-  // Verified against the visual tiles: encoded 2/4/6 paint #2166ac/#abd9e9/#969696,
-  // which is class = encoded - 1 (riverine / low-lying / mixed).
+  // Mechanism-type palettes from catalog datasets.yaml. All three verified
+  // against the visual tiles 2026-07-16: class = encoded - 1, colour distance 0.0.
   poa_flood_mechanism: { 0: '#e0e0e0', 1: '#2166ac', 2: '#fdae61', 3: '#abd9e9', 4: '#7b3294', 5: '#969696' },
+  poa_heat_mechanism: { 0: '#e0e0e0', 1: '#d73027', 2: '#fee08b', 3: '#fc8d59', 4: '#9970ab', 5: '#636363', 6: '#969696' },
+  poa_landslide_mechanism: { 0: '#e0e0e0', 1: '#b2182b', 2: '#2166ac', 3: '#8c510a', 4: '#d8b365', 5: '#4393c3', 6: '#a6611a', 7: '#5e3c99', 8: '#636363', 9: '#969696' },
 };
 
 // Local risk ramps — mirror the colorFns in generate-risk-tiles.ts (value → color).

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -121,8 +121,12 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
   poa_flood_mechanism:   { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/floods/flood_mechanism/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_risk:         { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_heat_hazard:       { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/hazard/tiles_visual/{z}/{x}/{y}.png" },
+  // Like flood, the path segment is `heat_mechanism` / `landslide_mechanism`,
+  // not the catalog dataset_id `poa_<haz>_mechanism_type`.
+  poa_heat_mechanism:    { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/heat/heat_mechanism/tiles_visual/{z}/{x}/{y}.png" },
   poa_landslide_risk:    { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/risk/tiles_visual/{z}/{x}/{y}.png" },
   poa_landslide_hazard:  { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/hazard/tiles_visual/{z}/{x}/{y}.png" },
+  poa_landslide_mechanism: { urlTemplate: "https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards/landslides/landslide_mechanism/tiles_visual/{z}/{x}/{y}.png" },
 };
 
 // Track failed tile URLs to avoid repeated 404s (cache for 1 hour)

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -110,9 +110,10 @@ export const FLOOD_INDEX_LAYERS: TileLayerDef[] = [
   {
     // Catalog dataset_id: poa_flood_mechanism_type (class_lookup, 250 m).
     // Value tiles store class+1 so raw 0 can mean nodata — hence offset -1.
-    // Porto Alegre's raster only contains riverine, low-lying and mixed;
-    // pluvial and drainage_constrained never occur (drainage is a proxy until
-    // municipal drainage data exists).
+    // Raster regenerated 2026-07 (IDW gap-fill + open-water mask, see
+    // docs/poa_mechanism_type_layer.md); POA now contains none, riverine,
+    // pluvial, low-lying and mixed. Drainage constrained still never occurs
+    // (drainage is a proxy until municipal drainage data exists).
     id: 'poa_flood_mechanism', name: 'Flood Mechanism', group: 'flood_indices', color: '#7b3294',
     tileLayerId: 'poa_flood_mechanism', available: true, hasValueTiles: true,
     valueEncoding: {
@@ -132,6 +133,23 @@ export const HEAT_INDEX_LAYERS: TileLayerDef[] = [
     tileLayerId: 'poa_heat_hazard', available: true, hasValueTiles: true,
     valueEncoding: hazardIndexEncoding('heat', 'hazard'),
   },
+  {
+    // Catalog dataset_id: poa_heat_mechanism_type (class_lookup, 250 m).
+    // Same class+1 encoding as flood mechanism (raw 0 = nodata, offset -1);
+    // verified against the visual tiles 2026-07-16 (colour distance 0.0).
+    // POA raster contains every class except limited nocturnal cooling.
+    id: 'poa_heat_mechanism', name: 'Heat Mechanism', group: 'heat_indices', color: '#d73027',
+    tileLayerId: 'poa_heat_mechanism', available: true, hasValueTiles: true,
+    valueEncoding: {
+      type: 'categorical', offset: -1, nodata: 0,
+      urlTemplate: `${CLIMATE_HAZARDS_BASE}/heat/heat_mechanism/tiles_values/{z}/{x}/{y}.png`,
+      classes: {
+        0: 'Without clear dominant', 1: 'UHI built-up', 2: 'Shade deficit',
+        3: 'High daytime LST', 4: 'Limited nocturnal cooling',
+        5: 'High social exposure', 6: 'Mixed',
+      },
+    },
+  },
 ];
 
 // Landslide hazard overlay — catalog path is `landslides` (PLURAL, like `floods`).
@@ -140,6 +158,26 @@ export const LANDSLIDE_INDEX_LAYERS: TileLayerDef[] = [
     id: 'poa_landslide_hazard', name: 'Landslide Hazard', group: 'landslide_indices', color: '#a16207',
     tileLayerId: 'poa_landslide_hazard', available: true, hasValueTiles: true,
     valueEncoding: hazardIndexEncoding('landslides', 'hazard'),
+  },
+  {
+    // Catalog dataset_id: poa_landslide_mechanism_type (class_lookup, 90 m —
+    // NOT the 250 m grid; only pixels with landslide hazard > 0 are classified,
+    // so most of the city is nodata). Same class+1 encoding as flood mechanism;
+    // verified against the visual tiles 2026-07-16 (colour distance 0.0).
+    // POA raster contains steep activatable slope, rainfall trigger, vegetation
+    // deficit, drainage saturation and mixed.
+    id: 'poa_landslide_mechanism', name: 'Landslide Mechanism', group: 'landslide_indices', color: '#8c510a',
+    tileLayerId: 'poa_landslide_mechanism', available: true, hasValueTiles: true,
+    valueEncoding: {
+      type: 'categorical', offset: -1, nodata: 0,
+      urlTemplate: `${CLIMATE_HAZARDS_BASE}/landslides/landslide_mechanism/tiles_values/{z}/{x}/{y}.png`,
+      classes: {
+        0: 'Without clear dominant', 1: 'Steep activatable slope', 2: 'Rainfall trigger',
+        3: 'Low cohesion wet', 4: 'Vegetation deficit', 5: 'Drainage saturation',
+        6: 'Disturbed bare slope', 7: 'Upslope convergence',
+        8: 'High social exposure', 9: 'Mixed',
+      },
+    },
   },
 ];
 


### PR DESCRIPTION
## What

Mau published the mechanism-type layers for all three hazards (catalog `poa_flood_mechanism_type`, `poa_heat_mechanism_type`, `poa_landslide_mechanism_type` — methodology in [`docs/poa_mechanism_type_layer.md`](https://github.com/joaquinOEF/NBS-Project-Preparation/blob/main/docs/poa_mechanism_type_layer.md)). This wires the two new ones into the app the same way flood mechanism was added, and refreshes the flood entry for the regenerated raster.

- **`shared/geospatial-layers.ts`** — `poa_heat_mechanism` (250 m, 7 classes) appended to `HEAT_INDEX_LAYERS`, `poa_landslide_mechanism` (90 m, 10 classes, only hazard-active slopes classified) appended to `LANDSLIDE_INDEX_LAYERS`. Both use the flood-proven `class_lookup` encoding (`categorical`, `offset: -1`, `nodata: 0`). Site explorer spreads these arrays, so the new cards appear in the heat/landslide groups automatically; `ALL_TILE_LAYERS` picks them up for value tooltips.
- **`server/routes/tileProxyRoutes.ts`** — visual-tile proxies for both (path segment is `heat_mechanism`/`landslide_mechanism`, not the dataset_id).
- **`scripts/generate-legends.ts`** — catalog palettes in `CLASS_COLORS`.
- **`client/public/sample-data/layer-legends.json`** — the two categorical legends, inserted surgically (identical to what the generator's deterministic `classes` branch emits) instead of a full regen, which re-samples all 36 other legends from S3 and isn't byte-stable.
- **Flood mechanism** — tile URLs and encoding unchanged; only the stale comment updated. The regenerated raster (IDW gap-fill + open-water mask) now contains **pluvial**, which the old comment said never occurs. Drainage-constrained is still absent (documented proxy).

## Verification

- Decoded live value tiles across the POA bbox at z12 and paired every encoded value against the visual-tile palette: **all three layers match `class = encoded − 1` at colour distance 0.0** (the disambiguation technique from the flood round, since the YAML alone can't settle the formula).
- Class inventory observed in the published rasters: flood = none/riverine/pluvial/low-lying/mixed; heat = all except limited-nocturnal-cooling; landslide = steep-activatable-slope/rainfall-trigger/vegetation-deficit/drainage-saturation/mixed.
- Booted the dev server locally and curled the two new proxy routes plus flood: all return HTTP 200 with valid 256×256 PNGs.
- `npx tsc --noEmit`: only the 3 pre-existing errors in unrelated files (`CboFilesView.tsx`, `use-toast.ts`).

## Not included (known follow-ups)

- Mau also published **GeoJSONs** with richer per-cell attributes (e.g. which mechanisms make up a `mixed` pixel, strengths, `is_interpolated`). Nothing in the app consumes them yet — surfacing that detail in the tooltip would be a separate feature.
- Layer names are raw strings like the rest of the index layers (no i18n keys), matching the existing flood mechanism convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)