### PR TITLE
fix(cohort): a workshop you opened stays open, and looks it

### DIFF
--- a/client/src/core/hooks/useCohort.ts
+++ b/client/src/core/hooks/useCohort.ts
@@ -50,7 +50,9 @@ export interface UseCohortResult {
   resetMember: (memberId: string) => Promise<boolean>;
   removeMember: (memberId: string) => Promise<boolean>;
   invite: (params: { orgName: string; neighborhood?: string; orgType?: 'community' | 'implementer' }) => Promise<CohortMember | null>;
-  unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<void>;
+  unlockPhase: (memberIds: string[] | 'all', phase: number) => Promise<boolean>;
+  /** Open a workshop for the whole cohort: unlock + stamp openedAt, atomically. */
+  openWorkshopPhase: (phase: number, openedAt: string) => Promise<boolean>;
   /** Close a workshop: re-lock its phase for every member and roll back sessions sitting in it. */
   closeWorkshopPhase: (phase: number) => Promise<{ relocked: number; rolledBack: number } | null>;
   saveWorkshops: (workshops: WorkshopConfig[]) => Promise<void>;
@@ -90,6 +92,20 @@ export function useCohort(): UseCohortResult {
 
   // Boot resolution — /mine establishes who we are (admin vs scoped) and the
   // starting cohort. Admins additionally pull the full cohort directory.
+  //
+  // ⚠️ COHORT-SELECTION-LOST-ON-RELOAD (JVP, 2026-08-03: "I restarted server for
+  // the staging version and the W2 was closed, when I had opened it before").
+  // switchCohort used to live only in React state, so every reload resolved back
+  // to /mine — the coordinator's OWN cohort. An admin who had switched to
+  // another cohort, opened a workshop there, and then reloaded came back to a
+  // different cohort whose rail showed that workshop as never opened. Nothing
+  // was lost; they were looking at the wrong cohort, which is worse, because it
+  // reads as data loss and invites re-opening a workshop that is already open.
+  //
+  // The selection now rides in the URL (?cohort=<slug>): it survives reloads and
+  // restarts, it is shareable, and there is no stale localStorage to diverge
+  // from what is on screen. A slug the caller may not access simply 403s at the
+  // app.param guard and we keep /mine's cohort.
   const fetchCohort = useCallback(async () => {
     setLoading(true);
     try {
@@ -101,10 +117,15 @@ export function useCohort(): UseCohortResult {
       setIsAdmin(!!data.isAdmin);
       if (data.cohort?.coordinatorSlug) slugRef.current = data.cohort.coordinatorSlug;
       if (data.isAdmin) void refreshAllCohorts();
+
+      const wanted = new URLSearchParams(window.location.search).get('cohort');
+      if (wanted && wanted !== data.cohort?.coordinatorSlug) {
+        await loadCohort(wanted);
+      }
     } finally {
       setLoading(false);
     }
-  }, [refreshAllCohorts]);
+  }, [refreshAllCohorts, loadCohort]);
 
   useEffect(() => { fetchCohort(); }, [fetchCohort]);
 
@@ -114,7 +135,15 @@ export function useCohort(): UseCohortResult {
 
   const switchCohort = useCallback(async (cohortSlug: string) => {
     setLoading(true);
-    try { await loadCohort(cohortSlug); } finally { setLoading(false); }
+    try {
+      await loadCohort(cohortSlug);
+      // Write the selection into the URL so a reload lands on the SAME cohort.
+      // replaceState, not push: switching cohorts is changing what you're
+      // looking at, not navigating somewhere you'd expect Back to undo.
+      const url = new URL(window.location.href);
+      url.searchParams.set('cohort', cohortSlug);
+      window.history.replaceState(null, '', url.toString());
+    } finally { setLoading(false); }
   }, [loadCohort]);
 
   const provisionCohort = useCallback<UseCohortResult['provisionCohort']>(async (input) => {
@@ -173,13 +202,32 @@ export function useCohort(): UseCohortResult {
     return member;
   }, [refresh]);
 
+  // Per-member unlock (the "unlock next phase for this one org" card action).
+  // Returns ok so the caller can stop claiming success on a failed write — the
+  // bare `await fetch` here used to swallow every error while the toast fired
+  // regardless.
   const unlockPhase = useCallback(async (memberIds: string[] | 'all', phase: number) => {
-    await fetch(`/api/cohort/${slugRef.current}/unlock`, {
+    const r = await fetch(`/api/cohort/${slugRef.current}/unlock`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ memberIds, phase }),
     });
     await refresh();
+    return r.ok;
+  }, [refresh]);
+
+  // Open a workshop for the whole cohort. ONE server call that unlocks every
+  // member and stamps `openedAt` in a single transaction — this used to be two
+  // sequential client-driven writes to two tables, neither of which checked
+  // whether it succeeded.
+  const openWorkshopPhase = useCallback(async (phase: number, openedAt: string) => {
+    const r = await fetch(`/api/cohort/${slugRef.current}/open-workshop`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phase, openedAt }),
+    });
+    await refresh();
+    return r.ok;
   }, [refresh]);
 
   const closeWorkshopPhase = useCallback(async (phase: number): Promise<{ relocked: number; rolledBack: number } | null> => {
@@ -225,7 +273,7 @@ export function useCohort(): UseCohortResult {
 
   return {
     loading, cohort, members, isAdmin, allCohorts,
-    refresh, refreshAllCohorts, switchCohort, provisionCohort,
+    refresh, refreshAllCohorts, switchCohort, provisionCohort, openWorkshopPhase,
     resetCohort, resetMember, removeMember, invite, unlockPhase, closeWorkshopPhase, saveWorkshops, saveLanguage, deleteCohort,
   };
 }

--- a/client/src/core/pages/orchestrator-landing.tsx
+++ b/client/src/core/pages/orchestrator-landing.tsx
@@ -908,7 +908,7 @@ export default function OrchestratorLandingPage() {
 
   const {
     cohort, members, isAdmin, allCohorts,
-    invite, unlockPhase, closeWorkshopPhase, saveWorkshops, resetCohort, resetMember, removeMember, saveLanguage, deleteCohort,
+    invite, unlockPhase, openWorkshopPhase, closeWorkshopPhase, saveWorkshops, resetCohort, resetMember, removeMember, saveLanguage, deleteCohort,
     switchCohort, provisionCohort, refresh,
   } = useCohort();
   const cohortLanguage = (cohort?.settings as { language?: 'pt' | 'en' } | null)?.language ?? null;
@@ -1016,25 +1016,28 @@ export default function OrchestratorLandingPage() {
     toast({ title: t('orchestrator.cohort.phaseUnlocked', { defaultValue: `Phase ${next} unlocked`, phase: next }) });
   };
 
-  // Coordinator clicked "Open for cohort" on a specific workshop. Two things
-  // happen together: (1) bulk-unlock the workshop's phase for every member,
-  // (2) auto-stamp today's date into the workshop's `openedAt` so the cadence
-  // accumulates a real timeline as it runs. Scheduled `date` is left alone.
+  // Coordinator clicked "Open for cohort". ONE server call now does both halves
+  // — unlock the phase for every member AND stamp `openedAt` — in a single
+  // transaction. This used to be two sequential client-driven writes to two
+  // different tables, neither of which checked whether it succeeded, while the
+  // toast fired regardless: a failed or interrupted second write left the phase
+  // unlocked and the cadence rail showing the workshop as never opened, with no
+  // sign anything had gone wrong. Scheduled `date` is left alone.
   const handleOpenWorkshop = async (workshopIndex: number, todayISO: string) => {
     const workshop = (cohort?.settings as any)?.workshops?.[workshopIndex] as WorkshopConfig | undefined;
     if (!workshop) return;
-    await unlockPhase('all', workshop.unlocksPhase);
-    if (!workshop.openedAt) {
-      const updated: WorkshopConfig[] = ((cohort?.settings as any)?.workshops ?? []).map(
-        (w: WorkshopConfig, j: number) => (j === workshopIndex ? { ...w, openedAt: todayISO } : w),
-      );
-      await saveWorkshops(updated);
-    }
+    const ok = await openWorkshopPhase(workshop.unlocksPhase, todayISO);
     toast({
-      title: t('orchestrator.cohort.workshopOpened', {
-        defaultValue: `${workshop.name} opened for cohort`,
-        workshop: workshop.name,
-      }),
+      variant: ok ? undefined : 'destructive',
+      title: ok
+        ? t('orchestrator.cohort.workshopOpened', {
+            defaultValue: `${workshop.name} opened for cohort`,
+            workshop: workshop.name,
+          })
+        : t('orchestrator.cohort.workshopOpenFailed', {
+            defaultValue: `Could not open ${workshop.name} — nothing was changed. Try again.`,
+            workshop: workshop.name,
+          }),
     });
   };
 

--- a/e2e/cougar-cohort-selection-persist.spec.ts
+++ b/e2e/cougar-cohort-selection-persist.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+/** The `request` fixture and the browser have separate cookie jars — carry the
+ *  coordinator session created via the API over to the page. */
+async function shareSession(page: any, request: any) {
+  const { cookies } = await request.storageState();
+  await page.context().addCookies(cookies);
+}
+
+// COHORT-SELECTION-LOST-ON-RELOAD — the actual cause of JVP's 2026-08-03 report
+// ("I restarted server for the staging version and the W2 was closed, when I
+// had opened it before").
+//
+// The cadence rail is PER COHORT. `switchCohort` lived only in React state, so
+// every reload re-resolved through /api/cohort/mine — the coordinator's own
+// cohort. An admin who switched to another cohort, opened a workshop there and
+// then reloaded came back to a DIFFERENT cohort whose rail showed that workshop
+// as never opened. Nothing was lost; they were looking at the wrong thing,
+// which is worse than a plain bug: it reads as data loss, and invites reopening
+// a workshop that is already open.
+
+test.describe('COUGAR — the selected cohort survives a reload', () => {
+  test('an admin who switches cohorts and reloads stays on that cohort', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+
+    // Two cohorts, and an ADMIN (no cohortId) who can move between them.
+    const home = (await api.createCohort(`Home ${randomUUID().slice(0, 8)}`)).cohort;
+    const other = (await api.createCohort(`Other ${randomUUID().slice(0, 8)}`)).cohort;
+    await api.createCoordinator({ email: `admin-${randomUUID()}@e2e.test`, password: 'pw-123456' });
+    await request.post(`/__test/cohort/${other.id}/member`, { data: { orgName: 'Org In Other' } });
+
+    // Open W2 in the OTHER cohort — the write the report thought had been lost.
+    const res = await request.patch(`/api/cohort/${other.coordinatorSlug}/open-workshop`, {
+      data: { phase: 2, openedAt: '2026-08-03' },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    // Land on that cohort the way the switcher now does, then reload.
+    await shareSession(page, request);
+    await page.goto(`/orchestrator?cohort=${other.coordinatorSlug}`);
+    await expect(page.getByText(other.name).first()).toBeVisible({ timeout: 30_000 });
+
+    await page.reload();
+
+    // The reload must NOT drop back to the admin's default cohort.
+    await expect(
+      page.getByText(other.name).first(),
+      'a reload must keep the cohort that was on screen',
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(home.name)).toHaveCount(0);
+  });
+
+  test('the URL keeps a cohort the caller may not read out of the dashboard', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    const mine = (await api.createCohort(`Mine ${randomUUID().slice(0, 8)}`)).cohort;
+    const foreign = (await api.createCohort(`Foreign ${randomUUID().slice(0, 8)}`)).cohort;
+    // SCOPED coordinator — may act only on `mine`.
+    await api.createCoordinator({
+      email: `scoped-${randomUUID()}@e2e.test`,
+      password: 'pw-123456',
+      cohortId: mine.id,
+    });
+
+    // A hand-edited or shared URL pointing at someone else's cohort must not
+    // load it. The server 403s at the app.param guard and the dashboard keeps
+    // the cohort the account actually owns.
+    await shareSession(page, request);
+    await page.goto(`/orchestrator?cohort=${foreign.coordinatorSlug}`);
+    await expect(page.getByText(mine.name).first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(foreign.name)).toHaveCount(0);
+  });
+});

--- a/e2e/cougar-workshop-open-atomic.spec.ts
+++ b/e2e/cougar-workshop-open-atomic.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { TestApi } from './helpers/testApi';
+
+// Workshop open/close reliability (JVP, 2026-08-03: "I restarted server for the
+// staging version and the W2 was closed, when I had opened it before").
+//
+// The reported symptom turned out to be the cohort SELECTION not surviving a
+// reload — covered in cougar-cohort-selection-persist.spec.ts. What this spec
+// pins is the machinery underneath, which was independently able to produce the
+// same appearance:
+//
+//   · opening a workshop was TWO client-driven writes to two different tables,
+//     neither error-checked, with the success toast firing regardless;
+//   · PATCH /workshops overwrote the array from the client's copy, so a stale
+//     page could null `openedAt` while re-locking nobody — the rail says
+//     "closed" and every org still has access.
+
+async function cohortWithMembers(request: any, n = 2) {
+  const api = new TestApi(request);
+  const cohort = (await api.createCohort(`WS ${randomUUID().slice(0, 8)}`)).cohort;
+  await api.createCoordinator({
+    email: `ws-${randomUUID()}@e2e.test`,
+    password: 'pw-123456',
+    cohortId: cohort.id,
+  });
+  for (let i = 0; i < n; i++) {
+    await request.post(`/__test/cohort/${cohort.id}/member`, {
+      data: { orgName: `Org ${i}`, unlockedPhases: [1] },
+    });
+  }
+  return { api, cohort };
+}
+
+const read = async (request: any, slug: string) =>
+  (await request.get(`/api/cohort/${slug}`)).json();
+
+test.describe('COUGAR — opening a workshop is one atomic act', () => {
+  test('one call unlocks every member AND stamps openedAt', async ({ request }) => {
+    const { cohort } = await cohortWithMembers(request);
+    const slug = cohort.coordinatorSlug;
+
+    const before = await read(request, slug);
+    expect(before.members.every((m: any) => !m.unlockedPhases.includes(2))).toBe(true);
+
+    const res = await request.patch(`/api/cohort/${slug}/open-workshop`, {
+      data: { phase: 2, openedAt: '2026-08-03' },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    const after = await read(request, slug);
+    // Both halves, from ONE request — the pair that used to be able to split.
+    expect(after.members.every((m: any) => m.unlockedPhases.includes(2))).toBe(true);
+    const w2 = after.cohort.settings.workshops.find((w: any) => w.unlocksPhase === 2);
+    expect(w2.openedAt).toBe('2026-08-03');
+  });
+
+  test('re-opening keeps the original date, and never double-adds a phase', async ({ request }) => {
+    const { cohort } = await cohortWithMembers(request);
+    const slug = cohort.coordinatorSlug;
+
+    await request.patch(`/api/cohort/${slug}/open-workshop`, { data: { phase: 2, openedAt: '2026-08-01' } });
+    await request.patch(`/api/cohort/${slug}/open-workshop`, { data: { phase: 2, openedAt: '2026-08-09' } });
+
+    const after = await read(request, slug);
+    const w2 = after.cohort.settings.workshops.find((w: any) => w.unlocksPhase === 2);
+    // The rail is a record of when the workshop was actually held.
+    expect(w2.openedAt).toBe('2026-08-01');
+    for (const m of after.members) {
+      expect(m.unlockedPhases.filter((p: number) => p === 2)).toHaveLength(1);
+    }
+  });
+
+  test('editing the cadence cannot clear openedAt', async ({ request }) => {
+    const { cohort } = await cohortWithMembers(request);
+    const slug = cohort.coordinatorSlug;
+
+    await request.patch(`/api/cohort/${slug}/open-workshop`, { data: { phase: 2, openedAt: '2026-08-03' } });
+    const opened = await read(request, slug);
+
+    // Exactly the shape a stale page sends: the whole array, openedAt null. It
+    // used to be written verbatim — closing the workshop on the rail while
+    // re-locking nobody, so orgs kept access to a workshop shown as closed.
+    const stale = opened.cohort.settings.workshops.map((w: any) => ({
+      name: w.name, date: w.date, unlocksPhase: w.unlocksPhase, openedAt: null,
+    }));
+    const res = await request.patch(`/api/cohort/${slug}/workshops`, { data: { workshops: stale } });
+    expect(res.ok()).toBeTruthy();
+
+    const after = await read(request, slug);
+    const w2 = after.cohort.settings.workshops.find((w: any) => w.unlocksPhase === 2);
+    expect(w2.openedAt, 'a cadence edit must not silently close a workshop').toBe('2026-08-03');
+    // …and the edit itself still applied.
+    expect(after.cohort.settings.workshops).toHaveLength(stale.length);
+  });
+
+  test('close-workshop still reverses both halves together', async ({ request }) => {
+    const { cohort } = await cohortWithMembers(request);
+    const slug = cohort.coordinatorSlug;
+
+    await request.patch(`/api/cohort/${slug}/open-workshop`, { data: { phase: 2, openedAt: '2026-08-03' } });
+    await request.patch(`/api/cohort/${slug}/close-workshop`, { data: { phase: 2 } });
+
+    const after = await read(request, slug);
+    const w2 = after.cohort.settings.workshops.find((w: any) => w.unlocksPhase === 2);
+    expect(w2.openedAt).toBeNull();
+    expect(after.members.every((m: any) => !m.unlockedPhases.includes(2))).toBe(true);
+    // Phase 1 is open-on-invite by design and can never be taken away.
+    expect(after.members.every((m: any) => m.unlockedPhases.includes(1))).toBe(true);
+  });
+
+  test('an invalid phase changes nothing', async ({ request }) => {
+    const { cohort } = await cohortWithMembers(request);
+    const slug = cohort.coordinatorSlug;
+    for (const phase of [0, 8, 'x', null]) {
+      const res = await request.patch(`/api/cohort/${slug}/open-workshop`, { data: { phase } });
+      expect(res.status()).toBe(400);
+    }
+    const after = await read(request, slug);
+    expect(after.members.every((m: any) => m.unlockedPhases.join() === '1')).toBe(true);
+  });
+});

--- a/server/routes/cohortRoutes.ts
+++ b/server/routes/cohortRoutes.ts
@@ -573,12 +573,26 @@ export function registerCohortRoutes(app: Express): void {
     const incoming = req.body?.workshops;
     if (!Array.isArray(incoming)) { res.status(400).json({ error: 'workshops must be an array' }); return; }
 
-    const workshops: WorkshopConfig[] = incoming.map((w: any) => ({
-      name: String(w.name ?? ''),
-      date: w.date ? String(w.date) : null,
-      unlocksPhase: Number(w.unlocksPhase) || 1,
-      openedAt: w.openedAt ? String(w.openedAt) : null,
-    }));
+    // `openedAt` is NOT client-writable here. This route exists to edit the
+    // cadence — names, dates, which phase a workshop unlocks. It used to accept
+    // the whole array verbatim, so any edit from a page whose `cohort` object
+    // predated an opening silently cleared `openedAt` for every workshop — and
+    // unlike close-workshop it re-locked nobody, leaving the rail showing
+    // "closed" while every org still had access. Opening and closing go through
+    // their own endpoints, which move the flag and the members together.
+    const existingByPhase = new Map(
+      ((cohort.settings as CohortSettings | null)?.workshops ?? [])
+        .map(w => [Number(w.unlocksPhase), w.openedAt ?? null]),
+    );
+    const workshops: WorkshopConfig[] = incoming.map((w: any) => {
+      const unlocksPhase = Number(w.unlocksPhase) || 1;
+      return {
+        name: String(w.name ?? ''),
+        date: w.date ? String(w.date) : null,
+        unlocksPhase,
+        openedAt: existingByPhase.get(unlocksPhase) ?? null,
+      };
+    });
     const settings: CohortSettings = { ...(cohort.settings as CohortSettings), workshops };
     await db.update(cohorts).set({ settings }).where(eq(cohorts.id, cohort.id));
     res.json({ ok: true });
@@ -631,6 +645,64 @@ export function registerCohortRoutes(app: Express): void {
       await db.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
     }
     res.json({ ok: true, updated: targets.length });
+  }));
+
+  // Open a workshop — the exact mirror of close-workshop below, and the reason
+  // this endpoint exists at all (JVP, 2026-08-03: "I restarted server for the
+  // staging version and the W2 was closed, when I had opened it before").
+  //
+  // "Open for cohort" used to be TWO client-driven writes to two different
+  // tables — PATCH /unlock (cohort_members.unlockedPhases, which actually gates
+  // the org) then PATCH /workshops (cohorts.settings.workshops[].openedAt,
+  // which the cadence rail displays). Three ways that drifts:
+  //
+  //   1. Neither call checked `r.ok`, and the success toast fired regardless.
+  //      A failed or interrupted second write left the phase unlocked with the
+  //      rail showing the workshop as never opened — silently.
+  //   2. They are sequential and non-atomic. Navigate away between them and you
+  //      get the same split.
+  //   3. PATCH /workshops overwrites the whole array from the CLIENT's copy, so
+  //      any later edit from a stale page nulls `openedAt` — and unlike this
+  //      route's mirror below it re-locks nobody, leaving the rail saying
+  //      "closed" while every org still has access.
+  //
+  // One request, one transaction, server-side merge. The client no longer
+  // decides what `openedAt` was.
+  app.patch('/api/cohort/:coordinatorSlug/open-workshop', wrap(async (req, res) => {
+    const cohort = await findCohortByCoordinatorSlug(req.params.coordinatorSlug);
+    if (!cohort) { res.status(404).json({ error: 'cohort not found' }); return; }
+
+    const phaseNum = Number(req.body?.phase);
+    if (!phaseNum || phaseNum < 1 || phaseNum > 7) { res.status(400).json({ error: 'invalid phase (1-7)' }); return; }
+    // The date is the coordinator's local "today" — the server may be in
+    // another timezone, and the cadence rail is a record of when the workshop
+    // was actually held. Validated, never trusted raw into settings.
+    const openedAt = /^\d{4}-\d{2}-\d{2}$/.test(String(req.body?.openedAt ?? ''))
+      ? String(req.body.openedAt)
+      : new Date().toISOString().slice(0, 10);
+
+    const settings: CohortSettings = (cohort.settings as CohortSettings | null) ?? ({} as CohortSettings);
+    const workshops: WorkshopConfig[] = (settings.workshops ?? []).map(w =>
+      // Merge, don't replace: only this workshop's openedAt changes, and only
+      // if it wasn't already stamped (re-opening keeps the original date).
+      Number(w.unlocksPhase) === phaseNum && !w.openedAt ? { ...w, openedAt } : w);
+
+    const members = await db.select().from(cohortMembers).where(eq(cohortMembers.cohortId, cohort.id));
+    let unlocked = 0;
+
+    await db.transaction(async tx => {
+      await tx.update(cohorts).set({ settings: { ...settings, workshops } }).where(eq(cohorts.id, cohort.id));
+      for (const m of members) {
+        const current = Array.isArray(m.unlockedPhases) ? (m.unlockedPhases as number[]) : [1];
+        if (current.includes(phaseNum)) continue;
+        const next = [...current, phaseNum].sort((a, b) => a - b);
+        await tx.update(cohortMembers).set({ unlockedPhases: next }).where(eq(cohortMembers.id, m.id));
+        unlocked++;
+      }
+    });
+
+    console.log(`[cohort] opened workshop phase ${phaseNum} for cohort ${cohort.id}: unlocked=${unlocked}/${members.length}`);
+    res.json({ ok: true, phase: phaseNum, openedAt, unlocked, members: members.length });
   }));
 
   // Close a workshop — the reverse of "Open for cohort" (field ask 2026-07-16:

--- a/server/services/phaseGating.ts
+++ b/server/services/phaseGating.ts
@@ -53,8 +53,19 @@ export async function getPhasePolicyForCbo(cboStateId: string): Promise<PhasePol
       maxAllowedPhase: Math.max(...unlocked),
       memberId: member.id,
     };
-  } catch {
-    return UNGATED;
+  } catch (e: any) {
+    // A DB error is NOT "this CBO is standalone". Returning UNGATED here made
+    // the gate fail OPEN: unlockedPhases [1,2,3,4,5] for everyone, so a
+    // transient connection blip — exactly what a redeploy or restart produces —
+    // let any org walk into a workshop the coordinator hasn't opened. The two
+    // situations look identical to the caller and are opposites.
+    //
+    // Fail closed instead: phase 1 only, which every invited org has by design.
+    // The worst case is an org briefly told "the next workshop isn't open yet",
+    // which self-corrects on the next successful query — versus an org running
+    // an encontro the coordination never opened, which does not.
+    console.error(`[phaseGating] policy lookup failed for ${cboStateId}; failing CLOSED:`, e?.message || e);
+    return { gated: true, unlockedPhases: [1], maxAllowedPhase: 1, memberId: null };
   }
 }
 


### PR DESCRIPTION
> "I restarted server for the staging version and the W2 was closed, when I had opened it before."

## The actual cause was your hypothesis, and it isn't data loss

> *"maybe what happens is that when it refreshed it changed the actual cohort that was chosen?"*

Exactly that. The cadence rail is **per cohort**, and `switchCohort` lived only in React state (`useCohort.ts:114`) — nothing persisted. Every reload re-resolved through `/api/cohort/mine`, the coordinator's *own* cohort. You switched to "Test June 23 · Joaquin", opened W2 there (that write landed fine), the restart forced a reload, and boot dropped you back on the default cohort whose W2 was never opened.

That's worse than a plain bug: it reads as data loss and invites re-opening a workshop that is already open. The selection now rides in the URL (`?cohort=<slug>`) — survives reloads and restarts, shareable, and no stale `localStorage` to diverge from what's on screen. A slug you may not read 403s at the `app.param` guard and the dashboard keeps its own cohort.

## The machinery underneath could produce the same appearance independently

**1 · Opening was two non-atomic client writes.** `PATCH /unlock` (`cohort_members.unlockedPhases` — what actually gates the org) then `PATCH /workshops` (`settings.workshops[].openedAt` — what the rail displays). Neither checked `r.ok`, and the toast fired regardless. A failed or interrupted second write left the phase unlocked with the rail showing "never opened", **silently**. Now one endpoint, one transaction, server-side merge, and the toast reports failure.

**2 · A cadence edit could silently close a workshop.** `PATCH /workshops` overwrote the array from the *client's* copy, so an edit from a stale page nulled `openedAt` for everything — and unlike `close-workshop` it re-locked nobody, leaving the rail saying "closed" while every org still had access. `openedAt` is no longer client-writable there.

**3 · The gate failed OPEN.** `getPhasePolicyForCbo` ended in `catch { return UNGATED }` — and `UNGATED` is `unlockedPhases: [1,2,3,4,5]`. A DB error opened **every workshop for everyone**, and a redeploy is exactly when a query is most likely to throw. "No cohort member" and "the database didn't answer" are opposite situations that returned the same answer. Now fails **closed** to phase 1, which every invited org has by design — worst case an org is briefly told the next workshop isn't open yet, which self-corrects. The alternative doesn't.

## Verification

7 new tests. The reload spec was **verified to fail without the client fix** and pass with it — a persistence test that passes both ways proves nothing. Whole suite: **133 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy
