### PR TITLE
E2 audit fixes round 2: hidden machine fields, multi-bairro picker, EN journey, live-model verification

### DIFF
--- a/client/src/core/components/orchestrator/CboProfileSummary.tsx
+++ b/client/src/core/components/orchestrator/CboProfileSummary.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 import { useTranslation } from 'react-i18next';
 import { Loader2, FileText } from 'lucide-react';
-import { CBO_SECTIONS, type CboState } from '@shared/cbo-schema';
+import { CBO_SECTIONS, isInternalCboField, type CboState } from '@shared/cbo-schema';
 
 type Profile = Pick<CboState, 'phase' | 'sections' | 'maturityScores' | 'totalMaturityScore' | 'gaps'>;
 
@@ -65,6 +65,8 @@ export function CboProfileSummary({
         const section = profile.sections?.[sec.id];
         if (!section) return null;
         const rows = Object.entries(section.fields)
+          // "_"-prefixed = E2 checkpoint machine state, not an answer.
+          .filter(([k]) => !isInternalCboField(k))
           .map(([k, f]) => {
             const v = fmt(f?.value);
             // org_profile enum fields may hold legacy machine ids ("funded") —

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -27,6 +27,7 @@ import {
   type PriorityFlag,
   type OpenInterventionSelectorParams,
   type InterventionSelectorResult,
+  isInternalCboField,
 } from '@shared/cbo-schema';
 import { orgProfileDisplayValue } from '@shared/cbo-field-catalog';
 import type { OpenMapParams, MapSelectionResult, SelectedAsset } from '@shared/concept-note-schema';
@@ -2461,7 +2462,11 @@ export default function CboProfilePage() {
                     </div>
                   );
                 }
-                const fields = Object.entries(section.fields);
+                // "_"-prefixed fields are E2 checkpoint machine state
+                // (risk %s, coords, confirm latches) — never render them.
+                const fields = Object.entries(section.fields).filter(
+                  ([k]) => !isInternalCboField(k)
+                );
                 const hasGaps = state.gaps.some(g => g.sectionId === sec.id);
                 const isHL = highlightedSections.includes(sec.id);
                 return (

--- a/e2e/cougar-e2-linear-journey.spec.ts
+++ b/e2e/cougar-e2-linear-journey.spec.ts
@@ -10,13 +10,178 @@ import { clickCenterZone } from './helpers/mapActions';
 // this whole spec runs WITHOUT a single fake-model script: if any step fell
 // through to the model, the fake model's default turn ("Vamos continuar")
 // would render instead of the next checkpoint and the assertions would fail.
+//
+// Runs in BOTH session languages — the templates carry full pt/en copy and a
+// drifted label on either side would silently strand that language's cohort.
 
-test.describe('COUGAR — E2 linear journey (all checkpoints)', () => {
+const LANGS = [
+  {
+    name: 'pt',
+    locale: 'pt-BR',
+    entry: 'Vamos começar o Encontro 2.',
+    skip: 'Já conheço SbN — pular',
+    oneOrMoreText: 'um bairro só ou em mais de um',
+    oneBairro: 'Um bairro',
+    confirmedText: 'confirmado',
+    forkText: 'lugar específico',
+    notYet: 'Ainda não',
+    askSupport: 'Pedir apoio à coordenação',
+    comeBack: 'Vou verificar e volto',
+    knowNow: 'Já sei o lugar',
+    cardRisk: 'Enchente',
+    confirmSite: 'Confirmar ✓',
+    currentUseText: 'Como é esse lugar hoje',
+    currentUsePick: 'Abandonado / degradado',
+    tenureText: 'acesso a esse espaço',
+    tenurePick: 'É da prefeitura, mas a gente usa',
+    photosText: 'fotos do lugar',
+    noPhotos: 'Não tenho agora',
+    exampleMark: 'ex.:',
+    makesSense: 'Faz sentido',
+    closingText: 'por onde começar a estudar',
+  },
+  {
+    name: 'en',
+    locale: 'en-US',
+    entry: "Let's start Encontro 2.",
+    skip: 'I know NbS — skip',
+    oneOrMoreText: 'one neighborhood or more than one',
+    oneBairro: 'One neighborhood',
+    confirmedText: 'confirmed',
+    forkText: 'specific place',
+    notYet: 'Not yet',
+    askSupport: 'Ask the coordination for help',
+    comeBack: "I'll check and come back",
+    knowNow: 'I know the place now',
+    cardRisk: 'Flood',
+    confirmSite: 'Confirm ✓',
+    currentUseText: 'What is this place like today',
+    currentUsePick: 'Abandoned / degraded',
+    tenureText: 'access to this space',
+    tenurePick: "It's the city's, but we use it",
+    photosText: 'photos of the place',
+    noPhotos: "I don't have any right now",
+    exampleMark: 'e.g.:',
+    makesSense: 'Makes sense',
+    closingText: 'where to start studying',
+  },
+] as const;
+
+for (const L of LANGS) {
+  test.describe(`COUGAR — E2 linear journey (all checkpoints, ${L.name})`, () => {
+    test.use({ locale: L.locale });
+
+    test('chat → mapa → chat, end to end, then survives reload', async ({ page, request }) => {
+      const api = new TestApi(request);
+      test.skip(!(await api.ping()).fakeModel, 'needs the fake model env (for seeding)');
+
+      await page.goto('/cbo-profile');
+      const marker = page.getByTestId('cbo-stream-status');
+      await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+      const cboId = (await marker.getAttribute('data-cbo-id'))!;
+      await api.seedState(cboId, { phase: 2, language: L.name });
+
+      const chip = (label: string) =>
+        page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
+      const input = page.getByTestId('cbo-chat-input');
+
+      // 1 · Entry template: famílias strip + continue/skip chips.
+      await input.fill(L.entry);
+      await input.press('Enter');
+      await expect(page.locator('[data-testid^="familia-card-"]').first()).toBeVisible({ timeout: 10_000 });
+      await expect(chip(L.skip)).toBeVisible();
+
+      // 2 · Skip → the one-or-more-bairros checkpoint (template, instant).
+      await chip(L.skip).click();
+      await expect(page.getByText(L.oneOrMoreText, { exact: false })).toBeVisible({ timeout: 8_000 });
+
+      // 3 · One bairro → Map 1: hazard tour, then the bairro pick, confirmed
+      // at the zone step (no site step in this session).
+      await chip(L.oneBairro).click();
+      await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 20_000 });
+      const tourNext = page.getByTestId('map-tour-next');
+      await expect(tourNext).toBeVisible({ timeout: 15_000 });
+      await tourNext.click();
+      await tourNext.click();
+      await tourNext.click();
+      await expect(tourNext).toHaveCount(0, { timeout: 10_000 });
+      await clickCenterZone(page);
+      const confirmBairro = page.getByTestId('map-confirm-bairro');
+      await expect(confirmBairro).toBeEnabled({ timeout: 10_000 });
+      await confirmBairro.click();
+
+      // 4 · Bairro checkpoint: confirmation + the "tem um lugar?" fork.
+      await expect(page.getByText(L.confirmedText, { exact: false })).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText(L.forkText, { exact: false })).toBeVisible();
+
+      // 4b · Detour through the "Ainda não" fork (decision A2: only the two
+      // post-it exits) and come back via the parked chip — proves resume.
+      await chip(L.notYet).click();
+      await expect(chip(L.askSupport)).toBeVisible({ timeout: 8_000 });
+      await chip(L.comeBack).click();
+      await expect(chip(L.knowNow)).toBeVisible({ timeout: 8_000 });
+      await chip(L.knowNow).click();
+
+      // 5 · Map 2: focused site session — chooser overlay → pin path.
+      await expect(page.getByTestId('map-simple-chooser')).toBeVisible({ timeout: 20_000 });
+      await page.getByTestId('map-simple-pin').click();
+      await page.waitForTimeout(500);
+      const mapBox2 = (await page.locator('.leaflet-container').first().boundingBox())!;
+      await page.mouse.click(mapBox2.x + mapBox2.width / 2, mapBox2.y + mapBox2.height / 2);
+      const confirmSite = page.getByTestId('map-confirm-site');
+      await expect(confirmSite).toBeEnabled({ timeout: 10_000 });
+      await confirmSite.click();
+
+      // 6 · Site card checkpoint: the B1 card + confirm chips.
+      const siteCard = page.getByTestId('cbo-site-card');
+      await expect(siteCard).toBeVisible({ timeout: 10_000 });
+      await expect(siteCard.getByText(L.cardRisk, { exact: false })).toBeVisible();
+      await chip(L.confirmSite).click();
+
+      // 7 · Describe stage, all templated: current use → tenure → photos.
+      await expect(page.getByText(L.currentUseText, { exact: false })).toBeVisible({ timeout: 8_000 });
+      await chip(L.currentUsePick).click();
+      await expect(page.getByText(L.tenureText, { exact: false })).toBeVisible({ timeout: 8_000 });
+      await chip(L.tenurePick).click();
+      await expect(page.getByText(L.photosText, { exact: false })).toBeVisible({ timeout: 8_000 });
+
+      // Tenure landed → the checkpoint scored site_control itself (the model
+      // never runs in this path, so the old skill-driven scoring can't happen).
+      // public-informal without municipal awareness = 1 per the rubric.
+      await expect
+        .poll(async () => {
+          const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+          const s = (body.state?.maturityScores ?? []).find((m: any) => m.metric === 'site_control');
+          return s?.score;
+        }, { timeout: 8_000 })
+        .toBe(1);
+
+      await chip(L.noPhotos).click();
+
+      // 8 · Famílias recommendation: ≥2 famílias, ranked, with example variants.
+      const reco = page.getByTestId('cbo-familia-reco');
+      await expect(reco).toBeVisible({ timeout: 8_000 });
+      expect(await reco.locator('[data-testid^="familia-reco-"]').count()).toBeGreaterThanOrEqual(2);
+      await expect(reco.getByText(L.exampleMark, { exact: false }).first()).toBeVisible();
+
+      // 9 · Close.
+      await chip(L.makesSense).click();
+      await expect(page.getByText(L.closingText, { exact: false })).toBeVisible({ timeout: 8_000 });
+
+      // 10 · Reload: the site card and the recommendation are composer-persisted.
+      await page.reload();
+      await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 20_000 });
+      await expect(page.getByTestId('cbo-familia-reco')).toBeVisible();
+    });
+  });
+}
+
+test.describe('COUGAR — E2 linear journey, multi-bairro', () => {
   test.use({ locale: 'pt-BR' });
 
-  test('chat → mapa → chat, end to end, then survives reload', async ({ page, request }) => {
+  test('two bairros → "qual bairro?" picker → focused map on the picked one', async ({ page, request }) => {
     const api = new TestApi(request);
-    test.skip(!(await api.ping()).fakeModel, 'needs the fake model env (for seeding)');
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
 
     await page.goto('/cbo-profile');
     const marker = page.getByTestId('cbo-stream-status');
@@ -26,93 +191,30 @@ test.describe('COUGAR — E2 linear journey (all checkpoints)', () => {
 
     const chip = (label: string) =>
       page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
-    const input = page.getByTestId('cbo-chat-input');
 
-    // 1 · Entry template: famílias strip + continue/skip chips.
-    await input.fill('Vamos começar o Encontro 2.');
-    await input.press('Enter');
-    await expect(page.locator('[data-testid^="familia-card-"]').first()).toBeVisible({ timeout: 10_000 });
-    await expect(chip('Já conheço SbN — pular')).toBeVisible();
-
-    // 2 · Skip → the one-or-more-bairros checkpoint (template, instant).
-    await chip('Já conheço SbN — pular').click();
-    await expect(page.getByText('um bairro só ou em mais de um', { exact: false })).toBeVisible({ timeout: 8_000 });
-
-    // 3 · "Um bairro" → Map 1: hazard tour, then the bairro pick, confirmed
-    // at the zone step (no site step in this session).
-    await chip('Um bairro').click();
-    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 20_000 });
-    const tourNext = page.getByTestId('map-tour-next');
-    await expect(tourNext).toBeVisible({ timeout: 15_000 });
-    await tourNext.click();
-    await tourNext.click();
-    await tourNext.click();
-    await expect(tourNext).toHaveCount(0, { timeout: 10_000 });
-    await clickCenterZone(page);
-    const confirmBairro = page.getByTestId('map-confirm-bairro');
-    await expect(confirmBairro).toBeEnabled({ timeout: 10_000 });
-    await confirmBairro.click();
-
-    // 4 · Bairro checkpoint: confirmation + the "tem um lugar?" fork.
-    await expect(page.getByText('confirmado', { exact: false })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('lugar específico', { exact: false })).toBeVisible();
-
-    // 4b · Detour through the "Ainda não" fork (decision A2: only the two
-    // post-it exits) and come back via the parked chip — proves resume.
-    await chip('Ainda não').click();
-    await expect(chip('Pedir apoio à coordenação')).toBeVisible({ timeout: 8_000 });
-    await chip('Vou verificar e volto').click();
-    await expect(chip('Já sei o lugar')).toBeVisible({ timeout: 8_000 });
-    await chip('Já sei o lugar').click();
-
-    // 5 · Map 2: focused site session — chooser overlay → pin path.
-    await expect(page.getByTestId('map-simple-chooser')).toBeVisible({ timeout: 20_000 });
-    await page.getByTestId('map-simple-pin').click();
-    await page.waitForTimeout(500);
-    const mapBox2 = (await page.locator('.leaflet-container').first().boundingBox())!;
-    await page.mouse.click(mapBox2.x + mapBox2.width / 2, mapBox2.y + mapBox2.height / 2);
-    const confirmSite = page.getByTestId('map-confirm-site');
-    await expect(confirmSite).toBeEnabled({ timeout: 10_000 });
-    await confirmSite.click();
-
-    // 6 · Site card checkpoint: the B1 card + confirm chips.
-    const siteCard = page.getByTestId('cbo-site-card');
-    await expect(siteCard).toBeVisible({ timeout: 10_000 });
-    await expect(siteCard.getByText('Enchente', { exact: false })).toBeVisible();
-    await chip('Confirmar ✓').click();
-
-    // 7 · Describe stage, all templated: current use → tenure → photos.
-    await expect(page.getByText('Como é esse lugar hoje', { exact: false })).toBeVisible({ timeout: 8_000 });
-    await chip('Abandonado / degradado').click();
-    await expect(page.getByText('acesso a esse espaço', { exact: false })).toBeVisible({ timeout: 8_000 });
-    await chip('É da prefeitura, mas a gente usa').click();
-    await expect(page.getByText('fotos do lugar', { exact: false })).toBeVisible({ timeout: 8_000 });
-
-    // Tenure landed → the checkpoint scored site_control itself (the model
-    // never runs in this path, so the old skill-driven scoring can't happen).
-    // public-informal without municipal awareness = 1 per the rubric.
-    await expect
-      .poll(async () => {
-        const body = await (await request.get(`/api/cbo/${cboId}`)).json();
-        const s = (body.state?.maturityScores ?? []).find((m: any) => m.metric === 'site_control');
-        return s?.score;
-      }, { timeout: 8_000 })
-      .toBe(1);
-    await chip('Não tenho agora').click();
-
-    // 8 · Famílias recommendation: ≥2 famílias, ranked, with example variants.
-    const reco = page.getByTestId('cbo-familia-reco');
-    await expect(reco).toBeVisible({ timeout: 8_000 });
-    expect(await reco.locator('[data-testid^="familia-reco-"]').count()).toBeGreaterThanOrEqual(2);
-    await expect(reco.getByText('ex.:', { exact: false }).first()).toBeVisible();
-
-    // 9 · Close.
-    await chip('Faz sentido').click();
-    await expect(page.getByText('Pronto', { exact: false })).toBeVisible({ timeout: 8_000 });
-
-    // 10 · Reload: the site card and the recommendation are composer-persisted.
+    // A two-zone map confirmation (same shape formatMapResult emits). Sent via
+    // the API — the chat input is single-line, so a typed multiline payload
+    // would collapse and never match the parser's ^-anchored zone lines. The
+    // reload after rehydrates the served fork from the persisted transcript.
+    const twoZones = [
+      'Map selection (composite mode):',
+      '- [zone] Bela Vista: HIGH risk, intervention: flood parks, area: 1.2 km², pop: 11.128, flood: 78%, heat: 41%, landslide: 12%, at (-30.0327, -51.1898)',
+      '- [zone] Santana: MEDIUM risk, intervention: green corridors, area: 1.6 km², pop: 20.000, flood: 35%, heat: 62%, landslide: 8%, at (-30.0450, -51.2050)',
+      'Total: 2 assets, 0 sampled points',
+    ].join('\n');
+    await request.post(`/api/cbo/${cboId}/chat`, { data: { message: twoZones, lang: 'pt', turnKind: 'map' } });
     await page.reload();
-    await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 20_000 });
-    await expect(page.getByTestId('cbo-familia-reco')).toBeVisible();
+
+    // Fork appears; "Sim" now routes through the bairro picker, one chip each.
+    await expect(page.getByText('lugar específico', { exact: false })).toBeVisible({ timeout: 10_000 });
+    await chip('Sim, tenho um lugar').click();
+    await expect(page.getByText('Em qual bairro fica o lugar?', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await expect(chip('Bela Vista')).toBeVisible();
+    await expect(chip('Santana')).toBeVisible();
+
+    // Picking one opens the focused site session inside THAT bairro.
+    await chip('Santana').click();
+    await expect(page.getByTestId('map-simple-chooser')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText('em Santana', { exact: false })).toBeVisible();
   });
 });

--- a/e2e/quality/cbo-e2-linear-live.spec.ts
+++ b/e2e/quality/cbo-e2-linear-live.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from '../helpers/testApi';
+
+// LIVE quality check — NON-GATING. The E2 linear flow's templates are fully
+// covered by deterministic specs; what they CANNOT cover is the handful of
+// model-owned turns the rewritten skill defines. This drives the REAL model
+// through the two most load-bearing ones:
+//   1. "Ver exemplos" → the model must show the examples strip AND re-offer
+//      the exact "✓ Entendi" chip (the checkpoint resumes on that label).
+//   2. "É outro tipo de lugar" on the site card → the model must converse
+//      (not re-serve checkpoints) and leave the user with a way forward.
+// Wording is non-deterministic → structural assertions only.
+//
+// Run on-demand against a real-model server (see cbo-live-smoke.spec.ts):
+//   RUN_LIVE_QUALITY=1 E2E_BASE_URL=http://localhost:5100 npx playwright test e2e/quality/cbo-e2-linear-live.spec.ts --project=chromium
+
+const RUN = process.env.RUN_LIVE_QUALITY === '1';
+
+test.describe('E2 linear flow — live model-owned turns @live', () => {
+  test.use({ locale: 'pt-BR' });
+  test.skip(!RUN, 'Set RUN_LIVE_QUALITY=1 and point E2E_BASE_URL at a real (non-fake-model) server to run.');
+
+  test('"Ver exemplos" → examples strip + the exact "✓ Entendi" chip', async ({ page, request }) => {
+    const api = new TestApi(request);
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    await api.seedState(cboId, { phase: 2, language: 'pt' });
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Vamos começar o Encontro 2.');
+    await input.press('Enter');
+    const verExemplos = page.locator('[data-testid^="cbo-option-"][data-option-label="Ver exemplos"]');
+    await expect(verExemplos).toBeVisible({ timeout: 15_000 });
+    await verExemplos.click();
+
+    // REAL model turn: the skill's Turn-2 job — examples strip + confirm ask.
+    await expect(page.locator('[data-testid^="showcase-card-"]').first()).toBeVisible({ timeout: 120_000 });
+    // The label matters, not just "some question": the next checkpoint fires
+    // on "entendi". Accept the exact chip or any option containing it.
+    await expect(page.locator('[data-testid^="cbo-option-"]').filter({ hasText: /entendi/i }).first()).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('"É outro tipo de lugar" → the model converses and does not strand the user', async ({ page, request }) => {
+    const api = new TestApi(request);
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    await api.seedState(cboId, { phase: 2, language: 'pt' });
+
+    const input = page.getByTestId('cbo-chat-input');
+    // Reach the site card via the checkpoint parser — the payload goes through
+    // the API (multiline; the chat input is single-line), then a reload
+    // rehydrates the served card + chips. No model involved up to here.
+    await request.post(`/api/cbo/${cboId}/chat`, {
+      data: {
+        message: [
+          'Map selection (composite mode):',
+          '- [zone] Bela Vista: HIGH risk, intervention: flood parks, area: 1.2 km², pop: 11.128, flood: 78%, heat: 41%, landslide: 12%, at (-30.0327, -51.1898)',
+          '- [custom] Terreno da associação at (-30.0330, -51.1900)',
+          'Total: 2 assets, 0 sampled points',
+        ].join('\n'),
+        lang: 'pt',
+        turnKind: 'map',
+      },
+    });
+    await page.reload();
+    await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 15_000 });
+
+    const outroTipo = page.locator('[data-testid^="cbo-option-"][data-option-label="É outro tipo de lugar"]');
+    await expect(outroTipo).toBeVisible();
+    await outroTipo.click();
+
+    // REAL model turn: it should ask what the place is (free text) — i.e. the
+    // turn ends with SOME prompt and no checkpoint hijack. Loose assertions.
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 120_000 });
+    const asked = await page.locator('[data-testid^="cbo-option-"]').count();
+    const inputEnabled = await input.isEnabled();
+    expect(asked > 0 || inputEnabled).toBeTruthy();
+
+    // Answer; the model should store it and put the user back on a path
+    // (re-offered confirm chips or a follow-up question — never a dead end).
+    await input.fill('É um pátio de escola que a gente usa nos fins de semana.');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 120_000 });
+    // Not stranded = the transcript shows the model's follow-up question and
+    // the user can still act (live chips, or after an SSE drop the reload path
+    // with a usable input). Long live turns drop the SSE occasionally
+    // (observed 2026-07-16) which downgrades the chips to their persisted
+    // render — the user types instead; that's degraded, not stranded.
+    await page.reload();
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const liveOptions = await page.locator('[data-testid^="cbo-option-"]').count();
+    const canType = await input.isEnabled().catch(() => false);
+    expect(liveOptions > 0 || canType).toBeTruthy();
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1315,7 +1315,7 @@ function buildFamiliaRecoItems(state: CboState, lang: string, modelItems?: Array
   const pct = (k: string) => Math.max(0, Math.min(100, parseInt(String(f[k]?.value ?? '0'), 10) || 0));
   const bairro = String(f.bairro?.value ?? '').split(',')[0].trim() || (lang === 'pt' ? 'seu bairro' : 'your neighborhood');
   const ranked = rankFamiliasForSite({
-    risks: { flood: pct('bairro_flood_pct'), heat: pct('bairro_heat_pct'), landslide: pct('bairro_landslide_pct') },
+    risks: { flood: pct('_bairro_flood_pct'), heat: pct('_bairro_heat_pct'), landslide: pct('_bairro_landslide_pct') },
     bairro,
     currentUse: String(f.current_use?.value ?? '') || undefined,
     siteName: String(f.site_name?.value ?? '') || undefined,
@@ -1402,13 +1402,17 @@ async function serveE2Checkpoint(
 
     if (sites.length === 0) {
       // CP: bairro confirmed (zone-only session) → the "tem um lugar?" fork.
+      // ALL zones persist in _bairros_json (a multi-bairro org picks which one
+      // the site is in later); the primary's risks seed the _pct fields until
+      // the site session pins them to the site's own bairro.
       const names = zones.map(z => z.name).join(', ');
       const z = zones[0];
       writeE2Fields(cboId, state, {
         bairro: names,
-        bairro_flood_pct: String(z.flood),
-        bairro_heat_pct: String(z.heat),
-        bairro_landslide_pct: String(z.landslide),
+        _bairros_json: JSON.stringify(zones),
+        _bairro_flood_pct: String(z.flood),
+        _bairro_heat_pct: String(z.heat),
+        _bairro_landslide_pct: String(z.landslide),
       }, pushEvent);
       say(`✓ **${names}** confirmado.`, `✓ **${names}** confirmed.`);
       ask(
@@ -1422,30 +1426,32 @@ async function serveE2Checkpoint(
       return finish('bairro-fork');
     }
 
-    // CP: site chosen → the site card + confirm.
+    // CP: site chosen → the site card + confirm. The site session's message
+    // carries the FOCUSED bairro's zone line — always prefer it: for a
+    // multi-bairro org it is the bairro the site is actually in, so the card
+    // and the recommendation use ITS risks (the _pct fields are re-pinned).
     const s = sites[sites.length - 1];
     const z = zones[0];
     writeE2Fields(cboId, state, {
-      ...(bairro ? {} : { bairro: z.name, bairro_flood_pct: String(z.flood), bairro_heat_pct: String(z.heat), bairro_landslide_pct: String(z.landslide) }),
+      ...(bairro ? {} : { bairro: z.name }),
+      _bairro_flood_pct: String(z.flood),
+      _bairro_heat_pct: String(z.heat),
+      _bairro_landslide_pct: String(z.landslide),
       site_name: s.name,
-      site_lat: String(s.lat),
-      site_lng: String(s.lng),
+      _site_lat: String(s.lat),
+      _site_lng: String(s.lng),
     }, pushEvent);
     const typeLabel = inferSiteTypeLabel(s.name, isPt ? 'pt' : 'en');
     pushEvent({
       type: 'show_site_card',
       card: {
         name: s.name,
-        bairro: bairro || z.name,
+        bairro: z.name,
         lat: s.lat,
         lng: s.lng,
         siteKind: s.kind,
         ...(typeLabel ? { siteTypeLabel: typeLabel } : {}),
-        risks: {
-          flood: bairro ? parseInt(val('bairro_flood_pct') || '0', 10) : z.flood,
-          heat: bairro ? parseInt(val('bairro_heat_pct') || '0', 10) : z.heat,
-          landslide: bairro ? parseInt(val('bairro_landslide_pct') || '0', 10) : z.landslide,
-        },
+        risks: { flood: z.flood, heat: z.heat, landslide: z.landslide },
       },
     } as any);
     ask('É isso mesmo?', 'Is that right?', [
@@ -1487,14 +1493,34 @@ async function serveE2Checkpoint(
     return finish('open-bairro-map');
   }
 
-  // "Tem um lugar" fork answers.
-  if (bairro && !siteName && (is(E2C.simTenho) || is(E2C.jaTenho))) {
+  // "Tem um lugar" fork answers. Multi-bairro orgs pick WHICH bairro the site
+  // is in first (one chip per bairro from _bairros_json); single-bairro orgs
+  // go straight to the focused map.
+  const storedBairros: Array<{ name: string; flood: number; heat: number; landslide: number }> = (() => {
+    try { return JSON.parse(val('_bairros_json') || '[]'); } catch { return []; }
+  })();
+  const openSiteMapOrPicker = (detail: string): true => {
+    if (storedBairros.length > 1) {
+      ask('Em qual bairro fica o lugar?', 'Which neighborhood is the place in?',
+        storedBairros.map(b => ({ pt: b.name, en: b.name })));
+      return finish(`${detail}-bairro-picker`);
+    }
     openMapPreset({ preset: 'e2_site_focused', focusZone: bairro.split(',')[0].trim() });
-    return finish('open-site-map');
+    return finish(detail);
+  };
+  if (bairro && !siteName && (is(E2C.simTenho) || is(E2C.jaTenho))) {
+    return openSiteMapOrPicker('open-site-map');
   }
   if (bairro && siteName && is(E2C.outroLugar)) {
-    openMapPreset({ preset: 'e2_site_focused', focusZone: bairro.split(',')[0].trim() });
-    return finish('open-site-map-again');
+    return openSiteMapOrPicker('open-site-map-again');
+  }
+  // Bairro-picker answer: the chip is one of the stored bairro names.
+  if (bairro && storedBairros.length > 1) {
+    const picked = storedBairros.find(b => msg === normChip(b.name));
+    if (picked) {
+      openMapPreset({ preset: 'e2_site_focused', focusZone: picked.name });
+      return finish('open-site-map-picked');
+    }
   }
   if (bairro && !siteName && is(E2C.aindaNao)) {
     say(
@@ -1535,7 +1561,7 @@ async function serveE2Checkpoint(
 
   // Site card confirmed → describe stage, first templated question (current use).
   if (siteName && !currentUse && is(E2C.confirmar)) {
-    writeE2Fields(cboId, state, { site_confirmed: 'yes' }, pushEvent);
+    writeE2Fields(cboId, state, { _site_confirmed: 'yes' }, pushEvent);
     ask('Como é esse lugar hoje?', 'What is this place like today?', E2_CURRENT_USE.map(o => ({ pt: o.pt, en: o.en })));
     return finish('ask-current-use');
   }

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -145,6 +145,13 @@ export interface CboFieldState {
   userEdited: boolean;
 }
 
+/** E2 checkpoint helper fields ("_"-prefixed): persisted so the linear flow
+ *  can derive its step and build the site card / recommendation, but hidden
+ *  from every human-facing field render (CBO document panel, coordinator
+ *  profile summary) — a raw "_bairro_flood_pct: 82" row is machine state,
+ *  not an answer. */
+export const isInternalCboField = (field: string) => field.startsWith('_');
+
 export interface CboSectionState {
   id: CboSectionId;
   title: string;


### PR DESCRIPTION
The remaining items from the post-merge audit, all four fixed:

## 1 · Checkpoint machine-state hidden from humans
The helper fields are now `_`-prefixed (`_bairro_flood_pct`, `_site_confirmed`, `_site_lat/_lng`, `_bairros_json`) and a shared `isInternalCboField` predicate filters them out of both field renders (CBO document panel + coordinator `CboProfileSummary`). `bairro`, `site_name`, `current_use`, `land_tenure` stay visible — they're answers, not machinery.

## 2 · Multi-bairro works properly
All confirmed zones persist (`_bairros_json`). When a multi-bairro org says "Sim, tenho um lugar", a new checkpoint asks **"Em qual bairro fica o lugar?"** (one chip per bairro) before opening the focused map on the picked one. The site card and famílias recommendation now always use the risks of the bairro the site is actually in (re-pinned from the site session's own zone line), not the first-selected one. New spec drives the two-zone → picker → focused-map path.

## 3 · EN journey spec
The full-journey spec is parameterized and runs in BOTH session languages — a drifted label on either side now fails CI instead of silently stranding that language's cohort. (Caught one already: the EN closing assertion was ambiguous.)

## 4 · Live-model verification — RAN, both green
New non-gating `e2e/quality/cbo-e2-linear-live.spec.ts` (@live), executed against a real-SDK local server:
- **"Ver exemplos"**: the model showed the examples strip and re-offered the exact "✓ Entendi" chip the checkpoint resumes on. ✅
- **"É outro tipo de lugar"**: the model conversed coherently (asked what the place is, followed up after the answer) and never hijacked a checkpoint. ✅

Two live observations (noted, not blockers): chip turns at phase 2 route to the light model (haiku) per the adaptive router — it handled both turns fine; and long live turns can drop the SSE mid-stream, downgrading live chips to their persisted render (the user can still type — degraded, not stranded; pre-existing class).

## Tests
Journey pt + en + multi-bairro + admin panel green; the full-suite run had 2 machine-load flakes (ECONNRESET) that pass in isolation. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)