### PR TITLE
fix(mobile): stop chasing events — converge instead (3rd report of the same bug)

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -909,32 +909,83 @@ export default function CboProfilePage() {
     const mount = document.getElementById('root');
     let raf = 0;
     let settle: ReturnType<typeof setTimeout> | undefined;
+    let watchdog: ReturnType<typeof setInterval> | undefined;
+    let lastH = -1;
+    let lastTop = -1;
+
+    // MEASURE + WRITE. Idempotent, so the watchdog can call it freely.
+    const apply = () => {
+      const v = window.visualViewport;
+      let h = v?.height ?? window.innerHeight;
+      let top = v?.offsetTop ?? 0;
+      // KEYBOARD STATE IS INFERRED FROM FOCUS, NOT FROM THE VIEWPORT. After
+      // the keyboard dismisses, iOS keeps REPORTING the stale smaller
+      // height/offset and often never fires another vv event (field report
+      // 2026-07-15 round 2: fine at session start, short shell + dead space
+      // after the first typed turn; known iOS 26 regression). No editable
+      // element focused ⇒ the keyboard cannot be open ⇒ trust the layout
+      // viewport. Skipped while pinch-zoomed (scale ≠ 1), where
+      // vv.height < innerHeight is legitimate.
+      const ae = document.activeElement as HTMLElement | null;
+      const editableFocused = !!ae && (
+        ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable
+      );
+      if (!editableFocused && (v?.scale ?? 1) === 1) {
+        h = Math.max(h, window.innerHeight);
+        top = 0;
+      }
+      // Clamp. A NEGATIVE offset would push the header above the visible top,
+      // and because the document is locked the user cannot scroll back to it —
+      // the app would simply have no header, with no recovery. Whatever iOS
+      // reports, the shell starts at or below the top of what's visible.
+      top = Math.max(0, top);
+      h = Math.max(1, h);
+      const rh = Math.round(h);
+      const rtop = Math.round(top);
+      // WRITE ONLY ON CHANGE. Setting a custom property invalidates style even
+      // when the value is identical, and the heartbeat below calls this twice a
+      // second for the whole session — an unconditional write would mean a
+      // style recalc every 500ms on every phone in the cohort, forever.
+      if (rh !== lastH) { root.style.setProperty('--cbo-vh', `${rh}px`); lastH = rh; }
+      if (rtop !== lastTop) { root.style.setProperty('--cbo-vv-top', `${rtop}px`); lastTop = rtop; }
+      if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
+      return { h: rh, top: rtop };
+    };
+
+    // SELF-HEALING WATCHDOG — the reason this is the third fix.
+    //
+    // Both previous fixes assumed "an event will tell us". The 2026-08-10 field
+    // report proves they don't always: iOS can leave the viewport displaced and
+    // fire nothing. So instead of trying to enumerate every event, compare what
+    // the shell ACTUALLY paints against what it should, and repair the drift.
+    // Convergence stops mattering which event was missed.
+    //
+    // It runs for the WHOLE life of the chat shell and never switches itself
+    // off. An earlier draft stopped after a few clean ticks — which reopens
+    // the same hole one level up, because a silent change arriving after it
+    // stopped would go undetected. A heartbeat with an off switch is not a
+    // heartbeat. The cost of leaving it on is two rect reads every 500ms:
+    // nothing next to the SSE stream and React's own work, even on the
+    // low-end Androids in the cohort. Skipped while backgrounded.
+    const reconcile = () => {
+      if (document.hidden) return;
+      const el = document.querySelector<HTMLElement>('[data-testid="cbo-shell"]');
+      const target = apply();
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const drift = Math.abs(r.top - target.top) > 1 || Math.abs(r.height - target.h) > 1;
+      // apply() has already rewritten the variables; the rect converges on the
+      // next frame. Nothing else to do — this branch exists so the condition
+      // is observable in a debugger and in the spec.
+      if (drift) root.setAttribute('data-cbo-vv-repaired', '1');
+    };
+    watchdog = setInterval(reconcile, 500);
+
     const setVH = () => {
       if (raf) return; // coalesce bursts (iOS fires resize+scroll together)
       raf = requestAnimationFrame(() => {
         raf = 0;
-        const v = window.visualViewport;
-        let h = v?.height ?? window.innerHeight;
-        let top = v?.offsetTop ?? 0;
-        // KEYBOARD STATE IS INFERRED FROM FOCUS, NOT FROM THE VIEWPORT. After
-        // the keyboard dismisses, iOS keeps REPORTING the stale smaller
-        // height/offset and often never fires another vv event (field report
-        // 2026-07-15 round 2: fine at session start, short shell + dead space
-        // after the first typed turn; known iOS 26 regression). No editable
-        // element focused ⇒ the keyboard cannot be open ⇒ trust the layout
-        // viewport. Skipped while pinch-zoomed (scale ≠ 1), where
-        // vv.height < innerHeight is legitimate.
-        const ae = document.activeElement as HTMLElement | null;
-        const editableFocused = !!ae && (
-          ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable
-        );
-        if (!editableFocused && (v?.scale ?? 1) === 1) {
-          h = Math.max(h, window.innerHeight);
-          top = 0;
-        }
-        root.style.setProperty('--cbo-vh', `${Math.round(h)}px`);
-        root.style.setProperty('--cbo-vv-top', `${Math.round(top)}px`);
-        if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
+        apply();
       });
     };
     // Focus changes are the reliable keyboard signal, but they land BEFORE the
@@ -954,6 +1005,15 @@ export default function CboProfilePage() {
     document.addEventListener('focusout', onFocusChange);
     window.addEventListener('orientationchange', setVH);
     window.addEventListener('resize', setVH);
+    // A document scroll used to be invisible here: the reset lived inside the
+    // vv handler, so a scroll that fired no vv event was never undone. With a
+    // fixed shell it can no longer displace anything, but the reset still runs
+    // — a scrolled locked document is a symptom worth clearing, not keeping.
+    window.addEventListener('scroll', setVH, { passive: true });
+    // Returning from the background, or a bfcache restore, is the other moment
+    // iOS hands back stale geometry with no resize event.
+    window.addEventListener('pageshow', setVH);
+    document.addEventListener('visibilitychange', setVH);
 
     // Lock document scroll the GENTLE way — overflow:hidden + full height on the
     // scroll chain (html → body → #root). NOT `position: fixed` on body: that
@@ -981,8 +1041,12 @@ export default function CboProfilePage() {
       document.removeEventListener('focusout', onFocusChange);
       window.removeEventListener('orientationchange', setVH);
       window.removeEventListener('resize', setVH);
+      window.removeEventListener('scroll', setVH);
+      window.removeEventListener('pageshow', setVH);
+      document.removeEventListener('visibilitychange', setVH);
       if (raf) cancelAnimationFrame(raf);
       clearTimeout(settle);
+      if (watchdog) clearInterval(watchdog);
       root.style.removeProperty('--cbo-vh');
       root.style.removeProperty('--cbo-vv-top');
       root.style.overflow = prev.htmlOverflow;
@@ -1807,7 +1871,15 @@ export default function CboProfilePage() {
   }
 
   return (
-    <div data-testid="cbo-shell" className="h-[100dvh] flex flex-col bg-background overflow-hidden" style={{ height: 'var(--cbo-vh, 100dvh)', transform: 'translateY(var(--cbo-vv-top, 0px))' }}>
+    // POSITION: FIXED, not in flow — see docs/mobile-viewport.md invariant 2.
+    // In flow, ANY document scroll drags the shell out of the visible window:
+    // the header goes above the top (unreachable, because the document is
+    // locked so the user cannot scroll back to it) and an equal dead band
+    // opens below the tab bar. Fixed makes the shell's paint position depend
+    // only on --cbo-vv-top, so document scroll — however it happened — cannot
+    // displace it. `top` rather than translateY: a transform would make the
+    // shell the containing block for any `fixed` descendant.
+    <div data-testid="cbo-shell" className="fixed inset-x-0 flex flex-col bg-background overflow-hidden" style={{ top: 'var(--cbo-vv-top, 0px)', height: 'var(--cbo-vh, 100dvh)' }}>
       {/* E2E stream-complete contract. SSE never goes network-idle, so Playwright
           waits on this hidden marker's attributes instead: data-streaming flips
           to 'false' when a turn ends, data-turns counts completed turns, and

--- a/docs/mobile-viewport.md
+++ b/docs/mobile-viewport.md
@@ -65,6 +65,28 @@ offset. Screenshot in the PR.
 9. **The lock is scoped to the chat shell** — welcome/preamble screens keep
    normal document scroll (a locked welcome stranded the CTA below the fold
    on short desktop viewports).
+10. **The shell is OUT OF FLOW** (`position: fixed`, `top: var(--cbo-vv-top)`).
+   In normal flow, any document scroll drags it out of the visible window:
+   the header ends up above the top edge — unreachable, because invariant 3
+   locks the document so the user cannot scroll back to it — and an equal dead
+   band opens under the tab bar. Round 3 (2026-08-10) was exactly this. Our
+   scroll lock is a REQUEST, not a guarantee; iOS scroll-into-view can still
+   move the scroll container. Fixed positioning makes that harmless instead of
+   fatal. Use `top`, not `translateY`: a transform makes the shell the
+   containing block for any `fixed` descendant.
+11. **Never a negative offset.** `top` is clamped to `>= 0`. There is no
+   recovery from a header above the visible top, so no reported value is
+   allowed to produce one.
+12. **A heartbeat reconciles, and never switches off.** Every 500ms, compare
+   the shell's real `getBoundingClientRect()` against what it should be and
+   re-apply. Rounds 1 and 2 both assumed "an event will tell us"; round 3
+   proved iOS can leave the viewport displaced and fire nothing at all. Do
+   NOT add an off switch after N stable ticks — a silent change arriving
+   afterwards is undetectable, which is the same hole one level up. The cost
+   is two rect reads per tick, and `apply()` writes the CSS variables ONLY
+   when a value actually changed (an unconditional write invalidates style
+   twice a second, forever, on every phone in the cohort).
+
 
 ## Do / Don't
 
@@ -78,6 +100,35 @@ offset. Screenshot in the PR.
 - ❌ Don't hand the document scroll back to the chat page "just for one
   screen" — rubber-banding moves the browser chrome and reopens the gap.
 
+## Round 3 — 2026-08-10
+
+Reported on a real iPhone: *"cant see the top section, cant scroll further up
+than that, and when I type the bottom part takes a big chunk."* Evidence:
+`docs/evidence/mobile-2026-08-10-*.png`.
+
+**Both existing tests passed while this was live**, which is the lesson. They
+could only express failures the shell's own two variables could produce — a
+wrong height, a wrong offset. The screenshots showed something else: the shell
+in the right *shape* but the wrong *place*, because the document underneath it
+had moved. Nothing measured where the shell actually painted.
+
+So round 3 changes the strategy rather than adding a fourth special case:
+
+| Round | Assumption | How it broke |
+|---|---|---|
+| 1 (2026-07 desktop pass) | height is enough | iOS also scrolls the visual viewport |
+| 2 (2026-07-15) | follow height + offset on every event | iOS stops firing events after dismissal |
+| 3 (2026-08-10) | events are unreliable — **converge anyway** | — |
+
+Invariant 12 is the substance: stop enumerating the events that must be caught,
+and instead compare painted geometry against intended geometry on a timer. It
+no longer matters which event was missed. Invariant 10 removes the failure mode
+that made a missed event catastrophic rather than cosmetic.
+
+⚠️ If there is a round 4, do not add a listener. Ask first why the heartbeat
+did not converge — that is a much smaller question than "which event did iOS
+skip this time".
+
 ## Regression net
 
 - `e2e/cbo-mobile-viewport-follower.spec.ts` stubs `window.visualViewport`
@@ -90,3 +141,21 @@ offset. Screenshot in the PR.
   2. Same on a low-end Android (Chrome + WhatsApp in-app browser).
   3. Rotate to landscape and back.
   4. Background the browser mid-keyboard, return.
+
+- Four round-3 cases in the same spec, each of which FAILS against the
+  pre-fix code (verified by checking out `origin/main`'s `cbo-profile.tsx` and
+  re-running): a document scroll cannot displace the shell · the shell
+  converges when no event ever fires · the header is never pushed above the
+  top · the shell stays out of flow.
+- ⚠️ Two traps when writing tests here, both of which produced a green test
+  that proved nothing:
+  · **`boundingBox()` does not move with document scroll.** Measure with
+    `getBoundingClientRect()` inside `page.evaluate` — viewport-relative by
+    definition.
+  · **`window.scrollTo` is a no-op under the lock.** With `height:100%` +
+    `overflow:hidden` on html, body and `#root`, BODY is the scroll box, and
+    the document's `scrollHeight` never exceeds its `clientHeight`. Scroll
+    `document.body.scrollTop` and assert it actually moved.
+  · Chromium fires a `visualViewport` scroll event when the page scrolls, which
+    silently rescues the defect. Stub a SILENT viewport when the point of the
+    test is that no event arrives.

--- a/e2e/cbo-mobile-viewport-follower.spec.ts
+++ b/e2e/cbo-mobile-viewport-follower.spec.ts
@@ -115,4 +115,154 @@ test.describe('COUGAR — chat shell follows the visual viewport', () => {
     await expect.poll(async () => (await shell.boundingBox())!.height, { timeout: 3_000 }).toBe(844);
     await expect.poll(async () => (await shell.boundingBox())!.y).toBe(0);
   });
+
+  // ── Round 3 (field report 2026-08-10) ────────────────────────────────────
+  // The two tests above both passed while the bug was live on a real iPhone,
+  // which is the point: they only covered failures the SHELL's own variables
+  // could express. The screenshots showed something neither could produce —
+  // the header scrolled off the top with no way back (the document is locked,
+  // so the user cannot scroll to it) and an equal dead band under the tab bar.
+  // That is a displaced shell, and a shell in normal flow is displaced by any
+  // document scroll. Evidence: docs/evidence/mobile-2026-08-10-*.png.
+
+  test('⚠️ a document scroll cannot displace the shell', async ({ page }) => {
+    // The visual viewport is stubbed and SILENT here on purpose. Chromium
+    // helpfully fires a visualViewport `scroll` event when the page scrolls,
+    // which triggers a re-measure and hides the defect; iOS is exactly where
+    // that event cannot be relied on. With no event to rescue it, the only
+    // thing keeping the shell in place is that it is out of flow.
+    await page.addInitScript(() => {
+      const vv = {
+        width: 390, height: 844, offsetTop: 0, offsetLeft: 0, pageTop: 0, pageLeft: 0, scale: 1,
+        addEventListener() {}, removeEventListener() {},
+      };
+      Object.defineProperty(window, 'visualViewport', { value: vv, configurable: true });
+    });
+
+    await page.goto('/cbo-profile');
+    const shell = page.getByTestId('cbo-shell');
+    await expect(shell).toBeVisible();
+    await expect.poll(async () => (await shell.boundingBox())!.y).toBe(0);
+
+    // iOS scroll-into-view moves the document even when we have locked it —
+    // our lock is a request, not a guarantee. Simulate it winning: hand the
+    // document real scrollable overflow and scroll it.
+    const scrolled = await page.evaluate(() => {
+      const spacer = document.createElement('div');
+      spacer.id = 'probe-spacer';
+      spacer.style.cssText = 'height:1200px';
+      document.body.appendChild(spacer);
+      document.documentElement.style.overflow = 'auto';
+      document.body.style.overflow = 'auto';
+      // The lock puts height:100% + overflow:hidden on html, body AND #root,
+      // so BODY is the scroll box here — not the document. Scrolling `window`
+      // is a no-op (scrollHeight never exceeds clientHeight) and an assertion
+      // built on it passes without testing anything. Verified by probe.
+      document.body.scrollTop = 240;
+      return document.body.scrollTop;
+    });
+    expect(scrolled, 'the scroll container really moved').toBeGreaterThan(0);
+
+    // A shell in flow would now be painted at y = -240: header gone, and an
+    // equal dead band at the bottom. Fixed positioning makes the document's
+    // scroll position irrelevant to where the shell lands.
+    //
+    // Measured with getBoundingClientRect INSIDE the page — that is
+    // viewport-relative by definition. Playwright's boundingBox() does not
+    // move with document scroll here, so it cannot see this defect at all.
+    const shellTop = () => page.evaluate(
+      () => document.querySelector('[data-testid="cbo-shell"]')!.getBoundingClientRect().top,
+    );
+    // Two independent things now have to go wrong for the user to see this:
+    // the shell is out of flow, AND a stray document scroll gets reset. Assert
+    // the end state — the shell's top edge is the top of the window — rather
+    // than either mechanism, so a future change is free to drop one of them
+    // as long as the guarantee holds.
+    await expect.poll(shellTop, { timeout: 3_000 }).toBe(0);
+
+    await page.evaluate(() => document.getElementById('probe-spacer')?.remove());
+  });
+
+  test('⚠️ the shell converges even when NO event ever fires', async ({ page }) => {
+    // The self-healing property. Both earlier fixes assumed an event would
+    // arrive to trigger a re-measure; the field report is a case where none
+    // did. Here the viewport changes completely silently — no resize, no
+    // scroll, no focus change — and the shell must still end up right.
+    await page.addInitScript(() => {
+      const listeners: Record<string, Set<() => void>> = {};
+      const vv = {
+        width: 390, height: 844, offsetTop: 0, offsetLeft: 0, pageTop: 0, pageLeft: 0, scale: 1,
+        addEventListener(t: string, fn: () => void) { (listeners[t] ??= new Set()).add(fn); },
+        removeEventListener(t: string, fn: () => void) { listeners[t]?.delete(fn); },
+        __setSilently(height: number, offsetTop: number) {
+          this.height = height;
+          this.offsetTop = offsetTop;
+        },
+      };
+      Object.defineProperty(window, 'visualViewport', { value: vv, configurable: true });
+    });
+
+    await page.goto('/cbo-profile');
+    const shell = page.getByTestId('cbo-shell');
+    await expect(shell).toBeVisible();
+
+    // Focus first, so the focus-based clamp does NOT mask the change — this
+    // has to be the heartbeat doing the work, not invariant 5b.
+    await page.getByTestId('cbo-chat-input').focus();
+    // …and wait out the 400ms post-focus settle re-measure. Without this pause
+    // the settle timer picks the change up and the test proves nothing: it
+    // passed against the unfixed code until the wait was added.
+    await page.waitForTimeout(900);
+    await page.evaluate(() => (window.visualViewport as any).__setSilently(500, 300));
+
+    await expect
+      .poll(async () => (await shell.boundingBox())!.height, { timeout: 5_000 })
+      .toBe(500);
+    expect((await shell.boundingBox())!.y).toBe(300);
+  });
+
+  test('⚠️ the header is never pushed above the top of the visible window', async ({ page }) => {
+    // The symptom the user actually reported: "cant see the top section, cant
+    // scroll further up than that". Whatever the viewport claims — including a
+    // negative offset — the shell starts at or below the visible top, because
+    // there is no recovery from a header the locked document cannot reach.
+    await page.addInitScript(() => {
+      const listeners: Record<string, Set<() => void>> = {};
+      const vv = {
+        width: 390, height: 844, offsetTop: 0, offsetLeft: 0, pageTop: 0, pageLeft: 0, scale: 1,
+        addEventListener(t: string, fn: () => void) { (listeners[t] ??= new Set()).add(fn); },
+        removeEventListener(t: string, fn: () => void) { listeners[t]?.delete(fn); },
+        __set(height: number, offsetTop: number) {
+          this.height = height;
+          this.offsetTop = offsetTop;
+          listeners['resize']?.forEach(fn => fn());
+          listeners['scroll']?.forEach(fn => fn());
+        },
+      };
+      Object.defineProperty(window, 'visualViewport', { value: vv, configurable: true });
+    });
+
+    await page.goto('/cbo-profile');
+    const shell = page.getByTestId('cbo-shell');
+    await expect(shell).toBeVisible();
+
+    await page.getByTestId('cbo-chat-input').focus();
+    await page.evaluate(() => (window.visualViewport as any).__set(600, -120));
+
+    await expect
+      .poll(async () => (await shell.boundingBox())!.y, { timeout: 3_000 })
+      .toBe(0);
+  });
+
+  test('the shell stays out of document flow', async ({ page }) => {
+    // Structural guard. The behavioural tests above all depend on this, and a
+    // future refactor that quietly returns the shell to flow would reopen the
+    // exact bug three field reports have now described.
+    await page.goto('/cbo-profile');
+    await expect(page.getByTestId('cbo-shell')).toBeVisible();
+    const position = await page.evaluate(
+      () => getComputedStyle(document.querySelector('[data-testid="cbo-shell"]')!).position,
+    );
+    expect(position).toBe('fixed');
+  });
 });


### PR DESCRIPTION
Third field report of the same bug. `docs/mobile-viewport.md` already said it "has now been fixed twice", so this PR deliberately does **not** add a fourth special case.

## What you saw

> "cant see the top section cant scroll further up than that, and when I type the bottom part takes a big chunk"

Header above the top of the window and **unreachable** — the document is scroll-locked, so there is no scrolling back to it. Tab bar floating mid-screen. With the keyboard up, a third of the screen dead.

Reproduced deterministically in the harness — before is your screenshot:

| before | after |
|---|---|
| header gone, composer + tab bar mid-screen, dead band below | header, progress bar, composer and tab bar all in place |

## ⚠️ Both existing tests passed while this was live

That's the important part. They could only express failures the shell's own two variables could produce — a wrong height, a wrong offset. The screenshots showed the shell in the right *shape* and the wrong *place*, because the document underneath it had moved. **Nothing measured where the shell actually painted.**

| Round | Assumption | How it broke |
|---|---|---|
| 1 (2026-07) | height is enough | iOS also scrolls the visual viewport |
| 2 (2026-07-15) | follow height + offset on every event | iOS stops firing events after dismissal |
| 3 (this) | events are unreliable — **converge anyway** | — |

## The change

- **`position: fixed`** (was in flow + `translateY`). Our scroll lock is a *request*, not a guarantee — iOS scroll-into-view can still move the scroll container, and in flow that drags the shell out of the window. Out of flow it can't. Uses `top` rather than a transform, so the shell stops being the containing block for `fixed` descendants.
- **Offset clamped to `>= 0`** — no reported value may produce an unreachable header.
- **A 500ms heartbeat** compares the shell's real `getBoundingClientRect()` against what it should be and re-applies. It **never switches off**: an early draft stopped after 4 clean ticks, which reopens the same hole one level up. `apply()` writes the CSS variables only when a value actually **changed** — unconditional writes would invalidate style twice a second, forever, on every phone in the cohort.
- Listeners added for `window` scroll, `pageshow`, `visibilitychange`.

## Research

The VirtualKeyboard API (`overlaysContent`, `env(keyboard-inset-height)`) is the clean answer and is **Chromium-only** — WebKit hasn't shipped it six years after the spec, so it's no help for the iPhones in this cohort. `interactive-widget=resizes-content` (already set) makes Android correct with zero JS; iOS ignores it. That leaves `visualViewport` as the only lever on iOS, which is what production chat web apps use — and the pattern they converge on is pinning to the visual viewport rather than trusting layout.

## Tests

Four new cases, **each verified to fail against `origin/main`'s `cbo-profile.tsx`** (checked out, re-run, confirmed red, restored):

- a document scroll cannot displace the shell
- the shell converges when **no event ever fires**
- the header is never pushed above the top
- the shell stays out of flow (structural guard)

⚠️ Two of them were green and meaningless first, and both traps are now written into the doc:
- **`boundingBox()` does not move with document scroll** — measure with `getBoundingClientRect()` inside `page.evaluate`.
- **`window.scrollTo` is a no-op under the lock** — with `height:100%` + `overflow:hidden` on html/body/`#root`, *body* is the scroll box and the document's `scrollHeight` never exceeds `clientHeight`. The test scrolled nothing and passed.
- Chromium also fires a `visualViewport` scroll event on page scroll, which silently rescues the defect; the test stubs a **silent** viewport where the point is that no event arrives.

## No UX regressions

Full suite: **247 passed**. The `w2-scenarios` / `cougar-e2-linear-journey` failures wander between runs, reproduce on `origin/main` too (1 failed / 244 passed on a clean baseline run), and each passes in isolation.

Invariant 9 (welcome/preamble keep normal document scroll) is untouched — those screens return before the shell renders. Invariant 7 (inputs ≥16px) untouched. No `fixed` descendants existed inside the shell, so dropping the transform changes nothing.

Note: the doc references `docs/evidence/mobile-2026-08-10-*.png`, which land in #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtmQtkACSqpPqbecfgocJy