### PR TITLE
fix(e2): the site card asks one question, about the place

### DIFF
--- a/client/src/core/components/cbo/CboSiteCard.tsx
+++ b/client/src/core/components/cbo/CboSiteCard.tsx
@@ -1,32 +1,53 @@
 import type { CboSiteCard as CboSiteCardPayload } from '@shared/cbo-schema';
 
-// E2 linear flow — the site card (decision B1): what the org picked on the
-// map, the bairro's risk profile as three level bars, and the inferred kind
-// of place when a name keyword gives it away. Served by the checkpoint right
-// after the focused site session confirms; the confirm chips ride in the
-// paired ask_user, not here (strips have no buttons).
+// E2 linear flow — the site card (decision B1): what the org picked on the map.
+// Served by the checkpoint right after the focused site session confirms; the
+// confirm chips ride in the paired ask_user, not here (strips have no buttons).
+//
+// The card answers ONE question — "is this the right place?" — and it has to
+// make that answerable. Two things it used to get wrong (JVP, 2026-08-03:
+// "what is the user supposed to choose here? if the risks are ok? if the site
+// is ok?"):
+//
+//  1. The place was often "Ponto marcado (-30.0577, -51.1936)". Nobody can
+//     confirm a latitude. Now: a thumbnail centred on the pin, and a
+//     reverse-geocoded street address as the headline.
+//  2. The three risk bars are BAIRRO MEANS, and they sat under an eyebrow
+//     reading "seu lugar" — so the card asserted them as this site's risk,
+//     invited the user to judge them, and offered no chip to disagree. Worse,
+//     the diagnostic asks exactly that question ~10 turns later and has to open
+//     by undoing this card: "isso é a média do bairro inteiro, NÃO do lugar de
+//     vocês". Now they're labelled as bairro averages, visually demoted, and
+//     carry a forward reference so the sequencing is legible instead of feeling
+//     like the same question twice.
 //
 // i18n: in-component STRINGS + lang prop (never i18n.language in a leaf —
 // pre-fetch race), same pattern as NbsFamiliaStrip.
 
 const STRINGS = {
   pt: {
-    eyebrow: 'Seu lugar · resumo automático',
+    eyebrow: 'O lugar que vocês marcaram',
     flood: '🌊 Enchente',
     heat: '🔥 Calor',
     landslide: '⛰️ Deslizam.',
     levels: ['Baixo', 'Médio', 'Alto'] as const,
     tipo: 'Tipo de lugar:',
     fromMap: '(pelo mapa)',
+    bairroAvg: 'No bairro, em média',
+    forward: 'Daqui a pouco eu te pergunto se isso bate com o que vocês vivem aí.',
+    mapAlt: 'Mapa do lugar marcado',
   },
   en: {
-    eyebrow: 'Your place · automatic summary',
+    eyebrow: 'The place you marked',
     flood: '🌊 Flood',
     heat: '🔥 Heat',
     landslide: '⛰️ Landslide',
     levels: ['Low', 'Medium', 'High'] as const,
     tipo: 'Kind of place:',
     fromMap: '(from the map)',
+    bairroAvg: 'Across the neighbourhood, on average',
+    forward: "In a moment I'll ask whether that matches what you live there.",
+    mapAlt: 'Map of the marked place',
   },
 };
 
@@ -36,15 +57,103 @@ function levelIdx(pct: number): 0 | 1 | 2 {
   return pct >= 66 ? 2 : pct >= 33 ? 1 : 0;
 }
 
+// ── Static map thumbnail ────────────────────────────────────────────────────
+// A CartoDB tile mosaic, not a Leaflet instance. This renders inside a chat
+// transcript row that persists and re-renders on every reload, so a live map
+// here would mean N map instances accumulating down the conversation — plus the
+// teardown races that already cost us a `_leaflet_pos` crash. Plain <img> tiles
+// are inert, cacheable and survive rehydration for free.
+//
+// 3×3, and the frame is capped — both follow from the same arithmetic. The pin
+// sits at `px` inside the mosaic; to leave no uncovered gutter the frame width W
+// needs `W/2 ≤ px ≤ MOSAIC − W/2`. With a 2×2 mosaic px only ranges over
+// [128, 384], which caps W at 256 — narrower than the card, which is exactly why
+// the first cut rendered a 512px strip floating in beige. 3×3 puts px in
+// [256, 512] and covers any frame up to 512 on both axes.
+const TILE = 256;
+const ZOOM = 16;
+const SPAN = 3; // tiles per side
+const MOSAIC = TILE * SPAN;
+/** Frame cap — must stay ≤ MOSAIC − 2×(TILE/2) = 512. Also "a smaller version
+ *  of the map", which is what the card is for: orient, don't explore. */
+const FRAME_W = 360;
+const FRAME_H = 132;
+
+function lngToTileX(lng: number, z: number): number {
+  return ((lng + 180) / 360) * 2 ** z;
+}
+function latToTileY(lat: number, z: number): number {
+  const r = (lat * Math.PI) / 180;
+  return ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) * 2 ** z;
+}
+
+function SiteThumb({ lat, lng, alt }: { lat: number; lng: number; alt: string }) {
+  const fx = lngToTileX(lng, ZOOM);
+  const fy = latToTileY(lat, ZOOM);
+  // Top-left tile of the block: the tile containing the point, minus one, so the
+  // point's own tile is the centre of the 3×3.
+  const x0 = Math.floor(fx) - 1;
+  const y0 = Math.floor(fy) - 1;
+  // Pin position within the mosaic — always in [TILE, 2×TILE] by construction.
+  const px = (fx - x0) * TILE;
+  const py = (fy - y0) * TILE;
+
+  const tiles: Array<[number, number]> = [];
+  for (let ty = 0; ty < SPAN; ty++)
+    for (let tx = 0; tx < SPAN; tx++) tiles.push([tx, ty]);
+
+  return (
+    <div
+      className='relative overflow-hidden rounded-lg border border-[#e2d9c4] dark:border-stone-700 bg-[#eee7d6]'
+      style={{ width: '100%', maxWidth: FRAME_W, height: FRAME_H }}
+      data-testid='cbo-site-thumb'
+    >
+      {/* The mosaic is translated so the pin sits at the centre of the frame. */}
+      <div
+        className='absolute'
+        style={{
+          width: MOSAIC,
+          height: MOSAIC,
+          left: `calc(50% - ${px}px)`,
+          top: `calc(50% - ${py}px)`,
+        }}
+      >
+        {tiles.map(([tx, ty], i) => (
+          <img
+            key={`${tx}-${ty}`}
+            src={`https://a.basemaps.cartocdn.com/light_all/${ZOOM}/${x0 + tx}/${y0 + ty}.png`}
+            alt={i === 0 ? alt : ''}
+            width={TILE}
+            height={TILE}
+            /* Not lazy: the card is one row in a transcript the user is looking
+               at right now, and lazy left it rendering as an empty beige box. */
+            draggable={false}
+            className='absolute select-none max-w-none'
+            style={{ left: tx * TILE, top: ty * TILE }}
+          />
+        ))}
+      </div>
+      {/* Pin, dead centre. */}
+      <div
+        className='absolute -translate-x-1/2 -translate-y-full text-[20px] leading-none pointer-events-none'
+        style={{ left: '50%', top: '50%' }}
+        aria-hidden
+      >
+        📍
+      </div>
+    </div>
+  );
+}
+
 function RiskBar({ label, pct, levels }: { label: string; pct: number; levels: readonly [string, string, string] }) {
   const idx = levelIdx(pct);
   return (
-    <div className='flex-1 rounded-lg border border-[#e2d9c4] bg-white dark:bg-stone-950 dark:border-stone-700 px-2 py-1.5'>
-      <div className='text-[10px] font-semibold text-muted-foreground'>{label}</div>
-      <div className='text-[13px] font-extrabold' style={{ color: LEVEL_COLORS[idx] }}>
+    <div className='flex-1 rounded-lg border border-[#e2d9c4] bg-white dark:bg-stone-950 dark:border-stone-700 px-2 py-1'>
+      <div className='text-[9.5px] font-semibold text-muted-foreground'>{label}</div>
+      <div className='text-[11.5px] font-bold' style={{ color: LEVEL_COLORS[idx] }}>
         {levels[idx]}
       </div>
-      <div className='h-1 rounded-full bg-[#eee7d6] dark:bg-stone-800 mt-1 overflow-hidden'>
+      <div className='h-[3px] rounded-full bg-[#eee7d6] dark:bg-stone-800 mt-1 overflow-hidden'>
         <div
           className='h-full rounded-full'
           style={{ width: `${Math.max(8, Math.min(100, pct))}%`, background: LEVEL_COLORS[idx] }}
@@ -56,6 +165,13 @@ function RiskBar({ label, pct, levels }: { label: string; pct: number; levels: r
 
 export function CboSiteCard({ card, lang }: { card: CboSiteCardPayload; lang: 'pt' | 'en' }) {
   const s = STRINGS[lang];
+  const hasCoords = typeof card.lat === 'number' && typeof card.lng === 'number';
+  // Address wins the headline when we have one; the raw name (often the
+  // coordinate placeholder) drops to a secondary line rather than vanishing —
+  // it's still what the rest of the system stored.
+  const headline = card.address || card.name;
+  const showNameBelow = !!card.address && card.name !== card.address;
+
   return (
     <div
       className='rounded-xl border border-[#e2d9c4] bg-[#f8f4ea] dark:bg-stone-900 dark:border-stone-700 overflow-hidden'
@@ -64,20 +180,50 @@ export function CboSiteCard({ card, lang }: { card: CboSiteCardPayload; lang: 'p
       <div className='px-3 pt-2 text-[9px] font-extrabold uppercase tracking-widest text-[#8a7d5c] dark:text-stone-400'>
         {s.eyebrow}
       </div>
-      <div className='px-3 pb-3 pt-1'>
-        <div className='text-sm font-bold'>📍 {card.name}</div>
-        <div className='text-[11px] text-muted-foreground mb-2'>{card.bairro}, Porto Alegre</div>
-        <div className='flex gap-1.5 mb-2'>
-          <RiskBar label={s.flood} pct={card.risks.flood} levels={s.levels} />
-          <RiskBar label={s.heat} pct={card.risks.heat} levels={s.levels} />
-          <RiskBar label={s.landslide} pct={card.risks.landslide} levels={s.levels} />
+      <div className='px-3 pb-3 pt-1.5'>
+        {hasCoords && (
+          <div className='mb-2'>
+            <SiteThumb lat={card.lat!} lng={card.lng!} alt={s.mapAlt} />
+          </div>
+        )}
+
+        <div className='text-sm font-bold' data-testid='cbo-site-card-name'>
+          📍 {headline}
         </div>
+        <div className='text-[11px] text-muted-foreground'>
+          {card.bairro}, Porto Alegre
+        </div>
+        {showNameBelow && (
+          <div className='text-[10px] text-muted-foreground/80 mt-0.5'>
+            {card.name}
+          </div>
+        )}
+
         {card.siteTypeLabel && (
-          <div className='rounded-lg border border-dashed border-[#e2d9c4] dark:border-stone-700 bg-white dark:bg-stone-950 px-2.5 py-1.5 text-[11.5px]'>
+          <div className='mt-2 rounded-lg border border-dashed border-[#e2d9c4] dark:border-stone-700 bg-white dark:bg-stone-950 px-2.5 py-1.5 text-[11.5px]'>
             {s.tipo} <span className='font-bold'>{card.siteTypeLabel}</span>{' '}
             <span className='text-muted-foreground'>{s.fromMap}</span>
           </div>
         )}
+
+        {/* Bairro context — visually subordinate to the place, and named as an
+            average so the card never claims to describe this site. */}
+        <div className='mt-3 pt-2 border-t border-[#e2d9c4] dark:border-stone-700'>
+          <div
+            className='text-[9px] font-extrabold uppercase tracking-widest text-[#8a7d5c] dark:text-stone-400 mb-1'
+            data-testid='cbo-site-card-risk-label'
+          >
+            {s.bairroAvg}
+          </div>
+          <div className='flex gap-1.5'>
+            <RiskBar label={s.flood} pct={card.risks.flood} levels={s.levels} />
+            <RiskBar label={s.heat} pct={card.risks.heat} levels={s.levels} />
+            <RiskBar label={s.landslide} pct={card.risks.landslide} levels={s.levels} />
+          </div>
+          <div className='text-[10.5px] text-muted-foreground mt-1.5 leading-snug'>
+            ↳ {s.forward}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/core/components/maps/MapMicroapp.tsx
+++ b/client/src/core/components/maps/MapMicroapp.tsx
@@ -529,11 +529,19 @@ export default function MapMicroapp({
     show.bringToBack();
   }, [basemap, mapReady]);
 
-  // CBO site step opens on satellite; tour + neighborhood steps stay political.
+  // Every CBO step opens on the political basemap. The site step used to force
+  // satellite, on the theory that imagery helps you recognise your own yard —
+  // but you have to FIND the yard first, and satellite carries no street names,
+  // no bus stops, no praça labels (JVP, 2026-08-03: "hard to choose a location
+  // here"). Orientation comes from streets; recognition comes from imagery, and
+  // orientation comes first. Satellite stays one tap away on the toggle, which
+  // is where it earns its keep — checking you pinned the right side of the
+  // street once you know which street it is.
+  //
   // Fires on step change only, so a manual toggle within a step isn't overridden.
   useEffect(() => {
     if (!params.allowDeferSite) return;
-    setBasemap(compositeStep === 'assets' ? 'satellite' : 'political');
+    setBasemap('political');
   }, [compositeStep, params.allowDeferSite]);
 
   // CBO site step: draw mode starts OFF — the user arms "Um ponto" / "Desenhar

--- a/e2e/cougar-e2-site-card-clarity.spec.ts
+++ b/e2e/cougar-e2-site-card-clarity.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// E2 site step — the card asks ONE question, about the PLACE (JVP, 2026-08-03:
+// "what is the user supposed to choose here? if the risks are ok? if the site
+// is ok?").
+//
+// The three risk bars are bairro MEANS. Under an eyebrow reading "seu lugar"
+// they read as this site's risk, invited a judgement, and offered no chip to
+// disagree — while the diagnostic asks exactly that ~10 turns later and has to
+// open by undoing the card ("isso é a média do bairro inteiro, NÃO do lugar de
+// vocês"). What this pins: the card names the place, shows it, and labels the
+// risk block as a neighbourhood average.
+
+const SITE_PAYLOAD = [
+  'Map selection (composite mode):',
+  '- [zone] Partenon: MEDIUM risk, intervention: urban forest, area: 8.1 km², pop: 45.768, flood: 22%, heat: 51%, landslide: 14%, at (-30.0577, -51.1936)',
+  '- [custom] Ponto marcado (-30.0577, -51.1936) at (-30.0577, -51.1936)',
+  'Total: 2 assets, 0 sampled points',
+].join('\n');
+
+async function toSiteCard(page: Page, request: any): Promise<string> {
+  const api = new TestApi(request);
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+  await api.seedState(cboId, { phase: 2 });
+
+  await request.post(`/api/cbo/${cboId}/chat`, {
+    data: { message: SITE_PAYLOAD, lang: 'pt', turnKind: 'map' },
+  });
+  await page.reload();
+  await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 20_000 });
+  return cboId;
+}
+
+test.describe('COUGAR — E2 site card confirms the place, not the risk', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('the question names what is being confirmed', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toSiteCard(page, request);
+
+    // "É isso mesmo?" over a card full of risk bars asked two questions at once.
+    await expect(page.getByText('Esse é o lugar certo?', { exact: false })).toBeVisible();
+    await expect(page.getByText('É isso mesmo?', { exact: false })).toHaveCount(0);
+  });
+
+  test('risk is labelled as a bairro average and defers to the later beat', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toSiteCard(page, request);
+
+    const card = page.getByTestId('cbo-site-card');
+    // The eyebrow no longer claims these numbers describe their place.
+    await expect(card).not.toContainText(/SEU LUGAR/i);
+    await expect(page.getByTestId('cbo-site-card-risk-label')).toContainText(/no bairro, em média/i);
+    // And the sequencing is stated, so the later hazard check doesn't read as a
+    // repeat of a question the card already asked.
+    await expect(card).toContainText(/daqui a pouco/i);
+  });
+
+  test('a dropped pin gets a map thumbnail, not just a latitude', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toSiteCard(page, request);
+
+    // The thumbnail is the only way to answer "is the pin on the right block?".
+    const thumb = page.getByTestId('cbo-site-thumb');
+    await expect(thumb).toBeVisible();
+    await expect(thumb.locator('img').first()).toHaveAttribute('src', /basemaps\.cartocdn\.com/);
+
+    // Tiles must actually PAINT, not just carry a src. The first cut used
+    // loading="lazy" and rendered an empty beige box.
+    await expect
+      .poll(async () => page.$$eval('[data-testid="cbo-site-thumb"] img',
+        imgs => imgs.filter(i => (i as HTMLImageElement).naturalWidth > 0).length),
+        { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(9);
+
+    // And they must COVER the frame — no uncovered gutter. A 2×2 mosaic only
+    // guarantees coverage to 256px, which left the map floating in beige on a
+    // wider card; 3×3 covers any frame up to 512.
+    const gutter = await page.evaluate(() => {
+      const frame = document.querySelector('[data-testid="cbo-site-thumb"]')!.getBoundingClientRect();
+      const m = (document.querySelector('[data-testid="cbo-site-thumb"] img') as HTMLElement)
+        .parentElement!.getBoundingClientRect();
+      return { left: m.left - frame.left, top: m.top - frame.top,
+               right: frame.right - m.right, bottom: frame.bottom - m.bottom };
+    });
+    for (const [side, v] of Object.entries(gutter)) {
+      expect(v, `uncovered ${side} gutter in the thumbnail`).toBeLessThanOrEqual(0);
+    }
+
+    // The headline is an address when Nominatim answered, and the raw
+    // coordinate name when it didn't — but never ONLY a bare coordinate with no
+    // map to check it against. (Nominatim is a live dependency; asserting a
+    // specific street would make this spec flaky by design.)
+    await expect(page.getByTestId('cbo-site-card-name')).toBeVisible();
+
+    await page.screenshot({ path: 'test-results/e2-site-card.png' });
+  });
+});
+

--- a/knowledge/_skills/encontro-2.md
+++ b/knowledge/_skills/encontro-2.md
@@ -41,7 +41,13 @@ LOG shows already happened.
    bairro, satellite, chooser: buscar pelo nome / lugar conhecido / marcar no
    mapa). Ainda não → pedir apoio à coordenação OR "vou verificar e volto"
    (the flow parks and resumes at this fork).
-4. **Site card** (bairro risks + inferred type) → Confirmar.
+4. **Site card** → "Esse é o lugar certo?" → Confirmar. O card confirma o
+   **lugar**, não o risco: mostra uma miniatura do mapa centrada no ponto e,
+   quando o lugar foi marcado com um pin, o **endereço** (Nominatim reverse —
+   vira o `site_name`, então some o "Ponto marcado (-30.05…, -51.19…)"). Os
+   três riscos aparecem embaixo, rotulados como **média do bairro**, com uma
+   linha avisando que a pergunta sobre riscos vem depois. NUNCA trate esses
+   números como o risco do lugar deles — é exatamente o que o beat 7 desfaz.
 5. **Describe**: como é o lugar hoje (current_use) → acesso/posse (land_tenure).
    If the org has uploaded files, each of these two OPENS WITH A SENTENCE
    QUOTED FROM THEM ("No arquivo que vocês mandaram eu li: …" → "É assim que

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -26,6 +26,7 @@ import { db } from "../db";
 import { cohortMembers, type SupportRequest } from "@shared/cohort-schema";
 import { resolveOpenMapParams } from "@shared/cbo-map-presets";
 import { rankFamiliasForSite, inferSiteTypeLabel } from "@shared/nbs-recommendation";
+import { reverseGeocode, isPlaceholderSiteName } from "./geocodeService";
 import {
   E2_WORRIES,
   orderWorriesByData,
@@ -1858,7 +1859,25 @@ async function serveE2Checkpoint(
       _site_lat: String(s.lat),
       _site_lng: String(s.lng),
     }, pushEvent);
-    const typeLabel = inferSiteTypeLabel(s.name, isPt ? 'pt' : 'en');
+    // A dropped pin is stored as "Ponto marcado (-30.0577, -51.1936)" — and the
+    // next thing we do is ask the org to confirm it. Nobody can confirm a
+    // latitude, and that string then travels into the transcript, the concept
+    // note and the coordinator roster as the name of the place. Reverse-geocode
+    // it to a street address, and write that back as `site_name` so there is
+    // ONE name everywhere downstream rather than a display alias.
+    //
+    // Only for the coordinate placeholders: a name the user typed or that OSM
+    // supplied ("Praça da Encol") is already better than any address we'd fetch.
+    // Fails soft — a slow or unhelpful Nominatim leaves the coordinate name.
+    let address: string | null = null;
+    if (isPlaceholderSiteName(s.name)) {
+      address = await reverseGeocode(s.lat, s.lng);
+      if (address) writeE2Fields(cboId, state, { site_name: address }, pushEvent);
+    }
+    // Infer the kind of place from the best name we now have: "R. São Manoel"
+    // tells us nothing, but a geocode that lands on "Praça Itália" or "EMEF
+    // Vila Nova" feeds the same keyword rules the picked-place path uses.
+    const typeLabel = inferSiteTypeLabel(address || s.name, isPt ? 'pt' : 'en');
     pushEvent({
       type: 'show_site_card',
       card: {
@@ -1867,11 +1886,17 @@ async function serveE2Checkpoint(
         lat: s.lat,
         lng: s.lng,
         siteKind: s.kind,
+        ...(address ? { address } : {}),
         ...(typeLabel ? { siteTypeLabel: typeLabel } : {}),
         risks: { flood: z.flood, heat: z.heat, landslide: z.landslide },
       },
     } as any);
-    ask('É isso mesmo?', 'Is that right?', [
+    // "É isso mesmo?" over a card carrying three risk bars asked two questions
+    // at once and accepted an answer to neither — the chips are all about the
+    // PLACE, and the risk question belongs to the diagnostic beat that comes
+    // later and is built to receive an answer (pior / mais ou menos / mais
+    // tranquilo). Name what is being confirmed.
+    ask('Esse é o lugar certo?', 'Is this the right place?', [
       { pt: E2C.confirmar.pt, en: E2C.confirmar.en },
       { pt: E2C.outroTipo.pt, en: E2C.outroTipo.en, dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
       { pt: E2C.outroLugar.pt, en: E2C.outroLugar.en, dPt: 'Voltar pro mapa', dEn: 'Back to the map' },

--- a/server/services/geocodeService.ts
+++ b/server/services/geocodeService.ts
@@ -1,0 +1,135 @@
+// ============================================================================
+// REVERSE GEOCODING — a coordinate becomes an address
+// ============================================================================
+// When a CBO drops a pin instead of picking a named OSM place, the site is
+// stored as "Ponto marcado (-30.0577, -51.1936)" (MapMicroapp's customPointName
+// fallback). That string then IS the place: the site card asks "is this right?"
+// about it, and it flows into the transcript, the concept note, the coordinator
+// roster and the família why-lines. Nobody can confirm, correct or repeat a
+// latitude to their team.
+//
+// Nominatim's /reverse turns it into a street address. Deliberately narrow:
+//
+//  - Fails SOFT. A geocode is a nicety; losing the site because OSM was slow is
+//    not acceptable. Every failure path returns null and the caller keeps the
+//    coordinate name.
+//  - Identifying User-Agent, per Nominatim's usage policy. The same omission is
+//    what returned 406 from Overpass in this codebase — an anonymous request to
+//    an OSM endpoint gets refused, not throttled, and it looks like a bug.
+//  - Cached to 5 decimal places (~1 m). One pin per org per workshop makes the
+//    cache mostly about retries and reloads, not volume.
+//  - 1 request/second, which is Nominatim's published limit. At cohort volume
+//    the queue never actually holds anything.
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org';
+
+// Nominatim refuses anonymous traffic. Kept in one place so it can't drift from
+// the contact address OSM expects to be able to reach.
+const USER_AGENT =
+  'OEF-NBS-Project-Preparation/1.0 (Open Earth Foundation; contact@openearth.org)';
+
+const cache = new Map<string, string | null>();
+const key = (lat: number, lng: number) => `${lat.toFixed(5)},${lng.toFixed(5)}`;
+
+// Serialize + space out requests: Nominatim's limit is per-IP, so concurrent
+// callers have to share one lane.
+let lastCallAt = 0;
+let chain: Promise<unknown> = Promise.resolve();
+const MIN_GAP_MS = 1100;
+
+function schedule<T>(fn: () => Promise<T>): Promise<T> {
+  const run = chain.then(async () => {
+    const wait = Math.max(0, lastCallAt + MIN_GAP_MS - Date.now());
+    if (wait > 0) await new Promise(r => setTimeout(r, wait));
+    lastCallAt = Date.now();
+    return fn();
+  });
+  // Keep the chain alive even when a link rejects.
+  chain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Build a short, speakable address from a Nominatim address object.
+ *
+ * NOT the raw `display_name` — that is a comma-salad ending in "Região
+ * Geográfica Imediata de Porto Alegre, Rio Grande do Sul, Região Sul, 90000-000,
+ * Brasil", which is worse to confirm than the coordinate was. Street + number is
+ * what someone can check against the place they have in mind.
+ */
+function shortAddress(a: Record<string, string> | undefined): string | null {
+  if (!a) return null;
+  const street = a.road || a.pedestrian || a.footway || a.residential;
+  const place =
+    a.amenity || a.leisure || a.building || a.shop || a.park || a.school;
+  const number = a.house_number;
+
+  if (street) return number ? `${street}, ${number}` : street;
+  // No street (common for a pin dropped inside a park or a vila): fall back to
+  // the named feature, then to the smallest administrative unit we got.
+  return place || a.suburb || a.neighbourhood || a.quarter || null;
+}
+
+/**
+ * Reverse-geocode a point to a short street address. Returns null on any
+ * failure, on a timeout, or when the result carries nothing worth showing —
+ * callers must treat null as "keep whatever name you had".
+ */
+export async function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<string | null> {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  const k = key(lat, lng);
+  if (cache.has(k)) return cache.get(k) ?? null;
+
+  try {
+    const result = await schedule(async () => {
+      const url = new URL(`${NOMINATIM_URL}/reverse`);
+      url.searchParams.set('lat', String(lat));
+      url.searchParams.set('lon', String(lng));
+      url.searchParams.set('format', 'jsonv2');
+      url.searchParams.set('zoom', '18'); // building / street level
+      url.searchParams.set('addressdetails', '1');
+      url.searchParams.set('accept-language', 'pt-BR');
+
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 4000);
+      try {
+        const res = await fetch(url, {
+          headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+          signal: ctrl.signal,
+        });
+        if (!res.ok) return null;
+        const body = (await res.json()) as { address?: Record<string, string> };
+        return shortAddress(body?.address);
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+    cache.set(k, result);
+    return result;
+  } catch {
+    // Negative-cache too: a pin over water or outside OSM coverage would
+    // otherwise re-request on every reload of the same session.
+    cache.set(k, null);
+    return null;
+  }
+}
+
+/**
+ * True when a site name is a coordinate placeholder rather than a real name.
+ *
+ * Gating on this is what keeps the geocoder from ever overwriting a name the
+ * user chose or that OSM already supplied ("Praça da Encol", "EMEF Vila Nova").
+ * Matches both MapMicroapp fallbacks, pt and en.
+ */
+export function isPlaceholderSiteName(name: string | undefined | null): boolean {
+  if (!name) return false;
+  return /^(ponto marcado|área desenhada|area desenhada|marked point|drawn area)\b/i.test(
+    name.trim(),
+  );
+}

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -380,6 +380,19 @@ export interface CboSiteCard {
   siteKind: 'osm' | 'custom' | 'zone';
   /** Keyword-inferred kind of place ("praça", "escola", …); absent = unknown. */
   siteTypeLabel?: string;
+  /**
+   * Reverse-geocoded street address for a dropped pin, when Nominatim gave one.
+   * Shown as the card's headline so the org confirms a place it can recognise
+   * and repeat, instead of a latitude. Absent = we only have the coordinate.
+   */
+  address?: string;
+  /**
+   * Bairro-wide MEAN hazard scores, 0–100 — NOT measured at this site. The card
+   * must label them as such: the diagnostic's hazard-check beat exists to ask
+   * whether the bairro figure matches the org's own place, and a card that
+   * presents these as "your place's risk" pre-empts that question with an
+   * answer it never had. See shared/site-knowledge.ts → hazardCheckQuestion.
+   */
   risks: { flood: number; heat: number; landslide: number };
 }
 


### PR DESCRIPTION
From the screenshot review of the E2 site step.

## "What is the user supposed to choose here?"

`É isso mesmo?` sat under a card headed **SEU LUGAR** carrying three prominent risk bars. It asked two questions at once and accepted an answer to neither — every chip is about the **place**, and there was no way to disagree with the risk.

Worse: those bars are **bairro means** (`z.flood/heat/landslide`), presented as this site's. The diagnostic asks exactly that question ~10 turns later and has to open by undoing the card:

> "Nosso mapa diz que o risco de calor é **médio** no Partenon — mas isso é a média do bairro inteiro, **não do lugar de vocês**." — `hazardCheckQuestion()`

The card was manufacturing the misconception a later beat existed to correct. Which answers "how does this fit with what we ask later": it didn't — it pre-empted it with an answer it never had.

**Now:** the question is **"Esse é o lugar certo?"**. Risk stays but is demoted under a `No bairro, em média` rule with a forward reference — *"daqui a pouco eu te pergunto se isso bate com o que vocês vivem aí"* — so the sequencing is legible instead of reading as the same question twice.

## "Ponto marcado (-30.0577, -51.1936)"

Nobody can confirm a latitude, and that string travelled into the transcript, the concept note and the coordinator roster **as the name of the place**.

New `geocodeService` reverse-geocodes the pin and writes the result back as `site_name` — one name everywhere downstream, not a display alias. In the screenshot below it resolves to **Avenida Bento Gonçalves, 2018**.

Deliberately narrow: gated to the coordinate placeholders so a real OSM name (`Praça da Encol`) is never overwritten; fails soft; cached; rate-limited to Nominatim's 1 req/s; and sends an identifying `User-Agent` — the omission that returns **406** from OSM endpoints in this codebase.

## A map you can check the pin against

A 3×3 CartoDB tile thumbnail centred on the pin. Static `<img>` tiles, **not** a Leaflet instance: the card is a transcript row that re-renders on every reload, so live maps would accumulate instances and re-open the teardown races that cost us a `_leaflet_pos` crash.

3×3 rather than 2×2 is arithmetic, not taste. Coverage needs `W/2 ≤ px ≤ MOSAIC − W/2`; with 2×2 the pin offset only ranges over `[128, 384]`, capping the covered frame at **256px** — which is why the first cut rendered the map floating in beige gutters. 3×3 puts it in `[256, 512]` and covers any frame up to 512. The spec asserts all 9 tiles paint (`naturalWidth > 0` — the first cut used `loading="lazy"` and rendered an empty box) **and** that no gutter is left uncovered.

## Satellite is no longer forced

The site step opened on satellite. Satellite has no street names, and you have to *find* the yard before you can recognise it — orientation first. Political is the default; satellite stays one tap away on the existing toggle, where it earns its keep checking you pinned the right side of the street.

## Not done, deliberately

Renaming the `Confirmar ✓` chip. It's a documented exact-label contract the model re-shows when resuming a checkpoint, and 5 specs assert it — the gain is marginal now the question itself names what's being confirmed.

## Verification

3 new tests, plus the full E2/map suite: **58 passed**. Screenshot at `test-results/e2-site-card.png` (reproduce with `bash scripts/e2e-local.sh cougar-e2-site-card-clarity --project=chromium`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy
