### PR TITLE
feat(e2): COUGAR convening — hazard mechanisms, solution ordering, Teia Sprint + collaboration

### DIFF
--- a/client/src/core/components/cbo/NbsFamiliaSheet.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaSheet.tsx
@@ -18,7 +18,7 @@ import {
   DrawerHandle,
 } from '@/core/components/ui/drawer';
 import type { NbsFamiliaId } from '@shared/nbs-catalog';
-import { getFamilia, getSolution, solutionsForFamilia } from '@shared/nbs-catalog';
+import { getFamilia, getSolution, solutionsForFamilia, orderSolutionsByMechanism } from '@shared/nbs-catalog';
 import { NbsSolutionCard } from './NbsSolutionCard';
 import { NbsSolutionDetail } from './NbsSolutionDetail';
 import { CroquiLightbox } from './CroquiLightbox';
@@ -58,11 +58,15 @@ export function NbsFamiliaSheet({
   openFamiliaId,
   onClose,
   lang,
+  worries = [],
 }: {
   /** Which família to show. `null` closes the sheet. */
   openFamiliaId: NbsFamiliaId | null;
   onClose: () => void;
   lang: 'pt' | 'en';
+  /** What the org said worries them, as the mechanisms they named. Orders the
+   *  list so what answers their problem is on top — never hides anything. */
+  worries?: string[];
 }) {
   const s = STRINGS[lang];
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -70,7 +74,12 @@ export function NbsFamiliaSheet({
   const [croquiOpen, setCroquiOpen] = useState(false);
   const [filter, setFilter] = useState<SolutionFilter>(EMPTY_SOLUTION_FILTER);
   const familia = openFamiliaId ? getFamilia(openFamiliaId) : undefined;
-  const solutions = openFamiliaId ? solutionsForFamilia(openFamiliaId) : [];
+  // Ordered by the mechanism they named — Inundação puts margin and várzea work
+  // above rain gardens — and the filter still sees the whole set, because
+  // nothing is ever removed (see SOLUTION_MECHANISMS).
+  const solutions = openFamiliaId
+    ? orderSolutionsByMechanism(solutionsForFamilia(openFamiliaId), worries)
+    : [];
   const visibleSolutions = filterSolutions(solutions, filter);
   const openSolution = openSolutionId ? getSolution(openSolutionId) : undefined;
 

--- a/client/src/core/components/cbo/NbsFamiliaStrip.tsx
+++ b/client/src/core/components/cbo/NbsFamiliaStrip.tsx
@@ -20,11 +20,15 @@ export function NbsFamiliaStrip({
   familiaIds,
   intro,
   lang,
+  worries = [],
 }: {
   /** Which famílias to show; empty/undefined = all five. */
   familiaIds?: string[];
   intro?: string;
   lang: 'pt' | 'en';
+  /** Passed through so the variants inside a família are ordered by the
+   *  mechanism the org named (backlog #24). Ordering only — nothing hidden. */
+  worries?: string[];
 }) {
   const [openFamiliaId, setOpenFamiliaId] = useState<NbsFamiliaId | null>(null);
   const [croquiFamiliaId, setCroquiFamiliaId] = useState<NbsFamiliaId | null>(null);
@@ -59,6 +63,7 @@ export function NbsFamiliaStrip({
       </div>
 
       <NbsFamiliaSheet
+        worries={worries}
         openFamiliaId={openFamiliaId}
         onClose={() => setOpenFamiliaId(null)}
         lang={lang}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -456,6 +456,10 @@ export default function CboProfilePage() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Why the picker was opened, when a chip said so (`uploadPurpose` on the
+  // ask_user option). Consumed by the next upload and then cleared — untagged
+  // is the normal case and has to stay the default.
+  const pendingUploadPurposeRef = useRef<string | null>(null);
   const handleSelectRef = useRef<(label: string) => void>(() => {});
 
   const currentQuestion = activeQuestions[currentQuestionIdx] || null;
@@ -2177,7 +2181,12 @@ export default function CboProfilePage() {
                   multiSelected={multiSelectedOptions}
                   onMultiToggle={(label) => setMultiSelectedOptions(prev => { const next = new Set(prev); next.has(label) ? next.delete(label) : next.add(label); return next; })}
                   onMultiConfirm={() => { handleSelectOption(Array.from(multiSelectedOptions).join(', ')); setMultiSelectedOptions(new Set()); }}
-                  onUploadAction={() => fileInputRef.current?.click()}
+                  onUploadAction={(purpose) => {
+                    // Tagged uploads (the Teia Sprint chip) tell the next file
+                    // why it is being sent; everything else stays untagged.
+                    pendingUploadPurposeRef.current = purpose ?? null;
+                    fileInputRef.current?.click();
+                  }}
                 />
               </div>
             )}
@@ -2433,6 +2442,9 @@ export default function CboProfilePage() {
                     try {
                       const formData = new FormData();
                       formData.append('file', file);
+                      if (pendingUploadPurposeRef.current) {
+                        formData.append('purpose', pendingUploadPurposeRef.current);
+                      }
                       const data = await fetch(`/api/upload/cbo/${cboId}`, { method: 'POST', body: formData }).then(r => r.json());
                       // Gap 4 — link a site photo to the chosen site (best-effort;
                       // the server no-ops until a site exists). Images only.
@@ -2928,7 +2940,7 @@ function CboQuestionCard({
   /** Transcript mode: the question was already answered. Options are inert. */
   readOnly?: boolean;
   /** Opens the file picker — for options with action 'upload'. */
-  onUploadAction?: () => void;
+  onUploadAction?: (purpose?: string) => void;
 }) {
   const { t } = useTranslation();
   const isMulti = question.multiSelect;
@@ -2938,7 +2950,7 @@ function CboQuestionCard({
     (answeredValue ?? '').split(',').map(s => s.trim()).filter(Boolean)
   );
 
-  const handleClick = (label: string, action?: string) => {
+  const handleClick = (label: string, action?: string, uploadPurpose?: string) => {
     if (disabled || readOnly) return;
     if (isMulti && onMultiToggle) {
       onMultiToggle(label);
@@ -2950,7 +2962,7 @@ function CboQuestionCard({
     // answering: a server-templated checkpoint derives its position from the
     // answers, so a chip that only opened a picker would strand the flow.
     // Answer first, then open — the picker is modal and blocks the send.
-    if (action === 'upload_then_answer') onUploadAction?.();
+    if (action === 'upload_then_answer') onUploadAction?.(uploadPurpose);
   };
 
   return (
@@ -3008,7 +3020,7 @@ function CboQuestionCard({
           const isFocused = readOnly ? false : i === selectedIdx;
           const isHighlighted = readOnly ? isPicked : isMulti ? isChecked : isFocused;
           return (
-            <button key={i} onClick={() => handleClick(opt.label, opt.action)}
+            <button key={i} onClick={() => handleClick(opt.label, opt.action, opt.uploadPurpose)}
               disabled={readOnly}
               aria-current={isPicked || undefined}
               data-testid={readOnly ? `cbo-answered-option-${i}` : `cbo-option-${i}`}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -1982,6 +1982,13 @@ export default function CboProfilePage() {
                         familiaIds={parsed.familiaIds}
                         intro={parsed.intro}
                         lang={lang.startsWith('pt') ? 'pt' : 'en'}
+                        // The mechanisms they named in the worry beat, so the
+                        // variants inside a família lead with what answers their
+                        // problem (backlog #24). Read live from the profile —
+                        // the strip persists as a composer and re-renders on
+                        // reload, when this prop must still be right.
+                        worries={String(state?.sections?.intervention_site?.fields?.site_worry?.value ?? '')
+                          .split(',').map(w => w.trim()).filter(Boolean)}
                       />
                     </div>
                   );

--- a/e2e/cougar-e2-diagnostic.spec.ts
+++ b/e2e/cougar-e2-diagnostic.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, devices } from '@playwright/test';
 import { TestApi } from './helpers/testApi';
+import { familyOfWorry } from '../shared/site-knowledge';
 import { clickCenterZone } from './helpers/mapActions';
 
 // The W2 diagnostic beats (/refine 2026-07-31): frame → worry → story → photos
@@ -193,7 +194,10 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // Everything the diagnostic captured actually persisted.
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.site_story?.value)).toContain('dois dias');
     expect(String(f.site_photo_intent?.value)).toBe('skip');
     expect(JSON.parse(String(f._hazard_check_json?.value))).toMatchObject({ flood: 'worse' });
@@ -228,7 +232,8 @@ test.describe('COUGAR — W2 diagnostic beats', () => {
     // never reached the interest/role loops or the close.
     const depth = JSON.parse(String(f._depth_json?.value ?? '{}'));
     expect(depth.level, 'a depth read must exist mid-session').toBeTruthy();
-    expect(String(f.site_worry?.value)).toContain('flood');   // what worries them
+    // what worries them, stored as the MECHANISM they tapped (backlog #24)
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.current_use?.value)).toBeTruthy();        // what the place is
     expect(String(f.land_tenure?.value)).toBeTruthy();        // whether they can use it
     expect(String(f.site_name?.value)).toBeTruthy();          // where it is
@@ -366,7 +371,10 @@ test.describe('COUGAR — W2 degraded scenarios', () => {
 
     const body = await (await request.get(`/api/cbo/${cboId}`)).json();
     const f = body.state?.sections?.intervention_site?.fields ?? {};
-    expect(String(f.site_worry?.value)).toContain('flood');
+    // Stores the MECHANISM the org tapped, not the layer it scores against
+    // (backlog #24). The guarantee that matters — that it still resolves to
+    // the one flood raster we hold — is pinned in cougar-hazard-subtypes.
+    expect(familyOfWorry(String(f.site_worry?.value).split(',')[0])).toBe('flood');
     expect(String(f.bairro?.value ?? '')).not.toBe('');
   });
 

--- a/e2e/cougar-e2-interest-roles.spec.ts
+++ b/e2e/cougar-e2-interest-roles.spec.ts
@@ -95,6 +95,14 @@ test.describe('COUGAR — E2 interest + role loops', () => {
     await expect(chip('Pronto ✓')).toBeVisible({ timeout: 8_000 });
     await chip('Pronto ✓').click();
 
+    // Two convening questions stand between the roles and the closing now
+    // (backlog #26): the Teia Sprint application, then whether they have worked
+    // with other orgs in the network.
+    await expect(chip('Não mandamos')).toBeVisible({ timeout: 8_000 });
+    await chip('Não mandamos').click();
+    await expect(chip('Ainda não')).toBeVisible({ timeout: 8_000 });
+    await chip('Ainda não').click();
+
     // Closing only now.
     await expect(page.getByText('por onde começar a estudar', { exact: false })).toBeVisible({ timeout: 8_000 });
 

--- a/e2e/cougar-e2-linear-journey.spec.ts
+++ b/e2e/cougar-e2-linear-journey.spec.ts
@@ -51,6 +51,8 @@ const LANGS = [
     rolePick: 'Executar / implementar',
     doneList: 'Pronto ✓',
     closingText: 'por onde começar a estudar',
+    teiaNo: 'Não mandamos',
+    collabNo: 'Ainda não',
   },
   {
     name: 'en',
@@ -73,7 +75,7 @@ const LANGS = [
     tenurePick: "It's the city's, but we use it",
     frameText: 'our map is',
     worryText: 'worries you most',
-    worryPick: '💧 Flooding',
+    worryPick: '💧 Ponding',   // Alagamento — the pluvial mechanism (backlog #24)
     storyText: 'your own words',
     skipStory: "I'd rather skip",
     photosText: 'photos would help',
@@ -88,6 +90,8 @@ const LANGS = [
     rolePick: 'Implement on the ground',
     doneList: 'Done ✓',
     closingText: 'where to start studying',
+    teiaNo: "We didn't submit",
+    collabNo: 'Not yet',
   },
 ] as const;
 
@@ -216,6 +220,11 @@ for (const L of LANGS) {
       await chip(L.rolePick).click();
       await expect(chip(L.doneList)).toBeVisible({ timeout: 8_000 });
       await chip(L.doneList).click();
+      // The two convening questions now sit before the closing (backlog #26).
+      await expect(chip(L.teiaNo)).toBeVisible({ timeout: 8_000 });
+      await chip(L.teiaNo).click();
+      await expect(chip(L.collabNo)).toBeVisible({ timeout: 8_000 });
+      await chip(L.collabNo).click();
       await expect(page.getByText(L.closingText, { exact: false })).toBeVisible({ timeout: 8_000 });
 
       // 10 · Reload: the site card and the recommendation are composer-persisted.

--- a/e2e/cougar-hazard-subtypes.spec.ts
+++ b/e2e/cougar-hazard-subtypes.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import {
+  WORRY_SUBTYPES, E2_WORRIES, familyOfWorry, familiesOfWorries,
+  orderWorriesByData, photoPromptsFor, hazardsToCheck,
+} from '../shared/site-knowledge';
+import { needsScaleReframing } from '../shared/nbs-performance';
+import { rankFamiliasForSite } from '../shared/nbs-recommendation';
+
+// COUGAR convening, 2026-08-06: orgs don't experience "flood" as one thing.
+// Alagamento (water that pools), Inundação (the river overtopping) and Enxurrada
+// (water coming down with force) are three problems with three answers — and the
+// old chip merged the first two out loud ("A água que junta OU INVADE") under a
+// label that named only one of them.
+//
+// The mechanism is a LANGUAGE layer over the three rasters we actually hold.
+// Every consumer used to filter with `w === 'flood' || w === 'heat' || …`, which
+// drops an unknown id **silently** — so the failure mode this pins is not a
+// crash, it's an org quietly never being asked for photos again.
+
+test.describe('hazard mechanisms — a finer word over the same data', () => {
+  test('every mechanism resolves to a layer we actually have', () => {
+    for (const w of WORRY_SUBTYPES) {
+      if (w.id === 'other') { expect(w.family).toBeNull(); continue; }
+      expect(['flood', 'heat', 'landslide'], `${w.id} must score against a real raster`)
+        .toContain(w.family);
+    }
+    // The three water mechanisms share one layer. That is the whole design: we
+    // hold one flood raster, so three names cannot mean three numbers.
+    expect(['alagamento', 'inundacao', 'enxurrada'].map(familyOfWorry))
+      .toEqual(['flood', 'flood', 'flood']);
+  });
+
+  test('⚠️ legacy `flood` still resolves — sessions in the database used it', () => {
+    // JVP's test orgs and the three W2 test-kit orgs stored `site_worry: 'flood'`
+    // before the split. If that becomes an unknown id, they stop getting photo
+    // prompts and their depth read quietly degrades. Nothing throws.
+    expect(familyOfWorry('flood')).toBe('flood');
+    expect(familiesOfWorries(['flood'])).toEqual(['flood']);
+    expect(photoPromptsFor(['flood']).length).toBeGreaterThan(1);
+    expect(hazardsToCheck(['flood'], { flood: 10, heat: 10, landslide: 10 })).toContain('flood');
+  });
+
+  test('nothing downstream drops a mechanism on the floor', () => {
+    const low = { flood: 10, heat: 10, landslide: 10 };
+    for (const id of ['alagamento', 'inundacao', 'enxurrada'] as const) {
+      expect(hazardsToCheck([id], low), `${id} must still raise a flood check`).toContain('flood');
+      // …and it must ask for photographs, which is the beat that silently died
+      // if the id was unrecognised.
+      const prompts = photoPromptsFor([id]);
+      expect(prompts.length, `${id} must still produce prompts`).toBeGreaterThan(1);
+    }
+    // Three water mechanisms are ONE check, not three — the conversation caps
+    // at two checkpoints before it becomes a form.
+    expect(hazardsToCheck(['alagamento', 'inundacao', 'enxurrada'], low)).toEqual(['flood']);
+  });
+
+  test('the mechanism asks for the photo only it makes worth taking', () => {
+    const ids = (ws: string[]) => photoPromptsFor(ws).map(p => p.id);
+    expect(ids(['inundacao']), 'how high did it get').toContain('high-water-mark');
+    expect(ids(['enxurrada']), 'where does it come down').toContain('water-path');
+    // Alagamento keeps the generic flood set — pooling is what those ask about.
+    expect(ids(['alagamento'])).not.toContain('high-water-mark');
+    expect(ids(['alagamento'])).toContain('water-in');
+  });
+
+  test('naming Inundação IS the scale signal — no story keywords needed', () => {
+    // This beat existed to catch someone who said "flood" and then described the
+    // 2024 Guaíba event. That event is Inundação; now they can just say so.
+    expect(needsScaleReframing(['inundacao'], 'a gente cuida da horta')).toBe(true);
+    // Alagamento alone is the everyday water — no reframing, or the agent
+    // lectures an org about limits it never claimed to exceed.
+    expect(needsScaleReframing(['alagamento'], 'a água junta no canto')).toBe(false);
+    // …and the old story-keyword path still fires, for legacy rows.
+    expect(needsScaleReframing(['flood'], 'na enchente de 2024 o Guaíba subiu')).toBe(true);
+    expect(needsScaleReframing(['heat'], 'o Guaíba subiu em 2024')).toBe(false);
+  });
+
+  test('the worry the org named still lifts a família', () => {
+    const base = {
+      risks: { flood: 40, heat: 40, landslide: 40 },
+      bairro: 'Sarandi',
+      worries: ['inundacao'],
+    };
+    const ranked = rankFamiliasForSite(base as any);
+    const water = ranked.find((r: any) => r.familiaId === 'aguas-pluviais');
+    expect(water, 'the water família must be in the list').toBeTruthy();
+    // Same shape the old `['flood']` worry produced — the mechanism reaches the
+    // ranking through its family rather than being filtered out.
+    const viaFamily = rankFamiliasForSite({ ...base, worries: ['flood'] } as any);
+    expect(ranked.map((r: any) => r.familiaId)).toEqual(viaFamily.map((r: any) => r.familiaId));
+  });
+
+  test('chips: six, ordered by the data, everyday water first, "outra" last', () => {
+    expect(E2_WORRIES).toHaveLength(6);
+    const ordered = orderWorriesByData({ flood: 90, heat: 10, landslide: 5 });
+    expect(ordered.map(w => w.id)).toEqual(
+      ['alagamento', 'inundacao', 'enxurrada', 'heat', 'landslide', 'other']);
+    // The sort is stable, so the three water mechanisms keep catalogue order
+    // even when the data puts another hazard on top.
+    const heatFirst = orderWorriesByData({ flood: 10, heat: 90, landslide: 5 });
+    expect(heatFirst.map(w => w.id)).toEqual(
+      ['heat', 'alagamento', 'inundacao', 'enxurrada', 'landslide', 'other']);
+    expect(heatFirst[heatFirst.length - 1].id).toBe('other');
+  });
+
+  test('the chips say the mechanism in plain words, not just the technical term', () => {
+    const by = (id: string) => WORRY_SUBTYPES.find(w => w.id === id)!;
+    // The convening asked for the civil-defense term PAIRED with plain language.
+    expect(by('alagamento').pt).toContain('Alagamento');
+    expect(by('alagamento').dPt).toBe('A água que junta e não escoa');
+    expect(by('inundacao').dPt).toBe('O rio ou arroio que transborda');
+    expect(by('enxurrada').dPt).toBe('A água que desce com força');
+    // The merged wording is gone — that phrase is what mis-named the Guaíba.
+    for (const w of WORRY_SUBTYPES) expect(w.dPt).not.toContain('junta ou invade');
+  });
+});

--- a/e2e/cougar-solution-mechanisms.spec.ts
+++ b/e2e/cougar-solution-mechanisms.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import {
+  NBS_SOLUTIONS, SOLUTION_MECHANISMS, orderSolutionsByMechanism, mechanismNote,
+  solutionsForFamilia,
+} from '../shared/nbs-catalog';
+import { WORRY_SUBTYPES } from '../shared/site-knowledge';
+
+// Backlog #24, second half. COUGAR convening: "solution types differ
+// fundamentally by hazard type" — an org that says Inundação should not be shown
+// rain gardens first, because a rain garden answers Alagamento.
+//
+// The two rules that make a wrong tag cheap are what these pin:
+//   1. ORDER AND EXPLAIN, NEVER EXCLUDE — the flow promises "nada fica
+//      descartado", so every solution stays reachable whatever the tags say.
+//   2. The tags are OUR read, drafted from each solution's own whatItIs, and
+//      marked provisional until Robson/Hesioni confirm.
+
+test.describe('solution mechanisms — ordering, never hiding', () => {
+  test('⚠️ nothing is ever removed, whatever the org named', () => {
+    for (const familia of ['aguas-pluviais', 'verde-urbano', 'encostas-e-solo'] as const) {
+      const all = solutionsForFamilia(familia);
+      for (const worries of [['inundacao'], ['alagamento'], ['enxurrada', 'heat'], ['other'], []]) {
+        const ordered = orderSolutionsByMechanism(all, worries);
+        expect(ordered, `${familia} / ${worries.join('+')} must keep every solution`)
+          .toHaveLength(all.length);
+        expect(new Set(ordered.map(s => s.id))).toEqual(new Set(all.map(s => s.id)));
+      }
+    }
+  });
+
+  test('Inundação leads with the river answers, not the rain garden', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const first = orderSolutionsByMechanism(water, ['inundacao'])[0];
+    expect(SOLUTION_MECHANISMS[first.id]).toContain('inundacao');
+    // …and the rain garden is still there, just not first.
+    const ids = orderSolutionsByMechanism(water, ['inundacao']).map(s => s.id);
+    expect(ids).toContain('jardins-de-chuva');
+    expect(ids.indexOf('jardins-de-chuva')).toBeGreaterThan(0);
+  });
+
+  test('Alagamento leads with infiltration — the everyday-water answers', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const first = orderSolutionsByMechanism(water, ['alagamento'])[0];
+    expect(SOLUTION_MECHANISMS[first.id]).toContain('alagamento');
+  });
+
+  test('Enxurrada leads with the ones that name velocity or slope', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    const top = orderSolutionsByMechanism(water, ['enxurrada'])
+      .slice(0, 4).map(s => s.id);
+    // "escada hidráulica vegetada" says it in its own description:
+    // "terrenos inclinados, diminuindo sua velocidade".
+    expect(top).toContain('escada-hidraulica-vegetada');
+  });
+
+  test('no worry named, or only "outra coisa" — catalogue order, untouched', () => {
+    const water = solutionsForFamilia('aguas-pluviais');
+    for (const worries of [[], ['other']]) {
+      expect(orderSolutionsByMechanism(water, worries).map(s => s.id))
+        .toEqual(water.map(s => s.id));
+    }
+  });
+
+  test('every tag names a real mechanism, and every solution is accounted for', () => {
+    const known = new Set(WORRY_SUBTYPES.map(w => w.id));
+    for (const [id, tags] of Object.entries(SOLUTION_MECHANISMS)) {
+      expect(NBS_SOLUTIONS.some(s => s.id === id), `${id} is not a solution`).toBe(true);
+      for (const t of tags) expect(known, `${id} tagged with unknown "${t}"`).toContain(t);
+    }
+    // Every solution has an ENTRY — an empty list is a deliberate "neutral",
+    // a missing key is someone forgetting. The difference matters when a
+    // domain expert reads this map to confirm it.
+    for (const s of NBS_SOLUTIONS) {
+      expect(SOLUTION_MECHANISMS[s.id], `${s.id} has no entry`).toBeDefined();
+    }
+  });
+
+  test('the note speaks the org\'s words back, or says nothing', () => {
+    // Reuses the exact plain-language phrase from the chip they tapped, so the
+    // card and the question agree.
+    expect(mechanismNote('escada-hidraulica-vegetada', ['enxurrada'], 'pt'))
+      .toBe('pra a água que desce com força');
+    expect(mechanismNote('parques-lineares', ['inundacao'], 'pt'))
+      .toBe('pra o rio ou arroio que transborda');
+    // No match → no badge. A badge that says nothing is worse than none.
+    expect(mechanismNote('jardins-de-chuva', ['inundacao'], 'pt')).toBeNull();
+    expect(mechanismNote('hortas-urbanas', ['alagamento'], 'pt')).toBeNull();
+  });
+});

--- a/e2e/cougar-teia-collaboration.spec.ts
+++ b/e2e/cougar-teia-collaboration.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Backlog #26, from the COUGAR convening (2026-08-06).
+//
+// Orgs applied to the Teia Sprint government open call, which makes those
+// applications semi-formalised project proposals. W3 refines them into scope,
+// partnerships and funding — so the coordination team wants them BEFORE it
+// plans W3, and it wants to know who has a cross-org track record before it
+// designs partnerships. Both asks land at the close of W2.
+//
+// Two design decisions worth pinning:
+//  · Saying yes OPENS THE PICKER (JVP: "render directly the upload file button
+//    if they say yes"). Telling someone who just said yes to go hunt for a
+//    paperclip is the dead step already fixed once in backlog #20.
+//  · The collaboration question is yes/no + free text, NOT a pick-list of the
+//    cohort roster — that would show every org who else is in their hub, days
+//    after they told us they were anxious about their data (backlog #31).
+
+/** W2 walked to its last beat: everything before the close already answered.
+ *  The checkpoint chain is ordered, so reaching the final question means
+ *  satisfying the ones in front of it — far less brittle than walking all of W2
+ *  through the UI, and it is the state a real org arrives in. */
+const DONE_BEFORE_CLOSE = ([
+  ['bairro', 'Sarandi'],
+  ['site_name', 'Pátio da EMEI'],
+  ['_site_confirmed', 'yes'],
+  ['current_use', 'abandoned'],
+  ['land_tenure', 'public-informal'],
+  ['site_worry', 'alagamento'],
+  ['_worry_offered', 'yes'],
+  ['_worry_done', 'yes'],
+  ['_story_done', 'yes'],
+  ['_photos_done', 'yes'],
+  ['_check_done', 'yes'],
+  ['_interest_offered', 'yes'],
+  ['_interest_done', 'yes'],
+  ['nbs_interest', 'aguas-pluviais'],
+  ['_roles_offered', 'yes'],
+  ['_role_done', 'yes'],
+  ['role_preference', 'executar'],
+] as const).map(([field, value]) => ({ sectionId: 'intervention_site', field, value }));
+
+test.describe('COUGAR — Teia Sprint + prior collaboration', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('the Teia chip opens the file picker, and the file is tagged', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    // Straight to the ask: the beat is templated, so it only needs the state
+    // that gates it rather than the whole W2 walk.
+    await api.seedState(cboId, {
+      phase: 2,
+      language: 'pt',
+      sections: DONE_BEFORE_CLOSE,
+    });
+    await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'oi', lang: 'pt', turnKind: 'chip' } });
+    await page.reload();
+
+    const chip = (label: string) =>
+      page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
+    await expect(chip('Sim — subir agora')).toBeVisible({ timeout: 30_000 });
+
+    // Tapping it must open the picker itself — that is the whole point.
+    const chooser = page.waitForEvent('filechooser', { timeout: 10_000 });
+    await chip('Sim — subir agora').click();
+    const fc = await chooser;
+
+    await fc.setFiles({
+      name: 'teia-sprint-aplicacao.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('Proposta enviada ao Teia Sprint: horta comunitária no Sarandi.'),
+    });
+
+    // The upload arrives TAGGED, so the coordination team can find it among the
+    // site photos instead of scrolling for a filename they have to guess.
+    await expect.poll(async () => {
+      const docs = (await (await request.get(`/api/cbo/${cboId}/documents`)).json())?.documents ?? [];
+      return docs.find((d: any) => d.filename?.includes('teia-sprint'))?.purpose ?? null;
+    }, { timeout: 40_000 }).toBe('teia_sprint');
+
+    // …and answering advanced the flow rather than parking it on the upload.
+    const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(body.state?.sections?.intervention_site?.fields?.teia_sprint?.value).toBe('enviado');
+  });
+
+  test('"não mandamos" still moves on, then asks about working together', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.seedState(cboId, {
+      phase: 2, language: 'pt',
+      sections: DONE_BEFORE_CLOSE,
+    });
+    await request.post(`/api/cbo/${cboId}/chat`, { data: { message: 'oi', lang: 'pt', turnKind: 'chip' } });
+    await page.reload();
+
+    const chip = (label: string) =>
+      page.locator(`[data-testid^="cbo-option-"][data-option-label="${label}"]`);
+    await expect(chip('Não mandamos')).toBeVisible({ timeout: 30_000 });
+    await chip('Não mandamos').click();
+
+    // Straight into the collaboration question — no dead end for an org that
+    // never applied.
+    await expect(page.getByText('outras organizações da rede', { exact: false }))
+      .toBeVisible({ timeout: 20_000 });
+    await chip('Sim, já fizemos').click();
+
+    // Yes means "tell me who", in their own words. NOT a roster to tick.
+    await expect(page.getByText('Com quem?', { exact: false })).toBeVisible({ timeout: 20_000 });
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('Com a Encosta Viva, num mutirão de plantio.');
+    await input.press('Enter');
+
+    await expect.poll(async () => {
+      const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+      const f = body.state?.sections?.intervention_site?.fields ?? {};
+      return [f.teia_sprint?.value, f.prior_collaboration?.value, f.prior_collaboration_detail?.value];
+    }, { timeout: 30_000 }).toEqual(['nao-enviou', 'sim', 'Com a Encosta Viva, num mutirão de plantio.']);
+  });
+});

--- a/server/routes/uploadRoutes.ts
+++ b/server/routes/uploadRoutes.ts
@@ -111,6 +111,11 @@ export function registerUploadRoutes(app: Express): void {
             filename: file.originalname,
             mimeType: file.mimetype,
             kind: kindFromUpload(file.originalname, file.mimetype),
+            // Why it was sent, when the client knows — today only the Teia
+            // Sprint chip sets it. `kind` stays the format: a Teia application
+            // is a pdf like any other pdf, and the coordination team still has
+            // to find it among the site photos.
+            purpose: req.body?.purpose === 'teia_sprint' ? 'teia_sprint' : null,
             sizeBytes: file.size,
             fullText: content,
             summary: content.slice(0, 280),

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1397,6 +1397,15 @@ const E2C: Record<string, { pt: string; en: string; desc?: { pt: string; en: str
   fazSentido: { pt: 'Faz sentido', en: 'Makes sense' },
   queroAjustar: { pt: 'Quero ajustar', en: 'I want to adjust' },
   prontoLista: { pt: 'Pronto ✓', en: 'Done ✓' },
+  // COUGAR convening 2026-08-06. Orgs applied to the Teia Sprint open call, which
+  // makes those applications semi-formalised project proposals — W3 refines them
+  // into scope, partnerships and funding, so the coordination wants them BEFORE
+  // it plans W3, not during.
+  teiaSobeAgora: { pt: 'Sim — subir agora', en: 'Yes — upload it now' },
+  teiaDepois: { pt: 'Sim, mando depois', en: 'Yes, I\'ll send it later' },
+  teiaNao: { pt: 'Não mandamos', en: "We didn't submit" },
+  colabSim: { pt: 'Sim, já fizemos', en: "Yes, we have" },
+  colabNao: { pt: 'Ainda não', en: 'Not yet' },
   outroPapel: { pt: 'Outro papel', en: 'Another role' },
   podePerguntar: { pt: 'Pode perguntar', en: 'Go ahead and ask' },
 };
@@ -1760,7 +1769,7 @@ async function serveE2Checkpoint(
   const ask = (
     qPt: string,
     qEn: string,
-    opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string; action?: 'upload_then_answer' }>,
+    opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string; action?: 'upload_then_answer'; uploadPurpose?: string }>,
   ) =>
     pushEvent({
       type: 'ask_user',
@@ -1769,6 +1778,10 @@ async function serveE2Checkpoint(
         label: isPt ? o.pt : o.en,
         description: isPt ? (o.dPt ?? '') : (o.dEn ?? ''),
         ...(o.action ? { action: o.action } : {}),
+        // Why the picker is opening, so the file arrives tagged. Without this
+        // the Teia application lands as one more pdf among the site photos —
+        // which is the thing the convening asked us to stop.
+        ...(o.uploadPurpose ? { uploadPurpose: o.uploadPurpose } : {}),
       })),
     } as any);
   const finish = (detail: string): true => {
@@ -2023,6 +2036,46 @@ async function serveE2Checkpoint(
     }
   };
 
+  // ── Teia Sprint + prior collaboration ────────────────────────────────────
+  // Two questions the convening asked for, at the close of W2 rather than in W3:
+  // the coordination team wants the applications as baseline concepts while it
+  // is still planning W3, and it wants to know who has a cross-org track record
+  // before it designs partnerships.
+  const askTeia = (): true => {
+    say(
+      'Quase lá. Uma coisa que pode ajudar bastante: vocês mandaram algum projeto pro **Teia Sprint**?',
+      'Almost there. One thing that helps a lot: did you submit a project to the **Teia Sprint**?',
+    );
+    ask('Mandaram algo pro Teia Sprint?', 'Did you submit anything to the Teia Sprint?', [
+      // Opens the file chooser on tap AND answers — the same seam the "tenho
+      // arquivos" chip uses. Telling someone who just said yes to go hunt for a
+      // paperclip is the dead step we already fixed once (backlog #20).
+      { pt: E2C.teiaSobeAgora.pt, en: E2C.teiaSobeAgora.en, dPt: 'Abre pra escolher o arquivo', dEn: 'Opens the file chooser', action: 'upload_then_answer', uploadPurpose: 'teia_sprint' },
+      { pt: E2C.teiaDepois.pt, en: E2C.teiaDepois.en, dPt: 'Sem problema', dEn: 'No problem' },
+      { pt: E2C.teiaNao.pt, en: E2C.teiaNao.en, dPt: 'Tudo bem também', dEn: "That's fine too" },
+    ]);
+    return finish('teia-ask');
+  };
+
+  const askCollab = (): true => {
+    ask(
+      'Vocês já fizeram algum projeto com outras organizações da rede?',
+      'Have you already done a project with other organizations in the network?',
+      [
+        { pt: E2C.colabSim.pt, en: E2C.colabSim.en, dPt: 'Me conta com quem', dEn: 'Tell me who with' },
+        { pt: E2C.colabNao.pt, en: E2C.colabNao.en, dPt: 'Seria a primeira vez', dEn: 'It would be a first' },
+      ],
+    );
+    return finish('collab-ask');
+  };
+
+  /** The close, gated behind the two convening questions. */
+  const closeOrAsk = async (): Promise<true> => {
+    if (val('_teia_done') !== 'yes') return askTeia();
+    if (val('_collab_done') !== 'yes') return askCollab();
+    return await closeE2();
+  };
+
   const closeE2 = async (): Promise<true> => {
     await persistDepth();
     const nome = String(state.sections.org_profile?.fields?.contact_name?.value || '').trim().split(/\s+/)[0];
@@ -2256,6 +2309,19 @@ async function serveE2Checkpoint(
     }, pushEvent);
     askRoles([...pickedRoles, other], false);
     return finish('role-other-captured');
+  }
+
+  // "Com quem?" is TYPED, so it must be captured above the chip gate — same as
+  // the story and the "outro papel" free text. Left below it, the answer would
+  // fall through to the model and W2 would never close.
+  if (val('_collab_detail_pending') === 'yes') {
+    writeE2Fields(cboId, state, {
+      prior_collaboration_detail: raw,
+      _collab_detail_pending: '',
+      _collab_done: 'yes',
+    }, pushEvent);
+    say('Anotado — isso ajuda a montar as duplas no Encontro 3.', 'Noted — that helps shape the pairings in Encontro 3.');
+    return await closeE2();
   }
 
   // ── Chip taps ──────────────────────────────────────────────────────────────
@@ -2624,6 +2690,50 @@ async function serveE2Checkpoint(
     }
   }
 
+  // ── Teia Sprint answer ────────────────────────────────────────────────────
+  // Reached only once the role loop is done, so it cannot swallow an earlier
+  // "Sim" from a different question.
+  if (val('_role_done') === 'yes' && val('_teia_done') !== 'yes') {
+    const teia =
+      is(E2C.teiaSobeAgora) ? 'enviado'
+      : is(E2C.teiaDepois) ? 'envia-depois'
+      : is(E2C.teiaNao) ? 'nao-enviou'
+      : null;
+    if (teia) {
+      writeE2Fields(cboId, state, { teia_sprint: teia, _teia_done: 'yes' }, pushEvent);
+      if (teia === 'enviado') {
+        // The picker is already open (upload_then_answer); the file lands on the
+        // normal upload path and is tagged by the pending purpose the client set.
+        say('Boa — sobe aí que eu guardo junto com o resto.', 'Great — upload it and I\'ll keep it with the rest.');
+      } else if (teia === 'envia-depois') {
+        say('Tranquilo. Quando mandarem, é só voltar aqui e subir.', 'No problem. When you do, come back and upload it here.');
+      }
+      return askCollab();
+    }
+    // Nothing matched — ask (or re-ask). The beat owns the turn until it is
+    // answered, the same way the worry and role loops do: an org that reloads
+    // mid-question, or types something instead of tapping, gets the question
+    // back rather than falling through to the model with W2 half-closed.
+    return askTeia();
+  }
+
+  // ── Prior collaboration ───────────────────────────────────────────────────
+  // Yes/no plus who, in their own words. Deliberately NOT a pick-list of the
+  // cohort: that would show every org who else is in their hub, days after they
+  // told us they were anxious about how their data is used (backlog #31).
+  if (val('_teia_done') === 'yes' && val('_collab_done') !== 'yes') {
+    if (is(E2C.colabSim)) {
+      writeE2Fields(cboId, state, { prior_collaboration: 'sim', _collab_detail_pending: 'yes' }, pushEvent);
+      say('Com quem? Pode falar do jeito que vocês lembram.', 'Who with? However you remember it.');
+      return finish('collab-detail-asked');
+    }
+    if (is(E2C.colabNao)) {
+      writeE2Fields(cboId, state, { prior_collaboration: 'nao', _collab_done: 'yes' }, pushEvent);
+      return await closeE2();
+    }
+    return askCollab();
+  }
+
   // Role loop: same shape; "Outro papel" hands one turn to free text above.
   if (val('_roles_offered') === 'yes' && val('_role_done') !== 'yes') {
     const role = E2_ROLES.find(r => is(r) && !pickedRoles.includes(r.id));
@@ -2632,7 +2742,7 @@ async function serveE2Checkpoint(
       writeE2Fields(cboId, state, { role_preference: next.join(', ') }, pushEvent);
       if (E2_ROLES.every(r => next.includes(r.id))) {
         writeE2Fields(cboId, state, { _role_done: 'yes' }, pushEvent);
-        return await closeE2();
+        return await closeOrAsk();
       }
       askRoles(next, false);
       return finish('role-picked');
@@ -2644,7 +2754,7 @@ async function serveE2Checkpoint(
     }
     if (is(E2C.prontoLista) && pickedRoles.length > 0) {
       writeE2Fields(cboId, state, { _role_done: 'yes' }, pushEvent);
-      return await closeE2();
+      return await closeOrAsk();
     }
   }
 

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -1,7 +1,7 @@
 // Per-org document store persistence (see docs/cbo-platform-architecture.md).
 
 import { db } from '../db';
-import { documents, type DocumentRow, type DocumentKind, type DocumentMeta } from '@shared/document-schema';
+import { documents, type DocumentRow, type DocumentKind, type DocumentPurpose, type DocumentMeta } from '@shared/document-schema';
 import { cboStates } from '@shared/cbo-db-schema';
 import { eq, desc, and, or, inArray, sql } from 'drizzle-orm';
 
@@ -45,6 +45,7 @@ export function toDocumentMeta(d: DocumentRow): DocumentMeta {
     filename: d.filename,
     mimeType: d.mimeType,
     kind: d.kind,
+    purpose: d.purpose ?? null,
     sizeBytes: d.sizeBytes,
     droppedInPhase: d.droppedInPhase,
     summary: d.summary,
@@ -65,6 +66,7 @@ export async function createDocument(input: {
   filename: string;
   mimeType?: string | null;
   kind?: DocumentKind | null;
+  purpose?: DocumentPurpose | null;
   sizeBytes?: number | null;
   fullText?: string | null;
   summary?: string | null;
@@ -77,6 +79,7 @@ export async function createDocument(input: {
     filename: input.filename,
     mimeType: input.mimeType ?? null,
     kind: input.kind ?? null,
+    purpose: input.purpose ?? null,
     sizeBytes: input.sizeBytes ?? null,
     fullText: input.fullText ?? null,
     summary: input.summary ?? null,
@@ -100,6 +103,7 @@ export interface DocumentSummary {
   id: string;
   filename: string;
   kind: string | null;
+  purpose: string | null;
   droppedInPhase: number | null;
   summary: string | null;
 }
@@ -109,6 +113,7 @@ export async function listDocumentSummariesByOrg(orgId: string): Promise<Documen
       id: documents.id,
       filename: documents.filename,
       kind: documents.kind,
+      purpose: documents.purpose,
       droppedInPhase: documents.droppedInPhase,
       summary: documents.summary,
     })

--- a/shared/document-schema.ts
+++ b/shared/document-schema.ts
@@ -15,6 +15,20 @@ import { pgTable, text, varchar, integer, timestamp, index } from 'drizzle-orm/p
 // Mirrors fileExtract's ExtractKind.
 export type DocumentKind = 'pdf' | 'pptx' | 'docx' | 'xlsx' | 'text' | 'image' | 'audio' | 'other';
 
+/**
+ * WHY a document was uploaded, as opposed to what format it is.
+ *
+ * `kind` is the file format and always will be — a Teia Sprint application is a
+ * `pdf` like any other pdf. COUGAR convening 2026-08-06: orgs applied to the
+ * Teia Sprint open call, which makes those applications semi-formalised project
+ * proposals that W3 refines into scope, partnerships and funding. The
+ * coordination team needs to FIND them among the site photos and permits, so
+ * purpose is its own field rather than a naming convention on the filename.
+ *
+ * null = an ordinary upload, which is almost all of them.
+ */
+export type DocumentPurpose = 'teia_sprint';
+
 export const documents = pgTable('documents', {
   id: varchar('id').primaryKey().default(sql`gen_random_uuid()`),
   // The owning org — the locker is org-scoped so it accumulates across every
@@ -25,6 +39,9 @@ export const documents = pgTable('documents', {
   filename: text('filename').notNull(),
   mimeType: text('mime_type'),
   kind: text('kind').$type<DocumentKind>(),
+  // ⚠️ NEW COLUMN — needs `npm run db:push` before this deploys, or every upload
+  // 500s on an unknown column.
+  purpose: text('purpose').$type<DocumentPurpose>(),
   sizeBytes: integer('size_bytes'),
   // The WHOLE extracted text — not the 8K chat-truncated copy. This is what
   // later sessions read back via read_org_document.
@@ -51,6 +68,7 @@ export type DocumentMeta = {
   filename: string;
   mimeType: string | null;
   kind: DocumentKind | null;
+  purpose: DocumentPurpose | null;
   sizeBytes: number | null;
   droppedInPhase: number | null;
   summary: string | null;

--- a/shared/nbs-catalog.ts
+++ b/shared/nbs-catalog.ts
@@ -27,6 +27,7 @@
 // line. ⚠️ Written permission from Vila Flores/Rede to reuse them in-app is
 // pending (tracked in docs/photo-curation.md).
 
+import { WORRY_SUBTYPES, type WorryId } from './site-knowledge';
 import type { NbsInterventionTypeId } from './cbo-schema';
 import type { NbsCostBand, NbsDelivery } from './nbs-type-content';
 
@@ -704,6 +705,105 @@ export type NbsSolutionId = (typeof NBS_SOLUTIONS)[number]['id'];
 /** `/assets/nbs/solutions/<id>.jpg` — the solution's own card photo. */
 export function nbsSolutionPhoto(id: NbsSolutionId): string {
   return `/assets/nbs/solutions/${id}.jpg`;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WHICH MECHANISM A SOLUTION ANSWERS  ⚠️ PROVISIONAL
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// COUGAR convening 2026-08-06: "solution types differ fundamentally by hazard
+// type". An org that says Inundação should not be shown rain gardens first — a
+// rain garden answers Alagamento. So the mechanism the org names (see
+// WORRY_SUBTYPES) orders the solutions inside a família.
+//
+// ⚠️ TWO RULES, both load-bearing.
+//
+// 1. ORDER AND EXPLAIN, NEVER EXCLUDE. The flow promises, in its own words,
+//    "Nada fica descartado — dá pra ver as 27 soluções quando quiser." Keep that
+//    literally true. Then a wrong tag below costs an org some scrolling instead
+//    of hiding the answer they needed.
+// 2. THESE TAGS ARE OUR READ, NOT AN EXPERT'S — the same status as
+//    `classificationEstimated` on the solutions themselves. Each one is drafted
+//    from the solution's OWN `whatItIs` text, not invented: "escada hidráulica
+//    vegetada" says "diminuindo sua velocidade" in terrain "inclinado", which is
+//    Enxurrada; "parques lineares" says "ao longo de cursos d'água", which is
+//    Inundação. Robson/Hesioni to confirm at the convening — this map is
+//    deliberately one screen so it can be read and argued with in one sitting.
+//
+// An empty/absent entry is NEUTRAL, not "irrelevant": the solution simply never
+// gets reordered by mechanism. Better than a guess we cannot source.
+export const SOLUTION_MECHANISMS: Record<string, WorryId[]> = {
+  // ── Águas pluviais — water that pools, drains, or runs ────────────────────
+  'jardins-de-chuva': ['alagamento'],                       // "infiltrar… reduzindo o escoamento superficial"
+  'biovaletas': ['alagamento', 'enxurrada'],                // "escoamento mais lento… reduzindo erosão"
+  'canteiro-pluvial': ['alagamento'],                       // "receber e infiltrar… em áreas urbanas"
+  'bacia-de-retencao': ['alagamento', 'enxurrada'],         // "acumular temporariamente… regulando a vazão"
+  'wetland-construido': ['alagamento', 'inundacao'],        // "retenção de águas da chuva"; buffers a watercourse
+  'pavimentos-permeaveis': ['alagamento'],                  // "infiltração… reduzindo o escoamento"
+  'escada-hidraulica-vegetada': ['enxurrada'],              // "terrenos inclinados, diminuindo sua velocidade"
+  'terracos-de-chuva': ['enxurrada', 'alagamento'],         // "no declive do terreno… absorvem o escoamento"
+  'barraginha': ['enxurrada', 'alagamento'],                // "captam a água da chuva" on periurban slopes
+  'captacao-agua-da-chuva': ['alagamento'],                 // cisterns take rain off the surface
+  'ilhas-filtrantes-flutuantes': [],                        // water QUALITY in a body of water — no flood mechanism
+  // ── Verde urbano ──────────────────────────────────────────────────────────
+  'teto-verde': ['heat', 'alagamento'],                     // "retém água da chuva, reduz ilhas de calor"
+  'parques-e-florestas-urbanas': ['heat'],
+  'corredores-verdes': ['heat'],
+  'escola-verde': ['heat'],
+  'parque-naturalizado': ['heat'],
+  'parques-lineares': ['inundacao'],                        // "ao longo de cursos d'água"
+  // ── Encostas e solo — the slope itself, and water arriving down it ────────
+  'grade-viva': ['landslide', 'enxurrada'],                 // "estabilizam o solo em áreas inclinadas"
+  'muro-de-arrimo-verde': ['landslide'],
+  'solo-grampeado-verde': ['landslide'],
+  'contencoes-em-geocelulas': ['landslide', 'enxurrada'],
+  // ── Recuperação de ecossistemas ───────────────────────────────────────────
+  'reflorestamento': ['enxurrada', 'inundacao'],            // slope cover + "proteger recursos hídricos"
+  'restauracao-areas-umidas': ['inundacao'],                // "transição entre terra e água… resiliência"
+  // ── Agricultura urbana ────────────────────────────────────────────────────
+  // Food, soil and organic waste. Real climate value, but not an answer to a
+  // water or heat MECHANISM — so neutral rather than tagged for the sake of it.
+  'hortas-urbanas': [],
+  'compostagem': [],
+  'cozinha-comunitaria-biodigestor': [],
+  'sistema-alimentar-local': [],
+};
+
+/**
+ * Solutions reordered so the ones answering the org's named mechanism come
+ * first. NEVER filters — see rule 1 above. Stable, so within each group the
+ * catalogue order survives.
+ */
+export function orderSolutionsByMechanism(
+  solutions: NbsSolution[],
+  worries: string[],
+): NbsSolution[] {
+  const named = worries.filter(w => w && w !== 'other');
+  if (named.length === 0) return solutions;
+  const answers = (s: NbsSolution) =>
+    (SOLUTION_MECHANISMS[s.id] ?? []).some(m => named.includes(m));
+  return [...solutions].sort((a, b) => Number(answers(b)) - Number(answers(a)));
+}
+
+/**
+ * The one-line reason a solution is near the top, in the org's own vocabulary —
+ * "pra água que desce com força" reuses the exact plain-language phrase from the
+ * chip they tapped, so the card and the question say the same thing.
+ * Null when the solution doesn't answer anything they named: no badge is better
+ * than a badge that says nothing.
+ */
+export function mechanismNote(
+  solutionId: string,
+  worries: string[],
+  lang: 'pt' | 'en' = 'pt',
+): string | null {
+  const tags = SOLUTION_MECHANISMS[solutionId] ?? [];
+  const hit = worries.find(w => tags.includes(w as WorryId));
+  if (!hit) return null;
+  const sub = WORRY_SUBTYPES.find(w => w.id === hit);
+  if (!sub) return null;
+  const phrase = (lang === 'pt' ? sub.dPt : sub.dEn).toLowerCase();
+  return lang === 'pt' ? `pra ${phrase}` : `for ${phrase}`;
 }
 
 export function solutionsForFamilia(familiaId: NbsFamiliaId): NbsSolution[] {

--- a/shared/nbs-performance.ts
+++ b/shared/nbs-performance.ts
@@ -32,6 +32,8 @@
 // from `NBS_EVENT_SCALE` must carry `estimated`-style marking, the same
 // discipline as `classificationEstimated` in nbs-catalog.ts.
 
+import { familiesOfWorries } from './site-knowledge';
+
 /** What a retention figure is measured in — these are NOT interchangeable. */
 export type RetentionUnit =
   /** Cubic metres held per m² of intervention, per rain event. */
@@ -294,7 +296,16 @@ export const NBS_SCALE_HONESTY = {
  * the everyday water, and that the big flood is an advocacy conversation.
  */
 export function needsScaleReframing(worry: string[], story: string): boolean {
-  if (!worry.includes('flood')) return false;
+  // Through the family — the worry ids now carry the mechanism (Alagamento /
+  // Inundação / Enxurrada), and a literal `includes('flood')` would stop firing
+  // for every one of them: the honesty beat would go quiet exactly when the org
+  // is describing the event it exists for.
+  if (!familiesOfWorries(worry).includes('flood')) return false;
+  // Naming Inundação IS the signal. This function was reverse-engineering it
+  // from story keywords because the chip could not say it — "the 2024 event or
+  // a river/dike" is the definition of Inundação. Now that they can pick the
+  // word, take them at it and don't wait for the story to mention the Guaíba.
+  if (worry.includes('inundacao')) return true;
   const s = story.toLowerCase();
   return /enchente|2024|guaíba|guaiba|dique|rio subiu|subiu o rio|inunda|the flood|dike|river rose/.test(s);
 }

--- a/shared/nbs-recommendation.ts
+++ b/shared/nbs-recommendation.ts
@@ -13,6 +13,7 @@
 // calls the show_familia_recommendation tool with its own whys, which override
 // these per-família.
 
+import { familiesOfWorries } from './site-knowledge';
 import {
   NBS_FAMILIAS,
   solutionsForFamilia,
@@ -244,8 +245,11 @@ export function rankFamiliasForSite(input: FamiliaRecoInput): RankedFamilia[] {
     // The worry the org named. Capped so the hazard data still shapes the
     // order — a stated worry should lift a família decisively, not seize the
     // ranking — and marked `guaranteed` so no trimming can hide it.
-    const named = (input.worries ?? []).filter(
-      (w): w is 'flood' | 'heat' | 'landslide' => w === 'flood' || w === 'heat' || w === 'landslide');
+    // Through the family: worries now carry the finer mechanism (Alagamento /
+    // Inundação / Enxurrada) and this scores against the one flood layer we
+    // have. A raw `w === 'flood'` filter would drop every one of them and
+    // silently stop honouring the worry they just told us about.
+    const named = familiesOfWorries(input.worries ?? []);
     const answersAWorry = named.find(h => f.hazards[h] >= 0.6);
     const worryBoost = answersAWorry ? Math.min(0.35, 0.35 * f.hazards[answersAWorry]) : 0;
 

--- a/shared/site-knowledge.ts
+++ b/shared/site-knowledge.ts
@@ -25,15 +25,80 @@
 // participant, while broad prompts surface what the facilitator never thought to
 // ask.
 
+/** The three layers we hold data for. One raster each; nothing finer exists. */
 export type HazardKey = 'flood' | 'heat' | 'landslide';
 
-/** What an organization can name as the thing that worries them at this place. */
-export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string; dPt: string; dEn: string }> = [
-  { id: 'flood', pt: '💧 Alagamento', en: '💧 Flooding', dPt: 'A água que junta ou invade', dEn: 'Water that pools or comes in' },
-  { id: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
-  { id: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
-  { id: 'other', pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
+/**
+ * The MECHANISM an organization names — one level finer than the data.
+ *
+ * COUGAR convening, 2026-08-06 (Vila Flores / PxG / OEF / BwB): orgs do not
+ * experience "flood" as one thing. Water that pools and won't drain, a river
+ * that overtops, and water coming down a slope with velocity are three
+ * different problems that take three different solutions. The meeting
+ * standardised the civil-defense terms — Alagamento (pluvial/drainage),
+ * Inundação (river), Enxurrada (flash flood) — each paired with plain language.
+ *
+ * The old chip was already merging two of them out loud: "💧 Alagamento — A água
+ * que junta OU INVADE". "Junta" is Alagamento, "invade" is Inundação, and both
+ * sat under a label that named only the first. An org whose problem is the
+ * Guaíba was tapping a chip that called it the wrong thing.
+ *
+ * ⚠️ This is deliberately NOT a new data key. We hold exactly three rasters, so
+ * all three water mechanisms score against `flood`; `family` is how every
+ * consumer gets back to a key it has data for. The org's word is theirs and is
+ * stored as-is; the number stays the flood-family percentile and keeps saying
+ * so. See backlog #24.
+ */
+export type WorryId = 'alagamento' | 'inundacao' | 'enxurrada' | 'heat' | 'landslide' | 'other';
+
+export interface WorrySubtype {
+  id: WorryId;
+  /** The data key this mechanism is scored against. null = we have no layer. */
+  family: HazardKey | null;
+  pt: string;
+  en: string;
+  dPt: string;
+  dEn: string;
+}
+
+export const WORRY_SUBTYPES: WorrySubtype[] = [
+  { id: 'alagamento', family: 'flood', pt: '💧 Alagamento', en: '💧 Ponding', dPt: 'A água que junta e não escoa', dEn: "Water that pools and won't drain" },
+  { id: 'inundacao', family: 'flood', pt: '🌊 Inundação', en: '🌊 River flooding', dPt: 'O rio ou arroio que transborda', dEn: 'The river or stream overtopping' },
+  { id: 'enxurrada', family: 'flood', pt: '🌧️ Enxurrada', en: '🌧️ Flash flood', dPt: 'A água que desce com força', dEn: 'Water coming down with force' },
+  { id: 'heat', family: 'heat', pt: '🌡️ Calor', en: '🌡️ Heat', dPt: 'Sol forte, falta de sombra', dEn: 'Harsh sun, no shade' },
+  { id: 'landslide', family: 'landslide', pt: '⛰️ O barranco', en: '⛰️ The slope', dPt: 'Terra que desce, erosão', dEn: 'Earth coming down, erosion' },
+  { id: 'other', family: null, pt: 'Outra coisa', en: 'Something else', dPt: 'Me conta o que é', dEn: 'Tell me what it is' },
 ];
+
+/**
+ * The data key behind a worry, or null if we hold no layer for it.
+ *
+ * ⚠️ MIGRATION. Sessions that ran before the split stored the family id itself
+ * (`site_worry: 'flood'`), and those rows are still in the database — JVP's test
+ * orgs and the three W2 test-kit orgs. A legacy `flood` therefore has to keep
+ * resolving as "water, mechanism unspecified" rather than becoming an unknown
+ * id. Every consumer below filtered with `w === 'flood' || …`, which DROPS
+ * anything it doesn't recognise silently — so getting this wrong would not
+ * throw, it would quietly stop asking those orgs for photos.
+ */
+export function familyOfWorry(id: string): HazardKey | null {
+  const hit = WORRY_SUBTYPES.find(w => w.id === id);
+  if (hit) return hit.family;
+  return id === 'flood' || id === 'heat' || id === 'landslide' ? (id as HazardKey) : null;
+}
+
+/** The families behind a set of worries, deduped and order-preserving. */
+export function familiesOfWorries(worries: string[]): HazardKey[] {
+  const out: HazardKey[] = [];
+  for (const w of worries) {
+    const f = familyOfWorry(w);
+    if (f && !out.includes(f)) out.push(f);
+  }
+  return out;
+}
+
+/** What an organization can name as the thing that worries them at this place. */
+export const E2_WORRIES = WORRY_SUBTYPES;
 
 /**
  * Worry chips ordered by what the bairro data suggests, highest first — the
@@ -47,8 +112,12 @@ export const E2_WORRIES: Array<{ id: HazardKey | 'other'; pt: string; en: string
 export function orderWorriesByData(risks: Record<HazardKey, number>) {
   const hazards = E2_WORRIES.filter(w => w.id !== 'other');
   const other = E2_WORRIES.filter(w => w.id === 'other');
+  const riskOf = (w: WorrySubtype) => (w.family ? risks[w.family] ?? 0 : -1);
   return [
-    ...hazards.sort((a, b) => (risks[b.id as HazardKey] ?? 0) - (risks[a.id as HazardKey] ?? 0)),
+    // Array.prototype.sort is stable, so the three water mechanisms — which all
+    // score against the same `flood` number — keep the order they are declared
+    // in: Alagamento, Inundação, Enxurrada. Everyday first.
+    ...hazards.slice().sort((a, b) => riskOf(b) - riskOf(a)),
     ...other,
   ];
 }
@@ -87,6 +156,21 @@ const PHOTO_PROMPTS: Record<HazardKey | 'base', PhotoPrompt[]> = {
   ],
 };
 
+/**
+ * Prompts that only make sense for a named mechanism. Deliberately small: these
+ * are the questions a raster cannot answer and the generic flood prompts don't
+ * ask. See backlog #24 — this is where the finer term changes what we request,
+ * at no data cost.
+ */
+const MECHANISM_PROMPTS: Partial<Record<WorryId, PhotoPrompt[]>> = {
+  inundacao: [
+    { id: 'high-water-mark', pt: 'Até onde a água chegou — a marca na parede, se tiver', en: 'How high the water reached — the mark on the wall, if there is one' },
+  ],
+  enxurrada: [
+    { id: 'water-path', pt: 'Por onde a água desce quando vem com força', en: 'The path the water takes when it comes down hard' },
+  ],
+};
+
 /** Always offered last, and deliberately open — see the note on power imbalance. */
 export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
   id: 'open',
@@ -100,11 +184,23 @@ export const PHOTO_PROMPT_OPEN: PhotoPrompt = {
  * about water.
  */
 export function photoPromptsFor(worries: string[]): PhotoPrompt[] {
-  const hazards = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const hazards = familiesOfWorries(worries);
   if (hazards.length === 0) return [...PHOTO_PROMPTS.base, PHOTO_PROMPT_OPEN];
 
   const picked: PhotoPrompt[] = [];
   const seen = new Set<string>();
+  // The mechanism earns its keep here: the shot that settles Inundação (how
+  // high did it get?) is not the shot that settles Enxurrada (where does it
+  // come down?), and neither is in the generic flood set. These go FIRST — a
+  // named mechanism is the most specific thing we know about the site.
+  for (const w of worries) {
+    for (const prompt of MECHANISM_PROMPTS[w as WorryId] ?? []) {
+      if (!seen.has(prompt.id) && picked.length < 3) {
+        seen.add(prompt.id);
+        picked.push(prompt);
+      }
+    }
+  }
   // Round-robin across the named hazards, so every worry is represented before
   // any one of them gets a second prompt.
   for (let round = 0; round < 3 && picked.length < 3; round++) {
@@ -177,7 +273,7 @@ export function hazardCheckQuestion(
 
 /** Which hazards are worth checking: what they named, plus anything our data calls high. */
 export function hazardsToCheck(worries: string[], risks: Record<HazardKey, number>): HazardKey[] {
-  const named = worries.filter((w): w is HazardKey => w === 'flood' || w === 'heat' || w === 'landslide');
+  const named = familiesOfWorries(worries);
   const dataHigh = (['flood', 'heat', 'landslide'] as HazardKey[]).filter(h => (risks[h] ?? 0) >= 66);
   // Cap at two — three checkpoints is where a conversation becomes a form.
   return Array.from(new Set([...named, ...dataHigh])).slice(0, 2);


### PR DESCRIPTION
Backlog **#24 and #26**, both P0 for next week's convening. **Supersedes #458** — the three commits are co-dependent (#26's spec updates include the label change that #24 requires), and the hook won't let me add to an open PR's branch.

## #24 — the org's word (two commits)

The problem was already in the product's own copy: **"💧 Alagamento — *A água que junta ou invade*"**. "Junta" is Alagamento, "invade" is Inundação, both under a label naming only the first — so an org whose problem is the Guaíba was tapping a chip that called it something else.

Six chips now, ordered by the bairro data, everyday water first. **Not a new data key**: all three water mechanisms score against the one `flood` raster, and `family` is how every consumer gets back to a key we have data for. The org's word is stored as given; the number stays the flood-family percentile and keeps saying so.

The finer word already pays in two places — the **photo prompts** (the shot that settles Inundação is not the shot that settles Enxurrada) and the **scale-honesty beat**, which was reverse-engineering "the 2024 Guaíba event" from story keywords because the chip couldn't say Inundação.

Then it **orders the solutions**: `SOLUTION_MECHANISMS` tags all 27, drafted from each solution's *own* `whatItIs` (*escada hidráulica vegetada* says "diminuindo sua **velocidade**"; *parques lineares* says "ao longo de **cursos d'água**"), marked provisional for Robson/Hesioni. It **orders and explains, never excludes** — the flow promises "nada fica descartado", so a wrong tag costs scrolling, not access.

## #26 — the two questions that close W2

Orgs applied to the **Teia Sprint** open call, which makes those applications semi-formalised project proposals. The coordination team wants them *before* it plans W3, and wants to know who has a cross-org track record before designing partnerships.

Saying yes **opens the picker** (JVP: *"render directly the upload file button if they say yes"*), reusing the `upload_then_answer` seam.

The collaboration question is yes/no plus free text — deliberately **not** a pick-list of the cohort roster, which would show every org who else is in their hub days after they said they were anxious about their data (#31).

### ⚠️ Deploy step

New DB column **`documents.purpose`** — needs `npm run db:push` before this deploys, or every upload 500s. `kind` stays the *format*: a Teia application is a pdf like any other pdf, and the coordination still has to find it among the site photos.

## Two real bugs this surfaced

1. **The closing beats now own their turn.** An unmatched message re-asks instead of falling through to the model with W2 half-closed — otherwise an org that reloads mid-question, or types instead of tapping, loses the question entirely.
2. **"Com quem?" is typed**, so its capture had to move *above* the `turnKind !== 'chip'` gate, beside the story and "outro papel" captures. Below it, the answer fell through to the model and W2 never closed.

## Spec changes that are contract changes

`cougar-e2-interest-roles` and `cougar-e2-linear-journey` both asserted the closing lands immediately after the roles. Two questions now stand in front of it, so both walk them. Three `cougar-e2-diagnostic` assertions checked `site_worry` was literally `"flood"` — it's now the mechanism the org tapped, so they assert the guarantee that matters: that it still resolves to the one flood raster.

## Testing

Dialled back per JVP — targeted specs plus smoke per PR, full suite batched after a couple. **17 new specs green, smoke 53/53, full suite 174 passed** with the usual ambient pair (linear-journey en, w2-scenarios org 1), both green in isolation.

---

**On the queue:** this is the seventh open PR and none are merged. #452/#453 (Portuguese in the org's own document), #454 (the map at half size) and #455 (a map confirmation being silently discarded) all affect orgs using this next week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy