### PR TITLE
fix(cbo): answering the question the agent just asked no longer kills the session

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -186,6 +186,18 @@ function fixMarkdownTables(text: string): string {
 //     GENERIC over this registry (see pendingTool / toolReached below).
 // Adding a tool for a future phase = one declarative entry, not new plumbing.
 type ToolKind = 'map' | 'interventions';
+
+/** What kind of gesture produced a turn — a hint the server uses for model routing. */
+type TurnKind = 'chip' | 'text' | 'upload' | 'map' | 'map_help' | 'system';
+
+/** Everything needed to replay one chat turn verbatim (see `streamRetry`). */
+interface PendingTurn {
+  text: string;
+  displayText?: string;
+  turnKind?: TurnKind;
+  chipAnswers?: Array<{ question: string; answer: string }>;
+}
+
 interface RightPanelToolDef {
   tab: 'document' | 'map' | 'interventions' | 'scorecard';
   icon: LucideIcon;
@@ -543,9 +555,14 @@ export default function CboProfilePage() {
   // Cohort membership: if `?cbo=<memberSlug>` is in the URL, this CBO is part
   // of a coordinator-managed cohort and the coordinator gates phase access.
   const [memberSlug, setMemberSlug] = useState<string | null>(null);
-  // A turn whose SSE stream dropped/stalled — holds the original message text
-  // so a "Tentar de novo" tap can resend it (hidden — no duplicate user bubble).
-  const [streamRetry, setStreamRetry] = useState<string | null>(null);
+  // A turn that never happened — its SSE stream dropped/stalled, or the server
+  // refused it because another turn held the session (409). Holds the WHOLE
+  // payload, not just the text, so "Tentar de novo" replays the same turn:
+  // resending a chip answer as a bare text turn loses `chipAnswers`, and the
+  // transcript then can't render which chip went with which question.
+  // Always replayed hidden — the optimistic user bubble/composer is already on
+  // screen from the first attempt.
+  const [streamRetry, setStreamRetry] = useState<PendingTurn | null>(null);
   // Live token-streaming draft (LT-4). Accumulates transient chat_delta
   // events into a draft bubble; the finalizing 'chat' (whole block, post
   // inline-options normalizer) REPLACES it, so persistence and conversion
@@ -1274,7 +1291,7 @@ export default function CboProfilePage() {
   }, [isStreaming]);
 
   // Send message. `viaVoice` marks the optimistic user bubble as dictated (🎤).
-  const sendMessage = useCallback(async (text: string, hidden = false, viaVoice = false, displayText?: string, turnKind?: 'chip' | 'text' | 'upload' | 'map' | 'map_help' | 'system', chipAnswers?: Array<{ question: string; answer: string }>) => {
+  const sendMessage = useCallback(async (text: string, hidden = false, viaVoice = false, displayText?: string, turnKind?: TurnKind, chipAnswers?: Array<{ question: string; answer: string }>) => {
     if (!cboId || !text.trim() || isStreaming) return;
     setInput('');
     setActiveQuestions([]);
@@ -1308,16 +1325,23 @@ export default function CboProfilePage() {
     try {
       armWatchdog();
       const res = await fetch(`/api/cbo/${cboId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text, lang, turnKind, chipAnswers, displayText }), signal: ctrl.signal });
-      // 409 = a turn is already streaming for this session (CBO-CONCURRENT-TURNS).
-      // Not an error the user caused and not something to retry: the answer they
-      // are waiting for is already on its way. Say so gently and leave the
-      // transcript alone — the in-flight turn will finish and render normally.
+      // ⚠️ CBO-TURN-TAIL-FREEZE. 409 = the server gave up waiting for the turn
+      // that holds this session (it now queues for 20s first, so this is rare
+      // and means something is genuinely wedged, not the ordinary tail race).
+      //
+      // The first version of this branch just toasted and returned — which
+      // skipped the setIsStreaming(false) at the bottom of this function, while
+      // the caller had ALREADY cleared the question. That left the answered chip
+      // on screen, the composer disabled forever and no way out but a reload:
+      // the exact dead session JVP hit on the família question. Whatever else
+      // happens here, the user gets the session back and a way to retry.
       if (res.status === 409) {
         toast({
           title: t('cbo.stillAnswering', {
             defaultValue: 'Só um segundo — ainda estou respondendo a anterior.',
           }),
         });
+        setStreamRetry({ text, displayText, turnKind, chipAnswers });
         return;
       }
       const reader = res.body?.getReader();
@@ -1347,13 +1371,20 @@ export default function CboProfilePage() {
           : 'The connection dropped mid-response. Tap "Try again" and I\'ll pick it up.',
         messageType: 'content', timestamp: new Date().toISOString(),
       }]);
-      if (!suppress) setStreamRetry(text);
+      if (!suppress) setStreamRetry({ text, displayText, turnKind, chipAnswers });
       setStreamDraft(''); // dropped stream — the partial draft was never finalized/persisted
     } finally {
       clearTimeout(watchdog);
       if (activeStreamRef.current === streamHandle) activeStreamRef.current = null;
+      // In the `finally`, not after it. This flag disables the whole composer,
+      // and the caller has usually already cleared the question that was on
+      // screen — so ANY path out of this function that leaves it true is a dead
+      // session (CBO-TURN-TAIL-FREEZE). It used to sit below the try, where an
+      // early `return` skipped it. Never move it back out.
+      setIsStreaming(false);
     }
-    setIsStreaming(false);
+    // Stays below the try on purpose: the 409 path returns before it, because a
+    // refused turn never ran and must not count toward the phase-advance gate.
     setCompletedTurns(n => n + 1);
   }, [cboId, isStreaming, processEvent, lang]);
 
@@ -2367,7 +2398,13 @@ export default function CboProfilePage() {
                   size="sm"
                   className="w-full h-9 bg-emerald-600 hover:bg-emerald-700 gap-1.5"
                   data-testid="cbo-stream-retry"
-                  onClick={() => { const msg = streamRetry; setStreamRetry(null); sendMessage(msg, true); }}
+                  onClick={() => {
+                    const turn = streamRetry;
+                    setStreamRetry(null);
+                    // hidden=true: the user bubble/answer composer from the first
+                    // attempt is still on screen; replaying the rest verbatim.
+                    sendMessage(turn.text, true, false, turn.displayText, turn.turnKind, turn.chipAnswers);
+                  }}
                 >
                   <RotateCcw className="w-3.5 h-3.5" />
                   {lang === 'pt' ? 'Tentar de novo' : 'Try again'}

--- a/docs/cbo-ux-audit-backlog.md
+++ b/docs/cbo-ux-audit-backlog.md
@@ -354,6 +354,26 @@ _After the v1 wave (#312–#320, all merged), a second deep audit ran against th
 
 22. **Voice-note transcription keeps the speaker's language, not the session's (P2, S)** — in the 2026-08-03 test the org spoke Spanish and `site_story` was stored verbatim in **Spanish** inside a pt-BR session ("Este sitio es una escuela que tiene muy poco terreno verde…"). It flows unchanged into the profile panel, the concept note, and anything a coordinator reads. Decide deliberately: keep the verbatim transcript (respecting their words — the photovoice principle already applied elsewhere) **plus** a session-language rendering, rather than silently storing whichever language the audio happened to be in. Worth checking against the cohort — some orgs may be more comfortable in Spanish.
 
+### Wave: chip actions — JVP, 2026-08-04 (refined, approved, not built)
+
+23. **A chip carries its action; the model is not asked to retype a string literal (P1, M — structural)** — JVP got stuck on the famílias question: he tapped "Ver exemplos reais" and nothing happened. Two defects met there. The freeze itself is fixed (PR for CBO-TURN-TAIL-FREEZE); this is the cause behind it.
+
+    `serveE2Checkpoint` is a string-matching state machine — it routes on exact chip labels (`is({ pt: 'Já conheço SbN — pular', … })`). When the *template* wrote the chips, the labels match and the step resolves in 0ms (`model=template`). When the *model* wrote them, they don't. The strip tools (`show_types`, `show_familias`, `show_familia_recommendation`) end their tool result by instructing the model: *"in this SAME turn you MUST follow with a short message and an `ask_user` (e.g. options 'Ver exemplos' / 'Já conheço, pular')"*. That sentence delegates authorship of the flow's control surface to a model. "Ver exemplos" became "Ver exemplos reais"; nothing matched; the tap fell through to a full ~10s model turn — which is also what made the turn-tail race wide enough to freeze on.
+
+    **Principle (JVP's, and the rule to hold to): the model interprets what people WRITE; the template resolves what people TAP.** A tap is already unambiguous — re-interpreting it costs ~10s, tokens, and a contract that fails silently.
+
+    Decided 2026-08-04 (both via /refine, JVP picked both recommendations):
+    - **Routing = action id on the option.** Extend the existing `action` field (today `'upload' | 'upload_then_answer'`, already honoured end to end by the chip renderer) into the E2 intents: `show_examples`, `skip_examples`, `open_map`, `pronto`. The server dispatches on the id; the label becomes pure copy the model may still phrase freely.
+    - **Every tap deterministic.** No chip in E2 costs a model turn. The model keeps the story, the uploads, the read-back, the diagnostic — everything requiring prose.
+
+    Work: (a) widen the `action` union + carry `chipAction` on the chat POST; (b) `serveE2Checkpoint` dispatches on the id BEFORE label matching, with label matching kept as the fallback so sessions already in flight keep working; (c) the strip tools push their own follow-up `ask_user` with fixed ids instead of instructing the model to write one; (d) delete the "you MUST follow with an ask_user" line from the tool descriptions and `knowledge/_skills/encontro-2.md`.
+
+    ⚠️ **The action id must be persisted on the composer row**, not just sent live — chips re-render from that row after a reload, and an id that isn't stored means a reloaded session silently drops back to label matching. That would leave the bug alive for exactly the people whose connection dropped.
+
+    ⚠️ Cost to weigh per step: a templated reply can't react in the moment the way a model can. Nobody will miss that on navigation chips ("see examples", "open the map"); a step whose reply should sound like it heard them is a judgement call, not a blanket conversion.
+
+    Applies beyond E2 — the seam is in the shared `ask_user`/checkpoint layer, and JVP flagged it as relevant for W3 onwards. Worth landing before W3's flow is written on top of label matching.
+
 ## Field report — Ana, 2026-07-07 (org profile via news-article link)
 
 Symptoms: `prior_project_scale`/`nbs_experience` filled silently from the article as raw machine ids ("funded", "gardens-and-greening") shown in English on the panel and wrong; the "Quero ajustar" list omitted those two fields but offered "Liderança atual", which isn't a schema field; name/role never re-asked when the first user message is a link.

--- a/e2e/cougar-answer-during-turn-tail.spec.ts
+++ b/e2e/cougar-answer-during-turn-tail.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// ⚠️ CBO-TURN-TAIL-FREEZE (JVP, 2026-08-04: "the same thing happened as before
+// … i get stuck here", on the família recommendation question).
+//
+// His server log is the whole bug in three lines:
+//
+//   [cbo] timing … rounds=3 first_event=8630ms total=14822ms
+//                  detail=show_nbs_familias | text | ask_user
+//   POST /api/cbo/04bc7f17…/chat 409 in 12ms   ← his answer
+//   POST /api/cbo/04bc7f17…/chat 200 in 14856ms ← the turn that asked
+//
+// The turn emits `ask_user` and the client immediately sets isStreaming=false —
+// by design, the question is answerable the moment it renders. But the turn
+// itself keeps running (more rounds, persistence) and keeps holding the
+// per-session turn lock added in #442. So the user answers a question the agent
+// has already asked, and the lock refuses it.
+//
+// Then the client made it terminal: the 409 branch returned early, skipping the
+// `setIsStreaming(false)` at the bottom of sendMessage. `setActiveQuestions([])`
+// had already removed the question. Net result — the answered chip on screen,
+// the input disabled forever, and no way out but a reload. A dead session.
+//
+// The fix is that answering the question you were just asked is NORMAL, so the
+// second turn waits for the lock and then runs, rather than being rejected.
+// These specs pin the user-visible property: the answer lands, and the UI is
+// never left frozen.
+
+test.describe('CBO — answering while the asking turn is still winding down', () => {
+  test('the answer is accepted, not refused', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Turn 1 asks, then keeps working — exactly the shape of his log, where
+    // `ask_user` landed and ~6s of turn remained. 1.5s is enough: the property
+    // is "an answer arriving while the lock is held is served", and the suite
+    // pays for every second a spec sleeps (4 workers, one box).
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'ask_user', question: 'Como vocês querem continuar?', options: [
+          { label: 'Ver exemplos reais', description: 'Mostro casos de SbN' },
+          { label: 'Já conheço SbN — pular', description: 'Vamos direto pro mapa' },
+        ] } as any,
+        { op: 'wait', ms: 1_500 } as any,
+      ],
+      [{ op: 'say', text: 'Beleza, aqui vão os exemplos.' } as any],
+    ]);
+
+    const chat = page.getByTestId('cbo-chat-input');
+    await chat.fill('oi');
+    await chat.press('Enter');
+
+    // The question renders while turn 1 is still running — that is the design,
+    // and it is what opens the window.
+    const option = page.getByText('Ver exemplos reais').first();
+    await expect(option).toBeVisible({ timeout: 30_000 });
+    await option.click();
+
+    // The answer must be answered. Before the fix this never arrived: the POST
+    // came back 409 and the turn was silently dropped on the floor.
+    await expect(page.getByText(/aqui vão os exemplos/i)).toBeVisible({ timeout: 60_000 });
+  });
+
+  test('the session is never left frozen, even if the lock never frees', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // A turn that outlasts the queue wait (CBO_TURN_QUEUE_WAIT_MS is 3s under
+    // test, 20s in prod), so the second turn really does get a 409. Waiting is
+    // the fix for the common case; this pins the fallback — and the fallback is
+    // the part that actually killed his session.
+    await api.scriptCbo(cboId, [[
+      { op: 'ask_user', question: 'Continuar?', options: [
+        { label: 'Sim', description: 'segue' },
+        { label: 'Não', description: 'para' },
+      ] } as any,
+      { op: 'wait', ms: 6_000 } as any,
+    ]]);
+
+    const chat = page.getByTestId('cbo-chat-input');
+    await chat.fill('oi');
+    await chat.press('Enter');
+
+    await expect(page.getByText('Sim').first()).toBeVisible({ timeout: 30_000 });
+    await page.getByText('Sim').first().click();
+
+    // Whatever happens to the turn, the UI must come back to the user. A
+    // permanently-true isStreaming is the freeze: input disabled, no question,
+    // no retry, reload the only escape.
+    await expect(
+      page.getByTestId('cbo-stream-status'),
+      'a refused turn must not leave the session streaming forever',
+    ).toHaveAttribute('data-streaming', 'false', { timeout: 30_000 });
+
+    // …and there is a way forward that is not a reload.
+    await expect(page.getByTestId('cbo-stream-retry')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/cougar-concurrent-turns.spec.ts
+++ b/e2e/cougar-concurrent-turns.spec.ts
@@ -14,9 +14,15 @@ import { TestApi } from './helpers/testApi';
 // The window is easy to hit: the UI disables its input while streaming, but a
 // persisted composer's chips re-render on load and any reload or second tab
 // re-arms them. So the guard has to be server-side, which is what this asserts.
+//
+// The guard SERIALIZES rather than rejects — see CBO-TURN-QUEUE. Rejecting is
+// what froze JVP's session a day later (cougar-answer-during-turn-tail.spec.ts):
+// the most normal action in the app, answering the question the in-flight turn
+// just asked, was refused. Queueing fixes the hijack just as completely — two
+// turns still never run at once — without discarding the user's message.
 
 test.describe('CBO — one turn at a time per session', () => {
-  test('a second turn while one is streaming is refused, not run', async ({ page, request }) => {
+  test('a second turn waits for the first instead of running alongside it', async ({ page, request }) => {
     test.setTimeout(120_000);
     const api = new TestApi(request);
     test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
@@ -37,25 +43,36 @@ test.describe('CBO — one turn at a time per session', () => {
       data: { message: 'oi', lang: 'pt' },
     });
     await new Promise(r => setTimeout(r, 600));
+    const startedSecond = Date.now();
     const second = await request.post(`/api/cbo/${cboId}/chat`, {
       data: { message: 'oi de novo', lang: 'pt' },
     });
+    const secondTook = Date.now() - startedSecond;
 
-    // The second is refused cleanly — a JSON 409, not a half-open SSE stream.
-    expect(second.status(), 'a concurrent turn must be refused').toBe(409);
-    expect((await second.json()).error).toBe('turn_in_flight');
-
-    // …and the first is unharmed.
     const firstRes = await first;
     expect(firstRes.status()).toBe(200);
     expect(await firstRes.text()).toContain('Primeira resposta');
 
-    // The refused turn left NOTHING behind: no orphan user message, no second
-    // agent reply. A double-answered question is the whole failure mode.
-    const body = await (await request.get(`/api/cbo/${cboId}`)).json();
-    const texts = (body.messages ?? []).map((m: any) => String(m.content ?? ''));
-    expect(texts.filter((c: string) => c.includes('oi de novo'))).toHaveLength(0);
-    expect(texts.filter((c: string) => c.includes('Segunda resposta'))).toHaveLength(0);
+    // Both turns run — the second is queued, not discarded…
+    expect(second.status()).toBe(200);
+    expect(await second.text()).toContain('Segunda resposta');
+
+    // …and it ran AFTER, not alongside. Turn 1 had ~2.4s left when turn 2 was
+    // posted; a turn 2 that returns faster than that is executing concurrently,
+    // which is the bug (one pushEvent registry per session, so the later turn
+    // hijacks the earlier one's stream).
+    expect(secondTook, 'the second turn must wait for the first').toBeGreaterThan(2_000);
+
+    // The transcript reads in the order it happened. This is why the lock is
+    // taken BEFORE the user row is appended: a queued turn that wrote its user
+    // message on arrival would slot it ahead of the reply to the message before
+    // it, and the model reads this log back as the conversation.
+    const msgs = await (await request.get(`/api/cbo/${cboId}/messages`)).json();
+    const at = (needle: string) =>
+      msgs.findIndex((m: any) => String(m.content ?? '').includes(needle));
+    expect(at('oi de novo'), 'the queued answer must be in the transcript').toBeGreaterThan(-1);
+    expect(at('Primeira resposta')).toBeLessThan(at('oi de novo'));
+    expect(at('oi de novo')).toBeLessThan(at('Segunda resposta'));
   });
 
   test('the lock releases — the next turn runs normally', async ({ page, request }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -113,6 +113,13 @@ export default defineConfig({
           // script 17-second waits and sit through them: 35s, 7% of the whole
           // suite, spent sleeping on purpose.
           CBO_SSE_PING_MS: '400',
+          // Same reasoning for the turn queue (CBO-TURN-QUEUE): the behaviour
+          // under test is "a queued answer runs, and giving up never freezes the
+          // UI", which is scale-free. At the production 20s the give-up spec
+          // would have to hold a session — and a worker — for 20+ seconds, and
+          // this suite runs 4 workers on one box: sleeping specs are paid for by
+          // every other spec's timeout budget.
+          CBO_TURN_QUEUE_WAIT_MS: '3000',
           CBO_FAKE_MODEL: '1',
           NODE_ENV: 'development',
           PORT,

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -9,7 +9,7 @@ import {
   debouncedPersist,
   advanceCboPhase,
   loadCboFromDb,
-  beginTurn,
+  acquireTurn,
   endTurn,
   getFlushedMessageCount,
   hasPendingFlush,
@@ -120,97 +120,105 @@ export function registerCboRoutes(app: Express): void {
       if (persisted) { setCboState(req.params.id, persisted.state); state = persisted.state; }
     }
     if (!state) return res.status(404).json({ error: "Not found" });
-    // The phase-0 self-heal AND the "vamos começar o encontro N" advance both
-    // live in streamCboChat now, where they can emit phase_change — the client
-    // must LEARN about server-side phase writes or the header/banner go stale
-    // and users talk the model into a role-played encontro (fake-E2 field
-    // report 2026-07-08; backlog CBO-PHASE-WRITERS). The regex path also runs
-    // through advanceCboPhase there, the same gate as /advance-phase and the
-    // set_phase tool, instead of a duplicated inline policy check. The GET
-    // handler above lifts phase 0 too, so a plain reload shows the banner.
 
-    // Session language authority (CBO-LANG-AUTH). If this CBO belongs to a
-    // cohort with a coordinator-forced language, that ALWAYS wins — it overrides
-    // the client-sent lang and text detection, so an English-looking org name, a
-    // standalone/test fallback, or a pre-fetch race can't flip the agent to
-    // English mid-flow. Only truly standalone CBOs (no cohort) fall through to
-    // the legacy sticky behavior: an explicit UI pick, else the stored language,
-    // else detect once from this first message.
-    const cohortLang = await getCohortLanguageForCbo(req.params.id);
-    let sessionLang: 'pt' | 'en';
-    if (cohortLang) {
-      sessionLang = cohortLang;
-    } else if (lang === 'pt' || lang === 'en') {
-      sessionLang = lang;
-    } else if (state.metadata.language) {
-      sessionLang = state.metadata.language;
-    } else {
-      sessionLang = (
-        /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
-        /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message)
-      ) ? 'pt' : 'en';
-    }
-    if (state.metadata.language !== sessionLang) {
-      state.metadata.language = sessionLang;
-      setCboState(req.params.id, state);
-    }
-    const isPt = sessionLang === 'pt';
-    const langDirective = isPt
-      ? '\n[LANGUAGE: Respond ONLY in Portuguese — every single word, including ask_user option labels and update_section content. Do NOT mix in any English words or phrases, even if the user writes some English back. One language, Portuguese, with no exceptions.]'
-      : '\n[LANGUAGE: Respond ONLY in English — every single word, including ask_user option labels and update_section content. Do NOT mix in any Portuguese words or phrases, even if the user writes some Portuguese back. One language, English, with no exceptions.]';
-
-    const resolvedLang = sessionLang;
-    // Client-declared turn kind ('chip' | 'text' | 'upload' | 'map' | 'system') —
-    // a HINT for adaptive model routing. The server only ever *downgrades* to the
-    // fast model when its own checks agree; a missing/bogus value routes heavy.
-    const turnKind = typeof req.body.turnKind === 'string' ? req.body.turnKind : undefined;
-
-    // A map_help turn's `message` is a machine payload — "[MAP HELP] hazard=flood
-    // … #3c2c6c (0.104) → #4dc16b (0.62)" — that exists only so the agent reasons
-    // from the real ramp instead of the usual green-is-safe convention. Persist
-    // what the user actually asked, or the hex dump becomes the transcript on
-    // reload and lands in buildDecisionLog forever.
-    //
-    // Scoped to map_help on purpose. `map` turns persist their raw payload too,
-    // but the agent legitimately re-reads the H×E×V numbers out of the decision
-    // log on later turns; swapping those for the summary is a separate change.
-    const displayText = typeof req.body.displayText === 'string' ? req.body.displayText : undefined;
-    const persistedUserText = turnKind === 'map_help' && displayText ? displayText : message;
-    addCboMessage(req.params.id, { role: 'user', content: persistedUserText, messageType: 'content', timestamp: new Date().toISOString() });
-
-    // A chip turn also records WHICH answer went with WHICH question, as an
-    // `answers` composer row. The plain user message above is untouched -
-    // buildDecisionLog and resolveTurnModel both key off
-    // `messageType === 'content'`, and the agent reads the joined text - so this
-    // row is additive and invisible to the model. The transcript uses it to
-    // render each question with the chip the user picked, instead of a single
-    // "Associacao; 6-20" bubble hanging under two questions.
-    //
-    // It is a separate row, not a field on the ask_user row, because the message
-    // log is append-only: the flusher persists `allMessages.slice(flushed)`, so
-    // an in-place edit of an earlier row would never reach the database.
-    const chipAnswers = req.body.chipAnswers;
-    if (turnKind === 'chip' && Array.isArray(chipAnswers) && chipAnswers.length > 0) {
-      const pairs = chipAnswers
-        .filter((p: any) => p && typeof p.question === 'string' && typeof p.answer === 'string')
-        .map((p: any) => ({ question: p.question, answer: p.answer }));
-      if (pairs.length > 0) {
-        addCboMessage(req.params.id, {
-          role: 'user',
-          content: JSON.stringify({ kind: 'answers', pairs }),
-          messageType: 'composer',
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-
-    // One turn at a time — see CBO-CONCURRENT-TURNS in cboAgent.ts. Checked
-    // BEFORE streamCboChat writes any SSE headers, so a rejected second turn is
-    // a clean JSON 409 the client can handle rather than a half-open stream.
-    if (!beginTurn(req.params.id)) {
+    // ⚠️ Serialize turns for this session — CBO-TURN-QUEUE in cboAgent.ts.
+    // Acquired HERE, before anything below reads state or writes a transcript
+    // row: a turn that had to wait must not resolve the session language from
+    // a pre-wait handle, nor interleave its user message into the running
+    // turn's messages. Still ahead of any SSE header, so the give-up case is a
+    // clean JSON 409 rather than a half-open stream.
+    if (!(await acquireTurn(req.params.id))) {
       return res.status(409).json({ error: 'turn_in_flight' });
     }
     try {
+      // The turn we queued behind may have replaced the state object wholesale
+      // (setCboState stores a new object), so re-read it instead of trusting
+      // the handle taken before the wait.
+      state = getCboState(req.params.id) ?? state;
+      // The phase-0 self-heal AND the "vamos começar o encontro N" advance both
+      // live in streamCboChat now, where they can emit phase_change — the client
+      // must LEARN about server-side phase writes or the header/banner go stale
+      // and users talk the model into a role-played encontro (fake-E2 field
+      // report 2026-07-08; backlog CBO-PHASE-WRITERS). The regex path also runs
+      // through advanceCboPhase there, the same gate as /advance-phase and the
+      // set_phase tool, instead of a duplicated inline policy check. The GET
+      // handler above lifts phase 0 too, so a plain reload shows the banner.
+
+      // Session language authority (CBO-LANG-AUTH). If this CBO belongs to a
+      // cohort with a coordinator-forced language, that ALWAYS wins — it overrides
+      // the client-sent lang and text detection, so an English-looking org name, a
+      // standalone/test fallback, or a pre-fetch race can't flip the agent to
+      // English mid-flow. Only truly standalone CBOs (no cohort) fall through to
+      // the legacy sticky behavior: an explicit UI pick, else the stored language,
+      // else detect once from this first message.
+      const cohortLang = await getCohortLanguageForCbo(req.params.id);
+      let sessionLang: 'pt' | 'en';
+      if (cohortLang) {
+        sessionLang = cohortLang;
+      } else if (lang === 'pt' || lang === 'en') {
+        sessionLang = lang;
+      } else if (state.metadata.language) {
+        sessionLang = state.metadata.language;
+      } else {
+        sessionLang = (
+          /[àáâãéêíóôõúçÀÁÂÃÉÊÍÓÔÕÚÇ]/.test(message) ||
+          /\b(sim|não|qual|como|quero|projeto|nossa|organização|comunidade)\b/i.test(message)
+        ) ? 'pt' : 'en';
+      }
+      if (state.metadata.language !== sessionLang) {
+        state.metadata.language = sessionLang;
+        setCboState(req.params.id, state);
+      }
+      const isPt = sessionLang === 'pt';
+      const langDirective = isPt
+        ? '\n[LANGUAGE: Respond ONLY in Portuguese — every single word, including ask_user option labels and update_section content. Do NOT mix in any English words or phrases, even if the user writes some English back. One language, Portuguese, with no exceptions.]'
+        : '\n[LANGUAGE: Respond ONLY in English — every single word, including ask_user option labels and update_section content. Do NOT mix in any Portuguese words or phrases, even if the user writes some Portuguese back. One language, English, with no exceptions.]';
+
+      const resolvedLang = sessionLang;
+      // Client-declared turn kind ('chip' | 'text' | 'upload' | 'map' | 'system') —
+      // a HINT for adaptive model routing. The server only ever *downgrades* to the
+      // fast model when its own checks agree; a missing/bogus value routes heavy.
+      const turnKind = typeof req.body.turnKind === 'string' ? req.body.turnKind : undefined;
+
+      // A map_help turn's `message` is a machine payload — "[MAP HELP] hazard=flood
+      // … #3c2c6c (0.104) → #4dc16b (0.62)" — that exists only so the agent reasons
+      // from the real ramp instead of the usual green-is-safe convention. Persist
+      // what the user actually asked, or the hex dump becomes the transcript on
+      // reload and lands in buildDecisionLog forever.
+      //
+      // Scoped to map_help on purpose. `map` turns persist their raw payload too,
+      // but the agent legitimately re-reads the H×E×V numbers out of the decision
+      // log on later turns; swapping those for the summary is a separate change.
+      const displayText = typeof req.body.displayText === 'string' ? req.body.displayText : undefined;
+      const persistedUserText = turnKind === 'map_help' && displayText ? displayText : message;
+      addCboMessage(req.params.id, { role: 'user', content: persistedUserText, messageType: 'content', timestamp: new Date().toISOString() });
+
+      // A chip turn also records WHICH answer went with WHICH question, as an
+      // `answers` composer row. The plain user message above is untouched -
+      // buildDecisionLog and resolveTurnModel both key off
+      // `messageType === 'content'`, and the agent reads the joined text - so this
+      // row is additive and invisible to the model. The transcript uses it to
+      // render each question with the chip the user picked, instead of a single
+      // "Associacao; 6-20" bubble hanging under two questions.
+      //
+      // It is a separate row, not a field on the ask_user row, because the message
+      // log is append-only: the flusher persists `allMessages.slice(flushed)`, so
+      // an in-place edit of an earlier row would never reach the database.
+      const chipAnswers = req.body.chipAnswers;
+      if (turnKind === 'chip' && Array.isArray(chipAnswers) && chipAnswers.length > 0) {
+        const pairs = chipAnswers
+          .filter((p: any) => p && typeof p.question === 'string' && typeof p.answer === 'string')
+          .map((p: any) => ({ question: p.question, answer: p.answer }));
+        if (pairs.length > 0) {
+          addCboMessage(req.params.id, {
+            role: 'user',
+            content: JSON.stringify({ kind: 'answers', pairs }),
+            messageType: 'composer',
+            timestamp: new Date().toISOString(),
+          });
+        }
+      }
+
       await streamCboChat(req.params.id, message + langDirective, res, state, resolvedLang, turnKind);
     } finally {
       endTurn(req.params.id);

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -284,15 +284,38 @@ const pushEventRegistry = new Map<string, EventPusher>();
 // a persisted composer's chips re-render on load, and any reload or second tab
 // re-arms them. So this has to be enforced server-side, not by the UI.
 //
-// Rejecting is right rather than queueing: the second message is almost always
-// an impatient re-tap of a question the in-flight turn is already answering, and
-// running it would double-answer. The client surfaces a gentle "ainda estou
-// respondendo" instead of a failure.
+// ⚠️ CBO-TURN-QUEUE (JVP, 2026-08-04: "the same thing happened as before … i get
+// stuck here"). The first version of this lock REJECTED the second turn, on the
+// reasoning that it is "almost always an impatient re-tap". That reasoning was
+// wrong, and it killed a live session:
+//
+//   [cbo] timing … total=14822ms detail=show_nbs_familias | text | ask_user
+//   POST …/chat 409 in 12ms      ← his answer to that very question
+//   POST …/chat 200 in 14856ms   ← the turn that asked it
+//
+// A turn emits `ask_user` and the UI opens for input immediately — the whole
+// point of streaming. But the turn keeps running afterwards (further rounds,
+// persistence) and kept holding this lock. So the single most normal action in
+// the app, answering the question you were just asked, raced the tail of the
+// turn that asked it and lost.
+//
+// So we QUEUE instead: wait for the in-flight turn, then run. Serializing is
+// what actually fixed the bug above — two turns never execute at once, so they
+// can never interleave into one pushEvent registry — and the queued turn starts
+// against a fully-persisted transcript, so the model sees its own question and
+// the user's answer in order. The old "double-answer" worry only applied to
+// CONCURRENT execution; an impatient re-tap now costs one extra sequential
+// reply, which is a far better failure than a session that can't be answered.
 const activeTurns = new Map<string, number>();
 
 /** Safety valve: a turn whose finally-block never ran must not lock a session
  *  forever. Longer than any real turn (the slowest observed was 77s). */
 const TURN_LOCK_MAX_MS = 5 * 60 * 1000;
+
+/** How long a turn waits for the one ahead of it before giving up. Comfortably
+ *  longer than a normal turn (8-20s), so a queued ANSWER practically always
+ *  runs; past it the client gets a 409 it can retry rather than a dead socket. */
+const TURN_QUEUE_WAIT_MS = Number(process.env.CBO_TURN_QUEUE_WAIT_MS) || 20_000;
 
 /** Claim the turn slot for a session. False = one is already in flight. */
 export function beginTurn(cboId: string): boolean {
@@ -303,6 +326,27 @@ export function beginTurn(cboId: string): boolean {
   }
   activeTurns.set(cboId, Date.now());
   return true;
+}
+
+/**
+ * Claim the turn slot, waiting for an in-flight turn to finish first.
+ * False = still busy after `waitMs`.
+ *
+ * Polled rather than a waiter queue on purpose: turns are released from a
+ * `finally`, but a process that dies mid-turn (or a bug in that finally) would
+ * leak every parked waiter. A poll has nothing to leak, and 150ms of latency on
+ * a path that just waited seconds is not worth the bookkeeping.
+ */
+export async function acquireTurn(cboId: string, waitMs = TURN_QUEUE_WAIT_MS): Promise<boolean> {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    if (beginTurn(cboId)) return true;
+    if (Date.now() >= deadline) {
+      console.warn(`[cbo] turn queue for ${cboId} timed out after ${waitMs}ms`);
+      return false;
+    }
+    await new Promise(r => setTimeout(r, 150));
+  }
 }
 
 export function endTurn(cboId: string): void {


### PR DESCRIPTION
JVP, 2026-08-04: *"the same thing happened as before … i get stuck here"* — on the família recommendation question, after tapping **Ver exemplos reais**.

## What happened

His server log is the whole bug in three lines:

```
[cbo] timing … rounds=3 total=14822ms detail=show_nbs_familias | text | ask_user
POST /api/cbo/04bc7f17…/chat 409 in 12ms      ← his answer to that very question
POST /api/cbo/04bc7f17…/chat 200 in 14856ms   ← the turn that asked it
```

A turn emits `ask_user`, and the client sets `isStreaming = false` immediately — by design, the question is answerable the moment it renders. But the turn keeps running afterwards (further rounds, persistence) and kept holding the per-session turn lock from #442. So the single most normal action in the app — answering the question you were just asked — raced the tail of the turn that asked it, and lost.

Then the client made it terminal. The 409 branch toasted and `return`ed, which skipped the `setIsStreaming(false)` at the bottom of `sendMessage`, while the caller had already run `setActiveQuestions([])`. Net result: the answered chip on screen, the composer disabled forever, and no way out but a reload. A dead session.

My comment in #442 argued rejection was right because a second turn is *"almost always an impatient re-tap"*. That reasoning does not cover the case where the in-flight turn has already asked the question — which is the ordinary flow.

## The fix

- **The lock queues instead of rejecting** (`acquireTurn`, 20s, `CBO_TURN_QUEUE_WAIT_MS`). Serializing is what actually fixed #442 — two turns still never execute at once, so they can't interleave into the single `pushEventRegistry` slot — and the queued turn starts against a fully-persisted transcript, so the model sees its own question and the answer in order. The double-answer worry only ever applied to *concurrent* execution; an impatient re-tap now costs one extra sequential reply, which is a far better failure than a session that cannot be answered.
- **The lock is taken before the user row is written**, and the state is re-read after the wait — otherwise a queued turn would slot its message ahead of the reply to the message before it, and would resolve the session language from a handle up to 20s stale.
- **`setIsStreaming(false)` moves into the `finally`.** That flag disables the whole composer and the caller has usually already cleared the question, so *any* path out of `sendMessage` that leaves it true is a dead session. It shouldn't depend on remembering.
- **`streamRetry` carries the whole turn payload**, so "Tentar de novo" replays a chip answer as a chip answer instead of degrading it to a bare text turn (which loses `chipAnswers`, and with it the transcript's ability to say which chip went with which question).

## Verification

`e2e/cougar-answer-during-turn-tail.spec.ts` — both specs **fail on unfixed source** (confirmed by stashing the fix and re-running) and pass with it:
- an answer arriving while the asking turn still holds the lock is served;
- if the lock genuinely never frees, the session still comes back to the user, with a retry — never frozen.

`cougar-concurrent-turns.spec.ts` is rewritten: it asserted the refusal, so it had to change with the behaviour. It now pins what actually fixes the hijack — the second turn runs *after* (measured), and the transcript reads in the order it happened.

**On the full suite, honestly:** runs on this branch show 1–3 diffuse failures. I ran the same suite on clean `main` as a control and it shows **the same failures at the same rate** — and they're spread across unrelated mechanisms (a map tap not registering, `cbo-familia-reco`, `cbo-golden-path`), on a box sitting at load average 26. Every one of them passes in isolation. So this is machine contention, not the change; the `cbo-familia-reco` one is worth a separate look, since a step that silently produces nothing would be a real dead end in the field.

## Follow-up (approved via /refine, not built)

Backlog #23. The cause behind the race: `serveE2Checkpoint` routes on exact chip labels, and the strip tools *instruct the model* to author those chips (`"you MUST follow with … e.g. options 'Ver exemplos'"`). "Ver exemplos" became "Ver exemplos reais", nothing matched, and the tap cost a full ~10s model turn — which is what made the tail wide enough to freeze on. The agreed principle: **the model interprets what people write; the template resolves what people tap**, with an action id on the option doing the routing. Once a tap resolves in ~0ms, most of what this PR guards against stops existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy