### PR TITLE
test(w2): replace the 6s upload sleep with a real signal

### DIFF
--- a/e2e/w2-scenarios.spec.ts
+++ b/e2e/w2-scenarios.spec.ts
@@ -38,17 +38,53 @@ async function openSession(page: any, request: any) {
     await input.fill(text);
     await input.press('Enter');
   };
+  // Wait for the upload to LAND, rather than for a guessed number of seconds.
+  //
+  // The fixed 6s sleep here was the single most expensive line in the suite and
+  // a flake in both directions — too short under load, wasted when fast. It was
+  // also silently load-bearing: the `if (isVisible())` check after it had no
+  // wait of its own and only ever passed because the sleep had let the chip
+  // render.
+  //
+  // ⚠️ The obvious replacement is wrong, and measuring is the only way to see
+  // it. `setInputFiles` with N files triggers ONE CHAT TURN PER FILE, in
+  // sequence — `data-streaming` goes true→false once per upload. Instrumented
+  // with three photos:
+  //
+  //   11379:true 11395:false | 12852:true 12861:false
+  //   13686:true 13694:false | 14501:true 14510:false
+  //
+  // Four turns over ~3.1s. So a single `data-streaming=false` wait is satisfied
+  // 16ms in, by the FIRST turn, while three more are still coming — which is
+  // exactly why replacing the sleep with it broke org 1 and org 3. The 6s sleep
+  // only ever worked because 6 > 3.1.
+  //
+  // The correct signal is QUIESCENCE: every document has landed, and the stream
+  // has then been idle continuously for a settle window. That adapts to real
+  // speed instead of guessing at it.
+  const SETTLE_MS = 700;
   const upload = async (files: string[]) => {
+    const before = (await (await request.get(`/api/cbo/${cboId}/documents`)).json())?.documents?.length ?? 0;
     await page.locator('input[type="file"]').setInputFiles(files);
-    await page.waitForTimeout(6000); // extraction + the synthetic chat turn
-    // …and then wait for the turn to actually END. The sleep alone was load-
-    // sensitive: it was just sufficient at the old suite pace and started
-    // failing once the suite got faster and contention changed. While the
-    // transcript is still streaming it auto-scrolls, so every chip below is
-    // permanently "not stable" and Playwright waits out the whole test timeout
-    // on an element it can already see.
-    await expect(page.getByTestId('cbo-stream-status'))
-      .toHaveAttribute('data-streaming', 'false', { timeout: 60_000 });
+
+    // 1 · every file is extracted and stored
+    await expect
+      .poll(async () => {
+        const r = await request.get(`/api/cbo/${cboId}/documents`);
+        return r.ok() ? ((await r.json())?.documents?.length ?? 0) : 0;
+      }, { timeout: 60_000, intervals: [200, 300, 500] })
+      .toBeGreaterThanOrEqual(before + files.length);
+
+    // 2 · …and the per-file turns have stopped arriving
+    await expect
+      .poll(async () => page.evaluate(async (ms) => {
+        const el = document.querySelector('[data-testid="cbo-stream-status"]');
+        const idle = () => el?.getAttribute('data-streaming') === 'false';
+        if (!idle()) return false;
+        await new Promise(r => setTimeout(r, ms));
+        return idle();
+      }, SETTLE_MS), { timeout: 60_000, intervals: [300] })
+      .toBe(true);
   };
   return { cboId, page, request, chip, input, tap, type, upload };
 }


### PR DESCRIPTION
The fixed `waitForTimeout(6000)` in `w2-scenarios`' upload helper was the most expensive line in the suite, a flake in both directions, and **silently load-bearing** — the `if (isVisible())` check right after it had no wait of its own and only ever passed because the sleep had already let the chip render.

My first attempt to remove it broke org 1 and org 3, and I reverted rather than leave it half-done. Instrumenting the page explains why, and the answer isn't what either of us assumed.

## `setInputFiles` with N files is N chat turns

`data-streaming` goes `true→false` **once per file**. Measured with three photos:

```
11379:true  11395:false   ← a single "streaming false" wait returns HERE, 16ms in
12852:true  12861:false
13686:true  13694:false
14501:true  14510:false
```

Four turns over **~3.1 seconds**. So waiting for `data-streaming=false` is satisfied by the *first* turn while three more are still coming — the transcript keeps re-rendering and every chip below stays "not stable", which is how Playwright ended up waiting out full test timeouts on elements it could plainly see.

The 6s sleep only ever worked because 6 > 3.1.

## The fix

**Quiescence**: every document has landed, *and* the stream has then been idle continuously for 700ms. Adapts to real speed instead of guessing at it, and it's correct for any number of files.

## ⚠️ Also reverted, deliberately

On the way here I debounced the transcript's auto-scroll, on the theory that a burst of messages chained their smooth-scroll animations. Measured, it moved the number from **27 scroll events to 24** — the hypothesis was wrong, the animation was never the problem, and I'm not shipping a live UI change justified by a diagnosis that didn't hold up.

## Worth knowing separately

**Three photos costs four model turns.** That's a real product cost, not a test artifact — worth a look if uploads feel slow in the field.

Verified: full suite **157 passed, twice back to back**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy