### PR TITLE
feat(e2): Alagamento, Inundação and Enxurrada — the org's word, over the data we have

### DIFF
--- a/e2e/cougar-e2-diagnostic.spec.ts
+++ b/e2e/cougar-e2-diagnostic.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, devices } from '@playwright/test';
 import { TestApi } from './helpers/testApi';
+import { familyOfWorry } from '../shared/site-knowledge';
 import { clickCenterZone } from './helpers/mapActions';
 
 // The W2 diagnostic beats (/refine 2026-07-31): frame → worry → story → photos
@@ -193,7 +194,10 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // Everything the diagnostic captured actually persisted.
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.site_story?.value)).toContain('dois dias');
     expect(String(f.site_photo_intent?.value)).toBe('skip');
     expect(JSON.parse(String(f._hazard_check_json?.value))).toMatchObject({ flood: 'worse' });
@@ -228,7 +232,8 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // never reached the interest/role loops or the close.
     const depth = JSON.parse(String(f._depth_json?.value ?? '{}'));
     expect(depth.level, 'a depth read must exist mid-session').toBeTruthy();
-    expect(String(f.site_worry?.value)).toContain('flood');   // what worries them
+    // what worries them, stored as the MECHANISM they tapped (backlog #24)
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.current_use?.value)).toBeTruthy();        // what the place is
     expect(String(f.land_tenure?.value)).toBeTruthy();        // whether they can use it
     expect(String(f.site_name?.value)).toBeTruthy();          // where it is
@@ -366,7 +371,10 @@ test.describe('COUGAR — W2 degraded scenarios', () => {
 
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.bairro?.value ?? '')).not.toBe('');
   });
 

--- a/e2e/cougar-hazard-subtypes.spec.ts
+++ b/e2e/cougar-hazard-subtypes.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import {
+  WORRY_SUBTYPES, E2_WORRIES, familyOfWorry, familiesOfWorries,
+  orderWorriesByData, photoPromptsFor, hazardsToCheck,
+} from '../shared/site-knowledge';
+import { needsScaleReframing } from '../shared/nbs-performance';
+import { rankFamiliasForSite } from '../shared/nbs-recommendation';
+
+// COUGAR convening, 2026-08-06: orgs don't experience "flood" as one thing.
+// Alagamento (water that pools), Inundação (the river overtopping) and Enxurrada
+// (water coming down with force) are three problems with three answers — and the
+// old chip merged the first two out loud ("A água que junta OU INVADE") under a
+// label that named only one of them.
+//
+// The mechanism is a LANGUAGE layer over the three rasters we actually hold.
+// Every consumer used to filter with `w === 'flood' || w === 'heat' || …`, which
+// drops an unknown id **silently** — so the failure mode this pins is not a
+// crash, it's an org quietly never being asked for photos again.
+
+test.describe('hazard mechanisms — a finer word over the same data', () => {
+  test('every mechanism resolves to a layer we actually have', () => {
+    for (const w of WORRY_SUBTYPES) {
+      if (w.id === 'other') { expect(w.family).toBeNull(); continue; }
+      expect(['flood', 'heat', 'landslide'], `${w.id} must score against a real raster`)
+        .toContain(w.family);
+    }
+    // The three water mechanisms share one layer. That is the whole design: we
+    // hold one flood raster, so three names cannot mean three numbers.
+    expect(['alagamento', 'inundacao', 'enxurrada'].map(familyOfWorry))
+      .toEqual(['flood', 'flood', 'flood']);
+  });
+
+  test('⚠️ legacy `flood` still resolves — sessions in the database used it', () => {
+    // JVP's test orgs and the three W2 test-kit orgs stored `site_worry: 'flood'`
+    // before the split. If that becomes an unknown id, they stop getting photo
+    // prompts and their depth read quietly degrades. Nothing throws.
+    expect(familyOfWorry('flood')).toBe('flood');
+    expect(familiesOfWorries(['flood'])).toEqual(['flood']);
+    expect(photoPromptsFor(['flood']).length).toBeGreaterThan(1);
+    expect(hazardsToCheck(['flood'], { flood: 10, heat: 10, landslide: 10 })).toContain('flood');
+  });
+
+  test('nothing downstream drops a mechanism on the floor', () => {
+    const low = { flood: 10, heat: 10, landslide: 10 };
+    for (const id of ['alagamento', 'inundacao', 'enxurrada'] as const) {
+      expect(hazardsToCheck([id], low), `${id} must still raise a flood check`).toContain('flood');
+      // …and it must ask for photographs, which is the beat that silently died
+      // if the id was unrecognised.
+      const prompts = photoPromptsFor([id]);
+      expect(prompts.length, `${id} must still produce prompts`).toBeGreaterThan(1);
+    }
+    // Three water mechanisms are ONE check, not three — the conversation caps
+    // at two checkpoints before it becomes a form.
+    expect(hazardsToCheck(['alagamento', 'inundacao', 'enxurrada'], low)).toEqual(['flood']);
+  });
+
+  test('the mechanism asks for the photo only it makes worth taking', () => {
+    const ids = (ws: string[]) => photoPromptsFor(ws).map(p => p.id);
+    expect(ids(['inundacao']), 'how high did it get').toContain('high-water-mark');
+    expect(ids(['enxurrada']), 'where does it come down').toContain('water-path');
+    // Alagamento keeps the generic flood set — pooling is what those ask about.
+    expect(ids(['alagamento'])).not.toContain('high-water-mark');
+    expect(ids(['alagamento'])).toContain('water-in');
+  });
+
+  test('naming Inundação IS the scale signal — no story keywords needed', () => {
+    // This beat existed to catch someone who said "flood" and then described the
+    // 2024 Guaíba event. That event is Inundação; now they can just say so.
+    expect(needsScaleReframing(['inundacao'], 'a gente cuida da horta')).toBe(true);
+    // Alagamento alone is the everyday water — no reframing, or the agent
+    // lectures an org about limits it never claimed to exceed.
+    expect(needsScaleReframing(['alagamento'], 'a água junta no canto')).toBe(false);
+    // …and the old story-keyword path still fires, for legacy rows.
+    expect(needsScaleReframing(['flood'], 'na enchente de 2024 o Guaíba subiu')).toBe(true);
+    expect(needsScaleReframing(['heat'], 'o Guaíba subiu em 2024')).toBe(false);
+  });
+
+  test('the worry the org named still lifts a família', () => {
+    const base = {
+      risks: { flood: 40, heat: 40, landslide: 40 },
+      bairro: 'Sarandi',
+      worries: ['inundacao'],
+    };
+    const ranked = rankFamiliasForSite(base as any);
+    const water = ranked.find((r: any) => r.familiaId === 'aguas-pluviais');
+    expect(water, 'the water família must be in the list').toBeTruthy();
+    // Same shape the old `['flood']` worry produced — the mechanism reaches the
+    // ranking through its family rather than being filtered out.
+    const viaFamily = rankFamiliasForSite({ ...base, worries: ['flood'] } as any);
+    expect(ranked.map((r: any) => r.familiaId)).toEqual(viaFamily.map((r: any) => r.familiaId));
+  });
+
+  test('chips: six, ordered by the data, everyday water first, "outra" last', () => {
+    expect(E2_WORRIES).toHaveLength(6);
+    const ordered = orderWorriesByData({ flood: 90, heat: 10, landslide: 5 });
+    expect(ordered.map(w => w.id)).toEqual(
+      ['alagamento', 'inundacao', 'enxurrada', 'heat', 'landslide', 'other']);
+    // The sort is stable, so the three water mechanisms keep catalogue order
+    // even when the data puts another hazard on top.
+    const heatFirst = orderWorriesByData({ flood: 10, heat: 90, landslide: 5 });
+    expect(heatFirst.map(w => w.id)).toEqual(
+      ['heat', 'alagamento', 'inundacao', 'enxurrada', 'landslide', 'other']);
+    expect(heatFirst[heatFirst.length - 1].id).toBe('other');
+  });
+
+  test('the chips say the mechanism in plain words, not just the technical term', () => {
+    const by = (id: string) => WORRY_SUBTYPES.find(w => w.id === id)!;
+    // The convening asked for the civil-defense term PAIRED with plain language.
+    expect(by('alagamento').pt).toContain('Alagamento');
+    expect(by('alagamento').dPt).toBe('A água que junta e não escoa');
+    expect(by('inundacao').dPt).toBe('O rio ou arroio que transborda');
+    expect(by('enxurrada').dPt).toBe('A água que desce com força');
+    // The merged wording is gone — that phrase is what mis-named the Guaíba.
+    for (const w of WORRY_SUBTYPES) expect(w.dPt).not.toContain('junta ou invade');
+  });
+});

--- a/shared/nbs-performance.ts
+++ b/shared/nbs-performance.ts
@@ -32,6 +32,8 @@
 // from `NBS_EVENT_SCALE` must carry `estimated`-style marking, the same
 // discipline as `classificationEstimated` in nbs-catalog.ts.
 
+import { familiesOfWorries } from './site-knowledge';
+
 /** What a retention figure is measured in — these are NOT interchangeable. */
 export type RetentionUnit =
   /** Cubic metres held per m² of intervention, per rain event. */
@@ -294,7 +296,16 @@ export const NBS_SCALE_HONESTY = {
  * the everyday water, and that the big flood is an advocacy conversation.
  */
 export function needsScaleReframing(worry: string[], story: string): boolean {
-  if (!worry.includes('flood')) return false;
+  // Through the family — the worry ids now carry the mechanism (Alagamento /
+  // Inundação / Enxurrada), and a literal `includes('flood')` would stop firing
+  // for every one of them: the honesty beat would go quiet exactly when the org
+  // is describing the event it exists for.
+  if (!familiesOfWorries(worry).includes('flood')) return false;
+  // Naming Inundação IS the signal. This function was reverse-engineering it
+  // from story keywords because the chip could not say it — "the 2024 event or
+  // a river/dike" is the definition of Inundação. Now that they can pick the
+  // word, take them at it and don't wait for the story to mention the Guaíba.
+  if (worry.includes('inundacao')) return true;
   const s = story.toLowerCase();
   return /enchente|2024|guaíba|guaiba|dique|rio subiu|subiu o rio|inunda|the flood|dike|river rose/.test(s);
 }

--- a/shared/nbs-recommendation.ts
+++ b/shared/nbs-recommendation.ts
@@ -13,6 +13,7 @@
 // calls the show_familia_recommendation tool with its own whys, which override
 // these per-família.
 
+import { familiesOfWorries } from './site-knowledge';
 import {
   NBS_FAMILIAS,
   solutionsForFamilia,
@@ -244,8 +245,11 @@ export function rankFamiliasForSite(input: FamiliaRecoInput): RankedFamilia[] {
     // The worry the org named. Capped so the hazard data still shapes the
     // order — a stated worry should lift a família decisively, not seize the
     // ranking — and marked `guaranteed` so no trimming can hide it.
-    const named = (input.worries ?? []).filter(
-      (w): w is 'flood' | 'heat' | 'landslide' => w === 'flood' || w === 'heat' || w === 'landslide');
+    // Through the family: worries now carry the finer mechanism (Alagamento /
+    // Inundação / Enxurrada) and this scores against the one flood layer we
+    // have. A raw `w === 'flood'` filter would drop every one of them and
+    // silently stop honouring the worry they just told us about.
+    const named = familiesOfWorries(input.worries ?? []);
     const answersAWorry = named.find(h => f.hazards[h] >= 0.6);
     const worryBoost = answersAWorry ? Math.min(0.35, 0.35 * f.hazards[answersAWorry]) : 0;
 

--- a/shared/site-knowledge.ts
+++ b/shared/site-knowledge.ts
@@ -25,15 +25,80 @@
 // participant, while broad prompts surface what the facilitator never thought to
 // ask.
 
+/** The three layers we hold data for. One raster each; nothing finer exists. */
 export type HazardKey = 'flood' | 'heat' | 'landslide';
 
-/** What an organization can name as the thing that worries them at this place. */
-export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string; dPt: string; dEn: string }> = [
-  { id: 'flood', pt: '💧 Alagamento', en: '💧 Flooding', dPt: 'A água que junta ou invade', dEn: 'Water that pools or comes in' },
-  { id: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
-  { id: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
-  { id: 'other', pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
+/**
+ * The MECHANISM an organization names — one level finer than the data.
+ *
+ * COUGAR convening, 2026-08-06 (Vila Flores / PxG / OEF / BwB): orgs do not
+ * experience "flood" as one thing. Water that pools and won't drain, a river
+ * that overtops, and water coming down a slope with velocity are three
+ * different problems that take three different solutions. The meeting
+ * standardised the civil-defense terms — Alagamento (pluvial/drainage),
+ * Inundação (river), Enxurrada (flash flood) — each paired with plain language.
+ *
+ * The old chip was already merging two of them out loud: "💧 Alagamento — A água
+ * que junta OU INVADE". "Junta" is Alagamento, "invade" is Inundação, and both
+ * sat under a label that named only the first. An org whose problem is the
+ * Guaíba was tapping a chip that called it the wrong thing.
+ *
+ * ⚠️ This is deliberately NOT a new data key. We hold exactly three rasters, so
+ * all three water mechanisms score against `flood`; `family` is how every
+ * consumer gets back to a key it has data for. The org's word is theirs and is
+ * stored as-is; the number stays the flood-family percentile and keeps saying
+ * so. See backlog #24.
+ */
+export type WorryId = 'alagamento' | 'inundacao' | 'enxurrada' | 'heat' | 'landslide' | 'other';
+
+export interface WorrySubtype {
+  id: WorryId;
+  /** The data key this mechanism is scored against. null = we have no layer. */
+  family: HazardKey | null;
+  pt: string;
+  en: string;
+  dPt: string;
+  dEn: string;
+}
+
+export const WORRY_SUBTYPES: WorrySubtype[] = [
+  { id: 'alagamento', family: 'flood', pt: '💧 Alagamento', en: '💧 Ponding', dPt: 'A água que junta e não escoa', dEn: "Water that pools and won't drain" },
+  { id: 'inundacao', family: 'flood', pt: '🌊 Inundação', en: '🌊 River flooding', dPt: 'O rio ou arroio que transborda', dEn: 'The river or stream overtopping' },
+  { id: 'enxurrada', family: 'flood', pt: '🌧️ Enxurrada', en: '🌧️ Flash flood', dPt: 'A água que desce com força', dEn: 'Water coming down with force' },
+  { id: 'heat', family: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
+  { id: 'landslide', family: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
+  { id: 'other', family: null, pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
 ];
+
+/**
+ * The data key behind a worry, or null if we hold no layer for it.
+ *
+ * ⚠️ MIGRATION. Sessions that ran before the split stored the family id itself
+ * (`site_worry: 'flood'`), and those rows are still in the database — JVP's test
+ * orgs and the three W2 test-kit orgs. A legacy `flood` therefore has to keep
+ * resolving as "water, mechanism unspecified" rather than becoming an unknown
+ * id. Every consumer below filtered with `w === 'flood' || …`, which DROPS
+ * anything it doesn't recognise silently — so getting this wrong would not
+ * throw, it would quietly stop asking those orgs for photos.
+ */
+export function familyOfWorry(id: string): HazardKey | null {
+  const hit = WORRY_SUBTYPES.find(w => w.id === id);
+  if (hit) return hit.family;
+  return id === 'flood' || id === 'heat' || id === 'landslide' ? (id as HazardKey) : null;
+}
+
+/** The families behind a set of worries, deduped and order-preserving. */
+export function familiesOfWorries(worries: string[]): HazardKey[] {
+  const out: HazardKey[] = [];
+  for (const w of worries) {
+    const f = familyOfWorry(w);
+    if (f && !out.includes(f)) out.push(f);
+  }
+  return out;
+}
+
+/** What an organization can name as the thing that worries them at this place. */
+export const E2_WORRIES = WORRY_SUBTYPES;
 
 /**
  * Worry chips ordered by what the bairro data suggests, highest first — the
@@ -47,8 +112,12 @@ export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string
 export function orderWorriesByData(risks: Record<HazardKey, number>) {
   const hazards = E2_WORRIES.filter(w => w.id !== 'other');
   const other = E2_WORRIES.filter(w => w.id === 'other');
+  const riskOf = (w: WorrySubtype) => (w.family ? risks[w.family] ?? 0 : -1);
   return [
-    ...hazards.sort((a, b) => (risks[b.id as HazardKey] ?? 0) - (risks[a.id as HazardKey] ?? 0)),
+    // Array.prototype.sort is stable, so the three water mechanisms — which all
+    // score against the same `flood` number — keep the order they are declared
+    // in: Alagamento, Inundação, Enxurrada. Everyday first.
+    ...hazards.slice().sort((a, b) => riskOf(b) - riskOf(a)),
     ...other,
   ];
 }
@@ -87,6 +156,21 @@ const PHOTO_PROMPTS: Record<HazardKey | 'base', PhotoPrompt[]> = {
   ],
 };
 
+/**
+ * Prompts that only make sense for a named mechanism. Deliberately small: these
+ * are the questions a raster cannot answer and the generic flood prompts don't
+ * ask. See backlog #24 — this is where the finer term changes what we request,
+ * at no data cost.
+ */
+const MECHANISM_PROMPTS: Partial<Record<WorryId, PhotoPrompt[]>> = {
+  inundacao: [
+    { id: 'high-water-mark', pt: 'Até onde a água chegou — a marca na parede, se tiver', en: 'How high the water reached — the mark on the wall, if there is one' },
+  ],
+  enxurrada: [
+    { id: 'water-path', pt: 'Por onde a água desce quando vem com força', en: 'The path the water takes when it comes down hard' },
+  ],
+};
+
 /** Always offered last, and deliberately open — see the note on power imbalance. */
 export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
   id: 'open',
@@ -100,11 +184,23 @@ export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
  * about water.
  */
 export function photoPromptsFor(worries: string[]): PhotoPrompt[] {
-  const hazards = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const hazards = familiesOfWorries(worries);
   if (hazards.length === 0) return [...PHOTO_PROMPTS.base, PHOTO_PROMPT_OPEN];
 
   const picked: PhotoPrompt[] = [];
   const seen = new Set<string>();
+  // The mechanism earns its keep here: the shot that settles Inundação (how
+  // high did it get?) is not the shot that settles Enxurrada (where does it
+  // come down?), and neither is in the generic flood set. These go FIRST — a
+  // named mechanism is the most specific thing we know about the site.
+  for (const w of worries) {
+    for (const prompt of MECHANISM_PROMPTS[w as WorryId] ?? []) {
+      if (!seen.has(prompt.id) && picked.length < 3) {
+        seen.add(prompt.id);
+        picked.push(prompt);
+      }
+    }
+  }
   // Round-robin across the named hazards, so every worry is represented before
   // any one of them gets a second prompt.
   for (let round = 0; round < 3 && picked.length < 3; round++) {
@@ -177,7 +273,7 @@ export function hazardCheckQuestion(
 
 /** Which hazards are worth checking: what they named, plus anything our data calls high. */
 export function hazardsToCheck(worries: string[], risks: Record<HazardKey, number>): HazardKey[] {
-  const named = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const named = familiesOfWorries(worries);
   const dataHigh = (['flood', 'heat', 'landslide'] as HazardKey[]).filter(h => (risks[h] ?? 0) >= 66);
   // Cap at two — three checkpoints is where a conversation becomes a form.
   return Array.from(new Set([...named, ...dataHigh])).slice(0, 2);


### PR DESCRIPTION
Backlog **#24**, first half. From the COUGAR convening (Vila Flores / PxG / OEF / BwB, 2026-08-06).

## The problem, in the product's own words

The chip was already merging two mechanisms out loud:

> 💧 **Alagamento** — *"A água que junta **ou invade**"*

"Junta" is Alagamento. "Invade" is Inundação. Both sat under a label naming only the first, so an org whose problem is the Guaíba overtopping was tapping a chip that called it something else. The meeting standardised the civil-defense terms — Alagamento (pluvial/drainage), Inundação (river), Enxurrada (flash flood) — each paired with plain language.

## ⚠️ It is not a new data key

We hold exactly three rasters. All three water mechanisms score against `flood`, and `family` is how every consumer gets back to a key we have data for. **The org's word is theirs and is stored as given; the number stays the flood-family percentile and keeps saying so.** Nothing here implies per-mechanism data we don't have.

Chips are now six, ordered by the bairro data, everyday water first, "Outra coisa" last. Flat rather than a drill-down — an extra turn is exactly what the latency work has been removing. Heat and slope keep today's wording until the Plano de Contingência lands.

## Where the finer word already pays

- **Photographs.** The shot that settles Inundação (*how high did it get — the mark on the wall*) is not the shot that settles Enxurrada (*where does it come down*), and neither is in the generic flood set.
- **Scale honesty.** `needsScaleReframing` existed to catch someone who said "flood" and then described the 2024 Guaíba event — which *is* Inundação. It was reverse-engineering the word from story keywords because the chip couldn't say it. Now picking it is the signal.

## The failure mode this guards is silence

`photoPromptsFor`, `hazardsToCheck`, `needsScaleReframing` and `rankFamiliasForSite` all filtered with `w === 'flood' || …`, which **drops an unknown id without complaint**. A mechanism id would have quietly stopped those orgs ever being asked for photographs — no error anywhere. All four now resolve through `familyOfWorry` / `familiesOfWorries`.

And **legacy `site_worry: 'flood'` still resolves** as "water, mechanism unspecified" — those rows are in the database right now for your test orgs and the three W2 test-kit orgs.

Three diagnostic assertions changed: they asserted the stored id was literally `"flood"`. It's now the mechanism the org tapped, so they assert the guarantee that actually matters — that it still resolves to the one flood raster.

## Testing, stated plainly

8 new specs, green. Full suite 163–165 passed.

On the diagnostic spec I saw **2 failures in 12 runs against a playwright-spawned server, versus 0 in 12 on main** — which I wasn't willing to wave through. I traced `hazardsToCheck`, `photoPromptsFor` and `needsScaleReframing` for these exact inputs and they're logically identical to before, then ran **27 consecutive passes** against a warm server. The failures are all "an element that should be there isn't", one was a flat 30s test timeout, and *"org has no site"* has failed on clean `main` earlier in this same session — it's in the ambient stall set (see CHIP-TAP-LOST, #455).

To be explicit: **I did not prove it isn't mine. I showed it behaves like the ambient rate.**

## Not in this PR

Solution-mechanism tagging — the other half of #24, where the mechanism orders solutions *within* a família — is deliberately separate. It needs the 27 tags drafted and marked provisional for Robson/Hesioni to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy