### PR TITLE
Catalog filter chips: what can we do ourselves, and at what cost

### DIFF
--- a/client/src/core/components/cbo/NbsDesktopGrids.tsx
+++ b/client/src/core/components/cbo/NbsDesktopGrids.tsx
@@ -18,6 +18,14 @@ import { NbsSolutionDetail } from './NbsSolutionDetail';
 import { NbsShowcaseCardItem } from './NbsShowcaseCard';
 import { CroquiLightbox } from './CroquiLightbox';
 import type { CroquiLightboxContent } from './CroquiLightbox';
+import {
+  EMPTY_SOLUTION_FILTER,
+  NbsSolutionFilterChips,
+  filterSolutions,
+  isFilterActive,
+  solutionFilterEmptyText,
+  type SolutionFilter,
+} from './NbsSolutionFilterChips';
 
 const GRID = 'grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3';
 const STRINGS = {
@@ -47,16 +55,35 @@ export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
   );
   const [openSolutionId, setOpenSolutionId] = useState<string | null>(null);
   const [croqui, setCroqui] = useState<CroquiLightboxContent | null>(null);
+  const [filter, setFilter] = useState<SolutionFilter>(EMPTY_SOLUTION_FILTER);
   const s = STRINGS[lang];
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
   const typeIds = NBS_INTERVENTION_TYPES.filter(
     t => NBS_TYPE_CONTENT[t.id]
   ).map(t => t.id);
+  const anyVisible = NBS_FAMILIAS.some(
+    f => filterSolutions(solutionsForFamilia(f.id), filter).length > 0
+  );
 
   return (
     <div className='space-y-8'>
+      {/* Catalog-wide "o que a gente consegue fazer?" filter (Julia, biweekly
+          2026-07-16) — famílias with no matching solution collapse away. */}
+      <NbsSolutionFilterChips value={filter} onChange={setFilter} lang={lang} />
+      {isFilterActive(filter) && !anyVisible && (
+        <p
+          className='m-0 rounded-lg bg-muted px-3 py-4 text-center text-xs text-muted-foreground'
+          data-testid='solution-filter-empty'
+        >
+          {solutionFilterEmptyText(lang)}
+        </p>
+      )}
       {NBS_FAMILIAS.map(familia => {
-        const solutions = solutionsForFamilia(familia.id);
+        const solutions = filterSolutions(
+          solutionsForFamilia(familia.id),
+          filter
+        );
+        if (solutions.length === 0) return null;
         return (
           <section
             key={familia.id}

--- a/client/src/core/components/cbo/NbsFamiliaSheet.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaSheet.tsx
@@ -22,6 +22,14 @@ import { getFamilia, getSolution, solutionsForFamilia } from '@shared/nbs-catalo
 import { NbsSolutionCard } from './NbsSolutionCard';
 import { NbsSolutionDetail } from './NbsSolutionDetail';
 import { CroquiLightbox } from './CroquiLightbox';
+import {
+  EMPTY_SOLUTION_FILTER,
+  NbsSolutionFilterChips,
+  filterSolutions,
+  isFilterActive,
+  solutionFilterEmptyText,
+  type SolutionFilter,
+} from './NbsSolutionFilterChips';
 
 const STRINGS = {
   pt: {
@@ -60,12 +68,14 @@ export function NbsFamiliaSheet({
   const bodyRef = useRef<HTMLDivElement>(null);
   const [openSolutionId, setOpenSolutionId] = useState<string | null>(null);
   const [croquiOpen, setCroquiOpen] = useState(false);
+  const [filter, setFilter] = useState<SolutionFilter>(EMPTY_SOLUTION_FILTER);
   const familia = openFamiliaId ? getFamilia(openFamiliaId) : undefined;
   const solutions = openFamiliaId ? solutionsForFamilia(openFamiliaId) : [];
+  const visibleSolutions = filterSolutions(solutions, filter);
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
 
   // Fresh view state per família; scroll back to top on list ⇄ detail swaps.
-  useEffect(() => { setOpenSolutionId(null); }, [openFamiliaId]);
+  useEffect(() => { setOpenSolutionId(null); setFilter(EMPTY_SOLUTION_FILTER); }, [openFamiliaId]);
   useEffect(() => { bodyRef.current?.scrollTo(0, 0); }, [openSolutionId]);
 
   const handleOpenChange = useCallback(
@@ -197,8 +207,22 @@ export function NbsFamiliaSheet({
                   </span>
                 </button>
               )}
+              {/* "O que a gente consegue fazer?" — filters over the delivery/
+                  cost attributes the cards already badge (Julia, biweekly
+                  2026-07-16). Sticky so the chips survive the scroll. */}
+              <div className='sticky top-0 z-10 -mx-1 bg-background px-1 pb-2 pt-1'>
+                <NbsSolutionFilterChips value={filter} onChange={setFilter} lang={lang} />
+              </div>
+              {isFilterActive(filter) && visibleSolutions.length === 0 && (
+                <p
+                  className='m-0 rounded-lg bg-muted px-3 py-4 text-center text-xs text-muted-foreground'
+                  data-testid='solution-filter-empty'
+                >
+                  {solutionFilterEmptyText(lang)}
+                </p>
+              )}
               <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-                {solutions.map(solution => (
+                {visibleSolutions.map(solution => (
                   <NbsSolutionCard
                     key={solution.id}
                     solution={solution}

--- a/client/src/core/components/cbo/NbsSolutionFilterChips.tsx
+++ b/client/src/core/components/cbo/NbsSolutionFilterChips.tsx
@@ -1,0 +1,120 @@
+// NbsSolutionFilterChips — the "o que a gente consegue fazer?" filter over the
+// 27-solution catalog (Julia's ask, PxG<>OEF biweekly 2026-07-16): toggle chips
+// on the two attributes every solution already carries — delivery (mutirão /
+// parceria) and cost band. Same-dimension chips are exclusive; dimensions AND
+// together. Headless state: the host owns the SolutionFilter so the same leaf
+// serves the mobile família sheet and the desktop catalog grid.
+//
+// Design record: catalog-filters mockup, alternative A (chips), 2026-07-16.
+
+import type { NbsSolution } from '@shared/nbs-catalog';
+
+export interface SolutionFilter {
+  delivery: 'mutirao' | 'parceria' | null;
+  lowCost: boolean;
+}
+
+export const EMPTY_SOLUTION_FILTER: SolutionFilter = {
+  delivery: null,
+  lowCost: false,
+};
+
+export function isFilterActive(f: SolutionFilter): boolean {
+  return f.delivery !== null || f.lowCost;
+}
+
+export function filterSolutions(
+  solutions: NbsSolution[],
+  f: SolutionFilter
+): NbsSolution[] {
+  return solutions.filter(
+    s =>
+      (!f.delivery || s.delivery === f.delivery) &&
+      (!f.lowCost || s.costBand === 'baixo')
+  );
+}
+
+const STRINGS = {
+  pt: {
+    mutirao: '🤝 dá pra fazer em mutirão',
+    parceria: 'com parceria',
+    lowCost: '💰 custo baixo',
+    empty: 'Nenhuma solução com esses filtros — tira um filtro pra ver mais.',
+  },
+  en: {
+    mutirao: '🤝 can be a mutirão',
+    parceria: 'with a partner',
+    lowCost: '💰 low cost',
+    empty: 'No solution matches these filters — remove one to see more.',
+  },
+};
+
+export function solutionFilterEmptyText(lang: 'pt' | 'en'): string {
+  return STRINGS[lang].empty;
+}
+
+export function NbsSolutionFilterChips({
+  value,
+  onChange,
+  lang,
+}: {
+  value: SolutionFilter;
+  onChange: (next: SolutionFilter) => void;
+  lang: 'pt' | 'en';
+}) {
+  const s = STRINGS[lang];
+  const chip = (
+    on: boolean,
+    label: string,
+    toggle: () => void,
+    testid: string
+  ) => (
+    <button
+      type='button'
+      onClick={toggle}
+      aria-pressed={on}
+      data-testid={testid}
+      className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+        on
+          ? 'border-emerald-600 bg-emerald-50 text-emerald-800 dark:border-emerald-500 dark:bg-emerald-950/60 dark:text-emerald-300'
+          : 'border-border bg-card text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div
+      className='flex flex-wrap items-center gap-1.5'
+      data-testid='solution-filter-chips'
+    >
+      {chip(
+        value.delivery === 'mutirao',
+        s.mutirao,
+        () =>
+          onChange({
+            ...value,
+            delivery: value.delivery === 'mutirao' ? null : 'mutirao',
+          }),
+        'solution-filter-mutirao'
+      )}
+      {chip(
+        value.lowCost,
+        s.lowCost,
+        () => onChange({ ...value, lowCost: !value.lowCost }),
+        'solution-filter-lowcost'
+      )}
+      {chip(
+        value.delivery === 'parceria',
+        s.parceria,
+        () =>
+          onChange({
+            ...value,
+            delivery: value.delivery === 'parceria' ? null : 'parceria',
+          }),
+        'solution-filter-parceria'
+      )}
+    </div>
+  );
+}

--- a/e2e/cougar-e2-instant-entry.spec.ts
+++ b/e2e/cougar-e2-instant-entry.spec.ts
@@ -43,6 +43,16 @@ test.describe('COUGAR — instant E2 entry', () => {
     await expect(sheet).toBeVisible();
     expect(await sheet.locator('[data-testid^="solution-card-"]').count()).toBe(11);
 
+    // Filter chips inside the sheet (Julia, biweekly 2026-07-16): "mutirão"
+    // narrows to the community-buildable variants; clearing restores all 11.
+    await sheet.getByTestId('solution-filter-mutirao').click();
+    const mutiraoOnly = await sheet.locator('[data-testid^="solution-card-"]').count();
+    expect(mutiraoOnly).toBeGreaterThan(0);
+    expect(mutiraoOnly).toBeLessThan(11);
+    await expect(sheet.getByTestId('solution-card-bacia-de-retencao')).toHaveCount(0); // licença
+    await sheet.getByTestId('solution-filter-mutirao').click();
+    expect(await sheet.locator('[data-testid^="solution-card-"]').count()).toBe(11);
+
     // The sheet opens with the ANTES/DEPOIS croqui pair + captions (the
     // teaching moment); tapping it enlarges the pair with the Register-2
     // "ilustração esquemática" disclosure.

--- a/e2e/cougar-orchestrator-nbs-tabs.spec.ts
+++ b/e2e/cougar-orchestrator-nbs-tabs.spec.ts
@@ -52,6 +52,22 @@ test.describe('COUGAR — orchestrator NBS tabs', () => {
     expect(await page.locator('[data-testid^="familia-section-"]').count()).toBe(5);
     expect(await page.locator('[data-testid^="solution-card-"]').count()).toBe(27);
 
+    // Filter chips (Julia, biweekly 2026-07-16): "mutirão" narrows the catalog
+    // to the community-buildable subset; counts stay structural because the
+    // delivery classification is pending Robson's review.
+    await page.getByTestId('solution-filter-mutirao').click();
+    const mutiraoCount = await page.locator('[data-testid^="solution-card-"]').count();
+    expect(mutiraoCount).toBeGreaterThan(0);
+    expect(mutiraoCount).toBeLessThan(27);
+    await expect(page.getByTestId('solution-card-jardins-de-chuva')).toBeVisible();
+    await expect(page.getByTestId('solution-card-bacia-de-retencao')).toHaveCount(0); // licença
+    // AND with cost; then clear both — the full catalog returns.
+    await page.getByTestId('solution-filter-lowcost').click();
+    expect(await page.locator('[data-testid^="solution-card-"]').count()).toBeLessThanOrEqual(mutiraoCount);
+    await page.getByTestId('solution-filter-mutirao').click();
+    await page.getByTestId('solution-filter-lowcost').click();
+    expect(await page.locator('[data-testid^="solution-card-"]').count()).toBe(27);
+
     // Each família shows its ANTES/DEPOIS croqui pair BESIDE the variants in a
     // sticky paper panel with eyebrow labels separating "schematic drawing"
     // from "real photos"; clicking enlarges the pair in the lightbox.


### PR DESCRIPTION
## What

Julia's ask from the **2026-07-16 biweekly**: *"filter the NBS by … the ones you can have in your own community or with lower prices"*. The attributes already exist on every one of the 27 solutions (`delivery`: mutirão / parceria / licença, and `costBand`) — this adds the filter UI (mockup alternative A, chips, as chosen):

- **Mobile família sheet** (CBO chat → "Ver opções"): sticky chips row above the variants — `🤝 dá pra fazer em mutirão` / `💰 custo baixo` / `com parceria`, with an empty-state hint when a combination has no match.
- **Desktop Soluções tab** (orchestrator): one catalog-wide chips row; famílias with no matching solution collapse away.

Chips within a dimension are exclusive; dimensions AND together (Julia's "na minha comunidade **e** mais barato" case). Shared headless component `NbsSolutionFilterChips` + `filterSolutions` helper serve both surfaces.

Counts in the specs stay structural (>0, <27, known mutirão/licença exemplars) because the delivery/cost classification is still flagged `classificationEstimated` pending Robson's review — reclassification won't break tests.

## Tests

- `cougar-e2-instant-entry.spec.ts`: sheet filter narrows the 11 águas-pluviais variants and restores them. Passing.
- `cougar-orchestrator-nbs-tabs.spec.ts`: catalog-wide filter + AND with cost + full restore. Passing.
- tsc clean.

Independent of #419. No db:push. Pull main in Replit + republish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa