### PR TITLE
feat(e2): real cases, reachable while choosing — without answering the question

### DIFF
--- a/client/src/core/components/cbo/NbsExamplesSheet.tsx
+++ b/client/src/core/components/cbo/NbsExamplesSheet.tsx
@@ -1,0 +1,69 @@
+// ============================================================================
+// NbsExamplesSheet — real cases, reachable WHILE choosing
+// ============================================================================
+//
+// COUGAR convening 2026-08-06: "make NBS family examples more discoverable
+// through an exploratory component so users can reference back to case studies
+// while selecting solutions". Orgs were choosing famílias blind.
+//
+// ⚠️ It opens from a SECONDARY control on the question card, never from an
+// answer option. The E2 checkpoint machine derives its position from the
+// answers, so an option that only opened a sheet would either strand the flow
+// or answer the question by accident. Opening this must cost nothing: the
+// question is still there when it closes.
+//
+// Browsable, theirs first — not filtered to our recommendation. The ranking
+// that would do the filtering runs on bairro averages rather than their site,
+// and the flow already promises out loud that nothing is ruled out.
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/core/components/ui/sheet';
+import { NBS_SHOWCASE_CARDS, orderShowcaseCardsFor } from '@shared/nbs-showcase-cards';
+import { NbsShowcaseCardStrip } from './NbsShowcaseCard';
+
+const STRINGS = {
+  pt: {
+    title: 'Casos reais',
+    lead: 'Projetos que já aconteceram. Os mais parecidos com o que vocês contaram vêm primeiro.',
+  },
+  en: {
+    title: 'Real cases',
+    lead: 'Projects that already happened. The ones closest to what you told us come first.',
+  },
+} as const;
+
+export function NbsExamplesSheet({
+  open,
+  onClose,
+  lang,
+  families,
+  savedIds,
+  onToggleSave,
+}: {
+  open: boolean;
+  onClose: () => void;
+  lang: 'pt' | 'en';
+  /** Hazard families behind what the org named, so theirs sort to the top. */
+  families: string[];
+  savedIds: string[];
+  onToggleSave: (id: string, next: boolean) => void;
+}) {
+  const s = STRINGS[lang];
+  const cards = orderShowcaseCardsFor(NBS_SHOWCASE_CARDS, families);
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <SheetContent side="bottom" className="h-[85vh] overflow-y-auto" data-testid="nbs-examples-sheet">
+        <SheetHeader className="text-left">
+          <SheetTitle>{s.title}</SheetTitle>
+        </SheetHeader>
+        <p className="text-sm text-muted-foreground mt-1 mb-3">{s.lead}</p>
+        <NbsShowcaseCardStrip
+          cards={cards}
+          mode="browse"
+          savedIds={savedIds}
+          onToggleSave={onToggleSave}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -49,6 +49,8 @@ import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/c
 import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
 import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
+import { NbsExamplesSheet } from '@/core/components/cbo/NbsExamplesSheet';
+import { familiesOfWorries } from '@shared/site-knowledge';
 import { NbsTypeStrip } from '@/core/components/cbo/NbsTypeStrip';
 import { NbsFamiliaStrip } from '@/core/components/cbo/NbsFamiliaStrip';
 import { CboSiteCard } from '@/core/components/cbo/CboSiteCard';
@@ -417,7 +419,7 @@ export default function CboProfilePage() {
   // when they arrive in separate ticks, so this debounce is the cleanest
   // client-side cover.
   const [stableStreamEnded, setStableStreamEnded] = useState(false);
-  const [activeQuestions, setActiveQuestions] = useState<Array<{ id: string; question: string; options: any[]; multiSelect?: boolean }>>([]);
+  const [activeQuestions, setActiveQuestions] = useState<Array<{ id: string; question: string; options: any[]; multiSelect?: boolean; showExamples?: boolean }>>([]);
   const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0);
   const [questionAnswers, setQuestionAnswers] = useState<Record<number, string>>({});
   const [selectedOptionIdx, setSelectedOptionIdx] = useState(0);
@@ -477,6 +479,10 @@ export default function CboProfilePage() {
   // ask_user option). Consumed by the next upload and then cleared — untagged
   // is the normal case and has to stay the default.
   const pendingUploadPurposeRef = useRef<string | null>(null);
+  // Real cases, opened from a SECONDARY control on the question card — never an
+  // answer option, or the checkpoint machine would take it as the answer
+  // (backlog #27).
+  const [examplesOpen, setExamplesOpen] = useState(false);
   const handleSelectRef = useRef<(label: string) => void>(() => {});
 
   const currentQuestion = activeQuestions[currentQuestionIdx] || null;
@@ -535,7 +541,7 @@ export default function CboProfilePage() {
         let p: any = null;
         try { p = JSON.parse(m.content); } catch { break; }
         if (p?.kind !== 'ask_user' || !p.question) break;
-        restored.unshift({ id: `q_restored_${i}`, question: p.question, options: p.options ?? [], multiSelect: p.multiSelect, relatedSections: p.relatedSections });
+        restored.unshift({ id: `q_restored_${i}`, question: p.question, options: p.options ?? [], multiSelect: p.multiSelect, showExamples: p.showExamples, relatedSections: p.relatedSections });
       }
       setActiveQuestions(restored as any);
       setCurrentQuestionIdx(0); setQuestionAnswers({}); setSelectedOptionIdx(0);
@@ -1210,7 +1216,7 @@ export default function CboProfilePage() {
         const hasMap = !!(event as any).showMap;
         setActiveQuestions(prev => {
           if (prev.length === 0) { setCurrentQuestionIdx(0); setQuestionAnswers({}); }
-          return [...prev, { id: `q_${Date.now()}`, question: event.question, options: event.options, multiSelect: (event as any).multiSelect, relatedSections: (event as any).relatedSections }];
+          return [...prev, { id: `q_${Date.now()}`, question: event.question, options: event.options, multiSelect: (event as any).multiSelect, showExamples: (event as any).showExamples, relatedSections: (event as any).relatedSections }];
         });
         // Append the composer the server is persisting for this same event
         // (composers doc, Rule 1). `show_types`/`show_examples` always did this;
@@ -1219,7 +1225,7 @@ export default function CboProfilePage() {
         // reappeared on reload, from the persisted row. Now it never leaves.
         setMessages(prev => [...prev, {
           role: 'assistant',
-          content: JSON.stringify({ kind: 'ask_user', question: event.question, options: event.options, multiSelect: (event as any).multiSelect, showMap: (event as any).showMap, relatedSections: (event as any).relatedSections }),
+          content: JSON.stringify({ kind: 'ask_user', question: event.question, options: event.options, multiSelect: (event as any).multiSelect, showMap: (event as any).showMap, showExamples: (event as any).showExamples, relatedSections: (event as any).relatedSections }),
           messageType: 'composer',
           timestamp: new Date().toISOString(),
         }]);
@@ -2268,6 +2274,7 @@ export default function CboProfilePage() {
                     pendingUploadPurposeRef.current = purpose ?? null;
                     fileInputRef.current?.click();
                   }}
+                  onShowExamples={() => setExamplesOpen(true)}
                 />
               </div>
             )}
@@ -2489,6 +2496,20 @@ export default function CboProfilePage() {
                 <span>{voiceError}</span>
               </div>
             )}
+            <NbsExamplesSheet
+              open={examplesOpen}
+              onClose={() => setExamplesOpen(false)}
+              lang={lang.startsWith('pt') ? 'pt' : 'en'}
+              // Their hazard families, so the closest cases sort first. Read
+              // from the profile rather than the recommendation: the ranking
+              // runs on bairro averages, theirs is what they told us.
+              families={familiesOfWorries(
+                String(state?.sections?.intervention_site?.fields?.site_worry?.value ?? '')
+                  .split(',').map(w => w.trim()).filter(Boolean),
+              )}
+              savedIds={inspirationPicks}
+              onToggleSave={handleInspirationToggle}
+            />
             {streamRetry && !isStreaming && (
               <div className="mb-1.5">
                 <Button
@@ -3024,8 +3045,9 @@ function CboQuestionCard({
   onMultiConfirm,
   readOnly,
   onUploadAction,
+  onShowExamples,
 }: {
-  question: { question: string; options: any[]; multiSelect?: boolean };
+  question: { question: string; options: any[]; multiSelect?: boolean; showExamples?: boolean };
   selectedIdx: number;
   onSelect: (label: string) => void;
   disabled: boolean;
@@ -3038,6 +3060,9 @@ function CboQuestionCard({
   readOnly?: boolean;
   /** Opens the file picker — for options with action 'upload'. */
   onUploadAction?: (purpose?: string) => void;
+  /** Opens the real-cases sheet. Deliberately separate from onSelect: this must
+   *  never answer the question (backlog #27). */
+  onShowExamples?: () => void;
 }) {
   const { t } = useTranslation();
   const isMulti = question.multiSelect;
@@ -3144,6 +3169,20 @@ function CboQuestionCard({
         <Button size="sm" onClick={onMultiConfirm} disabled={disabled} className="w-full h-8 text-xs gap-1 bg-green-600 hover:bg-green-700">
           <Check className="w-3 h-3" /> {t('cbo.confirmSelected', { defaultValue: 'Confirm {{n}} selected', n: multiSet.size })}
         </Button>
+      )}
+      {/* ⚠️ SECONDARY control, deliberately outside the options list and styled
+          unlike them: choosing a família is the answer, looking at cases is not.
+          As an option it would either answer the question by accident or strand
+          the checkpoint machine, which reads its position from the answers. */}
+      {question.showExamples && !readOnly && onShowExamples && (
+        <button
+          type="button"
+          onClick={onShowExamples}
+          data-testid="cbo-show-examples"
+          className="mt-1 text-xs text-green-700 underline underline-offset-2 hover:text-green-800"
+        >
+          {t('cbo.seeRealCases', { defaultValue: 'Ver casos reais' })}
+        </button>
       )}
     </div>
   );

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1902,7 +1902,8 @@
       "whatWeWillDo": "What we'll do together",
       "youWillUse": "You'll use",
       "eyebrow": "Encontro {{n}}"
-    }
+    },
+    "seeRealCases": "See real cases"
   },
   "mapMicroapp": {
     "tourNext": "Next risk",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -2089,7 +2089,8 @@
       "whatWeWillDo": "O que vamos fazer juntas",
       "youWillUse": "Vocês vão usar",
       "eyebrow": "Encontro {{n}}"
-    }
+    },
+    "seeRealCases": "Ver casos reais"
   },
   "mapMicroapp": {
     "tourNext": "Próximo risco",

--- a/e2e/cougar-examples-while-choosing.spec.ts
+++ b/e2e/cougar-examples-while-choosing.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+import { orderShowcaseCardsFor, NBS_SHOWCASE_CARDS } from '../shared/nbs-showcase-cards';
+
+// Backlog #27, from the COUGAR convening: "make NBS family examples more
+// discoverable through an exploratory component so users can reference back to
+// case studies while selecting solutions". Orgs were choosing famílias blind.
+//
+// ⚠️ The whole risk of this feature is in HOW it opens. The chip contract is
+// "the chip still posts its message" — the E2 checkpoint machine derives its
+// position from the answers. So an examples option would either answer the
+// question by accident or strand the flow. It has to be a SECONDARY control,
+// and opening it must cost nothing: the question is still there afterwards.
+
+test.describe('COUGAR — real cases, reachable while choosing', () => {
+  test.use({ locale: 'pt-BR' });
+
+  test('opening the cases does NOT answer the question', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'set_phase', phase: 2 } as any,
+      { op: 'ask_user', question: 'Em quais famílias vocês teriam interesse?', options: [
+        { label: 'Gestão de Águas Pluviais', description: 'água da chuva' },
+        { label: 'Agricultura Urbana', description: 'comida' },
+      ], showExamples: true } as any,
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('oi');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    const control = page.getByTestId('cbo-show-examples');
+    await expect(control, 'the secondary control must be offered here').toBeVisible({ timeout: 30_000 });
+
+    const turnsBefore = (await (await request.get(`/api/cbo/${cboId}/messages`)).json()).length;
+
+    await control.click();
+    await expect(page.getByTestId('nbs-examples-sheet')).toBeVisible({ timeout: 10_000 });
+
+    // THE ASSERTION. No turn was sent, nothing was answered, and the question is
+    // still on screen behind the sheet.
+    await page.waitForTimeout(800);
+    const turnsAfter = (await (await request.get(`/api/cbo/${cboId}/messages`)).json()).length;
+    expect(turnsAfter, 'looking at cases must not post a turn').toBe(turnsBefore);
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('nbs-examples-sheet')).toBeHidden({ timeout: 10_000 });
+    await expect(
+      page.locator('[data-testid^="cbo-option-"][data-option-label="Gestão de Águas Pluviais"]'),
+      'the question must survive a trip to the cases',
+    ).toBeVisible();
+
+    // …and answering still works afterwards.
+    await page.locator('[data-testid^="cbo-option-"][data-option-label="Gestão de Águas Pluviais"]').click();
+    await expect.poll(async () =>
+      (await (await request.get(`/api/cbo/${cboId}/messages`)).json()).length,
+      { timeout: 20_000 }).toBeGreaterThan(turnsBefore);
+  });
+
+  test('the control is absent on questions that are not a choice', async ({ page, request }) => {
+    test.setTimeout(120_000);
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [[
+      { op: 'ask_user', question: 'Vocês atuam em um bairro só?', options: [
+        { label: 'Um bairro', description: 'só um' },
+        { label: 'Mais de um', description: 'vários' },
+      ] } as any,
+    ]]);
+    await page.getByTestId('cbo-chat-input').fill('oi');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+
+    await expect(page.locator('[data-testid^="cbo-option-"][data-option-label="Um bairro"]'))
+      .toBeVisible({ timeout: 30_000 });
+    // Offering cases beside "how many bairros?" would be noise.
+    await expect(page.getByTestId('cbo-show-examples')).toHaveCount(0);
+  });
+
+  test('theirs first, but nothing is filtered out', () => {
+    const all = NBS_SHOWCASE_CARDS;
+    const ordered = orderShowcaseCardsFor(all, ['heat']);
+    // Every case stays reachable — the ranking that would filter runs on bairro
+    // averages, not their site, and the flow promises nada fica descartado.
+    expect(ordered).toHaveLength(all.length);
+    expect(new Set(ordered.map(c => c.id))).toEqual(new Set(all.map(c => c.id)));
+    expect(ordered[0].hazard).toBe('heat');
+    // `mixed` speaks to their hazard among others — between theirs and the rest.
+    const firstOther = ordered.findIndex(c => c.hazard !== 'heat' && c.hazard !== 'mixed');
+    const firstMixed = ordered.findIndex(c => c.hazard === 'mixed');
+    if (firstMixed >= 0 && firstOther >= 0) expect(firstMixed).toBeLessThan(firstOther);
+    // No worry named yet → catalogue order, untouched.
+    expect(orderShowcaseCardsFor(all, []).map(c => c.id)).toEqual(all.map(c => c.id));
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -1754,10 +1754,14 @@ async function serveE2Checkpoint(
     qPt: string,
     qEn: string,
     opts: Array<{ pt: string; en: string; dPt?: string; dEn?: string; action?: 'upload_then_answer'; uploadPurpose?: string }>,
+    /** Offer "ver exemplos reais" beside this question — a SECONDARY control,
+     *  not an option. See showExamples in the ask_user event. */
+    withExamples = false,
   ) =>
     pushEvent({
       type: 'ask_user',
       question: isPt ? qPt : qEn,
+      ...(withExamples ? { showExamples: true } : {}),
       options: opts.map(o => ({
         label: isPt ? o.pt : o.en,
         description: isPt ? (o.dPt ?? '') : (o.dEn ?? ''),
@@ -1791,6 +1795,9 @@ async function serveE2Checkpoint(
         ? 'Which famílias would you be interested in running a project on? You can pick more than one — tap one at a time.'
         : 'Noted ✓ Any other?',
       opts,
+      // Choosing famílias is exactly the moment the convening asked for: let
+      // them look at real cases without losing the question.
+      true,
     );
   };
   const askRoles = (picked: string[], intro: boolean) => {
@@ -1981,7 +1988,7 @@ async function serveE2Checkpoint(
     ask('Faz sentido pra vocês?', 'Does this make sense to you?', [
       { pt: E2C.fazSentido.pt, en: E2C.fazSentido.en },
       { pt: E2C.queroAjustar.pt, en: E2C.queroAjustar.en, dPt: 'Quero mexer na lista', dEn: 'I want to change the list' },
-    ]);
+    ], true);
     return finish('familia-reco');
   };
 

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -54,7 +54,7 @@ export type FakeOp =
   | { op: 'thinking_step'; label: string; status?: 'active' | 'complete' } // live tool-activity label (pair with 'wait' to hold it visible)
   | { op: 'update_section'; sectionId: string; field: string; value: string; confidence?: Confidence; source?: string }
   | { op: 'confirm_doc_fields'; fields?: string[] } // commit values staged by doc-sourced free-text update_section
-  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean; allowReask?: boolean }
+  | { op: 'ask_user'; question: string; options: { label: string; description?: string; recommended?: boolean; action?: 'upload' }[]; multiSelect?: boolean; showMap?: boolean; showExamples?: boolean; allowReask?: boolean }
   | { op: 'score_maturity'; metric: string; score: number; justification?: string }
   | { op: 'set_phase'; phase: number }
   | { op: 'set_path'; path: 'has-project' | 'has-idea' | 'needs-help' } // emits path_set (display mirror; standalone sessions have no member row)
@@ -213,7 +213,7 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
           break;
         }
       }
-      pushEvent({ type: 'ask_user', question: op.question, options, showMap: op.showMap, multiSelect: op.multiSelect });
+      pushEvent({ type: 'ask_user', question: op.question, options, showMap: op.showMap, showExamples: op.showExamples, multiSelect: op.multiSelect });
       break;
     }
     case 'score_maturity': {

--- a/shared/cbo-schema.ts
+++ b/shared/cbo-schema.ts
@@ -350,7 +350,9 @@ export type CboEvent =
   // options[].action 'upload': the chip renders as a prominent attach banner
   // (paperclip icon) and opens the file picker instead of answering — the
   // intake opening's "send your site or documents" affordance.
-  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string; action?: 'upload' | 'upload_then_answer' }>; relatedSections?: string[]; showMap?: boolean; multiSelect?: boolean }
+  | { type: 'ask_user'; question: string; options: Array<{ label: string; description: string; recommended?: boolean; imageUrl?: string; location?: string; action?: 'upload' | 'upload_then_answer' }>; relatedSections?: string[]; showMap?: boolean;
+      /** Offer real cases beside this question, WITHOUT answering it. */
+      showExamples?: boolean; multiSelect?: boolean }
   | { type: 'open_map'; params: OpenMapParams }
   | { type: 'open_intervention_selector'; params: OpenInterventionSelectorParams }
   | { type: 'show_examples'; cardIds: string[]; mode: 'browse' | 'favorites'; intro?: string }

--- a/shared/nbs-showcase-cards.ts
+++ b/shared/nbs-showcase-cards.ts
@@ -294,3 +294,25 @@ export function filterShowcaseCards(opts?: { hazard?: ShowcaseHazard; typeRefs?:
     return true;
   });
 }
+
+
+/**
+ * The same 13 cases, with the ones matching what the org named first.
+ *
+ * COUGAR convening 2026-08-06: orgs should be able to reference real cases WHILE
+ * they choose, instead of choosing blind. Ordering rather than filtering is
+ * deliberate — the ranking that would do the filtering runs on bairro averages,
+ * not on their site, and an org finding something we didn't predict for them is
+ * a feature. Same promise the flow makes out loud: nada fica descartado.
+ *
+ * `mixed` sits between: it speaks to their hazard among others.
+ */
+export function orderShowcaseCardsFor(
+  cards: typeof NBS_SHOWCASE_CARDS,
+  families: string[],
+): typeof NBS_SHOWCASE_CARDS {
+  if (families.length === 0) return cards;
+  const rank = (c: { hazard: string }) =>
+    families.includes(c.hazard) ? 0 : c.hazard === 'mixed' ? 1 : 2;
+  return [...cards].sort((a, b) => rank(a) - rank(b));
+}


### PR DESCRIPTION
Backlog **#27** — the last P0 from the COUGAR convening: *"make NBS family examples more discoverable through an exploratory component so users can reference back to case studies while selecting solutions"*. Orgs were choosing famílias blind.

## The risk is entirely in *how* it opens

The chip contract is **"the chip still posts its message"** — the E2 checkpoint machine derives its position from the answers. So an examples *option* would either answer the question by accident or strand the flow.

It's a **secondary control** on the question card: outside the options list, styled unlike them. Choosing a família is the answer; looking at cases is not. The spec asserts that directly — opening the sheet posts **no turn**, and the question is still there when it closes.

That also means **#27 did not need the full chip-action refactor (#23) first**, which I'd flagged as a prerequisite during the refine. A secondary control sidesteps the answer contract instead of extending it — cheaper and lower risk than what I'd planned.

## Browsable, theirs first

All 13 cases stay reachable, with the ones matching their hazard on top and `mixed` between theirs and the rest. Not filtered to our recommendation: that ranking runs on **bairro averages rather than their site**, and an org finding something we didn't predict for them is the point. Same promise the flow already makes out loud — *nada fica descartado*.

## Offered only where someone is choosing

The família interest question and the recommendation acknowledgement. Beside "how many bairros?" it would be noise, and a spec pins that it stays absent there.

`showExamples` rides the `ask_user` event, the **persisted composer** and the **rehydration** path — so a reload doesn't silently drop the affordance. Same class of bug as the map params before they were persisted.

## Testing

Per JVP: 3 new specs green, 4 targeted, smoke 54/54. Full suite batched for the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy