### PR TITLE
fix(cbo): one turn at a time — two agents could run on the same session

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogTitle, AlertDialogDescription, AlertDialogAction, AlertDialogCancel,
 } from '@/core/components/ui/alert-dialog';
 import { useFileDrop } from '@/core/hooks/useFileDrop';
+import { useToast } from '@/core/hooks/use-toast';
 import {
   CBO_SECTIONS,
   phaseComplete,
@@ -324,6 +325,7 @@ function clearId() { try { localStorage.removeItem(sessionStorageKey()); } catch
 
 export default function CboProfilePage() {
   const { t, i18n } = useTranslation();
+  const { toast } = useToast();
   const lang = i18n.resolvedLanguage || 'en';
   const [cboId, setCboId] = useState<string | null>(null);
   const [state, setState] = useState<CboState | null>(null);
@@ -1270,6 +1272,18 @@ export default function CboProfilePage() {
     try {
       armWatchdog();
       const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang, turnKind, chipAnswers, displayText }), signal: ctrl.signal });
+      // 409 = a turn is already streaming for this session (CBO-CONCURRENT-TURNS).
+      // Not an error the user caused and not something to retry: the answer they
+      // are waiting for is already on its way. Say so gently and leave the
+      // transcript alone — the in-flight turn will finish and render normally.
+      if (res.status === 409) {
+        toast({
+          title: t('cbo.stillAnswering', {
+            defaultValue: 'Só um segundo — ainda estou respondendo a anterior.',
+          }),
+        });
+        return;
+      }
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1716,6 +1716,7 @@
     },
     "export": "Export profile",
     "startOver": "Start over",
+    "stillAnswering": "One second — I'm still answering the last one.",
     "working": "Working...",
     "phase": "Phase {{num}}/5, {{count}} sections filled",
     "continue": "Continue",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1900,6 +1900,7 @@
     },
     "export": "Exportar perfil",
     "startOver": "Recomeçar",
+    "stillAnswering": "Só um segundo — ainda estou respondendo a anterior.",
     "working": "Processando...",
     "phase": "Fase {{num}}/5, {{count}} seções preenchidas",
     "continue": "Continuar",

--- a/e2e/cougar-concurrent-turns.spec.ts
+++ b/e2e/cougar-concurrent-turns.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// ⚠️ CBO-CONCURRENT-TURNS (JVP, 2026-08-03: "there were like two flows running…
+// two agents. One had opened the map and it was going through the map but then
+// it started responding again like 'Oh I will show you the examples'").
+//
+// Nothing stopped a second /chat starting while the first was still streaming.
+// His server log showed two `Turn for <same cboId>` beginning 17s apart, and
+// because pushEventRegistry holds a SINGLE pusher per session, the later turn
+// silently hijacked the earlier one's event stream — one agent's map opened
+// while the other's prose kept arriving into the same transcript.
+//
+// The window is easy to hit: the UI disables its input while streaming, but a
+// persisted composer's chips re-render on load and any reload or second tab
+// re-arms them. So the guard has to be server-side, which is what this asserts.
+
+test.describe('CBO — one turn at a time per session', () => {
+  test('a second turn while one is streaming is refused, not run', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // A turn slow enough to overlap — the real one that let JVP in ran 76s.
+    await api.scriptCbo(cboId, [
+      [{ op: 'wait', ms: 3_000 } as any, { op: 'say', text: 'Primeira resposta.' }],
+      [{ op: 'say', text: 'Segunda resposta.' }],
+    ]);
+
+    // Fire both without awaiting the first — exactly the impatient re-tap.
+    const first = request.post(`/api/cbo/${cboId}/chat`, {
+      data: { message: 'oi', lang: 'pt' },
+    });
+    await new Promise(r => setTimeout(r, 600));
+    const second = await request.post(`/api/cbo/${cboId}/chat`, {
+      data: { message: 'oi de novo', lang: 'pt' },
+    });
+
+    // The second is refused cleanly — a JSON 409, not a half-open SSE stream.
+    expect(second.status(), 'a concurrent turn must be refused').toBe(409);
+    expect((await second.json()).error).toBe('turn_in_flight');
+
+    // …and the first is unharmed.
+    const firstRes = await first;
+    expect(firstRes.status()).toBe(200);
+    expect(await firstRes.text()).toContain('Primeira resposta');
+
+    // The refused turn left NOTHING behind: no orphan user message, no second
+    // agent reply. A double-answered question is the whole failure mode.
+    const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+    const texts = (body.messages ?? []).map((m: any) => String(m.content ?? ''));
+    expect(texts.filter((c: string) => c.includes('oi de novo'))).toHaveLength(0);
+    expect(texts.filter((c: string) => c.includes('Segunda resposta'))).toHaveLength(0);
+  });
+
+  test('the lock releases — the next turn runs normally', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [
+      [{ op: 'say', text: 'Um.' }],
+      [{ op: 'say', text: 'Dois.' }],
+    ]);
+
+    // A lock that never released would be far worse than the bug it fixes:
+    // the session would be permanently unable to answer.
+    const a = await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'a', lang: 'pt' } });
+    expect(a.status()).toBe(200);
+    const b = await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'b', lang: 'pt' } });
+    expect(b.status(), 'the lock must release after a turn completes').toBe(200);
+    expect(await b.text()).toContain('Dois');
+  });
+});

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -9,6 +9,8 @@ import {
   debouncedPersist,
   advanceCboPhase,
   loadCboFromDb,
+  beginTurn,
+  endTurn,
   getFlushedMessageCount,
   hasPendingFlush,
 } from "../services/cboAgent";
@@ -202,7 +204,17 @@ export function registerCboRoutes(app: Express): void {
       }
     }
 
-    await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang, turnKind);
+    // One turn at a time — see CBO-CONCURRENT-TURNS in cboAgent.ts. Checked
+    // BEFORE streamCboChat writes any SSE headers, so a rejected second turn is
+    // a clean JSON 409 the client can handle rather than a half-open stream.
+    if (!beginTurn(req.params.id)) {
+      return res.status(409).json({ error: 'turn_in_flight' });
+    }
+    try {
+      await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang, turnKind);
+    } finally {
+      endTurn(req.params.id);
+    }
     debouncedPersist(req.params.id);
   });
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -261,6 +261,54 @@ export function hasPendingFlush(id: string): boolean {
 type EventPusher = (event: CboEvent) => void;
 const pushEventRegistry = new Map<string, EventPusher>();
 
+// ── One turn at a time, per session ─────────────────────────────────────────
+// ⚠️ CBO-CONCURRENT-TURNS (JVP, 2026-08-03: "there were like two flows running…
+// two agents. One had opened the map and it was going through the map but then
+// it started responding again like 'Oh I will show you the examples'").
+//
+// Nothing stopped a second /chat from starting while the first was still
+// streaming. His server log shows it plainly — two `Turn for <same cboId>`
+// beginning 17s apart, the first finishing later:
+//
+//   [cbo] Turn for 7d0b… (phase 2, model claude-sonnet-4-6, 1/7 sections)
+//   [cbo] Turn for 7d0b… (phase 2, model claude-haiku-4-5, 1/7 sections)
+//   [cbo] timing … model=claude-sonnet-4-6 rounds=3 … total=16816ms
+//
+// Both then wrote into one transcript, and because `pushEventRegistry` holds a
+// SINGLE pusher per session, the later turn silently hijacked the earlier one's
+// event stream — so one agent's map opened while the other's prose kept
+// arriving. A 76-second turn (rounds=9, first_event=62557ms) in the same log
+// shows how wide the window gets.
+//
+// The window is easy to hit: the client disables its input while streaming, but
+// a persisted composer's chips re-render on load, and any reload or second tab
+// re-arms them. So this has to be enforced server-side, not by the UI.
+//
+// Rejecting is right rather than queueing: the second message is almost always
+// an impatient re-tap of a question the in-flight turn is already answering, and
+// running it would double-answer. The client surfaces a gentle "ainda estou
+// respondendo" instead of a failure.
+const activeTurns = new Map<string, number>();
+
+/** Safety valve: a turn whose finally-block never ran must not lock a session
+ *  forever. Longer than any real turn (the slowest observed was 77s). */
+const TURN_LOCK_MAX_MS = 5 * 60 * 1000;
+
+/** Claim the turn slot for a session. False = one is already in flight. */
+export function beginTurn(cboId: string): boolean {
+  const startedAt = activeTurns.get(cboId);
+  if (startedAt != null && Date.now() - startedAt < TURN_LOCK_MAX_MS) return false;
+  if (startedAt != null) {
+    console.warn(`[cbo] turn lock for ${cboId} exceeded ${TURN_LOCK_MAX_MS}ms — force-releasing`);
+  }
+  activeTurns.set(cboId, Date.now());
+  return true;
+}
+
+export function endTurn(cboId: string): void {
+  activeTurns.delete(cboId);
+}
+
 function setActivePushEvent(id: string, pusher: EventPusher) { pushEventRegistry.set(id, pusher); }
 
 // Session language per CBO, refreshed on every turn. The MCP server (and its


### PR DESCRIPTION
> "there were like two flows running… two agents. One had opened the map and it was going through the map but then it started responding again like 'Oh I will show you the examples'"

## Your log showed it outright

Two turns on the **same session id**, the second starting while the first was still running:

```
[cbo] Turn for 7d0b… (phase 2, model claude-sonnet-4-6, 1/7 sections)
[cbo] Turn for 7d0b… (phase 2, model claude-haiku-4-5, 1/7 sections)
[cbo] timing … model=claude-sonnet-4-6 rounds=3 … total=16816ms
```

Nothing stopped a second `/chat` starting mid-stream. And because `pushEventRegistry` holds a **single** pusher per session, the later turn silently **hijacked the earlier one's event stream** — which is why one agent's map opened while the other's prose kept arriving into the same transcript. A 76-second turn in the same log (`rounds=9, first_event=62557ms`) shows how wide the window gets.

The window can't be closed in the UI: the client disables its input while streaming, but a persisted composer's chips re-render on load, and any reload or second tab re-arms them. So the guard is server-side.

## Rejecting, not queueing

Deliberate. The second message is almost always an impatient re-tap of the question the in-flight turn is *already answering* — running it would double-answer.

The client gets a clean JSON **409**, checked *before* any SSE headers are written so it's never a half-open stream, and shows *"Só um segundo — ainda estou respondendo a anterior."* rather than a failure. The transcript is untouched; the first turn lands normally.

A lock that never released would be worse than the bug it fixes, so there's a 5-minute force-release (longer than any real turn — the slowest observed was 77s) and the release is in a `finally`.

## Verification

Tests assert **both halves**: a concurrent turn is refused *and leaves nothing behind* — no orphan user message, no second reply, because a double-answered question is the whole failure mode — and the lock releases so the next turn runs. **Verified to fail without the fix.**

Whole suite: **153 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy