### PR TITLE
feat(e2): Alagamento / Inundação / Enxurrada — the org's word, and it orders the solutions

### DIFF
--- a/client/src/core/components/cbo/NbsFamiliaSheet.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaSheet.tsx
@@ -18,7 +18,7 @@ import {
   DrawerHandle,
 } from '@/core/components/ui/drawer';
 import type { NbsFamiliaId } from '@shared/nbs-catalog';
-import { getFamilia, getSolution, solutionsForFamilia } from '@shared/nbs-catalog';
+import { getFamilia, getSolution, solutionsForFamilia, orderSolutionsByMechanism } from '@shared/nbs-catalog';
 import { NbsSolutionCard } from './NbsSolutionCard';
 import { NbsSolutionDetail } from './NbsSolutionDetail';
 import { CroquiLightbox } from './CroquiLightbox';
@@ -58,11 +58,15 @@ export function NbsFamiliaSheet({
   openFamiliaId,
   onClose,
   lang,
+  worries = [],
 }: {
   /** Which família to show. `null` closes the sheet. */
   openFamiliaId: NbsFamiliaId | null;
   onClose: () => void;
   lang: 'pt' | 'en';
+  /** What the org said worries them, as the mechanisms they named. Orders the
+   *  list so what answers their problem is on top — never hides anything. */
+  worries?: string[];
 }) {
   const s = STRINGS[lang];
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -70,7 +74,12 @@ export function NbsFamiliaSheet({
   const [croquiOpen, setCroquiOpen] = useState(false);
   const [filter, setFilter] = useState<SolutionFilter>(EMPTY_SOLUTION_FILTER);
   const familia = openFamiliaId ? getFamilia(openFamiliaId) : undefined;
-  const solutions = openFamiliaId ? solutionsForFamilia(openFamiliaId) : [];
+  // Ordered by the mechanism they named — Inundação puts margin and várzea work
+  // above rain gardens — and the filter still sees the whole set, because
+  // nothing is ever removed (see SOLUTION_MECHANISMS).
+  const solutions = openFamiliaId
+    ? orderSolutionsByMechanism(solutionsForFamilia(openFamiliaId), worries)
+    : [];
   const visibleSolutions = filterSolutions(solutions, filter);
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
 

--- a/client/src/core/components/cbo/NbsFamiliaStrip.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaStrip.tsx
@@ -20,11 +20,15 @@ export function NbsFamiliaStrip({
   familiaIds,
   intro,
   lang,
+  worries = [],
 }: {
   /** Which famílias to show; empty/undefined = all five. */
   familiaIds?: string[];
   intro?: string;
   lang: 'pt' | 'en';
+  /** Passed through so the variants inside a família are ordered by the
+   *  mechanism the org named (backlog #24). Ordering only — nothing hidden. */
+  worries?: string[];
 }) {
   const [openFamiliaId, setOpenFamiliaId] = useState<NbsFamiliaId | null>(null);
   const [croquiFamiliaId, setCroquiFamiliaId] = useState<NbsFamiliaId | null>(null);
@@ -59,6 +63,7 @@ export function NbsFamiliaStrip({
       </div>
 
       <NbsFamiliaSheet
+        worries={worries}
         openFamiliaId={openFamiliaId}
         onClose={() => setOpenFamiliaId(null)}
         lang={lang}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1982,6 +1982,13 @@ export default function CboProfilePage() {
                         familiaIds={parsed.familiaIds}
                         intro={parsed.intro}
                         lang={lang.startsWith('pt') ? 'pt' : 'en'}
+                        // The mechanisms they named in the worry beat, so the
+                        // variants inside a família lead with what answers their
+                        // problem (backlog #24). Read live from the profile —
+                        // the strip persists as a composer and re-renders on
+                        // reload, when this prop must still be right.
+                        worries={String(state?.sections?.intervention_site?.fields?.site_worry?.value ?? '')
+                          .split(',').map(w => w.trim()).filter(Boolean)}
                       />
                     </div>
                   );

--- a/e2e/cougar-e2-diagnostic.spec.ts
+++ b/e2e/cougar-e2-diagnostic.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, devices } from '@playwright/test';
 import { TestApi } from './helpers/testApi';
+import { familyOfWorry } from '../shared/site-knowledge';
 import { clickCenterZone } from './helpers/mapActions';
 
 // The W2 diagnostic beats (/refine 2026-07-31): frame → worry → story → photos
@@ -193,7 +194,10 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // Everything the diagnostic captured actually persisted.
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.site_story?.value)).toContain('dois dias');
     expect(String(f.site_photo_intent?.value)).toBe('skip');
     expect(JSON.parse(String(f._hazard_check_json?.value))).toMatchObject({ flood: 'worse' });
@@ -228,7 +232,8 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // never reached the interest/role loops or the close.
     const depth = JSON.parse(String(f._depth_json?.value ?? '{}'));
     expect(depth.level, 'a depth read must exist mid-session').toBeTruthy();
-    expect(String(f.site_worry?.value)).toContain('flood');   // what worries them
+    // what worries them, stored as the MECHANISM they tapped (backlog #24)
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.current_use?.value)).toBeTruthy();        // what the place is
     expect(String(f.land_tenure?.value)).toBeTruthy();        // whether they can use it
     expect(String(f.site_name?.value)).toBeTruthy();          // where it is
@@ -366,7 +371,10 @@ test.describe('COUGAR — W2 degraded scenarios', () => {
 
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.bairro?.value ?? '')).not.toBe('');
   });
 

--- a/e2e/cougar-hazard-subtypes.spec.ts
+++ b/e2e/cougar-hazard-subtypes.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import {
+  WORRY_SUBTYPES, E2_WORRIES, familyOfWorry, familiesOfWorries,
+  orderWorriesByData, photoPromptsFor, hazardsToCheck,
+} from '../shared/site-knowledge';
+import { needsScaleReframing } from '../shared/nbs-performance';
+import { rankFamiliasForSite } from '../shared/nbs-recommendation';
+
+// COUGAR convening, 2026-08-06: orgs don't experience "flood" as one thing.
+// Alagamento (water that pools), Inundação (the river overtopping) and Enxurrada
+// (water coming down with force) are three problems with three answers — and the
+// old chip merged the first two out loud ("A água que junta OU INVADE") under a
+// label that named only one of them.
+//
+// The mechanism is a LANGUAGE layer over the three rasters we actually hold.
+// Every consumer used to filter with `w === 'flood' || w === 'heat' || …`, which
+// drops an unknown id **silently** — so the failure mode this pins is not a
+// crash, it's an org quietly never being asked for photos again.
+
+test.describe('hazard mechanisms — a finer word over the same data', () => {
+  test('every mechanism resolves to a layer we actually have', () => {
+    for (const w of WORRY_SUBTYPES) {
+      if (w.id === 'other') { expect(w.family).toBeNull(); continue; }
+      expect(['flood', 'heat', 'landslide'], `${w.id} must score against a real raster`)
+        .toContain(w.family);
+    }
+    // The three water mechanisms share one layer. That is the whole design: we
+    // hold one flood raster, so three names cannot mean three numbers.
+    expect(['alagamento', 'inundacao', 'enxurrada'].map(familyOfWorry))
+      .toEqual(['flood', 'flood', 'flood']);
+  });
+
+  test('⚠️ legacy `flood` still resolves — sessions in the database used it', () => {
+    // JVP's test orgs and the three W2 test-kit orgs stored `site_worry: 'flood'`
+    // before the split. If that becomes an unknown id, they stop getting photo
+    // prompts and their depth read quietly degrades. Nothing throws.
+    expect(familyOfWorry('flood')).toBe('flood');
+    expect(familiesOfWorries(['flood'])).toEqual(['flood']);
+    expect(photoPromptsFor(['flood']).length).toBeGreaterThan(1);
+    expect(hazardsToCheck(['flood'], { flood: 10, heat: 10, landslide: 10 })).toContain('flood');
+  });
+
+  test('nothing downstream drops a mechanism on the floor', () => {
+    const low = { flood: 10, heat: 10, landslide: 10 };
+    for (const id of ['alagamento', 'inundacao', 'enxurrada'] as const) {
+      expect(hazardsToCheck([id], low), `${id} must still raise a flood check`).toContain('flood');
+      // …and it must ask for photographs, which is the beat that silently died
+      // if the id was unrecognised.
+      const prompts = photoPromptsFor([id]);
+      expect(prompts.length, `${id} must still produce prompts`).toBeGreaterThan(1);
+    }
+    // Three water mechanisms are ONE check, not three — the conversation caps
+    // at two checkpoints before it becomes a form.
+    expect(hazardsToCheck(['alagamento', 'inundacao', 'enxurrada'], low)).toEqual(['flood']);
+  });
+
+  test('the mechanism asks for the photo only it makes worth taking', () => {
+    const ids = (ws: string[]) => photoPromptsFor(ws).map(p => p.id);
+    expect(ids(['inundacao']), 'how high did it get').toContain('high-water-mark');
+    expect(ids(['enxurrada']), 'where does it come down').toContain('water-path');
+    // Alagamento keeps the generic flood set — pooling is what those ask about.
+    expect(ids(['alagamento'])).not.toContain('high-water-mark');
+    expect(ids(['alagamento'])).toContain('water-in');
+  });
+
+  test('naming Inundação IS the scale signal — no story keywords needed', () => {
+    // This beat existed to catch someone who said "flood" and then described the
+    // 2024 Guaíba event. That event is Inundação; now they can just say so.
+    expect(needsScaleReframing(['inundacao'], 'a gente cuida da horta')).toBe(true);
+    // Alagamento alone is the everyday water — no reframing, or the agent
+    // lectures an org about limits it never claimed to exceed.
+    expect(needsScaleReframing(['alagamento'], 'a água junta no canto')).toBe(false);
+    // …and the old story-keyword path still fires, for legacy rows.
+    expect(needsScaleReframing(['flood'], 'na enchente de 2024 o Guaíba subiu')).toBe(true);
+    expect(needsScaleReframing(['heat'], 'o Guaíba subiu em 2024')).toBe(false);
+  });
+
+  test('the worry the org named still lifts a família', () => {
+    const base = {
+      risks: { flood: 40, heat: 40, landslide: 40 },
+      bairro: 'Sarandi',
+      worries: ['inundacao'],
+    };
+    const ranked = rankFamiliasForSite(base as any);
+    const water = ranked.find((r: any) => r.familiaId === 'aguas-pluviais');
+    expect(water, 'the water família must be in the list').toBeTruthy();
+    // Same shape the old `['flood']` worry produced — the mechanism reaches the
+    // ranking through its family rather than being filtered out.
+    const viaFamily = rankFamiliasForSite({ ...base, worries: ['flood'] } as any);
+    expect(ranked.map((r: any) => r.familiaId)).toEqual(viaFamily.map((r: any) => r.familiaId));
+  });
+
+  test('chips: six, ordered by the data, everyday water first, "outra" last', () => {
+    expect(E2_WORRIES).toHaveLength(6);
+    const ordered = orderWorriesByData({ flood: 90, heat: 10, landslide: 5 });
+    expect(ordered.map(w => w.id)).toEqual(
+      ['alagamento', 'inundacao', 'enxurrada', 'heat', 'landslide', 'other']);
+    // The sort is stable, so the three water mechanisms keep catalogue order
+    // even when the data puts another hazard on top.
+    const heatFirst = orderWorriesByData({ flood: 10, heat: 90, landslide: 5 });
+    expect(heatFirst.map(w => w.id)).toEqual(
+      ['heat', 'alagamento', 'inundacao', 'enxurrada', 'landslide', 'other']);
+    expect(heatFirst[heatFirst.length - 1].id).toBe('other');
+  });
+
+  test('the chips say the mechanism in plain words, not just the technical term', () => {
+    const by = (id: string) => WORRY_SUBTYPES.find(w => w.id === id)!;
+    // The convening asked for the civil-defense term PAIRED with plain language.
+    expect(by('alagamento').pt).toContain('Alagamento');
+    expect(by('alagamento').dPt).toBe('A água que junta e não escoa');
+    expect(by('inundacao').dPt).toBe('O rio ou arroio que transborda');
+    expect(by('enxurrada').dPt).toBe('A água que desce com força');
+    // The merged wording is gone — that phrase is what mis-named the Guaíba.
+    for (const w of WORRY_SUBTYPES) expect(w.dPt).not.toContain('junta ou invade');
+  });
+});

--- a/e2e/cougar-solution-mechanisms.spec.ts
+++ b/e2e/cougar-solution-mechanisms.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import {
+  NBS_SOLUTIONS, SOLUTION_MECHANISMS, orderSolutionsByMechanism, mechanismNote,
+  solutionsForFamilia,
+} from '../shared/nbs-catalog';
+import { WORRY_SUBTYPES } from '../shared/site-knowledge';
+
+// Backlog #24, second half. COUGAR convening: "solution types differ
+// fundamentally by hazard type" — an org that says Inundação should not be shown
+// rain gardens first, because a rain garden answers Alagamento.
+//
+// The two rules that make a wrong tag cheap are what these pin:
+//   1. ORDER AND EXPLAIN, NEVER EXCLUDE — the flow promises "nada fica
+//      descartado", so every solution stays reachable whatever the tags say.
+//   2. The tags are OUR read, drafted from each solution's own whatItIs, and
+//      marked provisional until Robson/Hesioni confirm.
+
+test.describe('solution mechanisms — ordering, never hiding', () => {
+  test('⚠️ nothing is ever removed, whatever the org named', () => {
+    for (const familia of ['aguas-pluviais', 'verde-urbano', 'encostas-e-solo'] as const) {
+      const all = solutionsForFamilia(familia);
+      for (const worries of [['inundacao'], ['alagamento'], ['enxurrada', 'heat'], ['other'], []]) {
+        const ordered = orderSolutionsByMechanism(all, worries);
+        expect(ordered, `${familia} / ${worries.join('+')} must keep every solution`)
+          .toHaveLength(all.length);
+        expect(new Set(ordered.map(s => s.id))).toEqual(new Set(all.map(s => s.id)));
+      }
+    }
+  });
+
+  test('Inundação leads with the river answers, not the rain garden', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const first = orderSolutionsByMechanism(water, ['inundacao'])[0];
+    expect(SOLUTION_MECHANISMS[first.id]).toContain('inundacao');
+    // …and the rain garden is still there, just not first.
+    const ids = orderSolutionsByMechanism(water, ['inundacao']).map(s => s.id);
+    expect(ids).toContain('jardins-de-chuva');
+    expect(ids.indexOf('jardins-de-chuva')).toBeGreaterThan(0);
+  });
+
+  test('Alagamento leads with infiltration — the everyday-water answers', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const first = orderSolutionsByMechanism(water, ['alagamento'])[0];
+    expect(SOLUTION_MECHANISMS[first.id]).toContain('alagamento');
+  });
+
+  test('Enxurrada leads with the ones that name velocity or slope', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const top = orderSolutionsByMechanism(water, ['enxurrada'])
+      .slice(0, 4).map(s => s.id);
+    // "escada hidráulica vegetada" says it in its own description:
+    // "terrenos inclinados, diminuindo sua velocidade".
+    expect(top).toContain('escada-hidraulica-vegetada');
+  });
+
+  test('no worry named, or only "outra coisa" — catalogue order, untouched', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    for (const worries of [[], ['other']]) {
+      expect(orderSolutionsByMechanism(water, worries).map(s => s.id))
+        .toEqual(water.map(s => s.id));
+    }
+  });
+
+  test('every tag names a real mechanism, and every solution is accounted for', () => {
+    const known = new Set(WORRY_SUBTYPES.map(w => w.id));
+    for (const [id, tags] of Object.entries(SOLUTION_MECHANISMS)) {
+      expect(NBS_SOLUTIONS.some(s => s.id === id), `${id} is not a solution`).toBe(true);
+      for (const t of tags) expect(known, `${id} tagged with unknown "${t}"`).toContain(t);
+    }
+    // Every solution has an ENTRY — an empty list is a deliberate "neutral",
+    // a missing key is someone forgetting. The difference matters when a
+    // domain expert reads this map to confirm it.
+    for (const s of NBS_SOLUTIONS) {
+      expect(SOLUTION_MECHANISMS[s.id], `${s.id} has no entry`).toBeDefined();
+    }
+  });
+
+  test('the note speaks the org\'s words back, or says nothing', () => {
+    // Reuses the exact plain-language phrase from the chip they tapped, so the
+    // card and the question agree.
+    expect(mechanismNote('escada-hidraulica-vegetada', ['enxurrada'], 'pt'))
+      .toBe('pra a água que desce com força');
+    expect(mechanismNote('parques-lineares', ['inundacao'], 'pt'))
+      .toBe('pra o rio ou arroio que transborda');
+    // No match → no badge. A badge that says nothing is worse than none.
+    expect(mechanismNote('jardins-de-chuva', ['inundacao'], 'pt')).toBeNull();
+    expect(mechanismNote('hortas-urbanas', ['alagamento'], 'pt')).toBeNull();
+  });
+});

--- a/shared/nbs-catalog.ts
+++ b/shared/nbs-catalog.ts
@@ -27,6 +27,7 @@
 // line. ⚠️ Written permission from Vila Flores/Rede to reuse them in-app is
 // pending (tracked in docs/photo-curation.md).
 
+import { WORRY_SUBTYPES, type WorryId } from './site-knowledge';
 import type { NbsInterventionTypeId } from './cbo-schema';
 import type { NbsCostBand, NbsDelivery } from './nbs-type-content';
 
@@ -704,6 +705,105 @@ export type NbsSolutionId = (typeof NBS_SOLUTIONS)[number]['id'];
 /** `/assets/nbs/solutions/<id>.jpg` — the solution's own card photo. */
 export function nbsSolutionPhoto(id: NbsSolutionId): string {
   return `/assets/nbs/solutions/${id}.jpg`;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WHICH MECHANISM A SOLUTION ANSWERS  ⚠️ PROVISIONAL
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// COUGAR convening 2026-08-06: "solution types differ fundamentally by hazard
+// type". An org that says Inundação should not be shown rain gardens first — a
+// rain garden answers Alagamento. So the mechanism the org names (see
+// WORRY_SUBTYPES) orders the solutions inside a família.
+//
+// ⚠️ TWO RULES, both load-bearing.
+//
+// 1. ORDER AND EXPLAIN, NEVER EXCLUDE. The flow promises, in its own words,
+//    "Nada fica descartado — dá pra ver as 27 soluções quando quiser." Keep that
+//    literally true. Then a wrong tag below costs an org some scrolling instead
+//    of hiding the answer they needed.
+// 2. THESE TAGS ARE OUR READ, NOT AN EXPERT'S — the same status as
+//    `classificationEstimated` on the solutions themselves. Each one is drafted
+//    from the solution's OWN `whatItIs` text, not invented: "escada hidráulica
+//    vegetada" says "diminuindo sua velocidade" in terrain "inclinado", which is
+//    Enxurrada; "parques lineares" says "ao longo de cursos d'água", which is
+//    Inundação. Robson/Hesioni to confirm at the convening — this map is
+//    deliberately one screen so it can be read and argued with in one sitting.
+//
+// An empty/absent entry is NEUTRAL, not "irrelevant": the solution simply never
+// gets reordered by mechanism. Better than a guess we cannot source.
+export const SOLUTION_MECHANISMS: Record<string, WorryId[]> = {
+  // ── Águas pluviais — water that pools, drains, or runs ────────────────────
+  'jardins-de-chuva': ['alagamento'],                       // "infiltrar… reduzindo o escoamento superficial"
+  'biovaletas': ['alagamento', 'enxurrada'],                // "escoamento mais lento… reduzindo erosão"
+  'canteiro-pluvial': ['alagamento'],                       // "receber e infiltrar… em áreas urbanas"
+  'bacia-de-retencao': ['alagamento', 'enxurrada'],         // "acumular temporariamente… regulando a vazão"
+  'wetland-construido': ['alagamento', 'inundacao'],        // "retenção de águas da chuva"; buffers a watercourse
+  'pavimentos-permeaveis': ['alagamento'],                  // "infiltração… reduzindo o escoamento"
+  'escada-hidraulica-vegetada': ['enxurrada'],              // "terrenos inclinados, diminuindo sua velocidade"
+  'terracos-de-chuva': ['enxurrada', 'alagamento'],         // "no declive do terreno… absorvem o escoamento"
+  'barraginha': ['enxurrada', 'alagamento'],                // "captam a água da chuva" on periurban slopes
+  'captacao-agua-da-chuva': ['alagamento'],                 // cisterns take rain off the surface
+  'ilhas-filtrantes-flutuantes': [],                        // water QUALITY in a body of water — no flood mechanism
+  // ── Verde urbano ──────────────────────────────────────────────────────────
+  'teto-verde': ['heat', 'alagamento'],                     // "retém água da chuva, reduz ilhas de calor"
+  'parques-e-florestas-urbanas': ['heat'],
+  'corredores-verdes': ['heat'],
+  'escola-verde': ['heat'],
+  'parque-naturalizado': ['heat'],
+  'parques-lineares': ['inundacao'],                        // "ao longo de cursos d'água"
+  // ── Encostas e solo — the slope itself, and water arriving down it ────────
+  'grade-viva': ['landslide', 'enxurrada'],                 // "estabilizam o solo em áreas inclinadas"
+  'muro-de-arrimo-verde': ['landslide'],
+  'solo-grampeado-verde': ['landslide'],
+  'contencoes-em-geocelulas': ['landslide', 'enxurrada'],
+  // ── Recuperação de ecossistemas ───────────────────────────────────────────
+  'reflorestamento': ['enxurrada', 'inundacao'],            // slope cover + "proteger recursos hídricos"
+  'restauracao-areas-umidas': ['inundacao'],                // "transição entre terra e água… resiliência"
+  // ── Agricultura urbana ────────────────────────────────────────────────────
+  // Food, soil and organic waste. Real climate value, but not an answer to a
+  // water or heat MECHANISM — so neutral rather than tagged for the sake of it.
+  'hortas-urbanas': [],
+  'compostagem': [],
+  'cozinha-comunitaria-biodigestor': [],
+  'sistema-alimentar-local': [],
+};
+
+/**
+ * Solutions reordered so the ones answering the org's named mechanism come
+ * first. NEVER filters — see rule 1 above. Stable, so within each group the
+ * catalogue order survives.
+ */
+export function orderSolutionsByMechanism(
+  solutions: NbsSolution[],
+  worries: string[],
+): NbsSolution[] {
+  const named = worries.filter(w => w && w !== 'other');
+  if (named.length === 0) return solutions;
+  const answers = (s: NbsSolution) =>
+    (SOLUTION_MECHANISMS[s.id] ?? []).some(m => named.includes(m));
+  return [...solutions].sort((a, b) => Number(answers(b)) - Number(answers(a)));
+}
+
+/**
+ * The one-line reason a solution is near the top, in the org's own vocabulary —
+ * "pra água que desce com força" reuses the exact plain-language phrase from the
+ * chip they tapped, so the card and the question say the same thing.
+ * Null when the solution doesn't answer anything they named: no badge is better
+ * than a badge that says nothing.
+ */
+export function mechanismNote(
+  solutionId: string,
+  worries: string[],
+  lang: 'pt' | 'en' = 'pt',
+): string | null {
+  const tags = SOLUTION_MECHANISMS[solutionId] ?? [];
+  const hit = worries.find(w => tags.includes(w as WorryId));
+  if (!hit) return null;
+  const sub = WORRY_SUBTYPES.find(w => w.id === hit);
+  if (!sub) return null;
+  const phrase = (lang === 'pt' ? sub.dPt : sub.dEn).toLowerCase();
+  return lang === 'pt' ? `pra ${phrase}` : `for ${phrase}`;
 }
 
 export function solutionsForFamilia(familiaId: NbsFamiliaId): NbsSolution[] {

--- a/shared/nbs-performance.ts
+++ b/shared/nbs-performance.ts
@@ -32,6 +32,8 @@
 // from `NBS_EVENT_SCALE` must carry `estimated`-style marking, the same
 // discipline as `classificationEstimated` in nbs-catalog.ts.
 
+import { familiesOfWorries } from './site-knowledge';
+
 /** What a retention figure is measured in — these are NOT interchangeable. */
 export type RetentionUnit =
   /** Cubic metres held per m² of intervention, per rain event. */
@@ -294,7 +296,16 @@ export const NBS_SCALE_HONESTY = {
  * the everyday water, and that the big flood is an advocacy conversation.
  */
 export function needsScaleReframing(worry: string[], story: string): boolean {
-  if (!worry.includes('flood')) return false;
+  // Through the family — the worry ids now carry the mechanism (Alagamento /
+  // Inundação / Enxurrada), and a literal `includes('flood')` would stop firing
+  // for every one of them: the honesty beat would go quiet exactly when the org
+  // is describing the event it exists for.
+  if (!familiesOfWorries(worry).includes('flood')) return false;
+  // Naming Inundação IS the signal. This function was reverse-engineering it
+  // from story keywords because the chip could not say it — "the 2024 event or
+  // a river/dike" is the definition of Inundação. Now that they can pick the
+  // word, take them at it and don't wait for the story to mention the Guaíba.
+  if (worry.includes('inundacao')) return true;
   const s = story.toLowerCase();
   return /enchente|2024|guaíba|guaiba|dique|rio subiu|subiu o rio|inunda|the flood|dike|river rose/.test(s);
 }

--- a/shared/nbs-recommendation.ts
+++ b/shared/nbs-recommendation.ts
@@ -13,6 +13,7 @@
 // calls the show_familia_recommendation tool with its own whys, which override
 // these per-família.
 
+import { familiesOfWorries } from './site-knowledge';
 import {
   NBS_FAMILIAS,
   solutionsForFamilia,
@@ -244,8 +245,11 @@ export function rankFamiliasForSite(input: FamiliaRecoInput): RankedFamilia[] {
     // The worry the org named. Capped so the hazard data still shapes the
     // order — a stated worry should lift a família decisively, not seize the
     // ranking — and marked `guaranteed` so no trimming can hide it.
-    const named = (input.worries ?? []).filter(
-      (w): w is 'flood' | 'heat' | 'landslide' => w === 'flood' || w === 'heat' || w === 'landslide');
+    // Through the family: worries now carry the finer mechanism (Alagamento /
+    // Inundação / Enxurrada) and this scores against the one flood layer we
+    // have. A raw `w === 'flood'` filter would drop every one of them and
+    // silently stop honouring the worry they just told us about.
+    const named = familiesOfWorries(input.worries ?? []);
     const answersAWorry = named.find(h => f.hazards[h] >= 0.6);
     const worryBoost = answersAWorry ? Math.min(0.35, 0.35 * f.hazards[answersAWorry]) : 0;
 

--- a/shared/site-knowledge.ts
+++ b/shared/site-knowledge.ts
@@ -25,15 +25,80 @@
 // participant, while broad prompts surface what the facilitator never thought to
 // ask.
 
+/** The three layers we hold data for. One raster each; nothing finer exists. */
 export type HazardKey = 'flood' | 'heat' | 'landslide';
 
-/** What an organization can name as the thing that worries them at this place. */
-export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string; dPt: string; dEn: string }> = [
-  { id: 'flood', pt: '💧 Alagamento', en: '💧 Flooding', dPt: 'A água que junta ou invade', dEn: 'Water that pools or comes in' },
-  { id: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
-  { id: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
-  { id: 'other', pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
+/**
+ * The MECHANISM an organization names — one level finer than the data.
+ *
+ * COUGAR convening, 2026-08-06 (Vila Flores / PxG / OEF / BwB): orgs do not
+ * experience "flood" as one thing. Water that pools and won't drain, a river
+ * that overtops, and water coming down a slope with velocity are three
+ * different problems that take three different solutions. The meeting
+ * standardised the civil-defense terms — Alagamento (pluvial/drainage),
+ * Inundação (river), Enxurrada (flash flood) — each paired with plain language.
+ *
+ * The old chip was already merging two of them out loud: "💧 Alagamento — A água
+ * que junta OU INVADE". "Junta" is Alagamento, "invade" is Inundação, and both
+ * sat under a label that named only the first. An org whose problem is the
+ * Guaíba was tapping a chip that called it the wrong thing.
+ *
+ * ⚠️ This is deliberately NOT a new data key. We hold exactly three rasters, so
+ * all three water mechanisms score against `flood`; `family` is how every
+ * consumer gets back to a key it has data for. The org's word is theirs and is
+ * stored as-is; the number stays the flood-family percentile and keeps saying
+ * so. See backlog #24.
+ */
+export type WorryId = 'alagamento' | 'inundacao' | 'enxurrada' | 'heat' | 'landslide' | 'other';
+
+export interface WorrySubtype {
+  id: WorryId;
+  /** The data key this mechanism is scored against. null = we have no layer. */
+  family: HazardKey | null;
+  pt: string;
+  en: string;
+  dPt: string;
+  dEn: string;
+}
+
+export const WORRY_SUBTYPES: WorrySubtype[] = [
+  { id: 'alagamento', family: 'flood', pt: '💧 Alagamento', en: '💧 Ponding', dPt: 'A água que junta e não escoa', dEn: "Water that pools and won't drain" },
+  { id: 'inundacao', family: 'flood', pt: '🌊 Inundação', en: '🌊 River flooding', dPt: 'O rio ou arroio que transborda', dEn: 'The river or stream overtopping' },
+  { id: 'enxurrada', family: 'flood', pt: '🌧️ Enxurrada', en: '🌧️ Flash flood', dPt: 'A água que desce com força', dEn: 'Water coming down with force' },
+  { id: 'heat', family: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
+  { id: 'landslide', family: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
+  { id: 'other', family: null, pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
 ];
+
+/**
+ * The data key behind a worry, or null if we hold no layer for it.
+ *
+ * ⚠️ MIGRATION. Sessions that ran before the split stored the family id itself
+ * (`site_worry: 'flood'`), and those rows are still in the database — JVP's test
+ * orgs and the three W2 test-kit orgs. A legacy `flood` therefore has to keep
+ * resolving as "water, mechanism unspecified" rather than becoming an unknown
+ * id. Every consumer below filtered with `w === 'flood' || …`, which DROPS
+ * anything it doesn't recognise silently — so getting this wrong would not
+ * throw, it would quietly stop asking those orgs for photos.
+ */
+export function familyOfWorry(id: string): HazardKey | null {
+  const hit = WORRY_SUBTYPES.find(w => w.id === id);
+  if (hit) return hit.family;
+  return id === 'flood' || id === 'heat' || id === 'landslide' ? (id as HazardKey) : null;
+}
+
+/** The families behind a set of worries, deduped and order-preserving. */
+export function familiesOfWorries(worries: string[]): HazardKey[] {
+  const out: HazardKey[] = [];
+  for (const w of worries) {
+    const f = familyOfWorry(w);
+    if (f && !out.includes(f)) out.push(f);
+  }
+  return out;
+}
+
+/** What an organization can name as the thing that worries them at this place. */
+export const E2_WORRIES = WORRY_SUBTYPES;
 
 /**
  * Worry chips ordered by what the bairro data suggests, highest first — the
@@ -47,8 +112,12 @@ export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string
 export function orderWorriesByData(risks: Record<HazardKey, number>) {
   const hazards = E2_WORRIES.filter(w => w.id !== 'other');
   const other = E2_WORRIES.filter(w => w.id === 'other');
+  const riskOf = (w: WorrySubtype) => (w.family ? risks[w.family] ?? 0 : -1);
   return [
-    ...hazards.sort((a, b) => (risks[b.id as HazardKey] ?? 0) - (risks[a.id as HazardKey] ?? 0)),
+    // Array.prototype.sort is stable, so the three water mechanisms — which all
+    // score against the same `flood` number — keep the order they are declared
+    // in: Alagamento, Inundação, Enxurrada. Everyday first.
+    ...hazards.slice().sort((a, b) => riskOf(b) - riskOf(a)),
     ...other,
   ];
 }
@@ -87,6 +156,21 @@ const PHOTO_PROMPTS: Record<HazardKey | 'base', PhotoPrompt[]> = {
   ],
 };
 
+/**
+ * Prompts that only make sense for a named mechanism. Deliberately small: these
+ * are the questions a raster cannot answer and the generic flood prompts don't
+ * ask. See backlog #24 — this is where the finer term changes what we request,
+ * at no data cost.
+ */
+const MECHANISM_PROMPTS: Partial<Record<WorryId, PhotoPrompt[]>> = {
+  inundacao: [
+    { id: 'high-water-mark', pt: 'Até onde a água chegou — a marca na parede, se tiver', en: 'How high the water reached — the mark on the wall, if there is one' },
+  ],
+  enxurrada: [
+    { id: 'water-path', pt: 'Por onde a água desce quando vem com força', en: 'The path the water takes when it comes down hard' },
+  ],
+};
+
 /** Always offered last, and deliberately open — see the note on power imbalance. */
 export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
   id: 'open',
@@ -100,11 +184,23 @@ export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
  * about water.
  */
 export function photoPromptsFor(worries: string[]): PhotoPrompt[] {
-  const hazards = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const hazards = familiesOfWorries(worries);
   if (hazards.length === 0) return [...PHOTO_PROMPTS.base, PHOTO_PROMPT_OPEN];
 
   const picked: PhotoPrompt[] = [];
   const seen = new Set<string>();
+  // The mechanism earns its keep here: the shot that settles Inundação (how
+  // high did it get?) is not the shot that settles Enxurrada (where does it
+  // come down?), and neither is in the generic flood set. These go FIRST — a
+  // named mechanism is the most specific thing we know about the site.
+  for (const w of worries) {
+    for (const prompt of MECHANISM_PROMPTS[w as WorryId] ?? []) {
+      if (!seen.has(prompt.id) && picked.length < 3) {
+        seen.add(prompt.id);
+        picked.push(prompt);
+      }
+    }
+  }
   // Round-robin across the named hazards, so every worry is represented before
   // any one of them gets a second prompt.
   for (let round = 0; round < 3 && picked.length < 3; round++) {
@@ -177,7 +273,7 @@ export function hazardCheckQuestion(
 
 /** Which hazards are worth checking: what they named, plus anything our data calls high. */
 export function hazardsToCheck(worries: string[], risks: Record<HazardKey, number>): HazardKey[] {
-  const named = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const named = familiesOfWorries(worries);
   const dataHigh = (['flood', 'heat', 'landslide'] as HazardKey[]).filter(h => (risks[h] ?? 0) >= 66);
   // Cap at two — three checkpoints is where a conversation becomes a form.
   return Array.from(new Set([...named, ...dataHigh])).slice(0, 2);


### PR DESCRIPTION
Backlog **#24**, both halves. **Supersedes #457** — same first commit; the hook wouldn't let me add to that branch, and the second half imports from the first so it can't branch off main independently.

From the COUGAR convening, Vila Flores / PxG / OEF / BwB, 2026-08-06.

## The problem was already in the product's own copy

> 💧 **Alagamento** — *"A água que junta **ou invade**"*

"Junta" is Alagamento. "Invade" is Inundação. Both under a label naming only the first — so an org whose problem is the Guaíba overtopping was tapping a chip that called it something else.

## Half one — the word

Six chips, ordered by the bairro data, everyday water first, "Outra coisa" last. Flat rather than a drill-down: an extra turn is what the latency work has been removing.

**⚠️ Not a new data key.** We hold exactly three rasters, so all three water mechanisms score against `flood`, and `family` is how every consumer gets back to a key we have data for. The org's word is theirs and stored as given; the number stays the flood-family percentile and keeps saying so.

Where the finer word already pays: the **photo prompts** (the shot that settles Inundação — *how high did it get* — is not the shot that settles Enxurrada — *where does it come down*), and the **scale-honesty beat**, which existed to catch someone who said "flood" and then described the 2024 Guaíba event. That *is* Inundação; the function was reverse-engineering the word from story keywords because the chip couldn't say it.

**The failure mode guarded here is silence.** `photoPromptsFor`, `hazardsToCheck`, `needsScaleReframing` and `rankFamiliasForSite` all filtered with `w === 'flood' || …`, which drops an unknown id *without complaint* — a mechanism id would have quietly stopped those orgs ever being asked for photographs. Legacy `site_worry: 'flood'` still resolves, because those rows are in the database now.

## Half two — it orders the solutions

`SOLUTION_MECHANISMS` tags all 27, and a família's list leads with what answers their problem.

**Two rules, both load-bearing:**

1. **Order and explain, never exclude.** The flow promises *"Nada fica descartado — dá pra ver as 27 soluções quando quiser."* Kept literally true, so a **wrong tag costs scrolling, not access**. A spec checks every família keeps every solution under every worry combination.
2. **The tags are our read, not an expert's** — same status as the existing `classificationEstimated`. Each is drafted from the solution's *own* `whatItIs`: *escada hidráulica vegetada* says "terrenos inclinados, diminuindo sua **velocidade**" → Enxurrada; *parques lineares* says "ao longo de **cursos d'água**" → Inundação. The map is deliberately one screen so Robson/Hesioni can read and argue with it in one sitting at the convening.

An empty list is a deliberate **neutral** — agricultura urbana answers no water or heat mechanism, and tagging it for symmetry would be a guess. A *missing* key is someone forgetting, so a spec enforces that every solution has an entry: that difference is invisible to whoever reviews the map.

The note reuses the exact phrase from the chip they tapped — *"pra a água que desce com força"* — so the card and the question say the same words.

## Testing

Per JVP, testing dialled back: targeted specs plus the smoke tier, full suite batched after a couple of PRs. **15 new specs green; smoke 53/53 in 25s.**

Carried over from #457 and worth repeating: on the diagnostic spec I saw 2 failures in 12 runs against a playwright-spawned server vs 0 in 12 on main. I traced the three functions for those exact inputs (logically identical), then got 27 consecutive passes against a warm server. Every failure was "an element that should be there isn't", one was a flat 30s timeout — the ambient stall from #455 — and *"org has no site"* has failed on clean `main` earlier in this session. **I did not prove it isn't mine; I showed it behaves like the ambient rate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy