### PR TITLE
E2 post-merge audit fixes: site_control autoscore + família sheet layout

### DIFF
--- a/client/src/core/components/cbo/NbsFamiliaSheet.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaSheet.tsx
@@ -137,7 +137,13 @@ export function NbsFamiliaSheet({
           {openSolution ? (
             <NbsSolutionDetail solution={openSolution} lang={lang} />
           ) : (
-            <>
+            // max-w + centered so a desktop-width drawer doesn't render one
+            // huge full-width column; the solutions live in a GRID (1-col on
+            // phones, 2 from sm) — grid cells are also what makes the card's
+            // h-full mean "equal row height" instead of "as tall as the whole
+            // sheet body" (JVP screenshot 2026-07-16: one viewport-tall card
+            // per solution, chips pushed to the bottom by mt-auto).
+            <div className='mx-auto w-full max-w-3xl space-y-3'>
               {familia && (
                 <p className='m-0 text-xs leading-relaxed text-muted-foreground'>
                   {familia[lang].description}
@@ -191,18 +197,20 @@ export function NbsFamiliaSheet({
                   </span>
                 </button>
               )}
-              {solutions.map(solution => (
-                <NbsSolutionCard
-                  key={solution.id}
-                  solution={solution}
-                  lang={lang}
-                  onOpenFicha={setOpenSolutionId}
-                />
-              ))}
+              <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+                {solutions.map(solution => (
+                  <NbsSolutionCard
+                    key={solution.id}
+                    solution={solution}
+                    lang={lang}
+                    onOpenFicha={setOpenSolutionId}
+                  />
+                ))}
+              </div>
               <p className='m-0 pb-2 text-[10px] leading-tight text-muted-foreground/70'>
                 {s.credit} · {s.estNote}
               </p>
-            </>
+            </div>
           )}
         </div>
 

--- a/e2e/cougar-e2-linear-journey.spec.ts
+++ b/e2e/cougar-e2-linear-journey.spec.ts
@@ -87,6 +87,17 @@ test.describe('COUGAR — E2 linear journey (all checkpoints)', () => {
     await expect(page.getByText('acesso a esse espaço', { exact: false })).toBeVisible({ timeout: 8_000 });
     await chip('É da prefeitura, mas a gente usa').click();
     await expect(page.getByText('fotos do lugar', { exact: false })).toBeVisible({ timeout: 8_000 });
+
+    // Tenure landed → the checkpoint scored site_control itself (the model
+    // never runs in this path, so the old skill-driven scoring can't happen).
+    // public-informal without municipal awareness = 1 per the rubric.
+    await expect
+      .poll(async () => {
+        const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+        const s = (body.state?.maturityScores ?? []).find((m: any) => m.metric === 'site_control');
+        return s?.score;
+      }, { timeout: 8_000 })
+      .toBe(1);
     await chip('Não tenho agora').click();
 
     // 8 · Famílias recommendation: ≥2 famílias, ranked, with example variants.

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -105,11 +105,13 @@ under-construction; land_tenure: private-owned | formal-agreement |
 public-informal | public-no-access | mixed), then continue by re-asking the
 NEXT pending checkpoint question with its exact labels. When unclear, ask.
 
-## Scoring — site_control (now active)
+## Scoring — site_control (now active, scored by the platform)
 
-When `land_tenure` lands (you'll see it in CURRENT STATE), if you are handling
-a turn afterwards, call `score_maturity('site_control', …)` per the rubric —
-1-sentence Portuguese justification:
+The tenure checkpoint scores `site_control` automatically the moment
+`land_tenure` lands — you do NOT need to score it in the normal flow. Call
+`score_maturity('site_control', …)` only when the situation CHANGES through
+you (the user corrects their tenure answer, or reveals municipal awareness
+that upgrades a `public-informal` from 1 to 2). Rubric:
 
 ```
 SITE_CONTROL (0-3)

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1552,6 +1552,26 @@ async function serveE2Checkpoint(
     const tenureHit = E2_TENURE.find(o => is(o));
     if (tenureHit) {
       writeE2Fields(cboId, state, { land_tenure: tenureHit.id }, pushEvent);
+      // Score site_control HERE — the rubric is pure land_tenure, and in the
+      // happy path every remaining turn is a template, so the model (which
+      // used to do this scoring) never runs. public-informal scores 1, not 2:
+      // the 2 requires municipal awareness we haven't asked about — the model
+      // may raise it later if the conversation surfaces it.
+      const score = tenureHit.id === 'private-owned' || tenureHit.id === 'formal-agreement' ? 3
+        : tenureHit.id === 'mixed' ? 2 : 1;
+      const just: Record<string, { pt: string; en: string }> = {
+        'private-owned': { pt: 'A organização é dona do terreno.', en: 'The organization owns the land.' },
+        'formal-agreement': { pt: 'Acesso garantido por acordo formal.', en: 'Access secured by a formal agreement.' },
+        'mixed': { pt: 'Situação de posse mista — detalhes a verificar.', en: 'Mixed tenure — details to verify.' },
+        'public-informal': { pt: 'Uso informal de área pública, sem documento.', en: 'Informal use of public land, no document.' },
+        'public-no-access': { pt: 'Área pública sem acesso garantido.', en: 'Public land without guaranteed access.' },
+      };
+      state.maturityScores = state.maturityScores.filter(s => s.metric !== 'site_control');
+      state.maturityScores.push({ metric: 'site_control', score, justification: (isPt ? just[tenureHit.id]?.pt : just[tenureHit.id]?.en) ?? '' });
+      state.totalMaturityScore = state.maturityScores.reduce((sum, s) => sum + s.score, 0);
+      setCboState(cboId, state);
+      debouncedPersist(cboId);
+      pushEvent({ type: 'maturity_update', scores: state.maturityScores, total: state.totalMaturityScore, flags: state.priorityFlags } as any);
       say(
         'Boa! Antes de fechar: você tem **fotos do lugar**, uma proposta, plantas? Toca no 📎 aqui embaixo e anexa — eu leio e uso nos próximos encontros.',
         'Great! Before we close: do you have **photos of the place**, a proposal, plans? Tap the 📎 below and attach them — I read them and use them in the next encontros.',


### PR DESCRIPTION
Two findings from auditing the merged linear flow end-to-end:

1. **site_control was never scored in the happy path.** After #416, every turn from tenure to closing is a template — the model (which the skill told to score) never runs. The tenure checkpoint now scores it deterministically from the rubric (owned/formal → 3, mixed → 2, public-informal/no-access → 1 — the informal '2 with municipal awareness' upgrade stays with the model, which is the only one who'd learn that). Skill updated: model re-scores only when the user CHANGES tenure through it. Journey spec now asserts the score lands via the state API.

2. **Família sheet cards stretched to the full sheet height** (JVP screenshot): `NbsSolutionCard` has `h-full` for equal-height grid tracks, but the sheet body is a definite-height flex child, so each of the 11 cards resolved to ~90vh with the chips pushed to the bottom. The sheet list is now a real grid (1-col phone, 2-col from sm) inside a centered max-w-3xl column — verified with screenshots at 390px and 1440px.

Targeted specs + full suite pass (the one journey failure mid-audit was my own assertion reading the wrong response level, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)