### PR TITLE
Sync Mixed mechanism color with republished tiles (grey → magenta)

### DIFF
--- a/client/public/sample-data/layer-legends.json
+++ b/client/public/sample-data/layer-legends.json
@@ -162,7 +162,7 @@
       },
       {
         "value": 5,
-        "color": "#969696",
+        "color": "#8e0152",
         "label": "Mixed"
       }
     ],
@@ -243,7 +243,7 @@
       },
       {
         "value": 6,
-        "color": "#969696",
+        "color": "#8e0152",
         "label": "Mixed"
       }
     ],
@@ -339,7 +339,7 @@
       },
       {
         "value": 9,
-        "color": "#969696",
+        "color": "#8e0152",
         "label": "Mixed"
       }
     ],

--- a/scripts/generate-legends.ts
+++ b/scripts/generate-legends.ts
@@ -50,9 +50,11 @@ const CLASS_COLORS: Record<string, Record<number, string>> = {
   oef_dynamic_world: { 0: '#62B0CC', 1: '#488C5F', 2: '#98B982', 3: '#A0AAC3', 4: '#D7A55F', 5: '#CDB982', 6: '#B45F55', 7: '#AFA89E', 8: '#B9CDE1' },
   // Mechanism-type palettes from catalog datasets.yaml. All three verified
   // against the visual tiles 2026-07-16: class = encoded - 1, colour distance 0.0.
-  poa_flood_mechanism: { 0: '#e0e0e0', 1: '#2166ac', 2: '#fdae61', 3: '#abd9e9', 4: '#7b3294', 5: '#969696' },
-  poa_heat_mechanism: { 0: '#e0e0e0', 1: '#d73027', 2: '#fee08b', 3: '#fc8d59', 4: '#9970ab', 5: '#636363', 6: '#969696' },
-  poa_landslide_mechanism: { 0: '#e0e0e0', 1: '#b2182b', 2: '#2166ac', 3: '#8c510a', 4: '#d8b365', 5: '#4393c3', 6: '#a6611a', 7: '#5e3c99', 8: '#636363', 9: '#969696' },
+  // Mixed repainted grey #969696 → magenta #8e0152 in the 2026-07-16 republish
+  // (mixed = tied mechanisms, often the highest-priority cells — grey undersold it).
+  poa_flood_mechanism: { 0: '#e0e0e0', 1: '#2166ac', 2: '#fdae61', 3: '#abd9e9', 4: '#7b3294', 5: '#8e0152' },
+  poa_heat_mechanism: { 0: '#e0e0e0', 1: '#d73027', 2: '#fee08b', 3: '#fc8d59', 4: '#9970ab', 5: '#636363', 6: '#8e0152' },
+  poa_landslide_mechanism: { 0: '#e0e0e0', 1: '#b2182b', 2: '#2166ac', 3: '#8c510a', 4: '#d8b365', 5: '#4393c3', 6: '#a6611a', 7: '#5e3c99', 8: '#636363', 9: '#8e0152' },
 };
 
 // Local risk ramps — mirror the colorFns in generate-risk-tiles.ts (value → color).


### PR DESCRIPTION
## What

Mau repainted the **Mixed** class from grey `#969696` to magenta `#8e0152` in all three mechanism-type layers and republished the visual tiles (follow-up to the observation that Mixed — tied mechanisms, often the highest-priority cells — visually receded as grey). The map tiles come straight from S3 so they updated on their own; this PR syncs the two app-side palette copies:

- `scripts/generate-legends.ts` — `CLASS_COLORS` for the three mechanism layers
- `client/public/sample-data/layer-legends.json` — the three Mixed legend stops (surgical edit, same output the generator would produce)

No other class colors changed in the catalog.

## Verification

- Fetched the updated `datasets.yaml` from `Open-Earth-Foundation/geospatial-data`: Mixed → `#8e0152` in all three layers, everything else unchanged.
- Paired value-tile decode against visual-tile pixels across the POA bbox for all three layers: every class matches the new palette at **colour distance 0.0**, and class counts are identical to the pre-republish scan (pure recolor, no data change).
- Screenshot-verified in Site Explorer: heat mechanism map shows the (large) Mixed areas in magenta and the legend chip matches.

## Note

Browsers that loaded the old tiles recently may show grey for up to 24 h (tile proxy sends `Cache-Control: max-age=86400`); a hard refresh clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)