### PR TITLE
Showcase: five community-led NBS cases, told from the community's side

### DIFF
--- a/shared/nbs-showcase-cards.ts
+++ b/shared/nbs-showcase-cards.ts
@@ -170,6 +170,111 @@ export const NBS_SHOWCASE_CARDS: NbsShowcaseCard[] = [
       emoji: '🌊',
     },
   },
+  // ── Community-led cases (biweekly 2026-07-16: "look at how the community
+  // did it, how the process went") — the five below are organized/built by
+  // residents, not delivered to them. Facts web-verified 2026-07-16; the set
+  // is under Robson/Vila Flores validation (see the validation doc) — wrong
+  // picks get swapped, so keep each card self-contained.
+  {
+    id: 'rio-mutirao-reflorestamento',
+    org: 'Mutirão Reflorestamento',
+    city: 'Rio de Janeiro, RJ',
+    year: 1986,
+    hazard: 'mixed',
+    typeRefs: ['urban-forests'],
+    summaryPt: 'Moradores reflorestam as encostas das próprias comunidades',
+    summaryEn: 'Residents reforest the slopes of their own communities',
+    detailPt:
+      'Desde 1986, moradores das favelas cariocas são contratados em mutirão remunerado pra reflorestar as encostas onde vivem — mais de 15 mil pessoas já passaram pelo programa e mais de 3.500 ha de encostas em áreas de risco foram recuperados. A comunidade entra com o trabalho; a prefeitura com mudas, ferramentas, EPI e apoio técnico.',
+    detailEn:
+      'Since 1986, residents of Rio\'s favelas have been hired through paid mutirões to reforest the slopes where they live — over 15,000 people have taken part and 3,500+ ha of at-risk hillsides recovered. The community brings the work; the city brings seedlings, tools, PPE and technical support.',
+    // Fonte: prefeitura.rio (35 anos do programa) + World Bank blog (2023).
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '⛰️',
+    },
+  },
+  {
+    id: 'bh-jardim-chuva-barreiro',
+    org: 'Jardim de chuva da EMEI Solar Urucuia',
+    city: 'Belo Horizonte, MG',
+    year: 2025,
+    hazard: 'flood',
+    typeRefs: ['bioswales-rain-gardens'],
+    summaryPt: 'Um jardim de chuva feito em mutirão — começou com uma professora',
+    summaryEn: 'A rain garden built by mutirão — it started with one teacher',
+    detailPt:
+      'No Barreiro, uma professora da escola infantil procurou a prefeitura atrás de uma solução pro alagamento. O bairro se organizou: grupo de WhatsApp, reuniões, rifa pra bancar parte da obra — e o jardim foi plantado em mutirão com os moradores e as crianças (inaugurado em 2025). Primeiro jardim de chuva de BH feito em parceria com a comunidade.',
+    detailEn:
+      'In Barreiro, a preschool teacher went to the city hall looking for a flooding fix. The neighborhood organized: a WhatsApp group, meetings, a raffle to fund part of the works — and the garden was planted in a mutirão with residents and the school\'s children (opened 2025). BH\'s first rain garden built in partnership with a community.',
+    // Fonte: prefeitura.pbh.gov.br, informe técnico do Barreiro (set/2025).
+    photo: null,
+    placeholder: {
+      gradient: 'flood',
+      emoji: '🌧️',
+    },
+  },
+  {
+    id: 'sp-horta-das-corujas',
+    org: 'Horta das Corujas',
+    city: 'São Paulo, SP',
+    year: 2012,
+    hazard: 'biodiversity',
+    typeRefs: [],
+    summaryPt: 'Vizinhos ocuparam uma praça e criaram a 1ª horta comunitária de SP',
+    summaryEn: "Neighbors took over a square and created SP's first community garden",
+    detailPt:
+      'Nasceu de um grupo de Facebook (Hortelões Urbanos) e virou a primeira grande horta comunitária de São Paulo: 800 m² numa praça pública da Vila Beatriz, tocada por voluntários com escala de rega e canteiros adotados. No caminho, recuperaram uma das nascentes que alimentam o Córrego das Corujas. Sem dono, sem cerca — e funcionando desde 2012.',
+    detailEn:
+      "Born in a Facebook group (Hortelões Urbanos), it became São Paulo's first major community garden: 800 m² in a public square in Vila Beatriz, run by volunteers with a watering rota and adopted beds. Along the way they recovered one of the springs feeding the Córrego das Corujas. No owner, no fence — running since 2012.",
+    // Fonte: hortadascorujas.wordpress.com (Sobre a Horta) + Recicla Sampa.
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '🥬',
+    },
+  },
+  {
+    id: 'poa-hortas-agroflorestais',
+    org: 'Hortas Comunitárias Agroflorestais',
+    city: 'Porto Alegre, RS',
+    year: 2024,
+    hazard: 'biodiversity',
+    typeRefs: [],
+    summaryPt: 'Hortas agroflorestais escolhidas e mantidas pelas comunidades',
+    summaryEn: 'Agroforestry gardens chosen and kept by the communities',
+    detailPt:
+      'Porto Alegre está implantando 68 hortas comunitárias agroflorestais — os locais são escolhidos com a população pelo Orçamento Participativo e a manutenção é das próprias comunidades, com apoio da OSC Ecos. Dezesseis já funcionavam no fim de 2024. A da Lomba do Pinheiro articula moradores, secretarias e universidades no mesmo espaço.',
+    detailEn:
+      'Porto Alegre is rolling out 68 agroforestry community gardens — sites are chosen with residents through Participatory Budgeting and maintenance is done by the communities themselves, supported by the CSO Ecos. Sixteen were running by late 2024. The Lomba do Pinheiro garden brings residents, city departments and universities into one space.',
+    // Fonte: prefeitura.poa.br/smgov (dez/2024).
+    photo: null,
+    placeholder: {
+      gradient: 'biodiversity',
+      emoji: '🌱',
+    },
+  },
+  {
+    id: 'asa-um-milhao-de-cisternas',
+    org: 'ASA — Um Milhão de Cisternas (P1MC)',
+    city: 'Semiárido brasileiro',
+    year: 2003,
+    hazard: 'mixed',
+    typeRefs: [],
+    summaryPt: 'Mais de 1 milhão de cisternas construídas pelas próprias famílias',
+    summaryEn: 'Over 1 million cisterns built by the families themselves',
+    detailPt:
+      'A maior obra hídrica comunitária do país: famílias do Semiárido, com pedreiros locais capacitados pelo programa, construíram mais de 1 milhão de cisternas de placas de 16 mil litros pra captar água da chuva. Prova de que mutirão organizado chega a uma escala que nenhuma empreiteira alcançou — tecnologia simples, dona é a família.',
+    detailEn:
+      "Brazil's largest community-built water infrastructure: families across the Semiárido, with locally trained masons, built over 1 million 16,000-liter plate cisterns to harvest rainwater. Proof that organized mutirões reach a scale no contractor ever did — simple technology, owned by the family.",
+    // Fonte: asabrasil.org.br (P1MC).
+    photo: null,
+    placeholder: {
+      gradient: 'flood',
+      emoji: '🛢️',
+    },
+  },
 ];
 
 export function getShowcaseCard(id: string): NbsShowcaseCard | undefined {


### PR DESCRIPTION
## What

From the **2026-07-16 biweekly** — your own ask in the meeting: the examples strip's cases were provisional, and what matters is the community angle: *"look at how the community did it, look how the process went."* The six existing cards skew government-delivered (Curitiba parks, DRENURBS, Orla). This adds five cases organized/built by residents:

| Case | Where | The community angle |
|---|---|---|
| Mutirão Reflorestamento (1986–) | Rio de Janeiro | favela residents hired via paid mutirão reforested 3,500+ ha of their own at-risk slopes; 15k+ participants |
| Jardim de chuva EMEI Solar Urucuia (2025) | Belo Horizonte | started by one teacher; WhatsApp group + raffle funded it; planted in mutirão with residents and kids |
| Horta das Corujas (2012) | São Paulo | neighbors from a Facebook group occupied a public square; 800 m², volunteer-run, recovered a spring |
| Hortas Comunitárias Agroflorestais (2024) | **Porto Alegre** | 68 gardens sited via Orçamento Participativo, maintained by the communities; Lomba do Pinheiro flagship |
| ASA — Um Milhão de Cisternas (2003–) | Semiárido | 1M+ cisterns built by the families themselves — mutirão at national scale |

Facts web-verified today; source per card in a code comment. No new photos (gradient placeholders — the verified-photo rule holds). Cards appear in the E2 examples strip and the orchestrator Casos tab automatically.

**Validation:** the set goes to Robson/Vila Flores via the validation doc (link in the session summary) — each card is self-contained so a rejected pick swaps in one commit.

## Tests
Casos-tab spec passes (no count assertions on showcase cards); tsc clean. Independent of the other open PRs.

Sources: [prefeitura.rio — 35 anos do Mutirão Reflorestamento](https://prefeitura.rio/meio-ambiente/programa-de-reflorestamento-do-rio-completa-35-anos-com-186-maracanas-de-area-recuperada/) · [World Bank blog](https://blogs.worldbank.org/pt/latinamerica/no-rio-de-janeiro-reflorestamento-muda-vida-dos-moradores-das-favelas) · [PBH — jardim de chuva do Barreiro](https://prefeitura.pbh.gov.br/politica-urbana/informes-tecnicos/pbh-inaugura-no-barreiro-primeiro-jardim-de-chuva-em-parceria-com-comunidade) · [Horta das Corujas](https://hortadascorujas.wordpress.com/sobre-a-horta/) · [Prefeitura POA — hortas agroflorestais](https://prefeitura.poa.br/smgov/noticias/porto-alegre-ja-tem-16-hortas-comunitarias-agroflorestais-implementadas) · [ASA Brasil](https://www.asabrasil.org.br/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa