### PR TITLE
Ficha sources: always name the base MMA/GIZ/CNM documents

### DIFF
--- a/client/src/core/components/cbo/NbsSolutionDetail.tsx
+++ b/client/src/core/components/cbo/NbsSolutionDetail.tsx
@@ -91,6 +91,18 @@ export function NbsSolutionDetail({
   const ficha = getSolutionFicha(solution.id);
   const copy: NbsFichaCopy | undefined = ficha?.[lang];
   const familia = getFamilia(solution.familiaId);
+  // Fontes = the ficha's page-level citations + the card's base documents
+  // (solution.source) that the ficha doesn't already cite — Vila Flores asked
+  // that the official publications behind the content always be named
+  // (Aline, biweekly 2026-07-16). Dedupe by issuing org (MMA/GIZ/CNM).
+  const fichaSources = ficha?.sources ?? [];
+  const deckDocs = solution.source
+    .split(' | ')
+    .filter(doc => {
+      const org = doc.split(' — ')[0].trim();
+      return org && !fichaSources.some(x => x.includes(org));
+    });
+  const allSources = [...fichaSources, ...deckDocs];
   const legacyType = solution.legacyTypeId
     ? NBS_INTERVENTION_TYPES.find(t => t.id === solution.legacyTypeId)
     : undefined;
@@ -166,9 +178,12 @@ export function NbsSolutionDetail({
         </button>
       )}
 
-      {ficha && ficha.sources.length > 0 && (
-        <p className='m-0 border-t border-border pt-2 text-[10px] leading-snug text-muted-foreground/80'>
-          {s.fontes}: {ficha.sources.join(' · ')}
+      {allSources.length > 0 && (
+        <p
+          className='m-0 border-t border-border pt-2 text-[10px] leading-snug text-muted-foreground/80'
+          data-testid='solution-sources'
+        >
+          {s.fontes}: {allSources.join(' · ')}
         </p>
       )}
     </div>

--- a/e2e/cougar-orchestrator-nbs-tabs.spec.ts
+++ b/e2e/cougar-orchestrator-nbs-tabs.spec.ts
@@ -82,6 +82,10 @@ test.describe('COUGAR — orchestrator NBS tabs', () => {
     const fichaDialog = page.getByTestId('nbs-solution-dialog');
     await expect(fichaDialog).toBeVisible();
     await expect(fichaDialog.getByText(/Quem precisa dizer sim|Who has to say yes/)).toBeVisible();
+    // Every ficha names its official sources — page-level citations plus the
+    // base MMA/GIZ/CNM documents the deck card came from (Aline, 2026-07-16).
+    await expect(fichaDialog.getByTestId('solution-sources')).toBeVisible();
+    await expect(fichaDialog.getByTestId('solution-sources')).toContainText(/MMA|GIZ|CNM/);
     await page.getByTestId('solution-type-content-bacia-de-retencao').click();
     await expect(fichaDialog).toBeHidden();
     const dialog = page.getByTestId('nbs-type-dialog');


### PR DESCRIPTION
## What

Aline's point from the **2026-07-16 biweekly**: the NBS content is based on official publications (Ministério do Meio Ambiente, GIZ, CNM) and the platform should name them. Every ficha's **Fontes** footer now merges its page-level citations with the base documents from the deck card (`solution.source`), deduplicated by issuing org — so a ficha citing only "GIZ Catálogo p.50-55" also names the MMA manual its card content came from, and no solution renders without sources.

One component change (`NbsSolutionDetail`), reaches all three surfaces that host the ficha (mobile sheet, selector panel, desktop dialog).

## Tests

- `cougar-orchestrator-nbs-tabs.spec.ts` asserts the sources line renders and names at least one of MMA/GIZ/CNM. Passing; tsc clean.

Heads-up: this spec file is also touched by #421 in a different region — merge in any order, hunks don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa