### PR TITLE
Close workshop: the reverse of "Open for cohort"

### DIFF
--- a/client/src/core/components/orchestrator/WorkshopCadence.tsx
+++ b/client/src/core/components/orchestrator/WorkshopCadence.tsx
@@ -153,6 +153,7 @@ function WorkshopRow({
   index,
   disabled,
   onOpenForCohort,
+  onCloseForCohort,
   onUpdateDate,
 }: {
   workshop: WorkshopConfig;
@@ -160,10 +161,23 @@ function WorkshopRow({
   index: number;
   disabled?: boolean;
   onOpenForCohort: () => void;
+  onCloseForCohort: () => void;
   onUpdateDate: (date: string | null) => void;
 }) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language?.startsWith('pt') ? 'pt-BR' : 'en-US';
+
+  // Close-workshop inline confirm (opened by mistake — field ask 2026-07-16).
+  // First click arms; second click within 5s fires; the timer disarms so a
+  // stray click can't linger as a loaded gun. Phase 1 never closes (it is
+  // open-on-invite), so the button only exists for W2+ while Open.
+  const [closeArmed, setCloseArmed] = useState(false);
+  useEffect(() => {
+    if (!closeArmed) return;
+    const timer = setTimeout(() => setCloseArmed(false), 5000);
+    return () => clearTimeout(timer);
+  }, [closeArmed]);
+  const canClose = state === 'open' && workshop.unlocksPhase >= 2;
 
   // Curriculum context fallback — existing cohorts in the DB may have
   // workshops without description/expectedOutput (created before these
@@ -474,6 +488,29 @@ function WorkshopRow({
             {ctaLabel}
           </Button>
         )}
+        {canClose && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={disabled}
+            className={`h-8 text-xs whitespace-nowrap ${
+              closeArmed
+                ? 'border-red-300 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'
+                : 'text-muted-foreground'
+            }`}
+            onClick={() => {
+              if (!closeArmed) { setCloseArmed(true); return; }
+              setCloseArmed(false);
+              onCloseForCohort();
+            }}
+            data-testid={`button-close-workshop-${index}`}
+          >
+            <Lock className="w-3 h-3 mr-1.5" />
+            {closeArmed
+              ? t('orchestrator.cohort.closeWorkshopConfirm', { defaultValue: 'Click again to close for the cohort' })
+              : t('orchestrator.cohort.closeWorkshop', { defaultValue: 'Close workshop' })}
+          </Button>
+        )}
       </div>
       </>)}
     </div>
@@ -487,6 +524,7 @@ export function WorkshopCadence({
   workshops,
   disabled,
   onOpenWorkshop,
+  onCloseWorkshop,
   onUpdateWorkshops,
 }: {
   workshops: WorkshopConfig[];
@@ -497,6 +535,11 @@ export function WorkshopCadence({
    * the workshop's phase + persist `today` as the workshop's date (if blank).
    */
   onOpenWorkshop: (index: number, todayISO: string) => Promise<void>;
+  /**
+   * Coordinator confirmed "Close workshop" on `index` (opened by mistake).
+   * Caller should re-lock the phase cohort-wide + roll back sessions in it.
+   */
+  onCloseWorkshop: (index: number) => Promise<void>;
   /** Caller persists the workshops array (used by inline date editor). */
   onUpdateWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
 }) {
@@ -535,6 +578,7 @@ export function WorkshopCadence({
               const today = new Date().toISOString().slice(0, 10);
               await onOpenWorkshop(i, today);
             }}
+            onCloseForCohort={async () => { await onCloseWorkshop(i); }}
             onUpdateDate={async (next) => {
               const updated = workshops.map((w2, j) => (j === i ? { ...w2, date: next } : w2));
               await onUpdateWorkshops(updated);

--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -51,6 +51,8 @@ export interface UseCohortResult {
   removeMember: (memberId: string) => Promise<boolean>;
   invite: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<CohortMember | null>;
   unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
+  /** Close a workshop: re-lock its phase for every member and roll back sessions sitting in it. */
+  closeWorkshopPhase: (phase: number) => Promise<{ relocked: number; rolledBack: number } | null>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
   saveLanguage: (language: 'pt' | 'en' | null) => Promise<void>;
   deleteCohort: () => Promise<void>;
@@ -180,6 +182,17 @@ export function useCohort(): UseCohortResult {
     await refresh();
   }, [refresh]);
 
+  const closeWorkshopPhase = useCallback(async (phase: number): Promise<{ relocked: number; rolledBack: number } | null> => {
+    const r = await fetch(`/api/cohort/${slugRef.current}/close-workshop`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phase }),
+    });
+    const body = r.ok ? await r.json() : null;
+    await refresh();
+    return body;
+  }, [refresh]);
+
   const saveWorkshops = useCallback(async (workshops: WorkshopConfig[]) => {
     await fetch(`/api/cohort/${slugRef.current}/workshops`, {
       method: 'PATCH',
@@ -213,6 +226,6 @@ export function useCohort(): UseCohortResult {
   return {
     loading, cohort, members, isAdmin, allCohorts,
     refresh, refreshAllCohorts, switchCohort, provisionCohort,
-    resetCohort, resetMember, removeMember, invite, unlockPhase, saveWorkshops, saveLanguage, deleteCohort,
+    resetCohort, resetMember, removeMember, invite, unlockPhase, closeWorkshopPhase, saveWorkshops, saveLanguage, deleteCohort,
   };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -908,7 +908,7 @@ export default function OrchestratorLandingPage() {
 
   const {
     cohort, members, isAdmin, allCohorts,
-    invite, unlockPhase, saveWorkshops, resetCohort, resetMember, removeMember, saveLanguage, deleteCohort,
+    invite, unlockPhase, closeWorkshopPhase, saveWorkshops, resetCohort, resetMember, removeMember, saveLanguage, deleteCohort,
     switchCohort, provisionCohort, refresh,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
@@ -1040,6 +1040,24 @@ export default function OrchestratorLandingPage() {
 
   const handleUpdateWorkshops = async (next: WorkshopConfig[]) => {
     await saveWorkshops(next);
+  };
+
+  // Coordinator confirmed "Close workshop" (opened by mistake — field ask
+  // 2026-07-16). The server clears openedAt, re-locks the phase for every
+  // member, and rolls back sessions already sitting in it; their answers stay.
+  const handleCloseWorkshop = async (workshopIndex: number) => {
+    const workshop = (cohort?.settings as any)?.workshops?.[workshopIndex] as WorkshopConfig | undefined;
+    if (!workshop) return;
+    const result = await closeWorkshopPhase(workshop.unlocksPhase);
+    toast({
+      title: result
+        ? t('orchestrator.cohort.workshopClosed', {
+            defaultValue: '{{workshop}} closed — {{n}} org(s) re-locked',
+            workshop: workshop.name,
+            n: result.relocked,
+          })
+        : t('orchestrator.cohort.workshopCloseFailed', { defaultValue: 'Could not close the workshop' }),
+    });
   };
 
   const handleResetConfirm = async () => {
@@ -1338,6 +1356,7 @@ export default function OrchestratorLandingPage() {
           <WorkshopCadence
             workshops={workshops}
             onOpenWorkshop={handleOpenWorkshop}
+            onCloseWorkshop={handleCloseWorkshop}
             onUpdateWorkshops={handleUpdateWorkshops}
           />
         </div>

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -166,7 +166,11 @@
       "workshopOpened": "{{workshop}} aberto para o grupo",
       "orgType": "Tipo de organização",
       "orgTypeCommunity": "Org comunitária",
-      "orgTypeImplementer": "Implementadora / estúdio"
+      "orgTypeImplementer": "Implementadora / estúdio",
+      "closeWorkshop": "Fechar encontro",
+      "closeWorkshopConfirm": "Clica de novo pra fechar pro grupo",
+      "workshopClosed": "{{workshop}} fechado — {{n}} organização(ões) bloqueada(s) de novo",
+      "workshopCloseFailed": "Não foi possível fechar o encontro"
     },
     "demo": {
       "headerEyebrow": "Visão da articuladora",

--- a/e2e/cougar-close-workshop.spec.ts
+++ b/e2e/cougar-close-workshop.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Close workshop (field ask 2026-07-16: Rede SCbN POA opened W2 by mistake).
+// Closing must undo all three things opening did: the cadence rail state
+// (openedAt), every member's unlockedPhases, AND any session already sitting
+// in the closed phase — gating only clamps entry, so without the rollback an
+// org that had tapped the banner would keep running the closed encontro.
+
+test.describe('COUGAR — close workshop', () => {
+  test('W2 opened by mistake closes: re-locked cohort-wide, session rolled back', async ({ page, request }) => {
+    const api = new TestApi(page.request);
+    // A dedicated e2e cohort, NOT the admin fallback: an admin coordinator's
+    // /mine resolves to the shared "default" cohort, and this spec MUTATES
+    // workshop state — running it there once left W1 permanently "opened" and
+    // broke every later default-cohort spec (2026-07-16).
+    const { cohort } = await api.createCohort('Close Workshop Cohort');
+    await api.createCoordinator({
+      email: `close-${randomUUID()}@e2e.test`,
+      password: 'close-pass-123',
+      name: 'Close',
+      cohortId: cohort.id,
+    });
+    const member = (
+      await new TestApi(request).inviteMember(cohort.id, {
+        orgName: 'Org Close',
+        withSession: true,
+      })
+    ).member;
+
+    await page.goto('/orchestrator');
+
+    // Open W1 ("Mark as started") then W2 — the mistake being simulated.
+    await page.getByTestId('button-open-workshop-0').click();
+    const openW2 = page.getByTestId('button-open-workshop-1');
+    await expect(openW2).toBeVisible({ timeout: 10_000 });
+    await openW2.click();
+    await expect
+      .poll(async () => {
+        const body = await (await page.request.get('/api/cohort/mine')).json();
+        return body.members?.find((m: any) => m.id === member.id)?.unlockedPhases ?? [];
+      }, { timeout: 10_000 })
+      .toContain(2);
+
+    // The org already tapped the banner: its session sits in phase 2.
+    await new TestApi(request).seedState(member.cboStateId, { phase: 2 });
+
+    // Close W2 — the button lives on the expanded Open row; two-step confirm.
+    await page.getByTestId('workshop-toggle-1').click();
+    const closeBtn = page.getByTestId('button-close-workshop-1');
+    await expect(closeBtn).toBeVisible();
+    await closeBtn.click(); // arm
+    await expect(closeBtn).toContainText(/again|de novo/i);
+    await closeBtn.click(); // confirm
+
+    // Phase 2 leaves the member's unlockedPhases…
+    await expect
+      .poll(async () => {
+        const body = await (await page.request.get('/api/cohort/mine')).json();
+        return body.members?.find((m: any) => m.id === member.id)?.unlockedPhases ?? [];
+      }, { timeout: 10_000 })
+      .not.toContain(2);
+
+    // …the cadence rail shows W2 as next-up again…
+    await expect(page.getByTestId('workshop-row-1-nextUp')).toBeVisible({ timeout: 10_000 });
+
+    // …and the live session rolled back out of the closed phase (answers stay:
+    // the rollback touches state.phase only, never sections/fields).
+    await expect
+      .poll(async () => {
+        const body = await (await request.get(`/api/cbo/${member.cboStateId}`)).json();
+        return body.state?.phase;
+      }, { timeout: 10_000 })
+      .toBe(1);
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -22,7 +22,7 @@ import {
 import { createOrganization, linkCboStateToOrg, setMaturityTierForCboState } from '../services/orgPersistence';
 import { cboStates } from '@shared/cbo-db-schema';
 import { cboSectionsFilledCount, type CboState } from '@shared/cbo-schema';
-import { getCboMessages, getCboState, setCboState, loadCboFromDb } from '../services/cboAgent';
+import { getCboMessages, getCboState, setCboState, loadCboFromDb, debouncedPersist } from '../services/cboAgent';
 import { deleteCboState } from '../services/cboPersistence';
 import {
   requireCoordinator,
@@ -631,6 +631,66 @@ export function registerCohortRoutes(app: Express): void {
       await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
     }
     res.json({ ok: true, updated: targets.length });
+  }));
+
+  // Close a workshop — the reverse of "Open for cohort" (field ask 2026-07-16:
+  // Rede SCbN POA opened W2 by mistake). Three things happen together:
+  //   1. the workshop's `openedAt` is cleared in the cohort settings (the
+  //      cadence rail shows it as next-up/locked again),
+  //   2. the phase leaves every member's unlockedPhases (1 always stays —
+  //      it's open-on-invite by design, which is also why phase 1 can't close),
+  //   3. sessions already SITTING in the closed phase roll back to the highest
+  //      phase still unlocked — gating only clamps entry, so without this an
+  //      org that tapped the banner would keep running the closed encontro.
+  // Everything the org typed stays: fields persist, and the E2 checkpoints
+  // re-derive their position from saved fields, so reopening later resumes
+  // exactly where they left off.
+  app.patch('/api/cohort/:coordinatorSlug/close-workshop', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const phaseNum = Number(req.body?.phase);
+    if (!phaseNum || phaseNum < 2 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase (2-7)' }); return; }
+
+    const settings: CohortSettings = (cohort.settings as CohortSettings | null) ?? ({} as CohortSettings);
+    const workshops: WorkshopConfig[] = (settings.workshops ?? []).map(w =>
+      Number(w.unlocksPhase) === phaseNum ? { ...w, openedAt: null } : w);
+    await db.update(cohorts).set({ settings: { ...settings, workshops } }).where(eq(cohorts.id, cohort.id));
+
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    let relocked = 0;
+    let rolledBack = 0;
+    for (const m of members) {
+      const current = Array.isArray(m.unlockedPhases) ? (m.unlockedPhases as number[]) : [1];
+      if (!current.includes(phaseNum)) continue;
+      const next = current.filter(p => p !== phaseNum);
+      if (!next.includes(1)) next.push(1);
+      next.sort((a, b) => a - b);
+      const maxAllowed = Math.max(...next);
+      await db.update(cohortMembers).set({
+        unlockedPhases: next,
+        // The roster snapshot mirrors the live phase — clamp it too, or the
+        // dashboard keeps showing the closed workshop as in progress.
+        snapshotPhase: Math.min(Number(m.snapshotPhase ?? 1) || 1, maxAllowed),
+      }).where(eq(cohortMembers.id, m.id));
+      relocked++;
+
+      if (m.cboStateId) {
+        try {
+          const state = getCboState(m.cboStateId) ?? (await loadCboFromDb(m.cboStateId))?.state;
+          if (state && state.phase === phaseNum) {
+            state.phase = maxAllowed;
+            setCboState(m.cboStateId, state);
+            debouncedPersist(m.cboStateId);
+            rolledBack++;
+          }
+        } catch (e: any) {
+          console.error(`[cohort] close-workshop rollback failed for ${m.cboStateId}:`, e?.message || e);
+        }
+      }
+    }
+    console.log(`[cohort] closed workshop phase ${phaseNum} for cohort ${cohort.id}: relocked=${relocked} rolledBack=${rolledBack}`);
+    res.json({ ok: true, relocked, rolledBack });
   }));
 
   // Member-facing read by unguessable capability token (the new invite-link


### PR DESCRIPTION
## What

Field ask (2026-07-16): **Rede SCbN POA opened Workshop 2 by mistake** and there was no way back — opening was one-way.

The open workshop row on `/orchestrator` now carries a **"Close workshop"** button (two-click inline confirm; arms red, disarms after 5s). Closing undoes all three things opening did:

1. clears the workshop's `openedAt` — the cadence rail shows it as **Next up** again;
2. removes the phase from every member's `unlockedPhases` (+ clamps the roster `snapshotPhase`) — phase 1 never closes, it's open-on-invite by design;
3. **rolls back sessions already sitting in the closed phase** to the highest phase still unlocked — gating only clamps *entry*, so without this an org that had already tapped the banner would keep running the closed encontro.

Nothing an org typed is lost: the rollback touches `state.phase` only, and the E2 checkpoints re-derive their position from saved fields — reopening later resumes exactly where they left off.

New route `PATCH /api/cohort/:coordinatorSlug/close-workshop` returns `{ relocked, rolledBack }`; toast reports the count.

## Tests

New `e2e/cougar-close-workshop.spec.ts`: open W1+W2 → seed a member session into phase 2 → close W2 → asserts phase leaves `unlockedPhases`, the rail shows W2 as next-up, and the live session rolled back to phase 1. Passing (plus polish-round2 re-verified); tsc clean.

**Spec-hygiene note:** the spec creates its own e2e cohort instead of using the admin `/mine` fallback — that fallback is the shared *default* cohort, and a spec mutating its workshop state breaks every later default-cohort spec (this bit me while building; the e2e DB residue is cleaned). `cougar-orchestrator-nbs-tabs` and `cougar-polish-round2` still use the fallback but only read/self-heal — worth migrating some day.

## For the immediate case

Merge → pull main in Replit → republish → open Rede SCbN POA's dashboard → expand the W2 row → "Close workshop", click twice. The toast confirms how many orgs were re-locked. No db:push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK1vy7guBs7cXaR6XJYwoa