### PR TITLE
Show what "Mixed" mechanism pixels are made of in the hover tooltip

### DIFF
--- a/client/src/core/components/maps/ValueTooltip.tsx
+++ b/client/src/core/components/maps/ValueTooltip.tsx
@@ -14,6 +14,38 @@ interface Props {
   mapReady: boolean;
 }
 
+// ── Mixed-cell composition for mechanism layers ──────────────────────────────
+// The mechanism rasters only store the dominant class; for "Mixed" pixels the
+// server reduces the per-cell GeoJSON to [bbox, tied labels] per mixed cell
+// (/api/geospatial/mechanism-mix/:hazard, ~100–350 KB per hazard). Loaded once
+// per hazard when a mechanism layer is enabled; module-level so all maps share
+// it. Cells absent from the index (IDW gap-fill) show plain "Mixed".
+interface MixCell { b: [number, number, number, number]; m: string[] }
+const mixIndexCache = new Map<string, Promise<MixCell[]>>();
+
+function loadMixIndex(hazard: string): Promise<MixCell[]> {
+  let promise = mixIndexCache.get(hazard);
+  if (!promise) {
+    promise = fetch(`/api/geospatial/mechanism-mix/${hazard}`)
+      .then(r => (r.ok ? r.json() : { cells: [] }))
+      .then(d => d.cells ?? [])
+      .catch(() => {
+        mixIndexCache.delete(hazard); // let a later hover retry
+        return [];
+      });
+    mixIndexCache.set(hazard, promise);
+  }
+  return promise;
+}
+
+function lookupMixedComposition(cells: MixCell[], lat: number, lng: number): string[] | null {
+  for (const cell of cells) {
+    const [w, s, e, n] = cell.b;
+    if (lng >= w && lng <= e && lat >= s && lat <= n) return cell.m;
+  }
+  return null;
+}
+
 interface TooltipState {
   x: number;
   y: number;
@@ -27,6 +59,18 @@ export default function ValueTooltip({ mapRef, enabledLayers, mapReady }: Props)
   const activeValueLayers = enabledLayers.filter(
     (l) => l.hasValueTiles && l.valueEncoding?.urlTemplate
   );
+
+  // Prefetch the mixed-composition index as soon as a mechanism layer is on,
+  // so the first "Mixed" hover doesn't wait on the network.
+  const activeMechanismHazards = activeValueLayers
+    .map((l) => l.mechanismHazard)
+    .filter((h): h is NonNullable<typeof h> => !!h)
+    .join(",");
+  useEffect(() => {
+    for (const hazard of activeMechanismHazards.split(",").filter(Boolean)) {
+      loadMixIndex(hazard);
+    }
+  }, [activeMechanismHazards]);
 
   const handleMouseMove = useCallback(
     async (e: L.LeafletMouseEvent) => {
@@ -61,8 +105,18 @@ export default function ValueTooltip({ mapRef, enabledLayers, mapReady }: Props)
             if (!imgData) continue;
 
             const [r, g, b, a] = samplePixel(imgData, px, py);
-            const decoded = decodePixelDisplay(r, g, b, a, enc);
+            let decoded = decodePixelDisplay(r, g, b, a, enc);
             if (decoded === null) continue;
+
+            // Mechanism layers: expand "Mixed" into its tied mechanisms.
+            if (decoded === "Mixed" && layer.mechanismHazard) {
+              const mix = lookupMixedComposition(
+                await loadMixIndex(layer.mechanismHazard),
+                lat,
+                lng
+              );
+              if (mix) decoded = `Mixed (${mix.join(" + ")})`;
+            }
 
             lines.push({
               label: layer.name,

--- a/server/routes/tileProxyRoutes.ts
+++ b/server/routes/tileProxyRoutes.ts
@@ -1,4 +1,5 @@
 import type { Express, Request, Response } from "express";
+import { MECHANISM_KEY_LABELS } from "@shared/geospatial-layers";
 
 // ============================================================================
 // TILE PROXY — proxies S3 tile requests with CORS handling + caching
@@ -133,6 +134,91 @@ const OEF_TILE_LAYERS: Record<string, TileLayerConfig> = {
 const failedTiles = new Map<string, number>();
 const FAIL_CACHE_MS = 60 * 60 * 1000;
 
+// ── Mechanism-mix lookup (what a "Mixed" pixel is made of) ───────────────────
+// The mechanism rasters only store the dominant class; the per-cell GeoJSONs on
+// S3 (4–13 MB) carry the detail. This endpoint reduces each file to just its
+// mixed cells — [bbox, tied mechanism labels] — so the ValueTooltip can render
+// "Mixed (Riverine + Low-lying)" without the client downloading the full file.
+// Landslide has an explicit `mixed_tied_mechanisms` property; flood and heat
+// use their per-mechanism boolean flags. IDW gap-filled cells are absent from
+// the GeoJSONs, so hovers there fall back to plain "Mixed".
+const MECHANISM_GEOJSON_BASE =
+  'https://geo-test-api.s3.us-east-1.amazonaws.com/oef_calculation/release/v1/porto_alegre/climate_hazards';
+const MECHANISM_MIX_SOURCES: Record<string, { url: string; typeProp: string; tiedProp?: string; flagKeys: string[] }> = {
+  flood: {
+    url: `${MECHANISM_GEOJSON_BASE}/floods/flood_mechanism/flood_mechanism_type_poa_250m.geojson`,
+    typeProp: 'flood_mechanism_type',
+    flagKeys: ['riverine', 'pluvial', 'low_lying'],
+  },
+  heat: {
+    url: `${MECHANISM_GEOJSON_BASE}/heat/heat_mechanism/heat_mechanism_type_poa_250m.geojson`,
+    typeProp: 'heat_mechanism_type',
+    flagKeys: ['uhi_built_up', 'shade_deficit', 'high_daytime_lst', 'limited_nocturnal_cooling', 'high_social_exposure'],
+  },
+  landslide: {
+    url: `${MECHANISM_GEOJSON_BASE}/landslides/landslide_mechanism/landslide_mechanism_type_poa_90m.geojson`,
+    typeProp: 'landslide_mechanism_type',
+    tiedProp: 'mixed_tied_mechanisms',
+    flagKeys: ['steep_activatable_slope', 'rainfall_trigger', 'low_cohesion_wet', 'vegetation_deficit', 'drainage_saturation', 'disturbed_bare_slope', 'upslope_convergence', 'high_social_exposure'],
+  },
+};
+
+// [west, south, east, north] + tied mechanism display labels
+interface MixCell { b: [number, number, number, number]; m: string[] }
+const mixCellCache = new Map<string, MixCell[]>();
+const mixCellPending = new Map<string, Promise<MixCell[]>>();
+
+async function loadMixCells(hazard: string): Promise<MixCell[]> {
+  const cached = mixCellCache.get(hazard);
+  if (cached) return cached;
+  const pending = mixCellPending.get(hazard);
+  if (pending) return pending;
+
+  const src = MECHANISM_MIX_SOURCES[hazard];
+  const promise = (async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30000);
+    const response = await fetch(src.url, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!response.ok) throw new Error(`geojson fetch ${response.status}`);
+    const geojson = await response.json();
+
+    const cells: MixCell[] = [];
+    for (const feature of geojson.features ?? []) {
+      const props = feature.properties ?? {};
+      if (props[src.typeProp] !== 'mixed') continue;
+
+      const tied: string | null = src.tiedProp ? props[src.tiedProp] : null;
+      const keys: string[] = tied
+        ? tied.split(',').map(k => k.trim())
+        : src.flagKeys.filter(k => props[k] === true);
+      const labels = keys.map(k => MECHANISM_KEY_LABELS[k] ?? k);
+      if (labels.length === 0) continue;
+
+      let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+      for (const ring of feature.geometry?.coordinates ?? []) {
+        for (const [lng, lat] of ring) {
+          if (lng < w) w = lng;
+          if (lng > e) e = lng;
+          if (lat < s) s = lat;
+          if (lat > n) n = lat;
+        }
+      }
+      if (!isFinite(w)) continue;
+      const r6 = (v: number) => Math.round(v * 1e6) / 1e6;
+      cells.push({ b: [r6(w), r6(s), r6(e), r6(n)], m: labels });
+    }
+    mixCellCache.set(hazard, cells);
+    return cells;
+  })();
+  mixCellPending.set(hazard, promise);
+  try {
+    return await promise;
+  } finally {
+    mixCellPending.delete(hazard);
+  }
+}
+
 export function registerTileProxyRoutes(app: Express): void {
   // Register a proxy route for each tile layer
   Object.entries(OEF_TILE_LAYERS).forEach(([layerId, config]) => {
@@ -175,6 +261,22 @@ export function registerTileProxyRoutes(app: Express): void {
         res.status(204).end();
       }
     });
+  });
+
+  // Mixed-cell composition for the mechanism-type layers (see loadMixCells)
+  app.get('/api/geospatial/mechanism-mix/:hazard', async (req: Request, res: Response) => {
+    const { hazard } = req.params;
+    if (!MECHANISM_MIX_SOURCES[hazard]) {
+      return res.status(400).json({ error: `Unknown hazard '${hazard}'. Expected one of: ${Object.keys(MECHANISM_MIX_SOURCES).join(', ')}` });
+    }
+    try {
+      const cells = await loadMixCells(hazard);
+      res.setHeader('Cache-Control', 'public, max-age=86400');
+      res.json({ hazard, cells });
+    } catch (err) {
+      console.error(`[tiles] mechanism-mix ${hazard} failed:`, err);
+      res.status(502).json({ error: 'Failed to load mechanism GeoJSON from S3' });
+    }
   });
 
   // List available tile layers

--- a/shared/geospatial-layers.ts
+++ b/shared/geospatial-layers.ts
@@ -49,7 +49,30 @@ export interface TileLayerDef {
   // proxy — e.g. the local pre-rendered risk tiles under client/public/tiles/.
   // When absent, the proxy path `/api/geospatial/tiles/{tileLayerId}/…` is used.
   visualUrlTemplate?: string;
+  // Set on the poa_<haz>_mechanism layers. The raster only stores the dominant
+  // class, so a "Mixed" pixel says nothing about WHICH mechanisms are tied.
+  // That detail lives in the per-cell GeoJSON on S3; the ValueTooltip resolves
+  // it through /api/geospatial/mechanism-mix/{mechanismHazard} on hover.
+  mechanismHazard?: 'flood' | 'heat' | 'landslide';
 }
+
+// snake_case mechanism keys (GeoJSON property names / nbs_rules.py identifiers)
+// → the display labels used in valueEncoding.classes. Shared so the
+// mechanism-mix endpoint and the class labels can't drift apart.
+export const MECHANISM_KEY_LABELS: Record<string, string> = {
+  // flood
+  riverine: 'Riverine', pluvial: 'Pluvial', low_lying: 'Low-lying',
+  drainage_constrained: 'Drainage constrained',
+  // heat
+  uhi_built_up: 'UHI built-up', shade_deficit: 'Shade deficit',
+  high_daytime_lst: 'High daytime LST', limited_nocturnal_cooling: 'Limited nocturnal cooling',
+  high_social_exposure: 'High social exposure',
+  // landslide
+  steep_activatable_slope: 'Steep activatable slope', rainfall_trigger: 'Rainfall trigger',
+  low_cohesion_wet: 'Low cohesion wet', vegetation_deficit: 'Vegetation deficit',
+  drainage_saturation: 'Drainage saturation', disturbed_bare_slope: 'Disturbed bare slope',
+  upslope_convergence: 'Upslope convergence',
+};
 
 // Pre-rendered risk analysis layers (250m grid, generated locally)
 // Visual tiles: client/public/tiles/{name}/{z}/{x}/{y}.png
@@ -115,7 +138,7 @@ export const FLOOD_INDEX_LAYERS: TileLayerDef[] = [
     // pluvial, low-lying and mixed. Drainage constrained still never occurs
     // (drainage is a proxy until municipal drainage data exists).
     id: 'poa_flood_mechanism', name: 'Flood Mechanism', group: 'flood_indices', color: '#7b3294',
-    tileLayerId: 'poa_flood_mechanism', available: true, hasValueTiles: true,
+    tileLayerId: 'poa_flood_mechanism', available: true, hasValueTiles: true, mechanismHazard: 'flood',
     valueEncoding: {
       type: 'categorical', offset: -1, nodata: 0,
       urlTemplate: `${CLIMATE_HAZARDS_BASE}/floods/flood_mechanism/tiles_values/{z}/{x}/{y}.png`,
@@ -139,7 +162,7 @@ export const HEAT_INDEX_LAYERS: TileLayerDef[] = [
     // verified against the visual tiles 2026-07-16 (colour distance 0.0).
     // POA raster contains every class except limited nocturnal cooling.
     id: 'poa_heat_mechanism', name: 'Heat Mechanism', group: 'heat_indices', color: '#d73027',
-    tileLayerId: 'poa_heat_mechanism', available: true, hasValueTiles: true,
+    tileLayerId: 'poa_heat_mechanism', available: true, hasValueTiles: true, mechanismHazard: 'heat',
     valueEncoding: {
       type: 'categorical', offset: -1, nodata: 0,
       urlTemplate: `${CLIMATE_HAZARDS_BASE}/heat/heat_mechanism/tiles_values/{z}/{x}/{y}.png`,
@@ -167,7 +190,7 @@ export const LANDSLIDE_INDEX_LAYERS: TileLayerDef[] = [
     // POA raster contains steep activatable slope, rainfall trigger, vegetation
     // deficit, drainage saturation and mixed.
     id: 'poa_landslide_mechanism', name: 'Landslide Mechanism', group: 'landslide_indices', color: '#8c510a',
-    tileLayerId: 'poa_landslide_mechanism', available: true, hasValueTiles: true,
+    tileLayerId: 'poa_landslide_mechanism', available: true, hasValueTiles: true, mechanismHazard: 'landslide',
     valueEncoding: {
       type: 'categorical', offset: -1, nodata: 0,
       urlTemplate: `${CLIMATE_HAZARDS_BASE}/landslides/landslide_mechanism/tiles_values/{z}/{x}/{y}.png`,


### PR DESCRIPTION
## What

Follow-up to #413. The mechanism-type rasters only store the dominant class, so a "Mixed" pixel couldn't say *which* mechanisms are tied. Mau published per-cell GeoJSONs with exactly that detail — this wires them into the hover tooltip:

> **Heat Mechanism**
> Mixed (UHI built-up + Shade deficit + High daytime LST + High social exposure)

- **`server/routes/tileProxyRoutes.ts`** — new `GET /api/geospatial/mechanism-mix/:hazard`. The raw GeoJSONs are 4–13 MB, so the server fetches each from S3 once (in-memory cache, 24 h client cache) and reduces it to just the mixed cells as `[bbox, tied labels]`: 1,602 flood / 5,498 heat / 2,019 landslide cells ≈ 100–350 KB per hazard.
- **`shared/geospatial-layers.ts`** — `mechanismHazard` field marks the three mechanism layers; `MECHANISM_KEY_LABELS` maps the GeoJSON's snake_case keys to the same display labels as `valueEncoding.classes`, so the two can't drift.
- **`client/.../ValueTooltip.tsx`** — prefetches the index when a mechanism layer is enabled (module-level cache shared by Site Explorer, the CBO map and the Concept Note map) and expands `Mixed` via point-in-bbox lookup.

## Data semantics (worth knowing)

- **Landslide** uses the GeoJSON's explicit `mixed_tied_mechanisms` property — authoritative.
- **Flood/heat** GeoJSONs don't carry a tied list or strengths, so the tooltip uses the per-mechanism **boolean screening flags** (`riverine: true`, …). These can list more mechanisms than the strict "within 0.15 of the top strength" tie set — it's the best signal the published data offers, and it's what Mau pointed at ("el geojson dice cuáles son explícitamente").
- **IDW gap-filled cells** aren't in the GeoJSONs, so hovers there fall back to plain "Mixed".

## Verification

- Endpoint exercised live for all three hazards; the flood mixed-cell count (1,602) matches the raster inventory from the #413 tile scan exactly. Unknown hazard → 400.
- Hover-tested in Site Explorer with the dev server: found a mixed heat cell and confirmed the tooltip renders the composed label (screenshot-verified); non-mixed classes and other layers unaffected.
- `npx tsc --noEmit`: only the pre-existing errors in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)