### PR TITLE
fix(cbo): "Ver exemplos" showed nothing, and the agent talked over the gap

### DIFF
--- a/e2e/cbo-examples-never-empty.spec.ts
+++ b/e2e/cbo-examples-never-empty.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { NBS_SHOWCASE_CARDS, filterShowcaseCards, getShowcaseCard } from '../shared/nbs-showcase-cards';
+import { NBS_INTERVENTION_TYPES } from '../shared/cbo-schema';
+
+// ⚠️ EXAMPLES-STRIP-EMPTY (JVP, 2026-08-11, mobile test on Replit).
+//
+// The user tapped "Ver exemplos". The agent said "Vou mostrar alguns exemplos
+// reais de projetos de SbN em Porto Alegre e no Brasil!", NOTHING rendered, and
+// it went straight on to "Pronto! 🌱 Esses são projetos que já tão acontecendo".
+//
+// Two faults stacked. `show_examples` filtered the showcase cards and pushed
+// whatever came back, including an empty list; and cbo-profile.tsx renders an
+// empty strip as `return null` — a silent gap. So the agent narrated a strip the
+// user could not see.
+//
+// It was not rare: SEVEN of the 18 (type × hazard) filter combinations matched
+// zero cards, and `green-roofs-walls` matches zero on its own because no card
+// carries that typeRef.
+//
+// These tests pin the PROPERTY — a filter that excludes everything must widen,
+// never render nothing — plus the data gap that made it reachable, so adding a
+// seventh intervention type without a matching case is caught here rather than
+// on someone's phone.
+
+const HAZARDS = ['flood', 'heat', 'biodiversity'] as const;
+
+/** The widening the tool performs, mirrored so it can be asserted without a model. */
+function resolveExampleCards(args: {
+  cardIds?: string[];
+  hazardFilter?: (typeof HAZARDS)[number];
+  typeRefs?: string[];
+}): string[] {
+  const attempts: { id: string }[][] = [];
+  if (args.cardIds?.length) {
+    attempts.push(args.cardIds.map(getShowcaseCard).filter(Boolean) as { id: string }[]);
+  }
+  if (args.hazardFilter || args.typeRefs?.length) {
+    attempts.push(filterShowcaseCards({ hazard: args.hazardFilter, typeRefs: args.typeRefs }));
+    if (args.hazardFilter && args.typeRefs?.length) {
+      attempts.push(filterShowcaseCards({ typeRefs: args.typeRefs }));
+    }
+  }
+  attempts.push(filterShowcaseCards());
+  return (attempts.find(a => a.length > 0) ?? []).map(c => c.id);
+}
+
+test.describe('CBO examples strip — never renders nothing', () => {
+  test('every type × hazard combination resolves to at least one card', () => {
+    const empties: string[] = [];
+    for (const t of NBS_INTERVENTION_TYPES as any[]) {
+      for (const h of HAZARDS) {
+        // What the RAW filter does — recorded, not asserted; 7 of 18 are empty
+        // today and that is exactly why the widening exists.
+        if (filterShowcaseCards({ hazard: h, typeRefs: [t.id] }).length === 0) {
+          empties.push(`${t.id}+${h}`);
+        }
+        // What the TOOL does must never be empty.
+        expect(
+          resolveExampleCards({ hazardFilter: h, typeRefs: [t.id] }),
+          `${t.id} + ${h} must still show something`,
+        ).not.toHaveLength(0);
+      }
+    }
+    // Guard the premise: if this ever hits zero the widening is untested, and the
+    // test should be re-pointed at whatever the new gap is.
+    expect(empties.length, 'raw filter combinations that match no card').toBeGreaterThan(0);
+  });
+
+  test('a type with no showcase cards still shows examples', () => {
+    const orphan = (NBS_INTERVENTION_TYPES as any[])
+      .map(t => t.id)
+      .find(id => filterShowcaseCards({ typeRefs: [id] }).length === 0);
+    // green-roofs-walls today. If this becomes undefined every type has a case,
+    // which is the outcome we want — the assertion below just stops mattering.
+    if (!orphan) return;
+    expect(resolveExampleCards({ typeRefs: [orphan] })).not.toHaveLength(0);
+  });
+
+  test('hallucinated card ids fall back instead of rendering an empty strip', () => {
+    expect(resolveExampleCards({ cardIds: ['no-such-card', 'also-not-real'] })).not.toHaveLength(0);
+  });
+
+  test('the unfiltered set is non-empty — the last line of defence', () => {
+    expect(NBS_SHOWCASE_CARDS.length).toBeGreaterThan(0);
+    expect(filterShowcaseCards()).not.toHaveLength(0);
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -658,19 +658,57 @@ function createCboMcpTools(cboId: string) {
     },
     async (args: any) => {
       const showcase = await import("@shared/nbs-showcase-cards");
-      let cards: { id: string }[];
+
+      // WIDEN RATHER THAN SHOW NOTHING.
+      //
+      // Reported from the 2026-08-11 mobile test: the user tapped "Ver exemplos",
+      // the agent said "Vou mostrar alguns exemplos reais…", nothing rendered, and
+      // it carried straight on with "Pronto! Esses são projetos que já tão
+      // acontecendo". The strip was empty and the client renders an empty strip as
+      // `null` — a silent gap the agent then narrated over.
+      //
+      // It was not a rare edge. Measured over the 6 intervention types × 3
+      // hazards, SEVEN of the 18 filter combinations matched zero cards, and
+      // `green-roofs-walls` matches zero on its own because no showcase card
+      // carries that typeRef. A filter that excludes everything is a filter
+      // problem, not an answer, so fall back a step at a time and tell the model
+      // exactly what it ended up showing.
+      const attempts: Array<{ cards: { id: string }[]; note: string }> = [];
       if (Array.isArray(args.cardIds) && args.cardIds.length > 0) {
-        cards = args.cardIds
-          .map((id: string) => showcase.getShowcaseCard(id))
-          .filter(Boolean) as { id: string }[];
-      } else if (args.hazardFilter || (Array.isArray(args.typeRefs) && args.typeRefs.length > 0)) {
-        cards = showcase.filterShowcaseCards({ hazard: args.hazardFilter, typeRefs: args.typeRefs });
-      } else {
-        cards = showcase.filterShowcaseCards();
+        attempts.push({
+          cards: args.cardIds.map((id: string) => showcase.getShowcaseCard(id)).filter(Boolean) as { id: string }[],
+          note: 'the requested cardIds',
+        });
       }
-      const ids = cards.map(c => c.id);
+      if (args.hazardFilter || (Array.isArray(args.typeRefs) && args.typeRefs.length > 0)) {
+        attempts.push({
+          cards: showcase.filterShowcaseCards({ hazard: args.hazardFilter, typeRefs: args.typeRefs }),
+          note: 'the requested hazard + type filter',
+        });
+        if (args.hazardFilter && Array.isArray(args.typeRefs) && args.typeRefs.length > 0) {
+          attempts.push({
+            cards: showcase.filterShowcaseCards({ typeRefs: args.typeRefs }),
+            note: 'the type filter with the hazard dropped',
+          });
+        }
+      }
+      attempts.push({ cards: showcase.filterShowcaseCards(), note: 'the full set' });
+
+      const chosen = attempts.find(a => a.cards.length > 0) ?? attempts[attempts.length - 1];
+      const widened = chosen !== attempts[0];
+      const ids = chosen.cards.map(c => c.id);
+
+      // Last line of defence: never emit an empty strip. If even the full set is
+      // empty the catalog itself is broken, and saying so beats a blank screen.
+      if (ids.length === 0) {
+        return { content: [{ type: "text" as const, text: `FAILED: no showcase cards are available at all, so nothing was rendered. Do NOT tell the user you showed examples. Say you could not load them and move on with an \`ask_user\`.` }] };
+      }
+
       pushEvent({ type: 'show_examples', cardIds: ids, mode: args.mode ?? 'browse', intro: args.intro });
-      return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode. The strip has NO continue button. In browse mode, follow IN THE SAME TURN with a short message and an \`ask_user\` (e.g. "✓ Entendi" / "Tenho uma dúvida") so the user can continue. In favorites mode, let them save first — your next turn ends with that \`ask_user\`. Never leave the strip as the last thing in a turn.` }] };
+      const widenNote = widened
+        ? ` NOTE: your filter matched no cards, so this fell back to ${chosen.note} — describe what is on screen, not what you asked for.`
+        : '';
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} example(s) in ${args.mode ?? 'browse'} mode.${widenNote} The strip has NO continue button. In browse mode, follow IN THE SAME TURN with a short message and an \`ask_user\` (e.g. "✓ Entendi" / "Tenho uma dúvida") so the user can continue. In favorites mode, let them save first — your next turn ends with that \`ask_user\`. Never leave the strip as the last thing in a turn.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -690,11 +728,16 @@ function createCboMcpTools(cboId: string) {
     async (args: any) => {
       const schema = await import("@shared/cbo-schema");
       const all = schema.NBS_INTERVENTION_TYPES.map((t: any) => t.id);
-      const ids = Array.isArray(args.typeIds) && args.typeIds.length > 0
+      const requested = Array.isArray(args.typeIds) && args.typeIds.length > 0
         ? args.typeIds.filter((id: string) => all.includes(id))
         : all;
+      // Same failure mode as show_examples: filtering to nothing renders an empty
+      // strip, which the client draws as a gap and the agent narrates over. If
+      // every requested id was unknown, show them all rather than nothing.
+      const ids = requested.length > 0 ? requested : all;
+      const widenedTypes = requested.length === 0;
       pushEvent({ type: 'show_types', typeIds: ids, intro: args.intro });
-      return { content: [{ type: "text" as const, text: `Showed ${ids.length} NBS type(s). The strip is read-only and has NO buttons — in this SAME turn you MUST follow with a short message and an \`ask_user\` (e.g. options "Ver exemplos" / "Já conheço, pular") so the user has a way to continue. Do not end the turn on the strip alone.` }] };
+      return { content: [{ type: "text" as const, text: `Showed ${ids.length} NBS type(s).${widenedTypes ? ' NOTE: none of the ids you passed exist, so all types are shown — describe what is on screen.' : ''} The strip is read-only and has NO buttons — in this SAME turn you MUST follow with a short message and an \`ask_user\` (e.g. options "Ver exemplos" / "Já conheço, pular") so the user has a way to continue. Do not end the turn on the strip alone.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );


### PR DESCRIPTION
## What happened

From your mobile test: you tapped **"Ver exemplos"**, the agent said *"Vou mostrar alguns exemplos reais de projetos de SbN em Porto Alegre e no Brasil!"*, **nothing rendered**, and it carried straight on to *"Pronto! 🌱 Esses são projetos que já tão acontecendo…"*.

## Two faults stacked

`show_examples` filtered the showcase cards and pushed whatever came back — **including an empty list**. And `cbo-profile.tsx` renders an empty strip as `return null`, so an empty payload isn't an empty box, it's a **silent gap**. Nothing in between raised a word, so the model believed it had shown something.

## Not a rare edge

Measured across the 6 intervention types × 3 hazards: **7 of the 18 filter combinations match zero cards.**

| combination | cards |
|---|---|
| `flood-parks` + heat | 0 |
| `flood-parks` + biodiversity | 0 |
| `green-corridors` + flood | 0 |
| `green-corridors` + biodiversity | 0 |
| `green-roofs-walls` + anything | 0 |

`green-roofs-walls` matches zero **on its own** — no showcase card carries that typeRef. So "teach green roofs, then show me examples of green roofs" was a guaranteed blank.

## Fix: widen rather than show nothing

A filter that excludes everything is a filter problem, not an answer. The tool now falls back a step at a time — requested `cardIds` → hazard+type → type alone → the full set — and takes the first non-empty result.

Two things go with it:
- **the model is told when it widened** — *"your filter matched no cards, so this fell back to the full set — describe what is on screen, not what you asked for"* — so it stops narrating a strip it didn't get;
- if even the unfiltered set is empty, the tool returns `FAILED` and instructs the agent to say it couldn't load them, rather than emitting an empty strip.

`show_intervention_types` had the same shape (filtering to `[]` when every requested id is unknown) and gets the same guard.

## Verification

Reproduced live at mobile width with the exact input that caused the blank (`typeRefs: ['green-roofs-walls']`): **14 cards render where 0 did**, followed by the paired `ask_user`.

`e2e/cbo-examples-never-empty.spec.ts` pins the property *and* asserts the premise still holds — so adding a seventh intervention type with no matching case is caught here rather than on a coordinator's phone.

- `tsc --noEmit`: **5 errors, same as main**
- Full e2e: **253 passed, 0 failed**

## Not fixed here

**No showcase card represents `green-roofs-walls`.** The widening means a user always sees something, but they see the general set rather than green roofs specifically. That's content, not code — worth one case for the strip to be honest about what it was asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWutNw34isJNf1eefXLDvU