### PR TITLE
feat(cbo): a chip that needs a file opens the file picker

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -2844,13 +2844,19 @@ function CboQuestionCard({
     (answeredValue ?? '').split(',').map(s => s.trim()).filter(Boolean)
   );
 
-  const handleClick = (label: string) => {
+  const handleClick = (label: string, action?: string) => {
     if (disabled || readOnly) return;
     if (isMulti && onMultiToggle) {
       onMultiToggle(label);
     } else {
       onSelect(label);
     }
+    // 'upload_then_answer' is a NORMAL chip that also opens the file picker.
+    // Distinct from the 'upload' banner above, which opens the picker INSTEAD of
+    // answering: a server-templated checkpoint derives its position from the
+    // answers, so a chip that only opened a picker would strand the flow.
+    // Answer first, then open — the picker is modal and blocks the send.
+    if (action === 'upload_then_answer') onUploadAction?.();
   };
 
   return (
@@ -2908,7 +2914,7 @@ function CboQuestionCard({
           const isFocused = readOnly ? false : i === selectedIdx;
           const isHighlighted = readOnly ? isPicked : isMulti ? isChecked : isFocused;
           return (
-            <button key={i} onClick={() => handleClick(opt.label)}
+            <button key={i} onClick={() => handleClick(opt.label, opt.action)}
               disabled={readOnly}
               aria-current={isPicked || undefined}
               data-testid={readOnly ? `cbo-answered-option-${i}` : `cbo-option-${i}`}

--- a/e2e/cougar-chip-opens-file-picker.spec.ts
+++ b/e2e/cougar-chip-opens-file-picker.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// A chip that needs a file OPENS the file picker (JVP, 2026-08-03, after hitting
+// it twice in a real session: "i clicked the i have a file to add and did not
+// open the upload file dialog… instead it added a message in chat").
+//
+// The seam already existed end to end — `action` on the ask_user option type,
+// accepted by the model's tool, honoured by the chip renderer — but the server's
+// `ask()` helper flattened every option to label + description, so no templated
+// checkpoint could set it. The agent answered with prose telling the user to go
+// find the 📎 themselves.
+//
+// Two behaviours, deliberately distinct:
+//   'upload'              — the intake BANNER: opens the picker INSTEAD of answering.
+//   'upload_then_answer'  — a normal chip: answers AND opens the picker.
+// The second is what a templated checkpoint needs; a chip that only opened a
+// picker would never advance the flow.
+
+const chip = (page: Page, label: string) =>
+  page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
+
+/** Drive E2 to the photos beat, where the upload invite lives. */
+async function toPhotosBeat(page: Page, request: any): Promise<string> {
+  const api = new TestApi(request);
+  await page.goto('/cbo-profile');
+  const marker = page.getByTestId('cbo-stream-status');
+  await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+  const cboId = (await marker.getAttribute('data-cbo-id'))!;
+  await api.seedState(cboId, { phase: 2 });
+
+  await request.post(`/api/cbo/${cboId}/chat`, {
+    data: {
+      message: [
+        'Map selection (composite mode):',
+        '- [zone] Partenon: MEDIUM risk, intervention: urban forest, area: 8.1 km², pop: 45.768, flood: 22%, heat: 51%, landslide: 14%, at (-30.0577, -51.1936)',
+        '- [custom] Pátio da escola at (-30.0577, -51.1936)',
+        'Total: 2 assets, 0 sampled points',
+      ].join('\n'),
+      lang: 'pt',
+      turnKind: 'map',
+    },
+  });
+  await page.reload();
+  await expect(page.getByTestId('cbo-site-card')).toBeVisible({ timeout: 20_000 });
+  await chip(page, 'Confirmar ✓').click();
+  await expect(page.getByText('Como é esse lugar hoje', { exact: false })).toBeVisible({ timeout: 10_000 });
+  await chip(page, 'Pavimentado / impermeabilizado').click();
+  await expect(page.getByText('acesso a esse espaço', { exact: false })).toBeVisible({ timeout: 10_000 });
+  await chip(page, 'É da prefeitura, mas a gente usa').click();
+  await expect(page.getByText('mais preocupa', { exact: false })).toBeVisible({ timeout: 10_000 });
+  await chip(page, '🌡️ Calor').click();
+  await chip(page, 'Pronto ✓').click();
+  await expect(page.getByText('palavras de vocês', { exact: false })).toBeVisible({ timeout: 10_000 });
+  await chip(page, 'Prefiro pular').click();
+  await expect(page.getByText('fotos ajudam', { exact: false })).toBeVisible({ timeout: 15_000 });
+  return cboId;
+}
+
+test.describe('COUGAR — a chip that needs a file opens the picker', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('"Tenho arquivos pra anexar" opens the picker AND answers', async ({ page, request }) => {
+    test.setTimeout(180_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toPhotosBeat(page, request);
+
+    // The file dialog is native and invisible to the DOM — Playwright's
+    // filechooser event is the only honest way to assert it opened.
+    const chooser = page.waitForEvent('filechooser', { timeout: 10_000 });
+    await chip(page, 'Tenho arquivos pra anexar').click();
+    await expect(chooser, 'the chip must open the file picker').resolves.toBeTruthy();
+
+    // …and it must ALSO have answered, or the checkpoint machine stalls: the
+    // next question is the one that follows the upload invite.
+    await expect(page.getByText('Quando terminar de anexar', { exact: false }))
+      .toBeVisible({ timeout: 15_000 });
+
+    // The prose no longer tells them to do the thing that just happened.
+    await expect(page.getByText('Toca no 📎', { exact: false })).toHaveCount(0);
+  });
+
+  test('"Anexar mais" re-opens the picker without stranding the flow', async ({ page, request }) => {
+    test.setTimeout(180_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toPhotosBeat(page, request);
+
+    const first = page.waitForEvent('filechooser', { timeout: 10_000 });
+    await chip(page, 'Tenho arquivos pra anexar').click();
+    await first;
+    await expect(chip(page, 'Anexar mais')).toBeVisible({ timeout: 15_000 });
+
+    const again = page.waitForEvent('filechooser', { timeout: 10_000 });
+    await chip(page, 'Anexar mais').click();
+    await expect(again, 'attach-more must re-open the picker').resolves.toBeTruthy();
+
+    // Unhandled server-side this would fall through to the model, whose turn
+    // replaces the pending composer — the "Pronto, pode seguir" chip vanishes
+    // and the org is stranded mid-upload. It must still be there.
+    await expect(chip(page, 'Pronto, pode seguir')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('the flow still completes for someone who has no files', async ({ page, request }) => {
+    test.setTimeout(180_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    await toPhotosBeat(page, request);
+
+    // The other chips must be untouched by all this — no picker, normal answer.
+    await chip(page, 'Não tenho agora').click();
+    await expect(page.getByText('média do bairro', { exact: false })).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -699,7 +699,7 @@ Include showMap: true on a question only when the user genuinely needs the map t
         // action 'upload': renders as a prominent attach banner (paperclip
         // icon) that opens the file picker instead of sending an answer. Use
         // ONLY on the intake-opening "send your site or documents" option.
-        options: z.array(z.object({ label: z.string(), description: z.string().optional(), recommended: z.boolean().optional(), action: z.enum(['upload']).optional() })),
+        options: z.array(z.object({ label: z.string(), description: z.string().optional(), recommended: z.boolean().optional(), action: z.enum(['upload', 'upload_then_answer']).optional() })),
         relatedSections: z.array(z.string()).optional(),
         showMap: z.boolean().optional(),
         multiSelect: z.boolean().optional(),
@@ -1653,11 +1653,31 @@ async function serveE2Checkpoint(
   const pickedRoles = val('role_preference') ? val('role_preference').split(',').map(s => s.trim()).filter(Boolean) : [];
 
   const say = (pt: string, en: string) => pushEvent({ type: 'chat', content: isPt ? pt : en, role: 'assistant' } as any);
-  const ask = (qPt: string, qEn: string, opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string }>) =>
+  // `action` is the seam that lets a TEMPLATED checkpoint offer a chip that does
+  // something client-side as well as answering. It already existed end to end —
+  // declared on the ask_user option type, accepted by the model's tool, and
+  // honoured by the chip renderer (cbo-profile.tsx: `opt.action === 'upload'`
+  // opens the file picker) — but this helper flattened every option down to
+  // label + description, so no server checkpoint could ever set it. The result
+  // was the dead step JVP hit twice: tapping "Tenho arquivos pra anexar"
+  // answered the question and then told you to go find the 📎 yourself.
+  //
+  // Deliberately additive: the chip still posts its message. The checkpoint
+  // machine derives its position from the answers, so a chip that only opened a
+  // picker without answering would strand the flow.
+  const ask = (
+    qPt: string,
+    qEn: string,
+    opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string; action?: 'upload_then_answer' }>,
+  ) =>
     pushEvent({
       type: 'ask_user',
       question: isPt ? qPt : qEn,
-      options: opts.map(o => ({ label: isPt ? o.pt : o.en, description: isPt ? (o.dPt ?? '') : (o.dEn ?? '') })),
+      options: opts.map(o => ({
+        label: isPt ? o.pt : o.en,
+        description: isPt ? (o.dPt ?? '') : (o.dEn ?? ''),
+        ...(o.action ? { action: o.action } : {}),
+      })),
     } as any);
   const finish = (detail: string): true => {
     pushEvent({ type: 'done', summary: `E2 checkpoint (${detail})` } as any);
@@ -1773,7 +1793,10 @@ async function serveE2Checkpoint(
           };
     say(`${already.pt}\n\n${lines}`, `${already.en}\n\n${lines}`);
     ask('Como prefere?', 'What works best?', [
-      { pt: E2C.temArquivos.pt, en: E2C.temArquivos.en, dPt: 'Toco no 📎 e mando agora', dEn: "I'll tap 📎 and send now" },
+      // Opens the file picker on tap AND answers the question — see the note on
+      // `ask`. The description no longer instructs them to find the 📎 because
+      // the chip does it.
+      { pt: E2C.temArquivos.pt, en: E2C.temArquivos.en, dPt: 'Abre pra escolher os arquivos', dEn: 'Opens the file chooser', action: 'upload_then_answer' },
       { pt: 'Mando depois', en: "I'll send later", dPt: 'Fica anotado', dEn: "I'll note it down" },
       ...(docs.images > 0
         ? [{ pt: 'Já mandei o que tinha', en: 'I already sent what I had', dPt: 'Seguir com o que tem', dEn: 'Continue with what we have' }]
@@ -2398,13 +2421,27 @@ async function serveE2Checkpoint(
 
   // ── Beat 3 · photographs ──────────────────────────────────────────────────
   if (val('_story_done') === 'yes' && val('_photos_done') !== 'yes') {
+    // "Anexar mais" re-opens the picker (client-side) and must re-serve the SAME
+    // pending question. Left unhandled it would fall through to the model, whose
+    // turn replaces the pending composer — so the "Pronto, pode seguir" chip
+    // would vanish and the org would be stranded mid-upload.
+    if (is({ pt: 'Anexar mais', en: 'Attach more' })) {
+      ask('Quando terminar de anexar:', 'When you finish attaching:', [
+        { pt: E2C.prontoSeguir.pt, en: E2C.prontoSeguir.en },
+        { pt: 'Anexar mais', en: 'Attach more', dPt: 'Abre de novo', dEn: 'Opens it again', action: 'upload_then_answer' },
+      ]);
+      return finish('await-more-uploads');
+    }
     if (is(E2C.temArquivos)) {
+      // The picker is already open at this point (the chip opened it), so this
+      // no longer says "toca no 📎" — that instruction was the dead step.
       say(
-        'Show! Toca no 📎 e manda o que tiver. Quando terminar, toca abaixo.',
-        'Great! Tap 📎 and send what you have. When you finish, tap below.',
+        'Show! Escolhe os arquivos e manda. Quando terminar, toca abaixo.',
+        'Great! Pick your files and send them. When you finish, tap below.',
       );
       ask('Quando terminar de anexar:', 'When you finish attaching:', [
         { pt: E2C.prontoSeguir.pt, en: E2C.prontoSeguir.en },
+        { pt: 'Anexar mais', en: 'Attach more', dPt: 'Abre de novo', dEn: 'Opens it again', action: 'upload_then_answer' },
       ]);
       return finish('await-uploads');
     }

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -350,7 +350,7 @@ export type CboEvent =
   // options[].action 'upload': the chip renders as a prominent attach banner
   // (paperclip icon) and opens the file picker instead of answering — the
   // intake opening's "send your site or documents" affordance.
-  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string; action?: 'upload' }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string; action?: 'upload' | 'upload_then_answer' }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }


### PR DESCRIPTION
> "i clicked the i have a file to add and did not open the upload file dialog, shouldnt it have worked, instead it added a message in chat"

Tapping **"Tenho arquivos pra anexar"** posted a message and the agent replied *"Toca no 📎 e manda o que tiver"* — leaving you to go find the paperclip. The chip already knows what you want.

## The seam existed and nothing could reach it

`action` is declared on the `ask_user` option type, accepted by the model's tool, and **honoured by the chip renderer**. But the server's `ask()` helper flattened every option down to `label + description`, so no server-templated checkpoint could ever set it. Since the whole E2 flow *is* templated checkpoints, that meant nowhere it mattered.

`ask()` now carries `action` through — which makes this declarative for **every** workshop's upload invite (E1 documents, E2 site photos, E3a plans, E5 evidence), not one checkpoint at a time. That's the structural version you asked for.

## Two behaviours, deliberately distinct

This is the part that would have been a bug if I'd just reused the existing value:

| action | behaviour |
|---|---|
| `'upload'` | the intake **banner** — opens the picker **instead of** answering. Unchanged. |
| `'upload_then_answer'` | a normal chip — **answers AND** opens the picker. |

A templated checkpoint derives its position from the answers. A chip that only opened a picker would have opened a dialog and stranded the flow behind it.

## Also here

- The follow-up turn stops saying *"toca no 📎"* — the picker is already open by then, and that instruction **was** the dead step.
- It gains an **"Anexar mais"** chip that re-opens the picker, handled server-side so it re-serves the *same* pending question. Left unhandled it falls through to the model, whose turn replaces the pending composer — the "Pronto, pode seguir" chip vanishes and the org is stranded mid-upload.

## Verification

3 tests asserting the real Playwright **`filechooser` event** — the native dialog is invisible to the DOM, so nothing else actually proves it opened. Plus: the chip must *also* answer, attach-more must not strand, and the no-files path is untouched. **Whole suite: 151 passed.**

Closes backlog #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy