### PR TITLE
fix(cbo): closed-list profile fields are picked, not typed; regroup E1 cards

### DIFF
--- a/client/src/core/components/cbo/E1Cards.tsx
+++ b/client/src/core/components/cbo/E1Cards.tsx
@@ -8,25 +8,35 @@
 // member. Any field the agent writes that isn't in our 4 groups falls into
 // the "Outros" card so nothing is hidden.
 
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/core/components/ui/card';
-import { AlertTriangle, Lightbulb, Compass, Target } from 'lucide-react';
+import { AlertTriangle, Lightbulb, Compass, Target, Pencil } from 'lucide-react';
 import type { CboSectionState, CboGapEntry } from '@shared/cbo-schema';
 import { isInternalCboField } from '@shared/cbo-schema';
-import { cboFieldLabel, orgProfileDisplayValue } from '@shared/cbo-field-catalog';
+import {
+  cboFieldLabel,
+  orgProfileDisplayValue,
+  cboFieldOptionLabels,
+  isMultiValueCboField,
+} from '@shared/cbo-field-catalog';
 
 type GroupKey = 'quem-somos' | 'equipe' | 'historico' | 'caminho' | 'outros';
 
 const FIELD_GROUPS: Record<Exclude<GroupKey, 'outros'>, string[]> = {
-  // Identity — what + who (questionnaire v2 added main_activities + has_cnpj)
-  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'main_activities', 'has_cnpj', 'legal_form', 'year_founded'],
+  // Identity — what + who (questionnaire v2 added main_activities + has_cnpj).
+  // bairro_of_operation and groups_served live here rather than under Caminho:
+  // where an org works and who it serves are part of who they ARE, not of the
+  // triage answer about which path they take through the workshops (Ana, W2).
+  'quem-somos': ['org_name', 'contact_name', 'contact_role', 'mission_summary', 'main_activities', 'has_cnpj', 'legal_form', 'year_founded', 'bairro_of_operation', 'groups_served'],
   // Team — size + composition
   equipe: ['team_size', 'paid_vs_volunteer'],
   // History — funding track record + NBS experience (prior_project_scale is
   // the pre-v2 legacy field; old sessions still carry it, so it stays listed)
   historico: ['funding_history', 'funded_project_count', 'biggest_project_budget', 'prior_project_scale', 'nbs_experience', 'nbs_experience_detail', 'proud_moment'],
-  // Path — the triage answer + community served + bairro
-  caminho: ['bairro_of_operation', 'groups_served'],
+  // Path — the triage answer only. It renders from the pathChip footer, so the
+  // card carries no field rows of its own.
+  caminho: [],
 };
 
 const ALL_KNOWN_FIELDS = new Set<string>([
@@ -35,6 +45,111 @@ const ALL_KNOWN_FIELDS = new Set<string>([
   ...FIELD_GROUPS.historico,
   ...FIELD_GROUPS.caminho,
 ]);
+
+
+// Closed-list fields are edited by PICKING, not by typing. Ana's W2 note: the
+// profile tab accepted any prose even for banded/closed answers, so the
+// orchestrator lost the ability to compare orgs against standard categories.
+//
+// Mirrors EditableField's click-to-edit shape on purpose — this panel is a
+// DOCUMENT, so at rest every row reads as text and the controls only appear
+// once you choose to edit. Free-text fields keep EditableField untouched.
+//
+// The server rejects off-list values on /api/cbo/:id/edit too — this is the
+// affordance, that is the guard.
+function EnumField({
+  sectionId,
+  field,
+  value,
+  userEdited,
+  lang,
+  onSave,
+}: {
+  sectionId: string;
+  field: string;
+  value: string;
+  userEdited?: boolean;
+  lang: 'pt' | 'en';
+  onSave: (v: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [editing, setEditing] = useState(false);
+  const options = cboFieldOptionLabels(sectionId, field, lang);
+  const multi = isMultiValueCboField(sectionId, field);
+  const selected = new Set(value.split(/\s*[,;·|]\s*/).map(s => s.trim()).filter(Boolean));
+
+  if (!editing) {
+    return (
+      <div className="group flex items-start gap-1 min-w-0">
+        <span className="flex-1 min-w-0">{value}</span>
+        <button
+          onClick={e => { e.stopPropagation(); setEditing(true); }}
+          className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 p-0.5 rounded hover:bg-muted"
+          title={t('cbo.edit', { defaultValue: 'Editar' })}
+          data-testid={`cbo-enum-edit-${field}`}
+        >
+          <Pencil className="w-3 h-3 text-muted-foreground" />
+        </button>
+        {userEdited && <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-blue-400 mt-1.5" />}
+      </div>
+    );
+  }
+
+  if (multi) {
+    const toggle = (label: string) => {
+      const next = new Set(selected);
+      if (next.has(label)) next.delete(label); else next.add(label);
+      onSave(options.filter(o => next.has(o)).join(', '));
+    };
+    return (
+      <div className="space-y-1" onClick={e => e.stopPropagation()}>
+        <div className="flex flex-wrap gap-1" data-testid={`cbo-enum-multi-${field}`}>
+          {options.map(o => (
+            <button
+              key={o}
+              type="button"
+              onClick={() => toggle(o)}
+              aria-pressed={selected.has(o)}
+              className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+                selected.has(o)
+                  ? 'border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-200'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {o}
+            </button>
+          ))}
+        </div>
+        <div className="flex justify-end">
+          <button
+            onClick={() => setEditing(false)}
+            className="text-[10px] px-2 py-0.5 rounded text-muted-foreground hover:bg-muted"
+          >
+            {t('cbo.done', { defaultValue: 'Pronto' })}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <select
+      autoFocus
+      value={options.includes(value) ? value : ''}
+      onChange={e => { onSave(e.target.value); setEditing(false); }}
+      onBlur={() => setEditing(false)}
+      data-testid={`cbo-enum-${field}`}
+      className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-green-500"
+    >
+      {/* A legacy or agent-written value no longer on the list stays selected
+          rather than silently reading as empty. */}
+      {!options.includes(value) && <option value="">{value || '\u2014'}</option>}
+      {options.map(o => (
+        <option key={o} value={o}>{o}</option>
+      ))}
+    </select>
+  );
+}
 
 export function E1Cards({
   section,
@@ -95,11 +210,22 @@ export function E1Cards({
                             {t(`cbo.fields.${k}`, cboFieldLabel(k, isPt ? 'pt' : 'en'))}
                           </td>
                           <td className="px-3 py-1.5 text-sm">
-                            <EditableField
-                              value={orgProfileDisplayValue(k, String(v.value || ''), isPt ? 'pt' : 'en')}
-                              userEdited={v.userEdited}
-                              onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
-                            />
+                            {cboFieldOptionLabels(section.id, k, isPt ? 'pt' : 'en').length > 0 ? (
+                              <EnumField
+                                sectionId={section.id}
+                                field={k}
+                                value={orgProfileDisplayValue(k, String(v.value || ''), isPt ? 'pt' : 'en')}
+                                userEdited={v.userEdited}
+                                lang={isPt ? 'pt' : 'en'}
+                                onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                              />
+                            ) : (
+                              <EditableField
+                                value={orgProfileDisplayValue(k, String(v.value || ''), isPt ? 'pt' : 'en')}
+                                userEdited={v.userEdited}
+                                onSave={(newVal) => onFieldEdit(section.id, k, newVal)}
+                              />
+                            )}
                           </td>
                         </tr>
                       );

--- a/e2e/cougar-e1-enum-labels.spec.ts
+++ b/e2e/cougar-e1-enum-labels.spec.ts
@@ -89,6 +89,55 @@ test.describe('COUGAR — E1 enum fields render human labels, never machine ids'
     await expect(page.getByText('Oficinas de reciclagem', { exact: false })).toHaveCount(0);
   });
 
+  // Ana (W2): the profile tab accepted any prose even on banded/closed answers,
+  // so the orchestrator could not compare orgs against standard categories.
+  test('a closed-list field rejects an off-list manual edit, and offers the list instead', async ({ page, request }) => {
+    const api = new TestApi(request);
+    const ping = await api.ping();
+    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled on the target — skipping deterministic spec.');
+
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/);
+    const cboId = (await marker.getAttribute('data-cbo-id'))!;
+
+    await api.scriptCbo(cboId, [
+      [
+        { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'ONG / Associação' },
+        { op: 'say', text: 'Anotei.' },
+      ],
+    ]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    // Prose on a closed list is refused, and the response teaches the options.
+    const bad = await request.post(`/api/cbo/${cboId}/edit`, {
+      data: { sectionId: 'org_profile', field: 'legal_form', value: 'Associação de moradores da Vila' },
+    });
+    expect(bad.status(), 'an off-list value must not be accepted').toBe(400);
+    const body = await bad.json();
+    expect(body.field).toBe('legal_form');
+    expect(Array.isArray(body.allowed) && body.allowed.length > 0, 'the refusal must carry the allowed list').toBe(true);
+
+    // The stored value is untouched by the refused write.
+    const after = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(String(after.state?.sections?.org_profile?.fields?.legal_form?.value ?? ''))
+      .toBe('ONG / Associação');
+
+    // An on-list value still goes through.
+    const good = await request.post(`/api/cbo/${cboId}/edit`, {
+      data: { sectionId: 'org_profile', field: 'legal_form', value: 'Cooperativa' },
+    });
+    expect(good.status()).toBe(200);
+
+    // And the panel offers a picker rather than a free-text box.
+    await page.getByTestId('cbo-strip-document').click();
+    await page.getByTestId('cbo-enum-edit-legal_form').click();
+    await expect(page.getByTestId('cbo-enum-legal_form')).toBeVisible();
+  });
+
   test('a free-text value that matches no option passes through untouched', async ({ page, request }) => {
     const api = new TestApi(request);
     const ping = await api.ping();

--- a/server/routes/cboRoutes.ts
+++ b/server/routes/cboRoutes.ts
@@ -22,7 +22,7 @@ import {
 } from "../services/cboPersistence";
 import { clearMaturityTierForCboState } from "../services/orgPersistence";
 import { createEmptyCboState, CBO_SECTIONS, isInternalCboField, type CboState } from "@shared/cbo-schema";
-import { cboFieldLabel, cboDisplayValue, CBO_SECTION_TITLES, CBO_PRIORITY_FLAG_LABELS } from "@shared/cbo-field-catalog";
+import { cboFieldLabel, cboDisplayValue, CBO_SECTION_TITLES, CBO_PRIORITY_FLAG_LABELS, isCanonicalCboFieldValue, cboFieldOptionLabels } from "@shared/cbo-field-catalog";
 import {
   listDocumentsForScope,
   getDocumentForScope,
@@ -387,6 +387,19 @@ export function registerCboRoutes(app: Express): void {
   app.post("/api/cbo/:id/edit", async (req: Request, res: Response) => {
     const { sectionId, field, value } = req.body;
     if (!sectionId || !field || value === undefined) return res.status(400).json({ error: "sectionId, field, value required" });
+    // Closed lists stay closed on the manual path too. canonicalizeCboFieldValue
+    // lets unrecognized input through — correct for free text, but it meant the
+    // profile tab could store any prose on a banded/closed field, and the
+    // orchestrator then had nothing standard to compare orgs against (Ana, W2).
+    // The client offers a picker; this is the guard behind it.
+    if (!isCanonicalCboFieldValue(sectionId, field, String(value))) {
+      const lang = String(req.body?.lang ?? 'pt').startsWith('en') ? 'en' : 'pt';
+      return res.status(400).json({
+        error: `\"${value}\" is not an option for ${field}`,
+        field,
+        allowed: cboFieldOptionLabels(sectionId, field, lang),
+      });
+    }
     await handleCboEdit(req.params.id, sectionId, field, value, res);
     debouncedPersist(req.params.id);
   });

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -544,6 +544,49 @@ export const CBO_PRIORITY_FLAG_LABELS: Record<string, { pt: string; en: string }
  *
  * Unrecognized input passes through untouched — free text is the user's.
  */
+/** The enum options for any section+field, or null when the field is free
+ *  text. One lookup for both halves of the document — org_profile and the
+ *  SECTION_ENUMS sections — so callers don't have to know which is which. */
+export function cboFieldEnumOptions(sectionId: string, field: string): CboEnumOption[] | null {
+  if (sectionId === 'org_profile') return ORG_PROFILE_ENUMS[field] ?? null;
+  return SECTION_ENUMS[sectionId]?.[field] ?? null;
+}
+
+/** True when `value` sits on the closed list for section+field (multi-select:
+ *  every part must). Free-text fields are always valid.
+ *
+ *  ⚠️ Guards the MANUAL edit path. canonicalizeCboFieldValue deliberately lets
+ *  unrecognized input pass through — that is right for free text, but on a
+ *  closed list it let the profile tab store anything, so the orchestrator could
+ *  no longer compare orgs against standard categories (Ana, W2). Callers that
+ *  accept a user-supplied value for an enum field must reject on false. */
+export function isCanonicalCboFieldValue(sectionId: string, field: string, value: string): boolean {
+  const options = cboFieldEnumOptions(sectionId, field);
+  if (!options || typeof value !== 'string') return true;
+  if (!value.trim()) return true; // clearing a field is allowed
+  if (sectionId === 'org_profile') return isCanonicalOrgProfileValue(field, value);
+  const parts = value.split(',').map(p => p.trim()).filter(Boolean);
+  return parts.length > 0 && parts.every(part => {
+    const n = norm(part);
+    return options.some(
+      o => norm(o.id) === n || norm(o.pt) === n || norm(o.en) === n ||
+           (o.aliases ?? []).some(a => norm(a) === n),
+    );
+  });
+}
+
+/** The labels a manual editor should offer for section+field, in one language.
+ *  Empty when the field is free text. */
+export function cboFieldOptionLabels(sectionId: string, field: string, lang: 'pt' | 'en' = 'pt'): string[] {
+  return (cboFieldEnumOptions(sectionId, field) ?? []).map(o => (lang === 'pt' ? o.pt : o.en));
+}
+
+/** Multi-select fields store several values in one string. */
+export function isMultiValueCboField(sectionId: string, field: string): boolean {
+  if (sectionId === 'org_profile') return MULTI_FIELDS.has(field);
+  return field === 'nbs_interest' || field === 'site_worry';
+}
+
 export function canonicalizeCboFieldValue(sectionId: string, field: string, raw: string): string {
   if (typeof raw !== 'string' || !raw.trim()) return raw;
   if (sectionId === 'org_profile') return canonicalizeOrgProfileValue(field, raw);


### PR DESCRIPTION
Two of Ana's W2 items on the E1 profile panel. Source: [Tech Space - NbS Project Prep (COUGAR)](https://app.notion.com/p/openearth/Tech-Space-NbS-Project-Prep-COUGAR-397eb557728b80c9bb2bd220775a3570).

---

## 1. Closed lists stay closed on the manual edit path

> *"To edit directly in the profile tab you can write in any format (even for questions where we use bands or closed answers). Ideally that wouldn't be possible, since we want to be able to, via the orchestrator, compare the orgs with standard categories"*

`canonicalizeCboFieldValue` deliberately lets unrecognized input pass through — correct for free text, but it meant a manual edit could store **any prose on a closed list**, and the orchestrator then had nothing standard to compare orgs against.

The machinery already existed for the *document* path, which rejects off-list values. This reuses it on the manual path:

- **shared** — `cboFieldEnumOptions`, `isCanonicalCboFieldValue`, `cboFieldOptionLabels`, `isMultiValueCboField`. One lookup across both halves of the document, since `org_profile` stores chip labels while the `SECTION_ENUMS` sections store ids.
- **server** — `POST /api/cbo/:id/edit` refuses an off-list value with `400` plus the allowed list, so the API cannot be bypassed either.
- **client** — enum rows render a picker: a `select` for single values, toggle chips for multi-selects.

### Why click-to-edit

My first pass rendered a permanent `<select>` on every enum row. That turned the document panel into a form — and it broke three existing specs that read the panel as text, which was the useful signal. The picker now mirrors `EditableField`: at rest every row still reads as its label, and the control only appears once you choose to edit.

A legacy or agent-written value no longer on the list stays selected rather than silently reading as empty.

## 2. Served communities and bairro move to Quem somos

> *"The served communities shouldn't be at the caminho category but in quem somos as well as bairro."*

`bairro_of_operation` and `groups_served` move from **Caminho** to **Quem somos** — where an org works and who it serves are part of who they *are*, not of the triage answer about which path they take through the workshops. Caminho keeps its path chip, which was always its real content.

## Tests

`cougar-e1-enum-labels` gains a case: an off-list edit is refused **with** the allowed list, the stored value survives the refusal, an on-list edit still goes through, and the panel offers a picker.

- **17/17 passed** locally across `cougar-e1-enum-labels`, `cougar-doc-tab-portuguese`, `cougar-filled-count`, `cougar-e2-bairro-selectable`
- `npx tsc --noEmit`: 5 errors before, 5 after — all pre-existing, none in changed files

## Not in this PR

The other three items on that card are model-behaviour issues, not code paths — see the linked card. The `"Não temos certeza"` follow-up in particular is already specified correctly in `knowledge/_skills/encontro-1.md:238-239`; the model just is not following it, which is the PR #398 class of problem and needs a live session rather than a typecheck.