### PR TITLE
docs(arvc): record that these are vulnerability maps, not hazard maps

### DIFF
--- a/client/src/legacy/pages/site-explorer.tsx
+++ b/client/src/legacy/pages/site-explorer.tsx
@@ -43,6 +43,7 @@ import {
   arvcClass,
   arvcFeatureCollection,
   ARVC_DERIVED_NOTE,
+  ARVC_INTERPRETATION,
   ARVC_HAZARDS,
   type ArvcHazardId,
   type ArvcPayload,
@@ -1733,7 +1734,8 @@ export default function SiteExplorerPage() {
                 `<div style="font-size:11px;max-width:230px">` +
                   `<strong>${arvcClass(v)}</strong> — índice ${v.toFixed(2)}<br/>` +
                   `<span style="color:#888">${hazardMeta?.sourceTitle ?? ''}</span><br/>` +
-                  `<span style="color:#b45309">${ARVC_DERIVED_NOTE.en}</span>` +
+                  `<span style="color:#b45309">${ARVC_DERIVED_NOTE.en}</span><br/>` +
+                  `<span style="color:#6b7280">${ARVC_INTERPRETATION.en}</span>` +
                   `</div>`,
                 { sticky: true }
               );

--- a/docs/arvc-recovery.md
+++ b/docs/arvc-recovery.md
@@ -213,6 +213,53 @@ isolated how much of the gap is the 2050 horizon versus the different inputs.
 
 ---
 
+## What these layers actually measure — read before using them
+
+The ARVC composites are **not hazard maps**. They follow R = ∛(A × E × V), and in
+this dataset **exposure and vulnerability dominate the hazard term**.
+
+Two pieces of evidence, both from the published figures:
+
+**1. The landslide hazard map is flat.** Figura 21 (*Ameaça — Deslizamento*) is
+almost uniformly "Baixa" across the whole municipality; it does not resolve the
+morros. Figura 24 (*Risco — Deslizamento*) is nevertheless red across the entire
+built-up area, including the flat north where there are no slopes.
+
+**2. The six layers correlate at 0.83.**
+
+| | heat | flood | landslide | drought | arbovirus | storm |
+|---|---|---|---|---|---|---|
+| **heat** | 1.00 | 0.67 | 0.87 | 0.88 | 0.88 | 0.88 |
+| **flood** | 0.67 | 1.00 | 0.71 | 0.71 | 0.72 | 0.73 |
+| **landslide** | 0.87 | 0.71 | 1.00 | 0.89 | 0.88 | **0.94** |
+| **drought** | 0.88 | 0.71 | **0.89** | 1.00 | 0.89 | 0.89 |
+| **arbovirus** | 0.88 | 0.72 | 0.88 | 0.89 | 1.00 | 0.89 |
+| **storm** | 0.88 | 0.73 | **0.94** | 0.89 | 0.89 | 1.00 |
+
+Drought and landslide share no physical mechanism. Six unrelated hazards can only
+agree at 0.89 if what they mostly encode is the term they have in common.
+
+**There is still real per-hazard signal.** The landslide layer averages **0.583**
+inside SGB's 44 field-surveyed *deslizamento* sectors against **0.405** citywide,
+and is **not** elevated in flood sectors (0.405). Heat risk is also somewhat
+elevated there (0.485) because those are precarious hillside settlements — but
+landslide is elevated about 2.2× more than heat, which is genuine hazard-specific
+information. It is a minority of the variance, not noise.
+
+### Consequences
+
+- ✗ **Do not use ARVC landslide risk as a landslide susceptibility map.** For
+  terrain-driven landslide exposure, use the SGB layers already in the site
+  explorer — the field-surveyed Setorização de Risco and SGB's Suscetibilidade a
+  Movimento de Massa.
+- ✓ **Do use these for the question they answer:** which populated areas combine
+  a climate hazard with social vulnerability.
+- This also explains the ρ = +0.34 disagreement with our own `poa_heat_risk`
+  documented below: ours is hazard-led, theirs is vulnerability-led. They answer
+  different questions and neither is wrong.
+
+---
+
 ## Two bugs, and what they teach
 
 Both were caught by checks, not by looking at output that seemed fine.

--- a/shared/arvc.ts
+++ b/shared/arvc.ts
@@ -83,6 +83,46 @@ export const ARVC_DERIVED_NOTE = {
   pt: 'Reconstruído do mapa publicado em PDF — não é o dado oficial. Use para triagem, não para citação.',
 };
 
+/**
+ * ⚠️ HOW TO READ THESE LAYERS — they are not hazard maps.
+ *
+ * The ARVC composites follow the IPCC form R = ∛(Ameaça × Exposição ×
+ * Vulnerabilidade). In this dataset the exposure and vulnerability terms
+ * dominate, and the hazard term contributes comparatively little. Two pieces of
+ * evidence, both from the published figures themselves:
+ *
+ *  1. The landslide AMEAÇA map (Figura 21) is almost uniformly "Baixa" across
+ *     the whole municipality — it does not resolve the morros at all. The
+ *     landslide RISCO map (Figura 24) is nevertheless red across the entire
+ *     built-up area, including the flat north.
+ *
+ *  2. The six risk layers correlate with each other at a mean of 0.83
+ *     (landslide↔storm 0.94, drought↔landslide 0.89). Drought and landslide
+ *     share no physical mechanism. Six unrelated hazards can only agree that
+ *     strongly if what they mostly encode is the term they have in common.
+ *
+ * So read any ARVC risk layer as: "where vulnerable, exposed people are,
+ * modulated by a weaker hazard signal." There IS real per-hazard signal — the
+ * landslide layer averages 0.583 inside SGB's 44 field-surveyed deslizamento
+ * sectors against 0.405 citywide, and is not elevated in flood sectors — but it
+ * is a minority of the variance.
+ *
+ * ✗ Do NOT use ARVC landslide risk as a landslide susceptibility map. For
+ *   terrain-driven landslide exposure use the SGB layers already in the site
+ *   explorer: the field-surveyed Setorização de Risco, and SGB's
+ *   Suscetibilidade a Movimento de Massa.
+ * ✓ DO use these for the question they answer: which populated areas combine
+ *   climate hazard with social vulnerability.
+ *
+ * This also explains why ARVC heat risk and our own poa_heat_risk agree so
+ * poorly (Spearman ρ = +0.34): ours is hazard-led, theirs is vulnerability-led.
+ * They are answering different questions, and neither is wrong.
+ */
+export const ARVC_INTERPRETATION = {
+  en: 'ARVC risk = hazard × exposure × vulnerability, and exposure/vulnerability dominate. Read as "vulnerable populated areas", not as a hazard map. For landslide terrain use the SGB layers.',
+  pt: 'Risco ARVC = ameaça × exposição × vulnerabilidade, com exposição/vulnerabilidade dominando. Leia como "áreas povoadas vulneráveis", não como mapa de ameaça. Para terreno de deslizamento use as camadas do SGB.',
+};
+
 /** Cells absent from a hazard were masked at source. Absence ≠ safety. */
 export const ARVC_COVERAGE_NOTE = {
   en: 'The ARVC masks water, parks and áreas verdes out of its own index. A blank cell was excluded at source — it is not "low risk".',


### PR DESCRIPTION
Raised from the viewer: **the ARVC landslide risk layer covers the flat north of the city**, which is not where Porto Alegre has landslides.

The extraction is faithful — the published figure really does look like that. The problem is that the layer was being read as something it isn't.

## Evidence

**1. The ARVC's own landslide *hazard* map is flat.** Figura 21 (*Ameaça — Deslizamento*) is almost uniformly "Baixa" across the whole municipality — it does not resolve the morros at all. Yet Figura 24 (*Risco*) is red across the entire built-up area, including the flat north.

**2. The six risk layers correlate at 0.83 mean.**

| | heat | flood | landslide | drought | arbovirus | storm |
|---|---|---|---|---|---|---|
| **heat** | 1.00 | 0.67 | 0.87 | 0.88 | 0.88 | 0.88 |
| **flood** | 0.67 | 1.00 | 0.71 | 0.71 | 0.72 | 0.73 |
| **landslide** | 0.87 | 0.71 | 1.00 | 0.89 | 0.88 | **0.94** |
| **drought** | 0.88 | 0.71 | **0.89** | 1.00 | 0.89 | 0.89 |
| **arbovirus** | 0.88 | 0.72 | 0.88 | 0.89 | 1.00 | 0.89 |
| **storm** | 0.88 | 0.73 | **0.94** | 0.89 | 0.89 | 1.00 |

Drought and landslide share no physical mechanism. Six unrelated hazards can only agree at 0.89 if what they mostly encode is the term they have in common — E × V.

## But there IS real per-hazard signal

| ARVC landslide risk | mean |
|---|---|
| citywide | 0.405 |
| inside SGB's 44 surveyed **deslizamento** sectors | **0.583** |
| inside SGB **inundação** sectors | 0.405 |

Heat risk is also somewhat elevated in those sectors (0.485) — they're precarious hillside settlements — but landslide is elevated ~2.2× more. It's a minority of the variance, not noise.

## What changes

No data changes. The guidance now travels with the data — `shared/arvc.ts`, `docs/arvc-recovery.md`, and the hover tooltip:

- ✗ **Do not use ARVC landslide risk as a landslide susceptibility map.** For terrain, use the SGB layers already in the site explorer — the field-surveyed Setorização de Risco and Suscetibilidade a Movimento de Massa.
- ✓ **Do use it for what it answers:** which populated areas combine a climate hazard with social vulnerability.

This also explains the ρ = +0.34 disagreement with our own `poa_heat_risk` already documented in #448: ours is hazard-led, theirs is vulnerability-led. Different questions, neither wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWutNw34isJNf1eefXLDvU