### PR TITLE
E2 interest + role step: post-recommendation chip loops for portfolio clustering

### DIFF
--- a/e2e/cougar-e2-interest-roles.spec.ts
+++ b/e2e/cougar-e2-interest-roles.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// E2 interest + role step (2026-07-16 biweekly commitment): after the famílias
+// recommendation, "Faz sentido" no longer closes — it opens two templated chip
+// loops (which famílias the org would run a project on, then which role they
+// want to play), and only then the closing fires. All server-templated: any
+// leak to the model would render the fake model's default turn instead.
+//
+// The map stages are skipped via a synthetic composite payload posted through
+// the API (the chat input is single-line; a typed multiline payload would
+// collapse and never match the parser's ^-anchored lines).
+
+test.describe('COUGAR — E2 interest + role loops', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('Faz sentido → famílias interest → role picks (incl. outro papel) → closing, fields persisted', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model env (for seeding)');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+    await api.seedState(cboId, { phase: 2 });
+
+    const chip = (label: string) =>
+      page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
+    const input = page.getByTestId('cbo-chat-input');
+
+    // Fast-forward to the site card: one zone + one custom site in a single
+    // composite payload, then reload to rehydrate the served checkpoint.
+    await request.post(`/api/cbo/${cboId}/chat`, {
+      data: {
+        message: [
+          'Map selection (composite mode):',
+          '- [zone] Bela Vista: HIGH risk, intervention: flood parks, area: 1.2 km², pop: 11.128, flood: 78%, heat: 41%, landslide: 12%, at (-30.0327, -51.1898)',
+          '- [custom] Terreno da associação at (-30.0330, -51.1900)',
+          'Total: 2 assets, 0 sampled points',
+        ].join('\n'),
+        lang: 'pt',
+        turnKind: 'map',
+      },
+    });
+    await page.reload();
+    await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 15_000 });
+
+    // Describe stage (templated) up to the recommendation.
+    await chip('Confirmar ✓').click();
+    await expect(page.getByText('Como é esse lugar hoje', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await chip('Abandonado / degradado').click();
+    await expect(page.getByText('acesso a esse espaço', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await chip('É da prefeitura, mas a gente usa').click();
+    await expect(page.getByText('fotos do lugar', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await chip('Não tenho agora').click();
+    await expect(page.getByTestId('cbo-familia-reco')).toBeVisible({ timeout: 8_000 });
+
+    // "Faz sentido" now opens the interest question instead of closing.
+    await chip('Faz sentido').click();
+    await expect(page.getByText('famílias vocês teriam interesse', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('por onde começar a estudar', { exact: false })).toHaveCount(0);
+
+    // Interest loop: two picks, then Pronto — each pick re-offers what's left.
+    await chip('Gestão de Águas Pluviais').click();
+    await expect(page.getByText('Mais alguma?', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await expect(chip('Gestão de Águas Pluviais')).toHaveCount(0); // picked → no longer offered
+    await chip('Agricultura Urbana').click();
+    await expect(chip('Pronto ✓')).toBeVisible({ timeout: 8_000 });
+    await chip('Pronto ✓').click();
+
+    // Role loop: one catalog role + the "Outro papel" free-text turn.
+    await expect(page.getByText('vocês gostariam de ter nesses projetos', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await chip('Escrever o projeto').click();
+    await expect(page.getByText('Mais algum papel?', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await chip('Outro papel').click();
+    await expect(page.getByText('Me conta: que papel', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await input.fill('Mobilizar as famílias do entorno');
+    await input.press('Enter');
+    await expect(chip('Pronto ✓')).toBeVisible({ timeout: 8_000 });
+    await chip('Pronto ✓').click();
+
+    // Closing only now.
+    await expect(page.getByText('por onde começar a estudar', { exact: false })).toBeVisible({ timeout: 8_000 });
+
+    // Both fields persisted with canonical ids (+ the free-text role verbatim).
+    const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+    const fields = body.state?.sections?.intervention_site?.fields ?? {};
+    expect(String(fields.nbs_interest?.value)).toBe('aguas-pluviais, agricultura-urbana');
+    expect(String(fields.role_preference?.value)).toContain('escrever-projeto');
+    expect(String(fields.role_preference?.value)).toContain('outro: Mobilizar as famílias do entorno');
+
+    // Reload: the loops are over; the transcript still ends at the closing.
+    await page.reload();
+    await expect(page.getByText('por onde começar a estudar', { exact: false })).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/e2e/cougar-e2-linear-journey.spec.ts
+++ b/e2e/cougar-e2-linear-journey.spec.ts
@@ -38,6 +38,11 @@ const LANGS = [
     noPhotos: 'Não tenho agora',
     exampleMark: 'ex.:',
     makesSense: 'Faz sentido',
+    interestText: 'famílias vocês teriam interesse',
+    interestPick: 'Infraestrutura Verde Urbana',
+    roleText: 'vocês gostariam de ter nesses projetos',
+    rolePick: 'Executar / implementar',
+    doneList: 'Pronto ✓',
     closingText: 'por onde começar a estudar',
   },
   {
@@ -63,6 +68,11 @@ const LANGS = [
     noPhotos: "I don't have any right now",
     exampleMark: 'e.g.:',
     makesSense: 'Makes sense',
+    interestText: 'famílias would you be interested',
+    interestPick: 'Urban Green Infrastructure',
+    roleText: 'would you like to play in these projects',
+    rolePick: 'Implement on the ground',
+    doneList: 'Done ✓',
     closingText: 'where to start studying',
   },
 ] as const;
@@ -164,8 +174,16 @@ for (const L of LANGS) {
       expect(await reco.locator('[data-testid^="familia-reco-"]').count()).toBeGreaterThanOrEqual(2);
       await expect(reco.getByText(L.exampleMark, { exact: false }).first()).toBeVisible();
 
-      // 9 · Close.
+      // 9 · Interest + role loops (the Aug-12 biweekly commitment), then close.
       await chip(L.makesSense).click();
+      await expect(page.getByText(L.interestText, { exact: false })).toBeVisible({ timeout: 8_000 });
+      await chip(L.interestPick).click();
+      await expect(chip(L.doneList)).toBeVisible({ timeout: 8_000 });
+      await chip(L.doneList).click();
+      await expect(page.getByText(L.roleText, { exact: false })).toBeVisible({ timeout: 8_000 });
+      await chip(L.rolePick).click();
+      await expect(chip(L.doneList)).toBeVisible({ timeout: 8_000 });
+      await chip(L.doneList).click();
       await expect(page.getByText(L.closingText, { exact: false })).toBeVisible({ timeout: 8_000 });
 
       // 10 · Reload: the site card and the recommendation are composer-persisted.

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -36,7 +36,11 @@ LOG shows already happened.
    → convite pra fotos/arquivos (📎).
 6. **Famílias pra estudar** — always ≥2, ranked by risco do bairro × tipo de
    lugar × what the org shared → "Faz sentido / Quero ajustar".
-7. **Closing** — no `set_phase(3)` (the coordinator gates it).
+7. **Interesse + papel** (after "Faz sentido") — two templated chip loops:
+   quais famílias interessam (multi-pick, "Pronto ✓" fecha) and que papel
+   querem ter (multi-pick + "Outro papel" → one free-text turn the PLATFORM
+   captures). Feeds the coordination's portfolio clustering before Workshop 3.
+8. **Closing** — no `set_phase(3)` (the coordinator gates it).
 
 ## Voice
 
@@ -65,7 +69,10 @@ the platform watches for it to serve the next checkpoint.
 "Tenho uma dúvida", free-text questions mid-flow, "o que é X?" — answer warmly
 (use `search_knowledge` / `read_knowledge`), then re-show the SAME pending
 question with `ask_user` using the exact labels from the DECISION LOG, so the
-user lands back on the checkpoint they left.
+user lands back on the checkpoint they left. This includes mid-loop chats
+during the interesse/papel step: after answering, re-offer the pending chips
+exactly as the decision log shows them (remaining famílias/papéis +
+"Pronto ✓") — never invent your own interest/role labels.
 
 ### 3 · "É outro tipo de lugar" (site-card correction)
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -26,6 +26,7 @@ import { db } from "../db";
 import { cohortMembers, type SupportRequest } from "@shared/cohort-schema";
 import { resolveOpenMapParams } from "@shared/cbo-map-presets";
 import { rankFamiliasForSite, inferSiteTypeLabel } from "@shared/nbs-recommendation";
+import { NBS_FAMILIAS } from "@shared/nbs-catalog";
 import { nanoid } from "nanoid";
 import { eq } from "drizzle-orm";
 import { getOrgIdForCboState, listDocumentsByOrg, listDocumentSummariesByOrg, getDocumentForOrg } from "./documentPersistence";
@@ -1272,6 +1273,8 @@ const E2C: Record<string, { pt: string; en: string; desc?: { pt: string; en: str
   prontoSeguir: { pt: 'Pronto, pode seguir', en: "Done, let's continue" },
   fazSentido: { pt: 'Faz sentido', en: 'Makes sense' },
   queroAjustar: { pt: 'Quero ajustar', en: 'I want to adjust' },
+  prontoLista: { pt: 'Pronto ✓', en: 'Done ✓' },
+  outroPapel: { pt: 'Outro papel', en: 'Another role' },
 };
 
 // current_use / land_tenure enum chips (un-deferred from the old Beat 2b/3b —
@@ -1289,6 +1292,17 @@ const E2_TENURE: Array<{ id: string; pt: string; en: string }> = [
   { id: 'public-informal', pt: 'É da prefeitura, mas a gente usa', en: "It's the city's, but we use it" },
   { id: 'public-no-access', pt: 'É público mas não temos acesso garantido', en: "It's public but access isn't guaranteed" },
   { id: 'mixed', pt: 'Misto / não sei certinho', en: 'Mixed / not sure' },
+];
+// Implementation-role chips for the interest step (2026-07-16 biweekly: orgs
+// signal preferred roles before Workshop 3 so the coordination can cluster the
+// portfolio by role and scale). The taxonomy is the meeting's placeholder set —
+// pending Robson/Belén confirmation; labels are a data-only change.
+const E2_ROLES: Array<{ id: string; pt: string; en: string }> = [
+  { id: 'ser-consultada', pt: 'Ser consultada (dar opinião)', en: 'Be consulted (give input)' },
+  { id: 'escrever-projeto', pt: 'Escrever o projeto', en: 'Write the project' },
+  { id: 'receber-administrar', pt: 'Receber e administrar recursos', en: 'Receive and manage the funds' },
+  { id: 'executar', pt: 'Executar / implementar', en: 'Implement on the ground' },
+  { id: 'articular-parceiros', pt: 'Articular parceiros', en: 'Coordinate partners' },
 ];
 
 const normChip = (s: string) =>
@@ -1374,6 +1388,8 @@ async function serveE2Checkpoint(
   const siteName = val('site_name');
   const currentUse = val('current_use');
   const tenure = val('land_tenure');
+  const pickedFamilias = val('nbs_interest') ? val('nbs_interest').split(',').map(s => s.trim()).filter(Boolean) : [];
+  const pickedRoles = val('role_preference') ? val('role_preference').split(',').map(s => s.trim()).filter(Boolean) : [];
 
   const say = (pt: string, en: string) => pushEvent({ type: 'chat', content: isPt ? pt : en, role: 'assistant' } as any);
   const ask = (qPt: string, qEn: string, opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string }>) =>
@@ -1389,6 +1405,47 @@ async function serveE2Checkpoint(
   };
   const openMapPreset = (args: Record<string, unknown>) =>
     pushEvent({ type: 'open_map', params: resolveOpenMapParams(args as any, isPt ? 'pt' : 'en') } as any);
+
+  // ── Interest + role loops (2026-07-16 biweekly commitment for Aug 12) ──────
+  // After the famílias recommendation, orgs mark which famílias they'd want a
+  // project in and the role(s) they'd play. Multi-pick via chip loops: every
+  // pick re-offers what's left plus "Pronto ✓" — templated, park/resume-safe.
+  const askInterest = (picked: string[]) => {
+    const opts = NBS_FAMILIAS.filter(f => !picked.includes(f.id)).map(f => ({ pt: f.pt.label, en: f.en.label })) as Array<{ pt: string; en: string; dPt?: string; dEn?: string }>;
+    if (picked.length > 0) opts.push({ pt: E2C.prontoLista.pt, en: E2C.prontoLista.en, dPt: 'Fechar a lista', dEn: 'Close the list' });
+    ask(
+      picked.length === 0
+        ? 'Em quais famílias vocês teriam interesse em tocar um projeto? Pode marcar mais de uma — toca numa por vez.'
+        : 'Marcado ✓ Mais alguma?',
+      picked.length === 0
+        ? 'Which famílias would you be interested in running a project on? You can pick more than one — tap one at a time.'
+        : 'Noted ✓ Any other?',
+      opts,
+    );
+  };
+  const askRoles = (picked: string[], intro: boolean) => {
+    if (intro)
+      say(
+        'Fechou. E que **papel** vocês gostariam de ter nesses projetos? Também pode marcar mais de um.',
+        'Got it. And what **role** would you like to play in these projects? You can pick more than one too.',
+      );
+    const opts = E2_ROLES.filter(r => !picked.includes(r.id)).map(r => ({ pt: r.pt, en: r.en })) as Array<{ pt: string; en: string; dPt?: string; dEn?: string }>;
+    opts.push({ pt: E2C.outroPapel.pt, en: E2C.outroPapel.en, dPt: 'Me conta qual', dEn: 'Tell me which' });
+    if (picked.length > 0) opts.push({ pt: E2C.prontoLista.pt, en: E2C.prontoLista.en, dPt: 'Fechar a lista', dEn: 'Close the list' });
+    ask(
+      picked.length === 0 ? 'Que papel vocês imaginam?' : 'Marcado ✓ Mais algum papel?',
+      picked.length === 0 ? 'What role do you imagine?' : 'Noted ✓ Any other role?',
+      opts,
+    );
+  };
+  const closeE2 = (): true => {
+    const nome = String(state.sections.org_profile?.fields?.contact_name?.value || '').trim().split(/\s+/)[0];
+    say(
+      `✓ **Pronto${nome ? `, ${nome}` : ''}!** Marcamos **${siteName || bairro}** e já sabemos por onde começar a estudar.\n\nNo próximo encontro a gente escolhe juntas a solução que mais combina com esse lugar. Até lá! 🌱`,
+      `✓ **Done${nome ? `, ${nome}` : ''}!** We've marked **${siteName || bairro}** and we know where to start studying.\n\nIn the next encontro we'll pick together the solution that best fits this place. See you! 🌱`,
+    );
+    return finish('closing');
+  };
 
   // ── Map results ────────────────────────────────────────────────────────────
   if (turnKind === 'map' || raw.startsWith('Map selection (')) {
@@ -1460,6 +1517,18 @@ async function serveE2Checkpoint(
       { pt: E2C.outroLugar.pt, en: E2C.outroLugar.en, dPt: 'Voltar pro mapa', dEn: 'Back to the map' },
     ]);
     return finish('site-card');
+  }
+
+  // "Outro papel" answer — the ONLY free-text turn the checkpoint machine
+  // consumes, and only while the role question is explicitly waiting for it.
+  if (val('_role_other_pending') === 'yes' && val('_role_done') !== 'yes' && turnKind !== 'chip' && raw && !raw.startsWith('Map selection (')) {
+    const other = `outro: ${raw.replace(/\s+/g, ' ').slice(0, 120)}`;
+    writeE2Fields(cboId, state, {
+      role_preference: [...pickedRoles, other].join(', '),
+      _role_other_pending: '',
+    }, pushEvent);
+    askRoles([...pickedRoles, other], false);
+    return finish('role-other-captured');
   }
 
   // ── Chip taps ──────────────────────────────────────────────────────────────
@@ -1633,14 +1702,60 @@ async function serveE2Checkpoint(
     ]);
     return finish('familia-reco');
   }
-  // Recommendation acknowledged → closing.
-  if (is(E2C.fazSentido) && getCboMessages(cboId).some(m => m.messageType === 'composer' && m.content.includes('"kind":"familia_reco"'))) {
-    const nome = String(state.sections.org_profile?.fields?.contact_name?.value || '').trim().split(/\s+/)[0];
+  // Recommendation acknowledged → the interest question (not closing yet).
+  if (is(E2C.fazSentido) && val('_interest_done') !== 'yes' && getCboMessages(cboId).some(m => m.messageType === 'composer' && m.content.includes('"kind":"familia_reco"'))) {
     say(
-      `✓ **Pronto${nome ? `, ${nome}` : ''}!** Marcamos **${siteName || bairro}** e já sabemos por onde começar a estudar.\n\nNo próximo encontro a gente escolhe juntas a solução que mais combina com esse lugar. Até lá! 🌱`,
-      `✓ **Done${nome ? `, ${nome}` : ''}!** We've marked **${siteName || bairro}** and we know where to start studying.\n\nIn the next encontro we'll pick together the solution that best fits this place. See you! 🌱`,
+      'Boa! Última coisa — e essa parte ajuda a coordenação a montar os grupos dos próximos encontros.',
+      'Great! One last thing — this part helps the coordination shape the groups for the next encontros.',
     );
-    return finish('closing');
+    writeE2Fields(cboId, state, { _interest_offered: 'yes' }, pushEvent);
+    askInterest(pickedFamilias);
+    return finish('ask-interest');
+  }
+
+  // Interest loop: família picks accumulate; "Pronto ✓" (or all five) advances.
+  if (val('_interest_offered') === 'yes' && val('_interest_done') !== 'yes') {
+    const fam = NBS_FAMILIAS.find(f => is({ pt: f.pt.label, en: f.en.label }) && !pickedFamilias.includes(f.id));
+    if (fam) {
+      const next = [...pickedFamilias, fam.id];
+      writeE2Fields(cboId, state, { nbs_interest: next.join(', ') }, pushEvent);
+      if (next.length >= NBS_FAMILIAS.length) {
+        writeE2Fields(cboId, state, { _interest_done: 'yes', _roles_offered: 'yes' }, pushEvent);
+        askRoles(pickedRoles, true);
+        return finish('ask-roles');
+      }
+      askInterest(next);
+      return finish('interest-picked');
+    }
+    if (is(E2C.prontoLista) && pickedFamilias.length > 0) {
+      writeE2Fields(cboId, state, { _interest_done: 'yes', _roles_offered: 'yes' }, pushEvent);
+      askRoles(pickedRoles, true);
+      return finish('ask-roles');
+    }
+  }
+
+  // Role loop: same shape; "Outro papel" hands one turn to free text above.
+  if (val('_roles_offered') === 'yes' && val('_role_done') !== 'yes') {
+    const role = E2_ROLES.find(r => is(r) && !pickedRoles.includes(r.id));
+    if (role) {
+      const next = [...pickedRoles, role.id];
+      writeE2Fields(cboId, state, { role_preference: next.join(', ') }, pushEvent);
+      if (E2_ROLES.every(r => next.includes(r.id))) {
+        writeE2Fields(cboId, state, { _role_done: 'yes' }, pushEvent);
+        return closeE2();
+      }
+      askRoles(next, false);
+      return finish('role-picked');
+    }
+    if (is(E2C.outroPapel)) {
+      writeE2Fields(cboId, state, { _role_other_pending: 'yes' }, pushEvent);
+      say('Me conta: que papel vocês imaginam pra vocês nesses projetos?', 'Tell me: what role do you imagine for yourselves in these projects?');
+      return finish('role-other-asked');
+    }
+    if (is(E2C.prontoLista) && pickedRoles.length > 0) {
+      writeE2Fields(cboId, state, { _role_done: 'yes' }, pushEvent);
+      return closeE2();
+    }
   }
 
   return false;


### PR DESCRIPTION
## What

From the **2026-07-16 PxG <> OEF biweekly** (Vila Flores + Robson + BWB): before Workshop 3 the coordination needs each org's **NBS interest** and **preferred implementation role** so the portfolio can be clustered by topic, role and scale. Committed in the meeting for the **Aug 12** session.

"Faz sentido" on the famílias recommendation no longer closes E2. It now opens two server-templated chip loops:

1. **Interesse** — "Em quais famílias vocês teriam interesse em tocar um projeto?" Multi-pick: each pick re-offers the remaining famílias + "Pronto ✓". Stored as `nbs_interest` (canonical família ids).
2. **Papel** — "Que papel vocês gostariam de ter nesses projetos?" Same loop over: ser consultada / escrever o projeto / receber e administrar recursos / executar / articular parceiros, plus **"Outro papel"** which hands exactly one free-text turn to the platform (captured verbatim as `outro: …`). Stored as `role_preference`.

Then the closing (unchanged text). Both loops are checkpoints in `serveE2Checkpoint` — zero model involvement, park/resume-safe, and the ask_user composers self-document in the decision log so the model re-offers exact labels after mid-loop doubts (skill updated).

## Role taxonomy is a placeholder

The five roles are the ones named in the meeting (Julia's list). Pending Robson/Belén confirmation via Ana — label changes are a data-only edit to `E2_ROLES`.

## Tests

- New `e2e/cougar-e2-interest-roles.spec.ts`: full loop walk incl. "Outro papel" free text, canonical-id field assertions, reload persistence. Passing.
- `cougar-e2-linear-journey.spec.ts` extended through the new steps. Passing.
- tsc clean.

## Merge order

⚠️ Merge **#418 first**: the `_interest_*`/`_role_*` marker fields rely on its internal-field filter to stay out of the document panel (cosmetic until then). `cougar-e2-linear-journey.spec.ts` will conflict with #418's parameterized rewrite — resolution: apply this PR's step-9 block inside #418's LANGS loop (EN labels: Urban Green Infrastructure / Implement on the ground / Done ✓ / 'famílias would you be interested' / 'would you like to play in these projects').

No db:push needed. Pull main in Replit + republish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa