### PR TITLE
Fix SDK built-in tool leak: no more chipless questions, instant link feedback, single-flight turns

### DIFF
--- a/e2e/quality/cbo-e1-link-live.spec.ts
+++ b/e2e/quality/cbo-e1-link-live.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// LIVE quality check — NON-GATING. Guards the 2026-07-16 field failure: on a
+// pasted link the model (a) showed nothing for 65s (WebFetch runs before any
+// visible event), and (b) ended the turn via the SDK's built-in
+// AskUserQuestion — which renders nothing headless — leaving the user prose
+// with no chips. Fixes under test: the immediate server-side "Lendo …" label
+// and disallowedTools (Task/AskUserQuestion/… removed from the model's
+// context, so the ask lands as mcp ask_user chips).
+//
+// Run on-demand against a real-model server (see cbo-e2-linear-live.spec.ts):
+//   RUN_LIVE_QUALITY=1 E2E_BASE_URL=http://localhost:5100 npx playwright test e2e/quality/cbo-e1-link-live.spec.ts --project=chromium
+
+const RUN = process.env.RUN_LIVE_QUALITY === '1';
+
+test.describe('E1 link paste — live model @live', () => {
+  test.use({ locale: 'pt-BR' });
+  test.skip(!RUN, 'Set RUN_LIVE_QUALITY=1 and point E2E_BASE_URL at a real (non-fake-model) server to run.');
+
+  test('immediate progress label; turn ends with real chips, never bare prose', async ({ page }) => {
+    test.setTimeout(240_000); // one real link-paste turn ran 109s in the field
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('https://vilaflores.org/sobre/');
+    await input.press('Enter');
+
+    // The server-side label must appear BEFORE any model round could land —
+    // it's pushed at routing time, so a few seconds is generous.
+    await expect(page.getByText(/Lendo vilaflores\.org/i).first()).toBeVisible({ timeout: 6_000 });
+
+    // REAL model turn: extraction + bulk-confirm. The confirm must arrive as
+    // an ask_user (chips) — with the AskUserQuestion leak it arrived as prose.
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 180_000 });
+    expect(await page.locator('[data-testid^="cbo-option-"]').count()).toBeGreaterThan(0);
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1834,7 +1834,41 @@ async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: Ev
   }
 }
 
+// Single-flight per session. Live test 2026-07-16: a link-paste turn showed no
+// visible event for 65s, the user re-sent the link, and the two overlapping
+// model turns each re-stated the same field summary (the per-turn duplicate
+// guard can't see across turns). One model turn per cboId at a time; the
+// duplicate send gets an ephemeral "ainda tô nessa" and no second turn. The
+// timestamp is a stale-lock escape (a crashed/hung turn stops blocking after
+// 3 min — maxTurns ends real turns well before that).
+const chatTurnInFlight = new Map<string, number>();
+
 export async function streamCboChat(cboId: string, userMessage: string, res: Response, state: CboState, lang: string = 'en', turnKind?: string) {
+  const since = chatTurnInFlight.get(cboId);
+  if (since && Date.now() - since < 180_000) {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    const content = lang === 'pt'
+      ? 'Ainda tô terminando a resposta anterior — já te respondo aqui. 🙂'
+      : "Still finishing my previous reply — with you in a moment. 🙂";
+    // Written straight to the stream (not persisted): the notice is about THIS
+    // moment; on reload the real turn's outcome is the record that matters.
+    res.write(`data: ${JSON.stringify({ type: 'chat', content })}\n\n`);
+    res.write(`data: ${JSON.stringify({ type: 'done', summary: 'turn already in flight' })}\n\n`);
+    console.log(`[cbo] duplicate send while turn in flight for ${cboId} (${Date.now() - since}ms in)`);
+    res.end();
+    return;
+  }
+  chatTurnInFlight.set(cboId, Date.now());
+  try {
+    await streamCboChatInner(cboId, userMessage, res, state, lang, turnKind);
+  } finally {
+    chatTurnInFlight.delete(cboId);
+  }
+}
+
+async function streamCboChatInner(cboId: string, userMessage: string, res: Response, state: CboState, lang: string = 'en', turnKind?: string) {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
@@ -2192,6 +2226,25 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
   const { model, routing, reason } = resolveTurnModel(cboId, state, userMessage, turnKind, heavyModel);
   console.log(`[cbo] turn routing for ${cboId}: ${routing} (${reason}) kind=${turnKind ?? 'none'} model=${model}`);
 
+  // Link-paste turns open with WebFetch, and the tool_use label only fires
+  // when round 1 lands — live test 2026-07-16 measured 65s of blank screen
+  // before the first event, which is exactly how long it took the user to
+  // decide it was stuck and re-send. We know the shape of this turn before
+  // the model does: narrate it immediately.
+  if (reason === 'link-paste') {
+    const host = (userMessage.match(/https?:\/\/(?:www\.)?([^\/\s]+)/i)?.[1] ?? '').trim();
+    pushEvent({
+      type: 'thinking_step',
+      step: {
+        id: 'link-paste-prefetch',
+        label: lang === 'pt'
+          ? (host ? `Lendo ${host}… (pode levar um minutinho)` : 'Lendo o site… (pode levar um minutinho)')
+          : (host ? `Reading ${host}… (may take a minute)` : 'Reading the website… (may take a minute)'),
+        status: 'active',
+      },
+    } as any);
+  }
+
   // System prompt = the durable facts the agent needs (persona, tools, skill,
   // state, recent conversation, access policy). User prompt = just the new
   // turn. This mirrors conceptNoteAgent and is the SDK's expected shape;
@@ -2296,6 +2349,18 @@ async function streamWithSdk(cboId: string, userMessage: string, state: CboState
           // URL slug. WebFetch makes link ingestion real; the E1 skill pairs
           // it with an honesty rule (fetch fails → say so, ask for an upload).
           "WebFetch",
+        ],
+        // allowedTools is NOT enough: with bypassPermissions the SDK's
+        // built-ins stay callable even when absent from the list. Live test
+        // 2026-07-16: the model asked its question via the CLI's
+        // AskUserQuestion (renders NOTHING headless — the user got prose with
+        // no chips) and spawned a Task subagent mid-turn (109s total).
+        // disallowedTools removes these from the model's context entirely.
+        // WebFetch stays allowed (link ingestion); the file/exec tools are
+        // listed too so bypassPermissions can't resurrect them.
+        disallowedTools: [
+          "Task", "AskUserQuestion", "TodoWrite", "WebSearch",
+          "Bash", "Read", "Write", "Edit", "Glob", "Grep", "NotebookEdit",
         ],
         mcpServers: mcpServer ? { cbo: mcpServer } : {},
         permissionMode: "bypassPermissions",


### PR DESCRIPTION
## The field failure (JVP live test, 2026-07-16)

Pasting `https://vilaflores.org/sobre/`: 65 seconds of blank screen (user re-sent, doubling the turn), then the model asked its confirm question through the **SDK's built-in `AskUserQuestion` tool** — which renders nothing in our headless setup — so "Tá tudo certo?" arrived as prose with **no chips**, stranding the user. It also spawned a **`Task` subagent** mid-turn (109s total). Server line: `detail=WebFetch | WebFetch | text | Task | text | AskUserQuestion | text` + `silent_turn_fallback`.

**Root cause:** with `permissionMode: 'bypassPermissions'`, `allowedTools` does not remove the SDK's built-ins from the model's context — they stay callable, and "AskUserQuestion" is exactly the name a model reaches for when it wants to ask something.

## The fix — structural, one pipeline shared by all encontros (E1–E5)

1. **`disallowedTools`** on the query: `Task`, `AskUserQuestion`, `TodoWrite`, `WebSearch`, plus the file/exec tools (`Bash`/`Read`/`Write`/`Edit`/`Glob`/`Grep`/`NotebookEdit`) — removed from the model's context entirely, per the SDK contract. `WebFetch` stays (link ingestion).
2. **Instant link-paste feedback**: the router already classifies link-paste turns before the model starts, so we now push "Lendo vilaflores.org… (pode levar um minutinho)" at routing time instead of after the first model round.
3. **Single-flight per session**: a second send while a turn is streaming gets an ephemeral "ainda tô terminando a resposta anterior" and no second model turn (3-min stale-lock escape). This is what produced the triple-duplicated summary — the per-turn dedupe guard can't see across overlapping turns.

## Verified against the real SDK

New non-gating live spec `e2e/quality/cbo-e1-link-live.spec.ts`, run against a real-model server:

- **Before:** first event **65.4s**, ended `Task | text | AskUserQuestion | text`, prose only.
- **After:** first event **5.5s** (label instant), `text | WebFetch | WebFetch | text | update_section | ask_user`, chips rendered. Test green.

Fake-model suite (journey pt/en, interest-roles, instant-entry, multi-bairro) all green; tsc clean.

No db:push. Pull main in Replit + republish after merge — this one is worth deploying before any org touches the platform again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa