### PR TITLE
fix(arvc): our own risk layers are E×V-dominated too — corrects a claim now on main

### DIFF
--- a/docs/arvc-recovery.md
+++ b/docs/arvc-recovery.md
@@ -254,9 +254,32 @@ information. It is a minority of the variance, not noise.
   Movimento de Massa.
 - ✓ **Do use these for the question they answer:** which populated areas combine
   a climate hazard with social vulnerability.
-- This also explains the ρ = +0.34 disagreement with our own `poa_heat_risk`
-  documented below: ours is hazard-led, theirs is vulnerability-led. They answer
-  different questions and neither is wrong.
+### ⚠️ Our own layers have the same property
+
+Running the identical correlation test on our own composites:
+
+| | flood | heat | landslide |
+|---|---|---|---|
+| **flood** | 1.00 | **0.85** | – |
+| **heat** | 0.85 | 1.00 | **0.80** |
+| **landslide** | – | 0.80 | 1.00 |
+
+Mean off-diagonal **0.82**, against the ARVC's 0.83. Flood and heat share no
+physical mechanism either. This is the bairro-constant problem already recorded
+in `shared/site-knowledge.ts`: two of the three factors in every one of our risk
+scores are bairro constants shared across all hazards, so all three composites
+are largely the same E×V surface.
+
+*Caveat:* the landslide value tiles returned far fewer sampled cells than heat
+(1,121 vs 28,932), so its pairs rest on a smaller common set, and flood↔landslide
+had too few shared cells to compute.
+
+**This corrects an earlier statement in this document.** The ρ = +0.34
+disagreement between ARVC heat risk and our `poa_heat_risk` was explained as
+"ours is hazard-led, theirs is vulnerability-led". That is wrong. **Both are
+vulnerability-led.** They disagree because they use different vulnerability
+inputs, spatial units and vintages — not because one of them is about hazard.
+The criticism levelled at the ARVC above applies to our own layers equally.
 
 ---
 

--- a/shared/arvc.ts
+++ b/shared/arvc.ts
@@ -114,9 +114,21 @@ export const ARVC_DERIVED_NOTE = {
  * ✓ DO use these for the question they answer: which populated areas combine
  *   climate hazard with social vulnerability.
  *
- * This also explains why ARVC heat risk and our own poa_heat_risk agree so
- * poorly (Spearman ρ = +0.34): ours is hazard-led, theirs is vulnerability-led.
- * They are answering different questions, and neither is wrong.
+ * ⚠️ OUR OWN LAYERS HAVE THE SAME PROPERTY. Running the identical correlation
+ * test on poa_flood_risk / poa_heat_risk / poa_landslide_risk gives a mean
+ * off-diagonal of 0.82 — flood↔heat 0.85, heat↔landslide 0.80 — against the
+ * ARVC's 0.83. Flood and heat share no physical mechanism either. This is the
+ * bairro-constant problem already documented in shared/site-knowledge.ts: two of
+ * the three factors in every one of our risk scores are bairro constants shared
+ * across all hazards, so all three composites are largely the same E×V surface.
+ * (Caveat: the landslide tiles returned far fewer sampled cells than heat, so
+ * its pairs rest on a smaller common set, and flood↔landslide had too few shared
+ * cells to compute at all.)
+ *
+ * So the earlier reading of the ρ = +0.34 heat disagreement — "ours is
+ * hazard-led, theirs is vulnerability-led" — was WRONG. Both are
+ * vulnerability-led. They disagree because they use DIFFERENT vulnerability
+ * inputs, spatial units and vintages, not because one is about hazard.
  */
 export const ARVC_INTERPRETATION = {
   en: 'ARVC risk = hazard × exposure × vulnerability, and exposure/vulnerability dominate. Read as "vulnerable populated areas", not as a hazard map. For landslide terrain use the SGB layers.',


### PR DESCRIPTION
Correction to #450, which merged before this follow-up landed. **`main` currently carries the incorrect claim.**

## What's wrong on main

#450 explained the ρ = +0.34 disagreement between ARVC heat risk and our `poa_heat_risk` as:

> ours is hazard-led, theirs is vulnerability-led

That is **wrong**, and I only found out by running the skill's own sibling-correlation check on *our* layers instead of only on the recovered ones.

## The measurement

| | flood | heat | landslide |
|---|---|---|---|
| **flood** | 1.00 | **0.85** | – |
| **heat** | 0.85 | 1.00 | **0.80** |
| **landslide** | – | 0.80 | 1.00 |

Mean off-diagonal **0.82**, against the ARVC's **0.83**. Flood and heat share no physical mechanism. **Our own composites are E×V-dominated in exactly the way #450 criticised the ARVC for being.**

This is the bairro-constant problem already documented in `shared/site-knowledge.ts`: two of the three factors in every one of our risk scores are bairro constants shared across all hazards, so all three composites are largely the same E×V surface.

## The corrected reading

Both are vulnerability-led. They disagree because they use **different vulnerability inputs, spatial units and vintages** — not because one is about hazard. The criticism of the ARVC applies to our own layers equally, and that is now stated in both `shared/arvc.ts` and `docs/arvc-recovery.md`.

## Caveat, stated not buried

The landslide value tiles returned far fewer sampled cells than heat (1,121 vs 28,932), so its pairs rest on a smaller common set, and flood↔landslide had too few shared cells to compute at all. **flood↔heat = 0.85 is the solid number.**

## Why this matters beyond documentation

If three unrelated hazards correlate at 0.82, the site explorer is largely showing organisations the same map three times. That is a bigger issue for the August 26 session than anything in the recovered layers.

No data changes — interpretation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWutNw34isJNf1eefXLDvU