### PR TITLE
copy(cbo): rename the NbS "família" vocabulary to "grupo"

### DIFF
--- a/client/src/core/components/cbo/CboFamiliaRecommendation.tsx
+++ b/client/src/core/components/cbo/CboFamiliaRecommendation.tsx
@@ -43,7 +43,7 @@ export function CboFamiliaRecommendation({
       data-testid='cbo-familia-reco'
     >
       <div className='text-[9px] font-extrabold uppercase tracking-widest text-[#8a7d5c] dark:text-stone-400 mb-1.5'>
-        {s.eyebrow} · {items.length} famílias
+        {s.eyebrow} · {items.length} grupos
       </div>
       {intro && <p className='text-[11.5px] text-muted-foreground mb-1.5'>{intro}</p>}
       <div className='space-y-1.5'>

--- a/client/src/core/components/cbo/NbsDesktopGrids.tsx
+++ b/client/src/core/components/cbo/NbsDesktopGrids.tsx
@@ -30,14 +30,14 @@ import {
 const GRID = 'grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3';
 const STRINGS = {
   pt: {
-    croquiEyebrow: 'Croqui da família · ilustração esquemática',
+    croquiEyebrow: 'Croqui do grupo · ilustração esquemática',
     solutionsEyebrow: (n: number) => `As ${n} soluções · fotos reais`,
     ampliar: 'Toque para ampliar',
     antes: 'ANTES',
     depois: 'DEPOIS',
   },
   en: {
-    croquiEyebrow: 'Família croqui · schematic illustration',
+    croquiEyebrow: 'Grupo croqui · schematic illustration',
     solutionsEyebrow: (n: number) => `The ${n} solutions · real photos`,
     ampliar: 'Click to enlarge',
     antes: 'BEFORE',
@@ -68,7 +68,7 @@ export function NbsSolutionsGrid({ lang }: { lang: 'pt' | 'en' }) {
   return (
     <div className='space-y-8'>
       {/* Catalog-wide "o que a gente consegue fazer?" filter (Julia, biweekly
-          2026-07-16) — famílias with no matching solution collapse away. */}
+          2026-07-16) — grupos with no matching solution collapse away. */}
       <NbsSolutionFilterChips value={filter} onChange={setFilter} lang={lang} />
       {isFilterActive(filter) && !anyVisible && (
         <p

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -2914,7 +2914,7 @@ export default function CboProfilePage() {
                     onConfirm={(result: InterventionSelectorResult) => {
                       const hasSolutions = (result.solutionIds?.length ?? 0) > 0;
                       const message = hasSolutions
-                        ? `Selected NBS solution${result.solutionIds!.length > 1 ? 's' : ''}: ${result.labels.join(' + ')} (${result.solutionIds!.join(', ')}). Família${(result.familias?.length ?? 0) > 1 ? 's' : ''}: ${(result.familias ?? []).join(', ')}.${result.interventionTypes.length > 0 ? ` Mapped NBS types: ${result.interventionTypes.join(', ')}. Knowledge files: ${result.knowledgeFiles.join(', ')}` : ''}`
+                        ? `Selected NBS solution${result.solutionIds!.length > 1 ? 's' : ''}: ${result.labels.join(' + ')} (${result.solutionIds!.join(', ')}). Grupo${(result.familias?.length ?? 0) > 1 ? 's' : ''}: ${(result.familias ?? []).join(', ')}.${result.interventionTypes.length > 0 ? ` Mapped NBS types: ${result.interventionTypes.join(', ')}. Knowledge files: ${result.knowledgeFiles.join(', ')}` : ''}`
                         : result.label; // "I don't know — help me decide"
                       if (currentQuestion) handleSelectOption(message); else sendMessage(message);
                       setInterventionSelectorParams(null);
@@ -3243,7 +3243,7 @@ function CboQuestionCard({
         </Button>
       )}
       {/* ⚠️ SECONDARY control, deliberately outside the options list and styled
-          unlike them: choosing a família is the answer, looking at cases is not.
+          unlike them: choosing a grupo is the answer, looking at cases is not.
           As an option it would either answer the question by accident or strand
           the checkpoint machine, which reads its position from the answers. */}
       {question.showExamples && !readOnly && onShowExamples && (

--- a/e2e/cougar-e2-interest-roles.spec.ts
+++ b/e2e/cougar-e2-interest-roles.spec.ts
@@ -72,7 +72,7 @@ test.describe('COUGAR — E2 interest + role loops', () => {
 
     // "Faz sentido" now opens the interest question instead of closing.
     await chip('Faz sentido').click();
-    await expect(page.getByText('famílias vocês teriam interesse', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('grupos vocês teriam interesse', { exact: false })).toBeVisible({ timeout: 8_000 });
     await expect(page.getByText('por onde começar a estudar', { exact: false })).toHaveCount(0);
 
     // Interest loop: two picks, then Pronto — each pick re-offers what's left.

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -748,9 +748,9 @@ function createCboMcpTools(cboId: string) {
   // printed cards the cohort holds in the encontros.
   const showNbsFamilias = sdkTool(
     "show_nbs_familias",
-    "Render the educational NBS FAMÍLIAS strip inline in chat (5 famílias from the Rede SCbN POA card deck, each opening into its solution variants). Use as the FIRST action in E2 to build vocabulary. Optionally pass familiaIds for a subset; omit for all 5. STOP and wait for the user to read/react.",
+    "Render the educational NBS GRUPOS strip inline in chat (5 grupos from the Rede SCbN POA card deck, each opening into its solution variants). Use as the FIRST action in E2 to build vocabulary. Optionally pass familiaIds for a subset; omit for all 5. STOP and wait for the user to read/react.",
     {
-      familiaIds: z.array(z.string()).optional().describe("Subset of família ids: aguas-pluviais, verde-urbano, agricultura-urbana, encostas-e-solo, recuperacao-ecossistemas; omit for all 5"),
+      familiaIds: z.array(z.string()).optional().describe("Subset of grupo ids: aguas-pluviais, verde-urbano, agricultura-urbana, encostas-e-solo, recuperacao-ecossistemas; omit for all 5"),
       intro: z.string().optional().describe("Optional 1-line lead text rendered above the strip"),
     },
     async (args: any) => {
@@ -760,7 +760,7 @@ function createCboMcpTools(cboId: string) {
         ? args.familiaIds.filter((id: string) => all.includes(id))
         : undefined; // undefined = all five
       pushEvent({ type: 'show_familias', familiaIds: ids, intro: args.intro } as any);
-      return { content: [{ type: "text" as const, text: `Showed the famílias strip (${ids ? ids.length : 5} família(s)). It is read-only and has NO buttons — in this SAME turn you MUST follow with a short message and an \`ask_user\` (e.g. options "Ver exemplos" / "Já conheço, pular") so the user has a way to continue. Do not end the turn on the strip alone.` }] };
+      return { content: [{ type: "text" as const, text: `Showed the grupos strip (${ids ? ids.length : 5} grupo(s)). It is read-only and has NO buttons — in this SAME turn you MUST follow with a short message and an \`ask_user\` (e.g. options "Ver exemplos" / "Já conheço, pular") so the user has a way to continue. Do not end the turn on the strip alone.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -772,7 +772,7 @@ function createCboMcpTools(cboId: string) {
   // lines when it has context the server doesn't (photos, free-text answers).
   const showFamiliaRecommendation = sdkTool(
     "show_familia_recommendation",
-    "Render the closing 'famílias pra estudar' card for the captured site (always ≥2 famílias, ranked by the bairro's risks + what the org shared). Optionally pass per-família `why` lines grounded in what the USER said/uploaded; the server fills ranking, example variants, and any missing whys. In this SAME turn follow with an ask_user (e.g. 'Faz sentido' / 'Quero ajustar').",
+    "Render the closing 'grupos pra estudar' card for the captured site (always ≥2 grupos, ranked by the bairro's risks + what the org shared). Optionally pass per-grupo `why` lines grounded in what the USER said/uploaded; the server fills ranking, example variants, and any missing whys. In this SAME turn follow with an ask_user (e.g. 'Faz sentido' / 'Quero ajustar').",
     {
       items: z.array(z.object({
         familiaId: z.string().describe("aguas-pluviais | verde-urbano | agricultura-urbana | encostas-e-solo | recuperacao-ecossistemas"),
@@ -785,7 +785,7 @@ function createCboMcpTools(cboId: string) {
       if (!state) return { content: [{ type: "text" as const, text: "Error: not found" }], isError: true };
       const items = buildFamiliaRecoItems(state, getActiveCboLang(cboId), args.items);
       pushEvent({ type: 'show_familia_recommendation', items, intro: args.intro } as any);
-      return { content: [{ type: "text" as const, text: `Showed ${items.length} famílias (${items.map(i => i.familiaId).join(', ')}). The card is read-only — follow with an ask_user in this SAME turn.` }] };
+      return { content: [{ type: "text" as const, text: `Showed ${items.length} grupos (${items.map(i => i.familiaId).join(', ')}). The card is read-only — follow with an ask_user in this SAME turn.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );
@@ -1245,13 +1245,13 @@ USE THIS TOOL PROACTIVELY when guiding the user. Don't just ask questions — re
 
   const openInterventionSelector = sdkTool(
     "open_intervention_selector",
-    `Open the NBS Solution Selector micro-app — TWO-LEVEL: 5 famílias (from the Rede SCbN POA card deck) that expand into their 27 solution variants, each with the deck's real photo. YOU recommend at the FAMÍLIA level; the ORGANIZATION picks the variant (terrain, tenure and politics are theirs to know).
+    `Open the NBS Solution Selector micro-app — TWO-LEVEL: 5 grupos (from the Rede SCbN POA card deck) that expand into their 27 solution variants, each with the deck's real photo. YOU recommend at the FAMÍLIA level; the ORGANIZATION picks the variant (terrain, tenure and politics are theirs to know).
 
-Use this in Phase 3a after collecting site information. Pass siteHazards from Phase 2 data (or recommendedFamilias from guidance mode) to badge and pre-open the most relevant famílias. Only the top 2 famílias get the "Recommended" badge.
+Use this in Phase 3a after collecting site information. Pass siteHazards from Phase 2 data (or recommendedFamilias from guidance mode) to badge and pre-open the most relevant grupos. Only the top 2 grupos get the "Recommended" badge.
 
 ⚠️ siteHazards.landslide MUST be the site's landslide HAZARD (terrain susceptibility, 0–1) sampled on the E2 map (the poa_landslide_hazard layer value at the chosen point), NOT the landslide RISK. Landslide RISK is structurally tiny in POA (low exposure on the slopes ≈ 0), but the HAZARD is high on the morros — and it's what should drive slope-stabilizing NbS (urban forests, green corridors, whose roots stabilize slopes). If the E2 site sits on landslide-prone terrain (landslide hazard ≳ 0.2), pass that hazard value so those types surface as Recommended; a near-zero value would wrongly hide them.
 
-If the user went through guidance mode first (asked about problems, site conditions), pass recommendedFamilias with your recommended order — the selector will sort and badge accordingly. (recommendedTypes still works and maps to famílias.)
+If the user went through guidance mode first (asked about problems, site conditions), pass recommendedFamilias with your recommended order — the selector will sort and badge accordingly. (recommendedTypes still works and maps to grupos.)
 
 The user can select MULTIPLE solutions (e.g., wetland construído + biovaletas combo).
 
@@ -1266,9 +1266,9 @@ STOP and wait for the user's selection after calling this tool.`,
         heat: z.number().min(0).max(1),
         landslide: z.number().min(0).max(1),
       }).optional().describe("Hazard scores from Phase 2 to rank types by relevance. landslide = the site's landslide HAZARD (terrain susceptibility), NOT the risk — so slope-stabilizing NbS surface on the morros."),
-      recommendedTypes: z.array(z.string()).optional().describe("Legacy: ordered list of recommended TYPE ids; mapped to famílias. Prefer recommendedFamilias."),
+      recommendedTypes: z.array(z.string()).optional().describe("Legacy: ordered list of recommended TYPE ids; mapped to grupos. Prefer recommendedFamilias."),
       recommendedFamilias: z.array(z.string()).optional().describe("Ordered list of recommended FAMÍLIA ids from guidance mode: aguas-pluviais, verde-urbano, agricultura-urbana, encostas-e-solo, recuperacao-ecossistemas. First 2 get 'Recommended' badge and start expanded."),
-      maxRecommendations: z.number().optional().default(2).describe("How many famílias to badge as Recommended (default 2)"),
+      maxRecommendations: z.number().optional().default(2).describe("How many grupos to badge as Recommended (default 2)"),
     },
     async (args: any) => {
       // Same engine fence as open_map: the selector is an Encontro 3+ tool.
@@ -1832,10 +1832,10 @@ async function serveE2Checkpoint(
     if (picked.length > 0) opts.push({ pt: E2C.prontoLista.pt, en: E2C.prontoLista.en, dPt: 'Fechar a lista', dEn: 'Close the list' });
     ask(
       picked.length === 0
-        ? 'Em quais famílias vocês teriam interesse em tocar um projeto? Pode marcar mais de uma — toca numa por vez.'
+        ? 'Em quais grupos vocês teriam interesse em tocar um projeto? Pode marcar mais de uma — toca numa por vez.'
         : 'Marcado ✓ Mais alguma?',
       picked.length === 0
-        ? 'Which famílias would you be interested in running a project on? You can pick more than one — tap one at a time.'
+        ? 'Which grupos would you be interested in running a project on? You can pick more than one — tap one at a time.'
         : 'Noted ✓ Any other?',
       opts,
       // Choosing famílias is exactly the moment the convening asked for: let
@@ -2024,8 +2024,8 @@ async function serveE2Checkpoint(
     } as any);
     const items = ranking.items;
     say(
-      'Pra esse lugar, com o que você me contou, vale estudar essas famílias — não é veredito, é convite. **Nada fica descartado**: dá pra ver as 27 soluções quando quiser.',
-      "For this place, with what you've told me, these famílias are worth studying — not a verdict, an invitation. **Nothing is ruled out**: you can see all 27 solutions whenever you like.",
+      'Pra esse lugar, com o que você me contou, vale estudar esses grupos — não é veredito, é convite. **Nada fica descartado**: dá pra ver as 27 soluções quando quiser.',
+      "For this place, with what you've told me, these grupos are worth studying — not a verdict, an invitation. **Nothing is ruled out**: you can see all 27 solutions whenever you like.",
     );
     pushEvent({ type: 'show_familia_recommendation', items } as any);
     ask('Faz sentido pra vocês?', 'Does this make sense to you?', [
@@ -2830,7 +2830,7 @@ async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: Ev
     if (getCboMessages(cboId).some(m => m.messageType === 'composer' && (m.content.includes('"kind":"types"') || m.content.includes('"kind":"familias"')))) return false;
 
     const greeting = isPt
-      ? `Oi${nome ? `, ${nome}` : ''}. Antes de falar do seu território, dois minutos sobre as famílias de Solução baseada na Natureza — pra gente falar a mesma língua.`
+      ? `Oi${nome ? `, ${nome}` : ''}. Antes de falar do seu território, dois minutos sobre os grupos de Solução baseada na Natureza — pra gente falar a mesma língua.`
       : `Hi${nome ? `, ${nome}` : ''}. Before we talk about your territory, two minutes on the families of Nature-based Solutions — so we speak the same language.`;
     pushEvent({ type: 'chat', content: greeting, role: 'assistant' } as any);
     // The 5 famílias of the Rede SCbN POA deck (shared/nbs-catalog.ts) — the
@@ -2842,7 +2842,7 @@ async function serveEncontro2Entry(cboId: string, state: CboState, pushEvent: Ev
     pushEvent({
       type: 'chat', role: 'assistant',
       content: isPt
-        ? 'Essas são as 5 famílias de SbN — as mesmas das cartas que vocês vão usar nos encontros. Não precisa decorar: dá uma olhada nas que têm a ver com o seu território e, quando terminar, é só tocar abaixo.'
+        ? 'Esses são os 5 grupos de SbN — as mesmas das cartas que vocês vão usar nos encontros. Não precisa decorar: dá uma olhada nas que têm a ver com o seu território e, quando terminar, é só tocar abaixo.'
         : "These are the 5 families of NbS — the same ones on the cards you'll use in the encontros. No need to memorize them: look at the ones that match your territory and tap below when you're done.",
     } as any);
     const options = [
@@ -3505,10 +3505,10 @@ function buildDecisionLog(cboId: string): string {
         if (p.kind === 'priority') return '- You (agent) asked the user to rank the hazards by priority.';
         if (p.kind === 'anchoring') return '- You (agent) asked the community-anchoring questions.';
         if (p.kind === 'types') return '- You (agent) showed the NBS types strip.';
-        if (p.kind === 'familias') return '- You (agent) showed the NBS famílias strip (5 famílias, expandable into variants).';
+        if (p.kind === 'familias') return '- You (agent) showed the NBS grupos strip (5 grupos, expandable into variants).';
         if (p.kind === 'examples') return '- You (agent) showed real project examples.';
         if (p.kind === 'site_card') return `- You (agent) showed the site card: "${String(p.card?.name ?? '')}" in ${String(p.card?.bairro ?? '')} — and asked the user to confirm it.`;
-        if (p.kind === 'familia_reco') return `- You (agent) showed the famílias recommendation card: ${(p.items ?? []).map((i: any) => i.familiaId).join(', ')}.`;
+        if (p.kind === 'familia_reco') return `- You (agent) showed the grupos recommendation card: ${(p.items ?? []).map((i: any) => i.familiaId).join(', ')}.`;
       } catch {}
       return null;
     }
@@ -3719,10 +3719,10 @@ Score: Org Delivery Capacity (0-3), Team Technical Experience (0-3).`;
     case 2:
       return isPt
         ? `**Fase 2: Onde Atuamos** (intervention_site)
-⚠️ O fluxo linear do E2 é conduzido por checkpoints do servidor (mapas, cartão do lugar, uso atual, posse, fotos, famílias). Você só cuida do que a skill lista: exemplos, dúvidas, uploads, ajustes. NUNCA abra mapa por conta própria nem refaça perguntas dos checkpoints.
+⚠️ O fluxo linear do E2 é conduzido por checkpoints do servidor (mapas, cartão do lugar, uso atual, posse, fotos, grupos). Você só cuida do que a skill lista: exemplos, dúvidas, uploads, ajustes. NUNCA abra mapa por conta própria nem refaça perguntas dos checkpoints.
 Avaliar Controle do Local (0-3) quando land_tenure aparecer no estado.`
         : `**Phase 2: Where We Work** (intervention_site)
-⚠️ The linear E2 flow is driven by server checkpoints (maps, site card, current use, tenure, photos, famílias). You only handle what the skill lists: examples, doubts, uploads, adjustments. NEVER open a map on your own or redo checkpoint questions.
+⚠️ The linear E2 flow is driven by server checkpoints (maps, site card, current use, tenure, photos, grupos). You only handle what the skill lists: examples, doubts, uploads, adjustments. NEVER open a map on your own or redo checkpoint questions.
 Score Site Control (0-3) once land_tenure appears in state.`;
 
     case 3:

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -420,7 +420,7 @@ export const CBO_FIELD_LABELS: Record<string, { pt: string; en: string }> = {
   primary_hazard: { pt: 'Risco principal', en: 'Main hazard' },
   secondary_hazard: { pt: 'Risco secundário', en: 'Secondary hazard' },
   tertiary_hazard: { pt: 'Terceiro risco', en: 'Third hazard' },
-  nbs_interest: { pt: 'Famílias de interesse', en: 'Famílias of interest' },
+  nbs_interest: { pt: 'Grupos de interesse', en: 'Grupos of interest' },
   role_preference: { pt: 'Papel que querem ter', en: 'Role they want to play' },
   site_lat: { pt: 'Latitude', en: 'Latitude' },
   site_lng: { pt: 'Longitude', en: 'Longitude' },

--- a/shared/nbs-recommendation.ts
+++ b/shared/nbs-recommendation.ts
@@ -234,8 +234,8 @@ export function rankFamiliasForSite(input: FamiliaRecoInput): RankedFamilia[] {
     // heat. Phrase it as what this família works on, never as a ranking claim.
     const tail = primary === top.h
       ? {
-          pt: ` Essa família age principalmente ${HAZARD_WORDS[top.h].em} ${HAZARD_WORDS[top.h].pt}.`,
-          en: ` This família acts mainly on ${HAZARD_WORDS[top.h].en}.`,
+          pt: ` Esse grupo age principalmente ${HAZARD_WORDS[top.h].em} ${HAZARD_WORDS[top.h].pt}.`,
+          en: ` This grupo acts mainly on ${HAZARD_WORDS[top.h].en}.`,
         }
       : {
           pt: ` Ela age mais ${HAZARD_WORDS[primary].em} ${HAZARD_WORDS[primary].pt} e ajuda também ${HAZARD_WORDS[top.h].em} ${HAZARD_WORDS[top.h].pt}.`,

--- a/shared/nbs-solution-fichas.ts
+++ b/shared/nbs-solution-fichas.ts
@@ -87,7 +87,7 @@ export const NBS_SOLUTION_FICHAS: Record<string, NbsSolutionFicha> = {
       comoFunciona:
         'A biovaleta é uma vala rasa e comprida, com laterais em rampa (não paredes retas), plantada com vegetação. Em vez de só acumular água num ponto, ela conduz a água de um lugar a outro — de uma rua até um jardim de chuva, por exemplo — infiltrando parte dela pelo caminho. Em trechos mais inclinados, usa pequenas barreiras dentro da vala para frear a água e evitar erosão.',
       quantoCusta:
-        'R$ 200–500 por m² (referência GIZ, 2023) — a faixa mais barata da família, porque é rasa (até 60 cm) e não tem paredes de contenção.',
+        'R$ 200–500 por m² (referência GIZ, 2023) — a faixa mais barata do grupo, porque é rasa (até 60 cm) e não tem paredes de contenção.',
       quemPrecisaDizerSim:
         'Normalmente fica em canteiro central, estacionamento ou faixa pública estreita — depende de aprovação da prefeitura: EPTC se mexer em via/calçada, SMAMUS para o ambiente urbano, e DMAE se conectar à drenagem pública. Escavação e plantio dá para fazer em mutirão; o cálculo de vazão e a inclinação das barreiras (para não erodir) pedem um técnico.',
       quemCuidaDepois:
@@ -135,7 +135,7 @@ export const NBS_SOLUTION_FICHAS: Record<string, NbsSolutionFicha> = {
       comoFunciona:
         'A escada hidráulica vegetada é uma sequência de degraus construídos num trecho muito inclinado (acima de 5% de declive), geralmente com gabiões, para a água descer em degraus em vez de escorrer direto pelo barranco. Cada degrau quebra a força da água (dissipa energia) e, quando plantado, a vegetação aumenta o atrito da superfície e filtra um pouco a água que passa. Serve para levar a água de um jardim de chuva ou canteiro pluvial lá em cima até um ponto de saída lá embaixo, sem erodir o caminho.',
       quantoCusta:
-        'R$ 600–1.200 por m² (referência GIZ, 2023) — das mais caras da família, porque é obra estrutural (gabião, escavação com maquinário), não só paisagismo.',
+        'R$ 600–1.200 por m² (referência GIZ, 2023) — das mais caras do grupo, porque é obra estrutural (gabião, escavação com maquinário), não só paisagismo.',
       quemPrecisaDizerSim:
         'Envolve cálculo hidráulico e estrutural — o catálogo GIZ pede as mesmas normas técnicas de uma escada hidráulica convencional. Não é projeto de mutirão puro: precisa de técnico ou engenheiro para o dimensionamento, mesmo que a execução (colocar pedra no gabião, plantar) seja feita em mutirão depois. Em terreno público, a aprovação é da prefeitura — SMAMUS pelo ambiente urbano, EPTC se mexer em via — e o DMAE entra se a escada deságua na rede pública de drenagem.',
       quemCuidaDepois:
@@ -286,9 +286,9 @@ export const NBS_SOLUTION_FICHAS: Record<string, NbsSolutionFicha> = {
       quantoCusta:
         'Cisterna de placas de 16 mil litros, modelo padrão do Programa Cisternas: R$ 4.500 quando construída em mutirão com mão de obra capacitada pelo programa (ASA/P1MC); R$ 8.000 a R$ 10.500 quando contratada por edital público (MDS, 2024). Para reservatórios urbanos menores, de 500 a 5.000 litros em polietileno pronto, o preço fica entre R$ 1 e R$ 4 por litro de capacidade (estimativa de mercado).',
       quemPrecisaDizerSim:
-        'Captar água de telhado e guardar numa cisterna doméstica ou comunitária não exige licenciamento ambiental — é uma instalação predial simples. Se o uso for coletivo, numa sede comunitária ou escola, o recomendado é conversar com a Vigilância Sanitária municipal sobre o desenho do sistema (água não potável) e, se a cisterna estiver ligada à rede pluvial do terreno, avisar o DMAE. É a solução mais fácil de aprovar da família.',
+        'Captar água de telhado e guardar numa cisterna doméstica ou comunitária não exige licenciamento ambiental — é uma instalação predial simples. Se o uso for coletivo, numa sede comunitária ou escola, o recomendado é conversar com a Vigilância Sanitária municipal sobre o desenho do sistema (água não potável) e, se a cisterna estiver ligada à rede pluvial do terreno, avisar o DMAE. É a solução mais fácil de aprovar do grupo.',
       quemCuidaDepois:
-        'Limpeza da calha e do filtro antes de cada estação chuvosa, porque folhas entopem; limpeza da cisterna a cada 6 a 12 meses para tirar sedimento do fundo; e a cisterna precisa ficar sempre bem tampada, senão vira criadouro de mosquito da dengue. É a manutenção mais simples da família — pode ficar com a própria família ou o zelador do espaço comunitário.',
+        'Limpeza da calha e do filtro antes de cada estação chuvosa, porque folhas entopem; limpeza da cisterna a cada 6 a 12 meses para tirar sedimento do fundo; e a cisterna precisa ficar sempre bem tampada, senão vira criadouro de mosquito da dengue. É a manutenção mais simples do grupo — pode ficar com a própria família ou o zelador do espaço comunitário.',
     },
     en: {
       comoFunciona:
@@ -616,7 +616,7 @@ export const NBS_SOLUTION_FICHAS: Record<string, NbsSolutionFicha> = {
   'muro-de-arrimo-verde': {
     pt: {
       comoFunciona:
-        "É um muro de pedra ou de gabião (caixa de tela metálica cheia de pedra) que segura o empuxo do terreno atrás dele. Entre as pedras ou nas frestas do gabião, plantam-se mudas: as raízes crescem nos vãos e reforçam a estrutura com o tempo. É a solução mais 'dura' da família — funciona como um muro convencional, só que com vida dentro.",
+        "É um muro de pedra ou de gabião (caixa de tela metálica cheia de pedra) que segura o empuxo do terreno atrás dele. Entre as pedras ou nas frestas do gabião, plantam-se mudas: as raízes crescem nos vãos e reforçam a estrutura com o tempo. É a solução mais 'dura' do grupo — funciona como um muro convencional, só que com vida dentro.",
       quantoCusta:
         'R$ 200 a R$ 300 por m² para pedra ou gabião (base GIZ, 2023); a versão pré-fabricada tipo cribwall chega a R$ 1.000–2.000 por m². É custo alto em qualquer variante — envolve avaliação geotécnica, fundação e mão de obra especializada.',
       quemPrecisaDizerSim:
@@ -644,7 +644,7 @@ export const NBS_SOLUTION_FICHAS: Record<string, NbsSolutionFicha> = {
       comoFunciona:
         'Grampos de metal são cravados fundo na encosta em furos e fixados com calda de cimento injetada — como pinos grandes segurando o barranco por dentro. Uma tela cobre a face do talude e recebe plantio de grama ou trepadeiras. Suporta até 70° de inclinação e 20 m de altura, exceto onde a rocha está exposta.',
       quantoCusta:
-        'R$ 800 a R$ 1.000 por m² (base GIZ, 2023). É a opção mais cara da família: exige perfuração mecanizada, grampos e injeção de calda de cimento — equipamento e mão de obra especializada, não dá para mutirão.',
+        'R$ 800 a R$ 1.000 por m² (base GIZ, 2023). É a opção mais cara do grupo: exige perfuração mecanizada, grampos e injeção de calda de cimento — equipamento e mão de obra especializada, não dá para mutirão.',
       quemPrecisaDizerSim:
         'Nível licença, sem exceção. Precisa de projeto assinado por engenheiro com ART registrada no CREA, perfuração mecanizada e injeção de calda de cimento — o próprio catálogo GIZ cita a falta de técnicos qualificados como um desafio real para essa solução. Área de risco passa por liberação da Defesa Civil; a obra passa por licenciamento da SMAMUS. Não existe versão mutirão desta solução: a comunidade não deve tocar em grampo, perfuração ou tela estrutural.',
       quemCuidaDepois:


### PR DESCRIPTION
Closes Ana's W2 feedback item: **Change the name NbS "família" to "grupo"**.

Source: [Tech Space - NbS Project Prep (COUGAR)](https://app.notion.com/p/openearth/Tech-Space-NbS-Project-Prep-COUGAR-397eb557728b80c9bb2bd220775a3570), "Step 2 · Where we work".

## Scope

Display vocabulary only. Identifiers are deliberately untouched — `NBS_FAMILIAS` ids, `NbsFamiliaId`, `solutionsForFamilia`/`getFamilia`, `familiaRanker.ts`, the `selector-familia-*` testids and the component filenames all stay as they are.

## Why the agent prompts moved too

This is an LLM-driven chat, so most of what the org reads is generated by the model, not hardcoded. Renaming only the string literals would have left the assistant still saying "família" in everything it writes — the rename would not actually have landed for users. So the `cboAgent.ts` tool descriptions and system-prompt text move as well. Tool names, parameter names and the família ids quoted inside those descriptions are unchanged.

## Two traps this had to avoid

**"famílias" also means households here.** Left alone on purpose:

| Location | Text | Sense |
|---|---|---|
| `nbs-solution-fichas.ts:482` | "para cerca de 50 famílias" | households |
| `nbs-solution-fichas.ts:291` | "pode ficar com a própria família" | households |
| `CommunityAnchoringComposer.tsx:134` | "12 famílias na Rua Flores" | households |
| `nbs-showcase-cards.ts` | "agricultura familiar", "dona é a família" | households |
| `cboAgent.ts` | "nº de famílias" (document search) | households |

`nbs-solution-fichas.ts:291` carries **both** senses in a single sentence — "É a manutenção mais simples da família — pode ficar com a própria família ou o zelador". The first moved to "do grupo", the second did not.

**Portuguese gender.** "Família" is feminine, "grupo" is masculine, so a literal swap produced `Essa grupo age`, `Croqui da grupo`, `essas grupos`, `as grupos de Solução` and `Essas são as 5 grupos`. All corrected to masculine agreement.

## Tests

`e2e/cougar-e2-interest-roles.spec.ts:75` asserts on the visible question text, so its `getByText` follows the copy change. No testids touched.

`npx tsc --noEmit`: 5 errors before this change, 5 after — all pre-existing, in files this PR does not touch (`CboFilesView.tsx`, `use-toast.ts`, `agentService.ts`). Zero in the changed files.

## ⚠️ Before this ships

The model prompt changed, so the vocabulary the assistant actually produces needs a live E2 session to confirm — a typecheck cannot verify what an LLM says.