### PR TITLE
fix(maps): Porto Alegre was drawn at half size — four pixels of slack cost a whole zoom level

### DIFF
--- a/client/src/core/components/maps/MapMicroapp.tsx
+++ b/client/src/core/components/maps/MapMicroapp.tsx
@@ -479,6 +479,20 @@ export default function MapMicroapp({
       center: [-30.03, -51.22],
       zoom: 11,
       maxZoom: 19,
+      // ⚠️ MAP-CITY-AT-HALF-SIZE (JVP, 2026-08-04, while reporting the click
+      // bug: the bairros were unmissably tiny in his screenshots).
+      //
+      // Leaflet snaps fitBounds to WHOLE zoom levels by default, and Porto
+      // Alegre is a near-miss: the municipality needs ~568px of height at zoom
+      // 11 and the CBO panel offers ~564. Four pixels short, so the fit drops a
+      // full level — and a level is 2×. Measured at his window: the city filled
+      // 212×284 of a 590×596 map (36% of the width), median bairro 15px across,
+      // smallest tenth 8px. Apple's minimum touch target is 44px.
+      //
+      // zoomSnap:0 lets fitBounds pick 10.99 instead of falling to 10. Scoped to
+      // the CBO flow (allowDeferSite) — the city/concept-note maps are not in a
+      // half-width panel and were never asked to frame a whole municipality.
+      ...(params.allowDeferSite ? { zoomSnap: 0 } : {}),
     });
     // Two base layers; the swap effect below shows one. Esri World Imagery is
     // free (no key) and zooms to ~19 for site-level detail.
@@ -1164,7 +1178,14 @@ export default function MapMicroapp({
       try {
         map.invalidateSize();
         const b = zl.getBounds();
-        if (b.isValid()) map.fitBounds(b, { padding: [16, 16] });
+        // Asymmetric on purpose: the top of this map is occupied by an overlay
+        // the whole time — the hazard-tour caption during the tour, then the
+        // risk-ramp legend at the zone step. A symmetric fit tucks the northern
+        // bairros (Arquipélago, Sarandi, Anchieta) underneath it. They stay
+        // clickable — the legend is pointer-events-none — but "clickable while
+        // hidden behind a card" is not selectable in any sense a user cares
+        // about.
+        if (b.isValid()) map.fitBounds(b, { paddingTopLeft: [16, 76], paddingBottomRight: [16, 16] });
       } catch {}
     };
     fit();

--- a/e2e/cougar-e2-bairro-selectable.spec.ts
+++ b/e2e/cougar-e2-bairro-selectable.spec.ts
@@ -54,17 +54,35 @@ async function finishTour(page: Page): Promise<void> {
   await page.waitForTimeout(1200);
 }
 
-/** Centre of the largest bairro polygon currently on screen. */
+/**
+ * A point that genuinely lands ON a bairro — verified with elementFromPoint,
+ * not assumed from a bounding box.
+ *
+ * The old version took the biggest path's bbox centre. Two ways that lies: the
+ * biggest path in this pane is the municipal BOUNDARY outline (deliberately
+ * non-interactive since MAP-BOUNDARY-EATS-CLICKS), and a bairro's bbox centre
+ * can fall outside a concave shape. Both put the tap on empty map, which then
+ * reads as "clicking is broken" — it cost a full diagnosis cycle when the city
+ * refit merely changed which polygon happened to be largest.
+ */
 async function biggestZoneCentre(page: Page) {
   return page.evaluate(() => {
     const paths = Array.from(
-      document.querySelectorAll('.leaflet-overlay-pane path'),
+      document.querySelectorAll('.leaflet-overlay-pane path.leaflet-interactive'),
     ) as SVGPathElement[];
-    const big = paths
-      .map(p => p.getBoundingClientRect())
-      .filter(b => b.width > 15 && b.height > 15)
-      .sort((a, b) => b.width * b.height - a.width * a.height)[0];
-    return big ? { x: big.x + big.width / 2, y: big.y + big.height / 2 } : null;
+    const ranked = paths
+      .map(p => ({ p, b: p.getBoundingClientRect() }))
+      .filter(x => x.b.width > 15 && x.b.height > 15)
+      .sort((a, b) => b.b.width * b.b.height - a.b.width * a.b.height);
+    for (const { p, b } of ranked) {
+      for (const fx of [0.5, 0.35, 0.65]) {
+        for (const fy of [0.5, 0.35, 0.65]) {
+          const x = b.x + b.width * fx, y = b.y + b.height * fy;
+          if (document.elementFromPoint(x, y) === p) return { x, y };
+        }
+      }
+    }
+    return null;
   });
 }
 
@@ -164,6 +182,53 @@ test.describe('COUGAR — E2 Map 1 (e2_bairro)', () => {
     });
     expect(topIsOwnPath.checked, 'no bairro was big enough to probe').toBeGreaterThan(0);
     expect(topIsOwnPath.ok, 'a bairro tap must reach the bairro').toBe(topIsOwnPath.checked);
+  });
+
+  // ⚠️ MAP-CITY-AT-HALF-SIZE (JVP, 2026-08-04, in the screenshots he sent while
+  // reporting the click bug: Porto Alegre was a small clump in the middle).
+  //
+  // Leaflet snaps fitBounds to WHOLE zoom levels, and POA is a near-miss — the
+  // municipality needs ~568px of height and the panel offers ~564. Four pixels
+  // short, so the fit dropped a level, and a level is 2×. Measured here before
+  // the fix: the city filled 48% of the map, median bairro 15px across, the
+  // smallest tenth 8px, against a 44px minimum touch target.
+  //
+  // Every click test still passed, because a test clicks a computed centroid and
+  // does not care how big the target is. So this measures the thing a thumb
+  // cares about, at a real laptop window.
+  test.describe('at a laptop window', () => {
+    test.use({ viewport: { width: 1180, height: 800 } });
+
+    test('the city fills the panel — bairros are big enough to tap', async ({ page, request }) => {
+      test.setTimeout(120_000);
+      const api = new TestApi(request);
+      test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+      await bootToBairroMap(page, api);
+      await finishTour(page);
+      await page.waitForTimeout(1500); // staggered refits
+
+      const m = await page.evaluate(() => {
+        const paths = Array.from(document.querySelectorAll('.leaflet-overlay-pane path')) as SVGPathElement[];
+        const boxes = paths.map(p => p.getBoundingClientRect()).filter(b => b.width > 0);
+        const sizes = boxes.map(b => Math.sqrt(b.width * b.height)).sort((a, b) => a - b);
+        const mb = (document.querySelector('.leaflet-container') as HTMLElement).getBoundingClientRect();
+        return {
+          median: sizes[Math.floor(sizes.length / 2)],
+          p10: sizes[Math.floor(sizes.length * 0.1)],
+          fill: Math.max(
+            (Math.max(...boxes.map(b => b.right)) - Math.min(...boxes.map(b => b.left))) / mb.width,
+            (Math.max(...boxes.map(b => b.bottom)) - Math.min(...boxes.map(b => b.top))) / mb.height,
+          ),
+        };
+      });
+
+      // 48% before the fix, 85% after. A whole zoom level of slack sits between
+      // those, so this floor catches the snap-down without being brittle.
+      expect(m.fill, 'the city must fill the map, not sit in it as a clump').toBeGreaterThan(0.7);
+      expect(Math.round(m.median), 'median bairro was 15px — half a fingertip').toBeGreaterThan(22);
+      expect(Math.round(m.p10), 'the smallest tenth were 8px slivers').toBeGreaterThan(11);
+    });
   });
 
   test('one legend, no dead stepper, no risk choropleth', async ({ page, request }) => {


### PR DESCRIPTION
From the screenshots JVP sent on 2026-08-04 while reporting the click bug: the city sat as a small clump in the middle of the panel, bairros unmissably tiny. He was right that this was *not* what blocked the click (zooming in didn't help — that was the boundary lid, #446). It's a separate defect, and it's mine, from the fit change in #432.

## The mechanism

Leaflet snaps `fitBounds` to **whole zoom levels**. Porto Alegre is a near-miss: the municipality needs ~568px of height and the CBO panel offers ~564. Four pixels short, so the fit drops a full level — and a level is 2×.

## Measured, at his window (1180×800, map 590×596)

| | city fills | median bairro | smallest tenth |
|---|---|---|---|
| before | 48% | 15px | 8px |
| after | 85% | 26px | 14px |

Apple's minimum touch target is 44px. **26px is still under it**, and that's the honest ceiling for a whole-municipality view in a half-width panel — POA runs 38km north to south. The rest of the answer is `preselectZone`, which already means most orgs confirm the bairro E1 recorded instead of hunting for it on a map.

`zoomSnap: 0` lets the fit pick 10.99 rather than falling to 10. Scoped to the CBO flow (`allowDeferSite`) — the city/concept-note maps aren't in a half-width panel and were never asked to frame a municipality.

The fit padding is now asymmetric (76px at the top). The top of this map is occupied the whole time — the hazard-tour caption, then the risk-ramp legend — and a symmetric fit tucked Arquipélago, Sarandi and Anchieta underneath it. They stay clickable (the legend is `pointer-events-none`), but clickable-while-hidden isn't selectable in any sense a user cares about.

## Two test changes, both making an assertion mean what it claimed

**New:** measure what a thumb cares about — the city must fill >70% of the map and the median bairro must clear 22px, at a real laptop window. Every existing click test passed throughout this entire bug, because a test clicks a computed centroid and doesn't care how big the target is. Fails at `0.476` without the fix.

**Fixed helper:** `biggestZoneCentre` took the biggest path's bbox centre. The biggest path in that pane is the municipal **boundary** outline — deliberately non-interactive since #446 — and a bairro's bbox centre can fall outside a concave shape. Either way the tap lands on empty map and reads as "clicking is broken". It now picks the largest *interactive* path and verifies the point with `elementFromPoint` before tapping.

I diagnosed that rather than assuming it: a drifted tap on a verified-inside point selects fine, and `bboxCentreHitsOwnPath` came back `false`. The click path is healthy; the helper was aiming at scenery.

## Suite

`cougar-e2-bairro-selectable` 8/8. The map-walking specs (linear journey, diagnostic, linear map) 13/13 in isolation. On the full run, both linear-journey tests failed on `cbo-familia-reco` — the pre-existing dead end I've now seen across several runs and on clean `main`; the journey gets *past* the map fine. That one still needs its own investigation, and it's the step W2 ends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy