### PR TITLE
"Seus dados" notice: the standing answer to the extraction fear

### DIFF
--- a/client/src/core/components/cbo/CboDataNoticeDialog.tsx
+++ b/client/src/core/components/cbo/CboDataNoticeDialog.tsx
@@ -1,0 +1,116 @@
+// CboDataNoticeDialog — the plain-language "Seus dados" answer to the
+// extraction fear Antonia surfaced at the 2026-07-16 biweekly: orgs have seen
+// outsiders collect their data and deliver nothing, and were asking "what are
+// you going to do with that?" and "does the platform stop in December?".
+// This is the short honest version, always reachable from the chat header;
+// the full data terms are being drafted with the coordination (Ana) and will
+// replace the closing line's promise when confirmed.
+//
+// Copy rule: nothing here may promise what the coalition hasn't agreed to —
+// the "até quando" wording was written to be true under the current plan and
+// must be re-checked when the terms doc lands.
+
+import { ShieldCheck } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/core/components/ui/dialog';
+
+const STRINGS = {
+  pt: {
+    title: 'Seus dados são seus',
+    sections: [
+      {
+        h: 'O que acontece com o que você escreve aqui?',
+        p: 'Vira o perfil e o projeto da SUA organização — material de trabalho de vocês e da coordenação da rede. Não é pesquisa sobre vocês.',
+      },
+      {
+        h: 'Quem vê',
+        p: 'Você e a equipe de coordenação da rede (Vila Flores, OEF e Pyxera Global). Nada é vendido nem compartilhado fora da rede sem combinar com vocês.',
+      },
+      {
+        h: 'Pra que usamos',
+        p: 'Pra montar o projeto de vocês, enxergar projetos parecidos dentro da rede e preparar propostas de financiamento com esses dados.',
+      },
+      {
+        h: 'Até quando',
+        p: 'A plataforma acompanha a preparação dos projetos — o trabalho não termina em dezembro. Se algo for mudar no acesso, vocês serão avisadas com antecedência.',
+      },
+      {
+        h: 'Seus direitos',
+        p: 'A qualquer momento você pode baixar tudo (botão de exportar aqui em cima) ou pedir pra coordenação corrigir ou apagar os dados da sua organização.',
+      },
+    ],
+    footer:
+      'Um termo completo está sendo preparado junto com a coordenação — esta é a versão curta e honesta.',
+  },
+  en: {
+    title: 'Your data is yours',
+    sections: [
+      {
+        h: 'What happens with what you write here?',
+        p: "It becomes YOUR organization's profile and project — working material for you and the network's coordination. It is not research about you.",
+      },
+      {
+        h: 'Who sees it',
+        p: 'You and the network coordination team (Vila Flores, OEF and Pyxera Global). Nothing is sold or shared outside the network without agreeing with you first.',
+      },
+      {
+        h: 'What we use it for',
+        p: 'To build your project, spot similar projects across the network, and prepare funding proposals with this data.',
+      },
+      {
+        h: 'For how long',
+        p: 'The platform follows the projects through preparation — the work does not end in December. If access is ever going to change, you will be told in advance.',
+      },
+      {
+        h: 'Your rights',
+        p: 'At any time you can download everything (the export button above) or ask the coordination to correct or delete your organization’s data.',
+      },
+    ],
+    footer:
+      'A full terms document is being prepared with the coordination — this is the short, honest version.',
+  },
+};
+
+export function CboDataNoticeDialog({
+  open,
+  onOpenChange,
+  lang,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  lang: 'pt' | 'en';
+}) {
+  const s = STRINGS[lang];
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className='max-h-[85vh] max-w-md overflow-y-auto'
+        data-testid='cbo-data-notice-dialog'
+      >
+        <DialogHeader>
+          <DialogTitle className='flex items-center gap-2 text-base'>
+            <ShieldCheck className='h-5 w-5 text-emerald-600' />
+            {s.title}
+          </DialogTitle>
+        </DialogHeader>
+        <div className='space-y-3'>
+          {s.sections.map(sec => (
+            <section key={sec.h} className='space-y-0.5'>
+              <h4 className='m-0 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground'>
+                {sec.h}
+              </h4>
+              <p className='m-0 text-[13.5px] leading-relaxed'>{sec.p}</p>
+            </section>
+          ))}
+          <p className='m-0 border-t border-border pt-2 text-[11px] italic text-muted-foreground'>
+            {s.footer}
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -63,7 +63,8 @@ function parseUploadFilename(content: string): string | null {
   const m = content.match(UPLOAD_MSG_RE);
   return m ? m[1] : null;
 }
-import { LifeBuoy } from 'lucide-react';
+import { LifeBuoy, ShieldCheck } from 'lucide-react';
+import { CboDataNoticeDialog } from '@/core/components/cbo/CboDataNoticeDialog';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { localizedWorkshopName } from '@/lib/workshopHelpers';
@@ -560,6 +561,7 @@ export default function CboProfilePage() {
   // chat header. Pending count comes from /api/cbo-member/:slug; agent or
   // coordinator-side flows can also nudge the user to open this.
   const [supportDialogOpen, setSupportDialogOpen] = useState(false);
+  const [dataNoticeOpen, setDataNoticeOpen] = useState(false);
   const [supportPendingCount, setSupportPendingCount] = useState(0);
   // E2 educational strips (types + examples) are persisted as inline `composer`
   // messages in the transcript (see processEvent / messages.map) so they survive
@@ -1682,6 +1684,7 @@ export default function CboProfilePage() {
         />
       )}
       <CboFilesSheet cboId={cboId} open={filesSheetOpen} onOpenChange={setFilesSheetOpen} />
+      <CboDataNoticeDialog open={dataNoticeOpen} onOpenChange={setDataNoticeOpen} lang={lang === 'pt' ? 'pt' : 'en'} />
       <div className="flex flex-1 min-h-0">
         {/* LEFT: Chat — full width on mobile (when Chat tab active); on md+
             full width while the panel is collapsed (chat-first), half when
@@ -1770,6 +1773,23 @@ export default function CboProfilePage() {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>{t('cbo.export')}</TooltipContent>
+                </Tooltip>
+                {/* "Seus dados" — the standing answer to "what are you going
+                    to do with that?" (Antonia, biweekly 2026-07-16). Always
+                    visible so the answer exists before anyone has to ask. */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => setDataNoticeOpen(true)}
+                      data-testid="button-data-notice"
+                    >
+                      <ShieldCheck className="w-4 h-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{lang === 'pt' ? 'Seus dados' : 'Your data'}</TooltipContent>
                 </Tooltip>
                 {/* Restart is IRREVERSIBLE (deletes the whole session server-side).
                     It sits one thumb-width from Export on mobile, and the tooltip

--- a/e2e/cougar-data-notice.spec.ts
+++ b/e2e/cougar-data-notice.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+// "Seus dados" notice (biweekly 2026-07-16): the standing plain-language
+// answer to the cohort's extraction fear — always reachable from the chat
+// header, before anyone has to ask.
+
+test.describe('COUGAR — data notice', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('the shield button opens the plain-language data answer', async ({ page }) => {
+    await page.goto('/cbo-profile');
+    await expect(page.getByTestId('cbo-stream-status')).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+
+    await page.getByTestId('button-data-notice').click();
+    const dialog = page.getByTestId('cbo-data-notice-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Seus dados são seus')).toBeVisible();
+    await expect(dialog.getByText('não termina em dezembro', { exact: false })).toBeVisible();
+    await expect(dialog.getByText('corrigir ou apagar', { exact: false })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+  });
+});


### PR DESCRIPTION
## What

The trust issue Antonia surfaced at the **2026-07-16 biweekly**: cohort orgs have watched universities and NGOs collect their data and deliver nothing, and are asking *"what are you going to do with that?"* and *"does the platform stop after December?"*.

This adds a ShieldCheck button to the CBO chat header (next to export) that opens **"Seus dados são seus"** — five short plain-language sections in pt/en: what the data becomes (their own project, not research about them), who sees it (them + Vila Flores/OEF/Pyxera, nothing sold or shared outside the network without agreement), what it's used for, for how long, and their rights (export anytime via the existing button; ask coordination to correct/delete).

## ⚠️ One sentence needs confirmation before this is treated as final

*"A plataforma acompanha a preparação dos projetos — o trabalho não termina em dezembro. Se algo for mudar no acesso, vocês serão avisadas com antecedência."* — written to be true under the current plan, but it's a soft commitment. The full data-terms doc I'm drafting with Ana should confirm or adjust it; the dialog copy notes the full terms are coming.

## Tests

New `e2e/cougar-data-notice.spec.ts` (open → key claims visible → close). Passing; tsc clean. Independent of the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa