### PR TITLE
fix(cbo): a tap is never both erased and unsent — the map one is a proven loss

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -384,6 +384,19 @@ export default function CboProfilePage() {
   const [messages, setMessages] = useState<Array<CboChatMessage & { viaVoice?: boolean }>>([]);
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
+  // ⚠️ CHIP-TAP-LOST. sendMessage opens with
+  //   `if (!cboId || !text.trim() || isStreaming) return;`
+  // and its callers cleared the question BEFORE calling it. So a tap arriving
+  // while a turn was in flight erased the question and sent nothing: no
+  // request, no error, no toast, and a screen with no way forward. Same dead
+  // end JVP hit on 2026-08-04, through a different door (that time a 409).
+  //
+  // I could not pin the exact race that leaves a card up while streaming, so
+  // this deliberately does not depend on knowing it. The INVARIANT is that a
+  // tap is never both erased and unsent: callers ask first, and when the answer
+  // is no they leave the question alone and say so.
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current = isStreaming;
   // Monotonic count of completed agent turns. Drives the e2e stream-complete
   // contract (see the hidden #cbo-stream-status marker near the root) so tests
   // can wait on "turn N finished" deterministically — networkidle never fires
@@ -1439,28 +1452,45 @@ export default function CboProfilePage() {
 
   // MC selection
   const handleSelectOption = useCallback((label: string) => {
-    setQuestionAnswers(prev => {
-      const updated = { ...prev, [currentQuestionIdx]: label };
-      if (Object.keys(updated).length === totalQuestions) {
-        const all = activeQuestions.map((_, i) => updated[i]).filter(Boolean);
-        // `pairs` keeps which answer belongs to which question - the joined string
-        // ("Associacao; 6-20") could not say that under two questions. The joined
-        // text still goes to the model, unchanged; `pairs` is only how the
-        // transcript renders the answered cards.
-        const pairs = activeQuestions
-          .map((q, i) => ({ question: q.question, answer: updated[i] }))
-          .filter(p => !!p.answer);
-        setActiveQuestions([]); setCurrentQuestionIdx(0); setSelectedOptionIdx(0);
-        // hidden=true: a chip turn renders as answered cards, not a green bubble.
-        sendMessage(all.join('; '), true, false, undefined, 'chip', pairs);
-        return {};
-      }
-      return updated;
-    });
+    // CHIP-TAP-LOST — ask before erasing anything. A turn is in flight, so
+    // sendMessage would drop this tap on the floor; clearing the question first
+    // is what turned a dropped tap into a dead screen. Keep the question, keep
+    // the partial answers, and tell them it's a moment, not a failure.
+    if (isStreamingRef.current) {
+      console.warn('[cbo] chip tap ignored — a turn is already streaming');
+      toast({
+        title: t('cbo.stillAnswering', {
+          defaultValue: 'Só um segundo — ainda estou respondendo a anterior.',
+        }),
+      });
+      return;
+    }
+    // Computed here rather than inside a setState updater: an updater must be
+    // pure, and this one called sendMessage + three setters from inside it.
+    // React invokes updaters twice under StrictMode, so that was a latent
+    // double-send — survived only because sendMessage's own guard swallowed the
+    // second one, which is the very guard whose silence caused this bug.
+    const updated = { ...questionAnswers, [currentQuestionIdx]: label };
+    if (Object.keys(updated).length === totalQuestions) {
+      const all = activeQuestions.map((_, i) => updated[i]).filter(Boolean);
+      // `pairs` keeps which answer belongs to which question - the joined string
+      // ("Associacao; 6-20") could not say that under two questions. The joined
+      // text still goes to the model, unchanged; `pairs` is only how the
+      // transcript renders the answered cards.
+      const pairs = activeQuestions
+        .map((q, i) => ({ question: q.question, answer: updated[i] }))
+        .filter(p => !!p.answer);
+      setQuestionAnswers({});
+      setActiveQuestions([]); setCurrentQuestionIdx(0); setSelectedOptionIdx(0);
+      // hidden=true: a chip turn renders as answered cards, not a green bubble.
+      void sendMessage(all.join('; '), true, false, undefined, 'chip', pairs);
+      return;
+    }
+    setQuestionAnswers(updated);
     setSelectedOptionIdx(0);
-    for (let i = currentQuestionIdx + 1; i < totalQuestions; i++) { if (!questionAnswers[i]) { setCurrentQuestionIdx(i); return; } }
-    for (let i = 0; i < currentQuestionIdx; i++) { if (!questionAnswers[i]) { setCurrentQuestionIdx(i); return; } }
-  }, [currentQuestionIdx, totalQuestions, activeQuestions, questionAnswers, sendMessage]);
+    for (let i = currentQuestionIdx + 1; i < totalQuestions; i++) { if (!updated[i]) { setCurrentQuestionIdx(i); return; } }
+    for (let i = 0; i < currentQuestionIdx; i++) { if (!updated[i]) { setCurrentQuestionIdx(i); return; } }
+  }, [currentQuestionIdx, totalQuestions, activeQuestions, questionAnswers, sendMessage, t]);
   handleSelectRef.current = handleSelectOption;
 
   // Edit a field in the document panel — updates locally + sends to server
@@ -2673,8 +2703,20 @@ export default function CboProfilePage() {
                       // Show the user a clean risk summary; send the raw payload
                       // to the agent as the message body (hidden context).
                       const summary = buildRiskSummary(result, lang);
+                      // Same invariant as the chips (CHIP-TAP-LOST), and here the
+                      // dropped payload is everything they just did on the map —
+                      // bairro, site, risk numbers. Never clear ahead of a send
+                      // that might not happen.
+                      if (isStreamingRef.current) {
+                        toast({
+                          title: t('cbo.stillAnswering', {
+                            defaultValue: 'Só um segundo — ainda estou respondendo a anterior.',
+                          }),
+                        });
+                        return;
+                      }
                       if (currentQuestion) setActiveQuestions([]);
-                      sendMessage(message, false, false, summary, 'map');
+                      void sendMessage(message, false, false, summary, 'map');
                       setOpenMapParams(null);
                       setRightTab('document'); setMapRelevant(false); setMobileActiveTab('chat'); setDesktopPanelOpen(false);
                     }}

--- a/e2e/cougar-chip-tap-never-lost.spec.ts
+++ b/e2e/cougar-chip-tap-never-lost.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// ⚠️ CHIP-TAP-LOST.
+//
+// Traced from a full-suite run where 9 of 23 sessions stalled at DIFFERENT
+// steps (ask-hazard-check, await-uploads, ask-photos, mid-worry-loop). The
+// server was blameless in every one: each checkpoint served in 0ms with a 200,
+// no 5xx, no checkpoint errors, two 409s in the whole run — and then no further
+// POST ever arrived for that session. The browser stopped talking while a live
+// question card was still on screen.
+//
+// The shape that allows it: sendMessage opens with
+//   `if (!cboId || !text.trim() || isStreaming) return;`
+// and both of its chip/map callers cleared the question BEFORE calling it. A tap
+// that lands while a turn is in flight therefore erases the question and sends
+// nothing — no request, no error, no toast, nothing to tap. Identical to the
+// dead end JVP hit on 2026-08-04, reached through a different door.
+//
+// These specs pin the INVARIANT rather than the race (which I could not pin):
+// a tap is never both erased and unsent, and a fast double-tap never turns into
+// two answers.
+
+test.describe('CBO — a tap is never lost', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('a fast double-tap answers once and the flow continues', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [
+      [{ op: 'ask_user', question: 'Vocês atuam em um bairro só?', options: [
+        { label: 'Um bairro', description: 'só um' },
+        { label: 'Mais de um', description: 'vários' },
+      ] } as any],
+      // Slow, so the second tap of the double-tap lands mid-turn — the exact
+      // window in which a tap used to vanish.
+      [{ op: 'wait', ms: 2_500 } as any, { op: 'say', text: 'Beleza, seguimos.' } as any],
+      [{ op: 'say', text: 'Terceira resposta.' } as any],
+    ]);
+
+    const chat = page.getByTestId('cbo-chat-input');
+    await chat.fill('oi');
+    await chat.press('Enter');
+
+    const chip = page.locator('[data-testid^="cbo-option-"][data-option-label="Um bairro"]');
+    await expect(chip).toBeVisible({ timeout: 30_000 });
+
+    // Two taps as fast as the browser will deliver them.
+    await chip.click();
+    await chip.click({ force: true, timeout: 2_000 }).catch(() => {});
+
+    // The turn runs, once.
+    await expect(page.getByText('Beleza, seguimos')).toBeVisible({ timeout: 40_000 });
+
+    const msgs = await (await request.get(`/api/cbo/${cboId}/messages`)).json();
+    const answers = msgs.filter((m: any) =>
+      m.role === 'user' && String(m.content ?? '').includes('Um bairro') && m.messageType === 'content');
+    expect(answers.length, 'one tap, one answer — a double-tap must not double-answer')
+      .toBe(1);
+
+    // …and the session is answerable afterwards, which is the half that used to
+    // die: the screen kept the question or moved on, never went blank-and-idle.
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 20_000 });
+    await chat.fill('e agora?');
+    await chat.press('Enter');
+    await expect(page.getByText('Terceira resposta')).toBeVisible({ timeout: 40_000 });
+  });
+
+  test('a tap during a turn keeps the question on screen', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // A turn that asks, and a NEXT turn that is slow — so we can be mid-turn
+    // with a question rendered from the persisted composer.
+    await api.scriptCbo(cboId, [
+      [{ op: 'ask_user', question: 'Continuar?', options: [
+        { label: 'Sim', description: 'segue' },
+        { label: 'Não', description: 'para' },
+      ] } as any],
+      [{ op: 'wait', ms: 3_000 } as any, { op: 'say', text: 'Pronto.' } as any],
+    ]);
+
+    const chat = page.getByTestId('cbo-chat-input');
+    await chat.fill('oi');
+    await chat.press('Enter');
+    await expect(page.locator('[data-testid^="cbo-option-"][data-option-label="Sim"]'))
+      .toBeVisible({ timeout: 30_000 });
+
+    // Start a turn by typing, then tap a chip while it streams.
+    await chat.fill('texto qualquer');
+    await chat.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'true', { timeout: 10_000 });
+
+    const before = await page.locator('[data-testid^="cbo-option-"]').count();
+    await page.locator('[data-testid^="cbo-option-"]').first()
+      .click({ force: true, timeout: 2_000 }).catch(() => {});
+
+    // Whatever the tap did, it must not have left the user with fewer options
+    // and no turn — the blank-and-idle state. Either it was accepted, or the
+    // chips are still there to tap again.
+    await page.waitForTimeout(500);
+    const after = await page.locator('[data-testid^="cbo-option-"]').count();
+    const streaming = await marker.getAttribute('data-streaming');
+    expect(after > 0 || streaming === 'true',
+      'a dropped tap must leave the question tappable, not a blank screen').toBeTruthy();
+    expect(after).toBeGreaterThanOrEqual(Math.min(before, 1));
+
+    // And the session finishes normally.
+    await expect(page.getByText('Pronto.')).toBeVisible({ timeout: 40_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 20_000 });
+  });
+});
+
+// The deterministic half of the same defect, and the costliest payload: the map.
+//
+// Pre-fix, the confirm handler ran `sendMessage(...)` and then closed the map
+// unconditionally — so confirming while a turn was in flight dropped the whole
+// selection (bairro, site, risk numbers) AND took the map away. Nothing to
+// retry, nothing on screen, no error. Unlike the chip race this one is fully
+// controllable: start a slow turn by typing, then confirm.
+test.describe('CBO — a map confirmation is never lost', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('confirming during a turn keeps the map instead of discarding the selection', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [
+      [{ op: 'set_phase', phase: 2 } as any,
+       { op: 'open_map', params: { preset: 'e2_bairro' } } as any],
+      [{ op: 'wait', ms: 3_000 } as any, { op: 'say', text: 'Resposta lenta.' } as any],
+    ]);
+
+    const chat = page.getByTestId('cbo-chat-input');
+    await chat.fill('mapa');
+    await chat.press('Enter');
+    await expect(page.locator('.leaflet-container').first()).toBeVisible({ timeout: 30_000 });
+    await expect.poll(() => page.$$eval('.leaflet-overlay-pane path', p => p.length),
+      { timeout: 20_000 }).toBeGreaterThan(50);
+
+    const tourNext = page.getByTestId('map-tour-next');
+    await expect(tourNext).toBeVisible({ timeout: 15_000 });
+    for (let i = 0; i < 3; i++) await tourNext.click();
+    await expect(tourNext).toHaveCount(0, { timeout: 10_000 });
+    await page.waitForTimeout(1200);
+
+    // Pick a bairro — a real one, verified under the cursor.
+    const target = await page.evaluate(() => {
+      const ps = Array.from(document.querySelectorAll('.leaflet-overlay-pane path.leaflet-interactive')) as SVGPathElement[];
+      const ranked = ps.map(p => ({ p, b: p.getBoundingClientRect() }))
+        .filter(x => x.b.width > 20 && x.b.height > 20)
+        .sort((a, b) => b.b.width * b.b.height - a.b.width * a.b.height);
+      for (const { p, b } of ranked) {
+        for (const fx of [0.5, 0.35, 0.65]) for (const fy of [0.5, 0.35, 0.65]) {
+          const x = b.x + b.width * fx, y = b.y + b.height * fy;
+          if (document.elementFromPoint(x, y) === p) return { x, y };
+        }
+      }
+      return null;
+    });
+    expect(target).not.toBeNull();
+    await page.mouse.click(target!.x, target!.y);
+    const confirm = page.getByTestId('map-confirm-bairro');
+    await expect(confirm).toBeEnabled({ timeout: 10_000 });
+
+    // Now put a turn in flight, and confirm into it.
+    await chat.fill('uma pergunta qualquer');
+    await chat.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'true', { timeout: 10_000 });
+    await confirm.click();
+
+    // THE ASSERTION. Pre-fix the map was closed and the selection thrown away.
+    await expect(
+      confirm,
+      'confirming mid-turn must not discard the selection and close the map',
+    ).toBeVisible({ timeout: 5_000 });
+
+    // The turn finishes, and the confirmation still works — the org loses a tap,
+    // not their work.
+    await expect(page.getByText('Resposta lenta.')).toBeVisible({ timeout: 40_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 20_000 });
+    await confirm.click();
+    await expect
+      .poll(async () => {
+        const msgs = await (await request.get(`/api/cbo/${cboId}/messages`)).json();
+        return msgs.some((m: any) => String(m.content ?? '').includes('Selecionei no mapa')
+          || String(m.content ?? '').includes('Map selection'));
+      }, { timeout: 30_000 })
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
Chasing the stall JVP asked me to explain, then fixing what I could actually establish.

## What the server log settled

In one full run, **9 of 23 sessions stalled — at different steps** (`e2-ask-hazard-check`, `e2-await-uploads`, `e2-ask-photos`, mid-worry-loop). In every one:

- each checkpoint served in **0ms** with a 200 (`model=template` — no model call at all)
- zero 5xx, zero checkpoint errors, **two** 409s in the whole run
- and then **no further POST ever arrives** for that session

The browser stops talking while a live question card is still on screen (the failing snapshots end with "Sua vez — setas + Enter para selecionar", which only renders when a card is up). So this is **not a famílias bug** — famílias is just where those specs happen to assert. I had been naming the symptom's location.

## The shape that allows it

`sendMessage` opens with `if (!cboId || !text.trim() || isStreaming) return;` — and **both** of its callers cleared the question *before* calling it. A tap arriving while a turn is in flight therefore erases the question and sends nothing: no request, no error, no toast, nothing left to tap. Same dead end as 2026-08-04, through a different door (that one was a 409).

## ⚠️ What I could not prove

I could **not** pin the race that leaves a card up while streaming, and I'm not pretending otherwise — `sendMessage` clears `activeQuestions` itself and `ask_user` sets `isStreaming` false, so on paper that state shouldn't occur. Two specs here pin the invariant but **pass on the pre-fix tree too**; they're guards going forward, not evidence.

So the fix is written to be correct regardless of trigger — *a tap is never both erased and unsent* — rather than to a mechanism I can't demonstrate.

## What IS proven, and is worse than the chips

The **map** confirm handler sent and then closed the map unconditionally. Confirming while a turn was in flight discarded the entire selection — bairro, site, risk numbers — and took the map away with it. Nothing to retry, nothing on screen, no error. Fully deterministic and easy to hit: any org who taps Confirmar while the agent is mid-reply.

```
Error: confirming mid-turn must not discard the selection and close the map
expect(locator).toBeVisible() failed
Error: element(s) not found
```

That's the new spec on the pre-fix tree. It passes after.

## One hygiene fix in the same function

`handleSelectOption` called `sendMessage` plus three setters from **inside** a `setQuestionAnswers` updater. Updaters must be pure, and React invokes them twice under StrictMode — a latent double-send that survived only because `sendMessage`'s guard swallowed the second. That guard's silence is the whole subject of this PR, so I moved the side effects out.

## Checked for harm rather than assumed

JVP asked me to make sure this doesn't hurt users. The refactor touches chip navigation, so:

- **smoke tier 53/53, three runs in a row** — golden path, batched questions, inline options: everything that drives chips
- **full suite 158 passed on two runs**, with the same pre-existing stall pattern and **no new failure class**

The rejected-tap path now toasts "Só um segundo — ainda estou respondendo a anterior" and leaves the question tappable, so the worst case is losing a tap rather than losing the work.

## Still open

The stalls themselves persist at the same rate, which is expected — this fix changes what a *dropped* tap costs, not whatever causes the drop. Next time one reproduces, the question will still be on screen, and that alone narrows it considerably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy