### PR TITLE
fix(cbo): an upload we cannot read is still an upload we keep

### DIFF
--- a/client/src/core/hooks/useFileDrop.ts
+++ b/client/src/core/hooks/useFileDrop.ts
@@ -67,8 +67,18 @@ export function useFileDrop({ sessionId, sessionType, onFileProcessed, onError }
           }
 
           const data = await res.json();
-          const content = data.content || `[File uploaded: ${file.name}, ${data.contentLength} chars extracted]`;
-          onFileProcessed(file.name, content);
+          // A parse failure now returns 200 with the file safely stored, so it
+          // no longer trips the !res.ok branch above. Report it as kept-but-
+          // unread rather than as "0 chars extracted", which reads as success.
+          if (data.parsed === false) {
+            onFileProcessed(
+              file.name,
+              `[File "${file.name}" was received and stored, but its text could not be read automatically — nothing was extracted from it.]`,
+            );
+          } else {
+            const content = data.content || `[File uploaded: ${file.name}, ${data.contentLength} chars extracted]`;
+            onFileProcessed(file.name, content);
+          }
         } catch (err: any) {
           onError?.(err.message || 'Upload failed');
         } finally {

--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -2619,7 +2619,18 @@ export default function CboProfilePage() {
                       if (pendingUploadPurposeRef.current) {
                         formData.append('purpose', pendingUploadPurposeRef.current);
                       }
-                      const data = await fetch(`/api/upload/cbo/${cboId}`, { method: 'POST', body: formData }).then(r => r.json());
+                      const res = await fetch(`/api/upload/cbo/${cboId}`, { method: 'POST', body: formData });
+                      const data = await res.json();
+                      // Refused before it was ever read — too large, or a type
+                      // we don't take. Say which, with the fix. This used to be
+                      // reported to the org as "could not parse", i.e. as if
+                      // their document were corrupt.
+                      if (!res.ok) {
+                        await sendMessage(
+                          `I tried to upload "${file.name}" and it was refused. ${data.reason ?? ''} ${data.fix ?? ''} Tell them this plainly and continue with the current question.`.replace(/\s+/g, ' ').trim(),
+                        );
+                        continue;
+                      }
                       // Gap 4 — link a site photo to the chosen site (best-effort;
                       // the server no-ops until a site exists). Images only.
                       if (file.type.startsWith('image/') && data.savedPath && memberSlug) {
@@ -2629,9 +2640,22 @@ export default function CboProfilePage() {
                           body: JSON.stringify({ path: data.savedPath }),
                         }).catch(() => {});
                       }
-                      await sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${(data.content || '').slice(0, 8000)}\n\nPlease extract info, auto-fill sections, and score maturity.`);
+                      if (data.parsed === false) {
+                        // The file IS stored — original kept, doc row written,
+                        // retryable — we just cannot read it yet. Say that, so
+                        // the org is not told their document was lost when it
+                        // was not, and does not re-upload the same file hoping
+                        // for a different result (Ksa Rosa did, twice, and then
+                        // left the session).
+                        await sendMessage(
+                          `I uploaded "${file.name}". It is saved and the coordination team can open it, but the text could not be read automatically, so nothing was filled in from it. Acknowledge that it arrived and is on file, do NOT ask them to send it again, and continue with the current question.`,
+                        );
+                      } else {
+                        await sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${(data.content || '').slice(0, 8000)}\n\nPlease extract info, auto-fill sections, and score maturity.`);
+                      }
                     } catch {
-                      await sendMessage(`Uploaded "${file.name}" but could not parse.`);
+                      // Genuine transport failure — nothing reached the server.
+                      await sendMessage(`Uploaded "${file.name}" but it did not reach us. Ask them to try again.`);
                     }
                   }
                   setUploadingName(null);

--- a/client/src/legacy/pages/concept-note.tsx
+++ b/client/src/legacy/pages/concept-note.tsx
@@ -962,10 +962,16 @@ export default function ConceptNotePage() {
                   fetch(`/api/upload/concept-note/${noteId}`, { method: 'POST', body: formData })
                     .then(r => r.json())
                     .then(data => {
+                      // Parse failures return 200 with the file stored — say so
+                      // rather than sending an empty "Parsed content:" block.
+                      if (data.parsed === false) {
+                        sendMessage(`I uploaded "${file.name}". It is stored, but its text could not be read automatically, so nothing was filled in from it. Acknowledge it arrived and continue.`);
+                        return;
+                      }
                       const content = data.content || `[File: ${file.name}]`;
                       sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${content.slice(0, 8000)}\n\nPlease extract relevant information and auto-fill sections.`);
                     })
-                    .catch(() => sendMessage(`Uploaded "${file.name}" but could not parse it.`));
+                    .catch(() => sendMessage(`Uploaded "${file.name}" but it did not reach us.`));
                 }
                 e.target.value = '';
               }}

--- a/e2e/cbo-upload.spec.ts
+++ b/e2e/cbo-upload.spec.ts
@@ -35,4 +35,83 @@ test.describe('Upload intake + per-org KB', () => {
     expect(doc).toBeTruthy();
     expect(doc.fullText).toContain('community garden');
   });
+
+  // W2 (Aug 2026): four files were lost this way. saveAndParseUpload wrote the
+  // file to disk and THEN threw on extraction, so the caller never learned a
+  // file existed — no doc row, no blob, no manifest entry, and the org was told
+  // "could not parse" as if nothing had arrived. Ksa Rosa re-sent the same PDF,
+  // tried another, then left the session.
+  test('a file whose text cannot be read is still stored, and says so', async ({ request }) => {
+    const api = new TestApi(request);
+    const cohort = (await api.createCohort('Unparseable cohort')).cohort;
+    const { member } = await api.inviteMember(cohort.id, { orgName: 'Ksa Test', withSession: true });
+    const cboId = member.cboStateId as string;
+    expect(cboId).toBeTruthy();
+
+    // A .pdf with no extractable text layer — the scanned-document case, and
+    // the one that yields ok:true with an empty string rather than an error.
+    const resp = await request.post(`/api/upload/cbo/${cboId}`, {
+      multipart: {
+        file: {
+          name: 'estatuto.pdf',
+          mimeType: 'application/pdf',
+          buffer: Buffer.from('%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF'),
+        },
+      },
+    });
+
+    // It must NOT 500 — a file we cannot read is still a file we kept.
+    expect(resp.status(), 'an unreadable file is not a server error').toBe(200);
+    const body = await resp.json();
+    expect(body.parsed, 'the response tells the client extraction failed').toBe(false);
+    expect(body.parseError, 'and why').toBeTruthy();
+    expect(body.savedPath, 'the original was written').toBeTruthy();
+
+    // The durable record exists, marked failed and retryable — this is the
+    // whole point: the coordinator can still open it.
+    const docs = await api.listDocs(cboId);
+    const doc = docs.documents.find((d: any) => d.filename === 'estatuto.pdf');
+    expect(doc, 'an unreadable upload still files a document row').toBeTruthy();
+    expect(doc.parseStatus).toBe('failed');
+    expect(doc.parseError).toBeTruthy();
+    expect(doc.fullText ?? null, 'no text, because there is none — not a fake empty string').toBeNull();
+  });
+
+  // Regression guard: the success path must keep reporting parsed === true, so
+  // the client does not start announcing every good upload as unreadable.
+  test('a readable upload still reports parsed', async ({ request }) => {
+    const api = new TestApi(request);
+    const cohort = (await api.createCohort('Parsed cohort')).cohort;
+    const { member } = await api.inviteMember(cohort.id, { orgName: 'Parsed Org', withSession: true });
+    const cboId = member.cboStateId as string;
+
+    const resp = await request.post(`/api/upload/cbo/${cboId}`, {
+      multipart: { file: { name: 'ok.txt', mimeType: 'text/plain', buffer: Buffer.from('horta comunitária') } },
+    });
+    const body = await resp.json();
+    expect(body.parsed).toBe(true);
+    expect(body.parseError).toBeNull();
+
+    const docs = await api.listDocs(cboId);
+    const doc = docs.documents.find((d: any) => d.filename === 'ok.txt');
+    expect(doc.parseStatus).toBe('parsed');
+  });
+
+  test('a file refused before reading says why, and does not read as a parse failure', async ({ request }) => {
+    const api = new TestApi(request);
+    const cohort = (await api.createCohort('Oversize cohort')).cohort;
+    const { member } = await api.inviteMember(cohort.id, { orgName: 'Oversize Org', withSession: true });
+    const cboId = member.cboStateId as string;
+
+    // 26MB — over the 25MB ceiling. Multer refuses it before the route body.
+    const resp = await request.post(`/api/upload/cbo/${cboId}`, {
+      multipart: {
+        file: { name: 'portfolio.pdf', mimeType: 'application/pdf', buffer: Buffer.alloc(26 * 1024 * 1024, 1) },
+      },
+    });
+    expect(resp.status(), 'too large is 413, not a generic 500').toBe(413);
+    const body = await resp.json();
+    expect(body.reason, 'the org is told the real reason').toContain('25MB');
+    expect(body.fix, 'and what to do about it').toBeTruthy();
+  });
 });

--- a/server/routes/uploadRoutes.ts
+++ b/server/routes/uploadRoutes.ts
@@ -1,4 +1,4 @@
-import type { Express, Request, Response } from "express";
+import type { Express, Request, Response, NextFunction } from "express";
 import multer from "multer";
 import path from "path";
 import { saveAndParseUpload } from "../services/fileParser";
@@ -27,9 +27,11 @@ const RUNS_DIR = path.join(process.cwd(), 'knowledge', 'runs');
 // Multer config — store in memory, then save to run folder. The allow-list
 // mirrors what fileExtract.ts can actually turn into grounding text:
 // documents, spreadsheets, images (vision), and audio (transcription).
+const MAX_UPLOAD_MB = 25;
+
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 25 * 1024 * 1024 }, // 25MB — audio recordings run larger than docs
+  limits: { fileSize: MAX_UPLOAD_MB * 1024 * 1024 }, // audio recordings run larger than docs
   fileFilter: (_req, file, cb) => {
     const allowed = [
       '.pdf', '.docx', '.xlsx', '.txt', '.md', '.csv', '.tsv', '.json',      // docs
@@ -61,6 +63,35 @@ const audioUpload = multer({
   },
 });
 
+// Multer rejects a file BEFORE the route body runs — over the size limit, or an
+// extension the filter refuses. Without a handler those surface as a generic
+// 500, and the CBO client reported every one of them as "could not parse",
+// which is both wrong and unactionable: an org whose 30MB portfolio was refused
+// was told their PDF was corrupt. Ksa Rosa re-sent the same file, tried
+// another, then left the session (W2, 15 July).
+//
+// These are the only two ways multer can refuse, and each has a fix the org can
+// actually act on.
+function uploadErrorHandler(err: any, _req: Request, res: Response, next: NextFunction) {
+  if (!err) return next();
+  if (err?.code === 'LIMIT_FILE_SIZE') {
+    return res.status(413).json({
+      error: 'file too large',
+      reason: `That file is over the ${MAX_UPLOAD_MB}MB limit.`,
+      fix: 'Send a smaller version, or split it into parts.',
+    });
+  }
+  if (typeof err?.message === 'string' && err.message.includes('not supported')) {
+    return res.status(415).json({
+      error: 'unsupported type',
+      reason: err.message,
+      fix: 'Try a PDF, Word doc, spreadsheet, image, or audio recording.',
+    });
+  }
+  console.error('[upload] rejected:', err?.message || err);
+  return res.status(500).json({ error: String(err?.message ?? err) });
+}
+
 export function registerUploadRoutes(app: Express): void {
   // Upload a file for a concept note or CBO session
   // POST /api/upload/:type/:sessionId
@@ -77,7 +108,7 @@ export function registerUploadRoutes(app: Express): void {
       const runPrefix = type === 'cbo' ? `cbo-${sessionId}` : sessionId;
       const runDir = path.join(RUNS_DIR, runPrefix);
 
-      const { savedPath, content } = await saveAndParseUpload(
+      const { savedPath, content, parseError } = await saveAndParseUpload(
         file.buffer,
         file.originalname,
         runDir,
@@ -97,7 +128,7 @@ export function registerUploadRoutes(app: Express): void {
             name: file.originalname,
             path: savedPath,
             parsedAt: new Date().toISOString(),
-            summary: content.slice(0, 280),
+            summary: parseError ? '' : content.slice(0, 280),
           });
           setCboState(sessionId, state);
           debouncedPersist(sessionId);
@@ -117,10 +148,12 @@ export function registerUploadRoutes(app: Express): void {
             // to find it among the site photos.
             purpose: req.body?.purpose === 'teia_sprint' ? 'teia_sprint' : null,
             sizeBytes: file.size,
-            fullText: content,
-            summary: content.slice(0, 280),
+            fullText: parseError ? null : content,
+            summary: parseError ? null : content.slice(0, 280),
             droppedInPhase: state?.phase ?? null,
             source: 'upload',
+            parseStatus: parseError ? 'failed' : 'parsed',
+            parseError,
           });
           // Phase 2b: persist the ORIGINAL file durably (object storage) so it
           // survives container recycle and can be re-opened/re-processed.
@@ -140,12 +173,16 @@ export function registerUploadRoutes(app: Express): void {
         // Return first 10K chars of parsed content
         content: content.slice(0, 10000),
         truncated: content.length > 10000,
+        // A file we could not read is still a file we KEPT. The client says so
+        // rather than reporting a loss, and the doc row carries the reason.
+        parsed: !parseError,
+        parseError,
       });
     } catch (error: any) {
       console.error('[upload] Error:', error.message);
       res.status(500).json({ error: error.message });
     }
-  });
+  }, uploadErrorHandler);
 
   // Voice-note transcription for the chat composer. Unlike /api/upload/cbo/:id
   // (which stores a durable evidence document), this is a throwaway: the user

--- a/server/services/documentPersistence.ts
+++ b/server/services/documentPersistence.ts
@@ -72,6 +72,8 @@ export async function createDocument(input: {
   summary?: string | null;
   droppedInPhase?: number | null;
   source?: 'upload' | 'agent';
+  parseStatus?: 'parsed' | 'failed' | null;
+  parseError?: string | null;
 }): Promise<DocumentRow> {
   const [doc] = await db.insert(documents).values({
     orgId: input.orgId ?? null,
@@ -83,6 +85,8 @@ export async function createDocument(input: {
     sizeBytes: input.sizeBytes ?? null,
     fullText: input.fullText ?? null,
     summary: input.summary ?? null,
+    parseStatus: input.parseStatus ?? null,
+    parseError: input.parseError ?? null,
     droppedInPhase: input.droppedInPhase ?? null,
     source: input.source ?? 'upload',
   }).returning();

--- a/server/services/fileParser.ts
+++ b/server/services/fileParser.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { extractFromPath, extractToString } from './fileExtract';
+import { extractFromPath, extractUpload } from './fileExtract';
 
 /**
  * Parse an uploaded file (on disk) into grounding text.
@@ -22,7 +22,7 @@ export async function saveAndParseUpload(
   filename: string,
   runDir: string,
   mimeType?: string,
-): Promise<{ savedPath: string; content: string }> {
+): Promise<{ savedPath: string; content: string; parseError: string | null }> {
   const uploadsDir = path.join(runDir, 'uploads');
   await fs.mkdir(uploadsDir, { recursive: true });
 
@@ -30,8 +30,39 @@ export async function saveAndParseUpload(
   const savedPath = path.join(uploadsDir, safeName);
   await fs.writeFile(savedPath, buffer);
 
-  const content = await extractToString(buffer, filename, mimeType);
-  console.log(`[fileParser] Extracted ${safeName}: ${content.length} chars`);
-
-  return { savedPath, content };
+  // Use the STRUCTURED extractor result rather than extractToString, which
+  // flattens `{ ok: false, reason }` into the string
+  //   "[Couldn't read X: reason]"
+  // and hands it back as if it were the document's text. Downstream that
+  // placeholder was stored as `fullText`, summarised into the org's context
+  // pack, and posted to the agent under the heading "Parsed content:" — so an
+  // unreadable file was recorded as a read one, and the agent was asked to
+  // extract facts from an apology.
+  //
+  // The file is already on disk at this point, so a failure costs us the text,
+  // never the upload itself. Extraction is an ENRICHMENT of a file we have.
+  try {
+    const r = await extractUpload(buffer, { filename, mimeType });
+    if (!r.ok) {
+      const parseError = [r.reason, r.fix].filter(Boolean).join(' ').slice(0, 500);
+      console.warn(`[fileParser] Could not read ${safeName} (file kept): ${parseError}`);
+      return { savedPath, content: '', parseError };
+    }
+    // Extractors can succeed and still yield nothing — a scanned PDF with no
+    // text layer, an empty sheet. That is not a readable document either.
+    if (!r.text.trim()) {
+      console.warn(`[fileParser] ${safeName} extracted to empty text (file kept)`);
+      return {
+        savedPath,
+        content: '',
+        parseError: 'No text could be extracted from the file.',
+      };
+    }
+    console.log(`[fileParser] Extracted ${safeName}: ${r.text.length} chars`);
+    return { savedPath, content: r.text, parseError: null };
+  } catch (e: any) {
+    const parseError = String(e?.message ?? e).slice(0, 500);
+    console.error(`[fileParser] Extraction threw for ${safeName} (file kept): ${parseError}`);
+    return { savedPath, content: '', parseError };
+  }
 }

--- a/shared/document-schema.ts
+++ b/shared/document-schema.ts
@@ -47,6 +47,13 @@ export const documents = pgTable('documents', {
   // later sessions read back via read_org_document.
   fullText: text('full_text'),
   summary: text('summary'),
+  // Whether extraction succeeded. Null on every pre-existing row, which reads
+  // as 'parsed' — those rows only exist because extraction had succeeded.
+  // 'failed' means the original is stored and readable but has no text yet:
+  // retryable, and surfaced to the coordinator rather than silently dropped.
+  // ⚠️ NEW COLUMNS — needs `npm run db:push` before deploy.
+  parseStatus: text('parse_status').$type<'parsed' | 'failed'>(),
+  parseError: text('parse_error'),
   // Provenance: which phase the upload arrived in, and who added it.
   droppedInPhase: integer('dropped_in_phase'),
   source: text('source').$type<'upload' | 'agent'>().default('upload'),


### PR DESCRIPTION
Implements **S3** of the W2 structural diagnosis. Ten upload attempts across the cohort, six usable — and the losses turned out to be **three separate bugs**, none of which left a trace outside the chat transcript.

Diagnosis: https://claude.ai/code/artifact/1d7ac0e7-b574-422b-adb4-e3b4bb042696

## The three

**1. The extractor result was flattened into a string that lies.** `extractToString` turns `{ ok: false, reason }` into `"[Couldn't read X: reason]"` and returns it *as the document text*. Downstream that placeholder was stored as `fullText`, summarised into the org's context pack, and posted to the agent under the heading `Parsed content:`. An unreadable file was recorded as a read one, and the agent was asked to extract facts from an apology. `saveAndParseUpload` now uses `extractUpload` directly.

**2. Extraction can succeed and yield nothing.** A scanned PDF with no text layer returns `ok: true` with an empty string. Now treated as unread rather than as an empty success.

**3. Multer refusals were reported as parse failures.** A file over the 25MB ceiling is refused *before* the route body runs. With no error handler that surfaced as a generic 500, and the client reported it as "could not parse" — so an org whose portfolio was too large was told their PDF was corrupt. Now 413/415 with a reason and a fix.

## The through-line

`fileParser.ts` writes the file to disk **before** attempting extraction. So a read failure should never cost us the upload — extraction is an *enrichment of a file we already have*. That single idea removes all three.

## Backwards compatibility

- `parseStatus` / `parseError` are **nullable**. Every existing row reads as parsed, which is accurate — those rows only exist because extraction had succeeded.
- ⚠️ **needs `npm run db:push` before deploy** (new columns).
- The response gains `parsed` / `parseError`; existing fields are unchanged.

⚠️ **All three upload consumers were audited**, because this change moves parse failures from 500 to 200 — their existing `catch` blocks would otherwise stop firing and they would announce an empty `Parsed content:` block as a success. `cbo-profile`, `useFileDrop` and `concept-note` now all distinguish stored-but-unreadable from never-arrived.

## What the org is told

Not "could not parse", which reads as loss and invites re-uploading the same file — but that it arrived, is on file, and nothing was filled in from it. Ksa Rosa re-sent the same PDF, tried a second, then left the session.

## Tests

Three new cases in `cbo-upload`: an unreadable file is stored with `parseStatus: 'failed'` and null `fullText`; a readable one still reports `parsed`; an oversize file returns 413 with a reason naming the limit.

**11/11 pass** locally across `cbo-upload`, `cbo-intake-upload-banner`, `cougar-chip-opens-file-picker`, `cougar-teia-collaboration`, `cbo-voice-input`. `tsc` unchanged at 5 pre-existing errors.

## A correction to my own write-up

The W2 review said the photo vision reads were "stored nowhere". That was wrong — they are in the documents table and do reach the org context pack. I checked `perfil.json` and drew the wrong conclusion. The narrower real gap is that no *site field* references them; that is a separate change and is not in this PR.