### PR TITLE
perf(test): 4.2min → 2.1min, and a 30s inner loop

### DIFF
--- a/e2e/cbo-sse-heartbeat.spec.ts
+++ b/e2e/cbo-sse-heartbeat.spec.ts
@@ -3,17 +3,22 @@ import { TestApi } from './helpers/testApi';
 
 // SSE trust hardening (field report 2026-07-07): the SDK can think 10-20s
 // between events; proxies idle-kill silent sockets and the client's 60s
-// watchdog needs bytes to know the stream is alive. The server now emits a
-// `: ping` comment every 15s. This spec opens a raw chat stream against a
-// scripted 17s thinking gap and asserts (a) heartbeat bytes arrive mid-gap,
-// (b) the turn still completes with its done event, (c) the UI never shows
-// the connection-drop card for a healthy-but-slow turn.
+// watchdog needs bytes to know the stream is alive. The server emits a
+// `: ping` comment on an interval. This spec asserts (a) heartbeat bytes
+// arrive mid-gap, (b) the turn still completes with its done event, (c) the UI
+// never shows the connection-drop card for a healthy-but-slow turn.
+//
+// TIMING: the interval is scaled to 400ms here (CBO_SSE_PING_MS in
+// playwright.config.ts) so a "silent gap several pings long" costs ~1.2s
+// instead of 17. The ratio is what matters — the gap is still many multiples
+// of the cadence, which is the only thing these assertions depend on. Before
+// this, the two tests spent 35s sleeping: 7% of the entire suite.
 
 test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
   test.use({ locale: 'pt-BR' });
 
-  test('a 17s silent turn carries pings and completes without the drop card', async ({ page, request }) => {
-    test.setTimeout(90_000);
+  test('a silent turn carries pings and completes without the drop card', async ({ page, request }) => {
+    test.setTimeout(30_000);
     const api = new TestApi(request);
     test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
 
@@ -23,7 +28,7 @@ test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
     const cboId = (await marker.getAttribute('data-cbo-id'))!;
 
     await api.scriptCbo(cboId, [[
-      { op: 'wait', ms: 17_000 } as any,
+      { op: 'wait', ms: 1_400 } as any,
       { op: 'say', text: 'Demorei mas cheguei.' },
       { op: 'ask_user', question: 'Seguimos?', options: [{ label: 'Sim' }] },
     ]]);
@@ -51,14 +56,14 @@ test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
       };
     }, cboId);
 
-    // 17s gap at a 15s cadence → at least one ping, plus the full turn.
+    // A gap 3× the cadence → at least one ping, plus the full turn.
     expect(result.pings).toBeGreaterThanOrEqual(1);
     expect(result.sawDone).toBe(true);
     expect(result.sawSay).toBe(true);
   });
 
   test('the UI rides out a slow turn — no drop card, question arrives', async ({ page, request }) => {
-    test.setTimeout(90_000);
+    test.setTimeout(30_000);
     const api = new TestApi(request);
     test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
 
@@ -68,7 +73,7 @@ test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
     const cboId = (await marker.getAttribute('data-cbo-id'))!;
 
     await api.scriptCbo(cboId, [[
-      { op: 'wait', ms: 16_000 } as any,
+      { op: 'wait', ms: 1_400 } as any,
       { op: 'say', text: 'Pensei bastante nessa.' },
       { op: 'ask_user', question: 'Tudo certo?', options: [{ label: 'Sim' }] },
     ]]);

--- a/e2e/w2-scenarios.spec.ts
+++ b/e2e/w2-scenarios.spec.ts
@@ -41,6 +41,14 @@ async function openSession(page: any, request: any) {
   const upload = async (files: string[]) => {
     await page.locator('input[type="file"]').setInputFiles(files);
     await page.waitForTimeout(6000); // extraction + the synthetic chat turn
+    // …and then wait for the turn to actually END. The sleep alone was load-
+    // sensitive: it was just sufficient at the old suite pace and started
+    // failing once the suite got faster and contention changed. While the
+    // transcript is still streaming it auto-scrolls, so every chip below is
+    // permanently "not stable" and Playwright waits out the whole test timeout
+    // on an element it can already see.
+    await expect(page.getByTestId('cbo-stream-status'))
+      .toHaveAttribute('data-streaming', 'false', { timeout: 60_000 });
   };
   return { cboId, page, request, chip, input, tap, type, upload };
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test:e2e": "playwright test --project=chromium",
+    "test:smoke": "playwright test --project=smoke",
     "test:e2e:fast": "playwright test --project=chromium --grep-invert @live",
     "test:e2e:mobile": "playwright test --project=webkit-mobile",
     "test:e2e:full": "RUN_LIVE_WALKTHROUGH=1 E2E_VIDEO=on E2E_TRACE=on playwright test e2e/quality/cbo-live-walkthrough.spec.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,6 +38,51 @@ export default defineConfig({
     extraHTTPHeaders: process.env.TEST_API_SECRET ? { 'x-test-secret': process.env.TEST_API_SECRET } : {},
   },
   projects: [
+    // ── @smoke: the inner-loop tier ────────────────────────────────────────
+    // The full suite is 4.2 minutes. Running it after every small change cost
+    // ~30 minutes in a single session, most of it re-proving things that could
+    // not have broken. This tier is what runs WHILE iterating; the full suite
+    // runs once before a PR.
+    //
+    // The list is explicit and lives in one place rather than as @smoke tags
+    // scattered across 90 files — so it can be read, argued with, and pruned.
+    // What earns a place:
+    //   · the turn spine (golden path, batching, transcript parity)
+    //   · guards that fail SILENTLY (prompt persistence, re-ask, duplicate text,
+    //     stream retry) — the ones whose breakage looks like nothing happening
+    //   · the tenancy / auth boundary
+    //   · pure-function guardrails, which cost ~1ms and pin real logic
+    //   · a regression test for every bug that actually reached JVP
+    // What does not: multi-org scenario walkthroughs, catalog/tile fetches,
+    // layout polish, anything @live.
+    //
+    // RULE: when a bug reaches JVP and smoke was green, its regression test
+    // joins this list. That is the only thing keeping the tier honest.
+    {
+      name: 'smoke',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: [
+        // the spine
+        /cbo-golden-path/, /cbo-batched-questions/, /cbo-phase1-walkthrough/,
+        /cbo-transcript-parity/, /cbo-language/,
+        // silent-failure guards
+        /cbo-prompt-persist/, /cbo-reask-guard/, /cbo-duplicate-text-guard/,
+        /cbo-stream-retry/, /cbo-sse-heartbeat/, /cbo-upload/,
+        /cougar-inline-options/, /cougar-doc-stage-confirm/,
+        /cougar-map-overlay-stacking/,
+        // boundaries
+        /cohort-isolation/, /coordinator-auth/,
+        // regressions for bugs that reached the field
+        /cougar-e2-bairro-selectable/,      // clicks swallowed by pointer drift
+        /cougar-chip-opens-file-picker/,    // chip that needed a file didn't open it
+        /cougar-workshop-open-atomic/,      // opening a workshop was two writes
+        /cougar-cohort-selection-persist/,  // reload dropped the chosen cohort
+        /cougar-e2-site-card-clarity/,      // the card asked two questions at once
+        // ranking guardrails (pure functions — milliseconds, real coverage)
+        /cougar-e2-familia-ranking-context/,
+        /cougar-e2-risk-summary/, /cougar-e2-one-encoding-per-step/,
+      ],
+    },
     // Default deterministic suite — desktop Chromium. Skips the mobile-layout
     // spec (which needs the WebKit/iPhone project below).
     { name: 'chromium', use: { ...devices['Desktop Chrome'] }, testIgnore: /cbo-mobile-layout/ },
@@ -62,6 +107,12 @@ export default defineConfig({
         // suite never exercises the OAuth flow.
         env: {
           ENABLE_TEST_ROUTES: '1',
+          // Scale the SSE heartbeat down for tests. The behaviour under test —
+          // "pings arrive during a silent gap, and the drop card never fires" —
+          // is scale-free, but at the production 15s cadence the spec had to
+          // script 17-second waits and sit through them: 35s, 7% of the whole
+          // suite, spent sleeping on purpose.
+          CBO_SSE_PING_MS: '400',
           CBO_FAKE_MODEL: '1',
           NODE_ENV: 'development',
           PORT,

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -2735,9 +2735,15 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   // parser only consumes `data: ` lines, so this is invisible to it beyond
   // resetting the watchdog. With the heartbeat in place, 60s of true silence
   // now reliably means the connection is dead.
+  //
+  // The interval is env-overridable ONLY so the e2e suite can assert the
+  // behaviour without spending real seconds on it: the spec used to script a
+  // 17-second silent turn and wait it out, which cost 35s — 7% of the whole
+  // suite — sleeping on purpose. The logic under test is "pings arrive during a
+  // gap and the drop card never fires", and that is scale-free.
   const heartbeat = setInterval(() => {
     if (!clientGone && !res.writableEnded) res.write(': ping\n\n');
-  }, 15_000);
+  }, Number(process.env.CBO_SSE_PING_MS) || 15_000);
 
   res.on('close', () => {
     clearInterval(heartbeat);


### PR DESCRIPTION
> "why do things take such a long time building in this project do you run tests all the time? are they worth it?"

Measured before changing anything: **157 tests, 471s of CPU across 5 workers**, with the top 12 specs accounting for **61%** of it. Startup wasn't the problem (drizzle push is 1s, the server reuses). Two specs were.

## Results

| | before | after |
|---|---|---|
| Inner loop | 4.2 min | **30s** (`npm run test:smoke`, 52 tests) |
| Full suite | 4.2 min | **2.1 min** (151 tests) |
| Specs deleted | — | **none** |

## 1 · The heartbeat spec was sleeping on purpose: 35s → 5.8s

It scripted **17-second silent turns** and sat through them — 7% of the entire suite. The behaviour under test ("pings arrive during a gap, the drop card never fires") is scale-free, so the ping interval is now env-overridable and the suite runs it at 400ms. The gap is still many multiples of the cadence, which is the only thing those assertions depend on.

## 2 · A smoke tier for iterating

The list is **explicit and in one place** (a `smoke` project in `playwright.config.ts`) rather than `@smoke` tags scattered across 90 files — so it can be read, argued with, and pruned.

**Earns a place:** the turn spine · guards that fail *silently* (prompt persistence, re-ask, duplicate text, stream retry) — the ones whose breakage looks like nothing happening · the tenancy/auth boundary · pure-function guardrails that cost ~1ms · a regression test for every bug that actually reached the field.

**Doesn't:** scenario walkthroughs, catalog/tile fetches, layout polish, `@live`.

**The rule that keeps it honest**, written into the config: *when a bug reaches JVP and smoke was green, its regression test joins the list.* Today that would have added the swallowed-click test — the suite was 100% green while clicks were being eaten in production, because every test clicked with zero pointer drift.

## A latent flake this exposed

`w2-scenarios`' upload helper slept a fixed 6s. That was *just* sufficient at the old pace and started failing once the suite got faster and contention changed. It now also waits for `data-streaming=false` — while the transcript streams it auto-scrolls, so every chip below is permanently "not stable" and Playwright waits out the full test timeout on an element it can already see.

## Not done, deliberately

I tried replacing that 6s sleep outright with a documents-landed poll. It broke org 1 and org 3 in ways I couldn't settle quickly, so I reverted rather than leave it half-done. The sleep stays; the flake is fixed by waiting **more**, not less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy