### PR TITLE
fix(maps): the city boundary was a lid over every bairro — nothing but a bairro takes a click now

### DIFF
--- a/client/src/core/components/maps/MapMicroapp.tsx
+++ b/client/src/core/components/maps/MapMicroapp.tsx
@@ -565,6 +565,21 @@ export default function MapMicroapp({
               fillOpacity: 0.02,
               dashArray: '6 3',
             },
+            // ⚠️ MAP-BOUNDARY-EATS-CLICKS (JVP, 2026-08-04: "I cant click here on
+            // neighborhood… cant select"). Leaflet paths are interactive by
+            // DEFAULT, and this one is a filled polygon covering the entire
+            // municipality — so it is a city-sized click target sitting in the
+            // same SVG pane as the 94 bairros. Whichever of the two async fetches
+            // resolves LAST paints on top: locally the 2.5MB zones file lands
+            // after this one and the bairros win, so the bug is invisible here;
+            // with a warm cache (JVP's browser) this lands last and swallows
+            // every tap. His console proved it — `elementsFromPoint` at the tap
+            // returned `path.leaflet-interactive > path.leaflet-interactive`,
+            // this outline on top of the bairro it hid.
+            //
+            // It is decoration. It must never take a click, and then the race
+            // stops mattering rather than being one we have to win.
+            interactive: false,
           }).addTo(mapRef.current!);
           // Keep the outline, but don't let it drive the view on the bairro
           // step: the municipal boundary runs far south past Lami, so fitting
@@ -1530,9 +1545,15 @@ export default function MapMicroapp({
         if (polygonPreviewRef.current)
           map.removeLayer(polygonPreviewRef.current);
         if (polygonPointsRef.current.length >= 2) {
+          // interactive:false throughout the draw path — same family as
+          // MAP-BOUNDARY-EATS-CLICKS. Every shape here is FEEDBACK about what the
+          // user is drawing, and the drawing itself is driven by taps on the map.
+          // Left interactive, the preview line and the vertex dots sit exactly
+          // where the next tap is likely to land and eat it, so the polygon
+          // silently stops growing.
           polygonPreviewRef.current = L.polyline(
             [...polygonPointsRef.current, polygonPointsRef.current[0]],
-            { color: '#8b5cf6', weight: 2, dashArray: '4 4' }
+            { color: '#8b5cf6', weight: 2, dashArray: '4 4', interactive: false }
           ).addTo(map);
         }
         const vm = L.circleMarker([lat, lng], {
@@ -1541,6 +1562,7 @@ export default function MapMicroapp({
           fillColor: '#fff',
           fillOpacity: 1,
           weight: 2,
+          interactive: false,
         });
         vm.addTo(map);
         customMarkersRef.current.push(vm);
@@ -1563,6 +1585,9 @@ export default function MapMicroapp({
         fillColor: '#8b5cf6',
         fillOpacity: 0.3,
         weight: 2,
+        // The drawn area is a RESULT, not a control — and a filled one, so left
+        // interactive it covers its own footprint and blocks re-drawing over it.
+        interactive: false,
       });
       poly.addTo(map);
       customMarkersRef.current.push(poly);

--- a/e2e/cougar-e2-bairro-selectable.spec.ts
+++ b/e2e/cougar-e2-bairro-selectable.spec.ts
@@ -103,6 +103,69 @@ test.describe('COUGAR — E2 Map 1 (e2_bairro)', () => {
     ).toBeEnabled();
   });
 
+  // ⚠️ MAP-BOUNDARY-EATS-CLICKS (JVP, 2026-08-04: "I cant click here on
+  // neighborhood… cant select", again, a day after the drift fix).
+  //
+  // The municipal boundary outline is a FILLED polygon covering all of Porto
+  // Alegre, in the same SVG pane as the 94 bairros — and Leaflet paths are
+  // interactive by default. So the map carried a city-sized click target lying
+  // over every bairro. Whichever of the two async fetches painted LAST won:
+  // locally the 2.5MB zones file lands after the small boundary file and the
+  // bairros end up on top, which is the only reason the suite was green. On
+  // JVP's browser it landed the other way and every tap died. His console:
+  //
+  //   stack: path.leaflet-interactive > path.leaflet-interactive > DIV.absolute
+  //
+  // The tap-with-drift test above could not catch this — it was passing on the
+  // lucky side of a race. So this asserts the PROPERTY instead: nothing but a
+  // bairro may be clickable here. That was false on both builds, mine included.
+  test('only the bairros are clickable — no decorative layer takes a tap', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    const zones = await (await request.get('/sample-data/porto-alegre-neighborhood-zones.json')).json();
+    const bairroCount = zones.geoJson.features.length;
+
+    await bootToBairroMap(page, api);
+    await finishTour(page);
+
+    const paths = await page.$$eval('.leaflet-overlay-pane path', ps =>
+      ps.map(p => ({
+        interactive: p.classList.contains('leaflet-interactive'),
+        dash: p.getAttribute('stroke-dasharray'),
+      })),
+    );
+    // The boundary IS still drawn — this is not "delete the outline".
+    expect(paths.length, 'the boundary outline must still be on the map')
+      .toBeGreaterThan(bairroCount);
+    expect(
+      paths.filter(p => p.interactive).length,
+      'exactly the bairros may take a click — anything else is a lid over the map',
+    ).toBe(bairroCount);
+
+    // And the thing a user actually does: at a point inside a bairro, that
+    // bairro's own path is what receives the tap — nothing sits above it.
+    const topIsOwnPath = await page.evaluate(() => {
+      const ps = Array.from(document.querySelectorAll('.leaflet-overlay-pane path')) as SVGPathElement[];
+      const big = ps
+        .map(p => ({ p, b: p.getBoundingClientRect() }))
+        .filter(x => x.b.width > 25 && x.b.height > 25)
+        .sort((a, b) => b.b.width * b.b.height - a.b.width * a.b.height);
+      let checked = 0, ok = 0;
+      for (const { p, b } of big.slice(0, 12)) {
+        const x = b.x + b.width / 2, y = b.y + b.height / 2;
+        if (document.elementFromPoint(x, y) !== p) continue; // bbox centre outside the shape
+        checked++;
+        const above = document.elementsFromPoint(x, y);
+        if (above[0] === p) ok++;
+      }
+      return { checked, ok };
+    });
+    expect(topIsOwnPath.checked, 'no bairro was big enough to probe').toBeGreaterThan(0);
+    expect(topIsOwnPath.ok, 'a bairro tap must reach the bairro').toBe(topIsOwnPath.checked);
+  });
+
   test('one legend, no dead stepper, no risk choropleth', async ({ page, request }) => {
     test.setTimeout(120_000);
     const api = new TestApi(request);


### PR DESCRIPTION
JVP, 2026-08-04: *"I cant click here on neighborhood… cant select, we had this you broke it again"* — a day after the pointer-drift fix, and a completely different cause.

## What it was

His console named it in one line:

```
paths: 95   pointer-events: (inherit)
CLICK at 872 560 target= path.leaflet-interactive
  stack: path.leaflet-interactive  >  path.leaflet-interactive  >  DIV.absolute.inset-0
```

Two interactive paths under the cursor. The upper one is the **Porto Alegre municipal boundary** — a filled polygon covering the entire city, added to the same SVG pane as the 94 bairros. Leaflet paths are interactive by default, so the map carried a city-sized click target lying over every neighbourhood.

95 paths, 94 bairros. The extra one was eating every tap.

## Why it reproduced for him and not for me

Both layers are async fetches, and whichever resolves **last** paints on top. Locally the 2.5MB zones file lands after the small boundary file, so the bairros end up on top and the bug is invisible. On his browser it landed the other way.

I had written a comment at that exact line about these two fetches racing — for the *framing* — and missed that the same race decides what receives clicks.

The boundary is decoration. `interactive: false`, and the race stops mattering rather than being one we have to keep winning.

Three more instances of the same defect in the same file, fixed alongside: the polygon draw preview, its vertex dots, and the finished drawn area were all interactive results sitting exactly where the next tap is likely to land — so drawing could silently stall when a tap hit one.

## The test, which is the real point here

`a tap WITH pointer drift still selects a bairro` **could not have caught this**. It was passing on the lucky side of a race, on a defect that was present in my build too. A test that clicks and asserts the outcome can't see a lid that happens to be underneath today.

So the new spec asserts the property rather than the outcome:
- the number of interactive paths must equal the number of bairros — anything else is a lid over the map;
- at a point inside a bairro, `elementsFromPoint` must return that bairro's own path first.

Verified both ways:

```
without the fix:  Error: exactly the bairros may take a click
                  Expected: 94   Received: 95
with the fix:     7 passed
```

Map-heavy specs (site card, linear journey, diagnostic): 13 passed.

## Separate, not in this PR

While measuring I found the bairro map renders the city at **half size**: Porto Alegre needs 568px of height at zoom 11, the panel offers 564, and because Leaflet snaps to whole zoom levels that 4px shortfall drops it to zoom 10. Measured at his window size: 95 polygons, **median 15px across, smallest tenth at 8px** (Apple's minimum touch target is 44px). That is mine, from the fit change in #432. It is not what blocked the click — he checked, zooming in didn't help — so it stays out of this PR and gets its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy