### PR TITLE
fix(cbo): green main — narrow the manifest copy, follow the grupo rename

### DIFF
--- a/e2e/cbo-sse-heartbeat.spec.ts
+++ b/e2e/cbo-sse-heartbeat.spec.ts
@@ -75,7 +75,11 @@ test.describe('CBO — SSE heartbeat keeps slow turns alive', () => {
     await api.scriptCbo(cboId, [[
       { op: 'wait', ms: 1_400 } as any,
       { op: 'say', text: 'Pensei bastante nessa.' },
-      { op: 'ask_user', question: 'Tudo certo?', options: [{ label: 'Sim' }] },
+      // Two options on purpose. A one-option list is converted to prose before
+      // it reaches the user — the real tool has always done that, and since the
+      // fake model started sharing those guards it does too. A card scripted
+      // with one option would be asserting a state production cannot produce.
+      { op: 'ask_user', question: 'Tudo certo?', options: [{ label: 'Sim' }, { label: 'Quero ajustar' }] },
     ]]);
 
     const input = page.getByTestId('cbo-chat-input');

--- a/e2e/cougar-e1-manifest-copy.spec.ts
+++ b/e2e/cougar-e1-manifest-copy.spec.ts
@@ -11,8 +11,13 @@ import { TestApi } from './helpers/testApi';
 // and answered every one of them twice — the existing re-ask guard only catches
 // fields that are already ANSWERED.
 //
-// The words now live in the manifest. The model still decides which field to
-// ask and when; it no longer decides how.
+// The manifest owns the wording of the questions that broke — handed over at
+// the CLOSE GATE, which is where the broken one actually lives:
+// nbs_experience_detail is asked as prose and never reaches ask_user.
+//
+// ask_user itself deliberately does NOT rewrite questions. Chip labels cannot
+// identify a field reliably enough for that, and an earlier attempt silently
+// rewrote questions nobody had complained about.
 test.describe('COUGAR — E1 question wording comes from the manifest', () => {
   const bootstrap = async (page: any) => {
     await page.goto('/cbo-profile');
@@ -22,30 +27,7 @@ test.describe('COUGAR — E1 question wording comes from the manifest', () => {
     return { cboId: (await marker.getAttribute('data-cbo-id'))!, marker };
   };
 
-  test('a question the manifest owns is asked in its words, not the model\'s', async ({ page, request }) => {
-    const api = new TestApi(request);
-    const ping = await api.ping();
-    test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled — skipping deterministic spec.');
-    const { cboId } = await bootstrap(page);
-
-    const res = await request.post(`/__test/cbo/${cboId}/ask-guards`, {
-      data: {
-        lang: 'pt',
-        questions: [{
-          // Improvised wording, of the kind the model actually produces.
-          question: 'Como vocês estão organizados juridicamente aí?',
-          options: [{ label: 'ONG / Associação' }, { label: 'Cooperativa' }, { label: 'Coletivo informal' }],
-        }],
-      },
-    });
-    const body = await res.json();
-    expect(body.items).toHaveLength(1);
-    expect(body.items[0].kind).toBe('render');
-    expect(body.items[0].question, 'the manifest owns the wording').toBe('Qual é a forma jurídica de vocês?');
-    expect(body.copyNotes.join(' ')).toContain('legal_form');
-  });
-
-  test('an unlisted field keeps the model\'s wording — adoption is per field', async ({ request }) => {
+  test('ask_user never rewrites the question — the model owns chat wording', async ({ request }) => {
     const api = new TestApi(request);
     const ping = await api.ping();
     test.skip(!ping.fakeModel, 'CBO_FAKE_MODEL is not enabled — skipping deterministic spec.');
@@ -56,14 +38,17 @@ test.describe('COUGAR — E1 question wording comes from the manifest', () => {
       data: {
         lang: 'pt',
         questions: [{
-          question: 'Quantas pessoas tocam a organização?',
-          options: [{ label: '1–2' }, { label: '3–5' }, { label: '6–15' }],
+          question: 'Como é a estrutura da equipe?',
+          options: [{ label: 'Todas voluntárias' }, { label: 'Maioria pagas' }],
         }],
       },
     });
     const body = await res.json();
-    expect(body.items[0].question, 'team_size has no manifest copy, so nothing changes')
-      .toBe('Quantas pessoas tocam a organização?');
+    // Chip labels cannot identify a field reliably ("Sim"/"Ainda não" belong to
+    // has_cnpj AND nbs_experience), so this tool must never rewrite a question.
+    // The manifest's wording is handed over at the close gate instead.
+    expect(body.items[0].question, 'the question reaches the org exactly as asked')
+      .toBe('Como é a estrutura da equipe?');
   });
 
   // The bug this whole change exists for. nbs_experience_detail is asked as

--- a/e2e/cougar-e2-instant-entry.spec.ts
+++ b/e2e/cougar-e2-instant-entry.spec.ts
@@ -29,7 +29,7 @@ test.describe('COUGAR — instant E2 entry', () => {
     await input.press('Enter');
 
     // The full templated turn: greeting, famílias strip, follow-up line, chips.
-    await expect(page.getByText('famílias de Solução baseada na Natureza', { exact: false })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('grupos de Solução baseada na Natureza', { exact: false })).toBeVisible({ timeout: 8_000 });
     await expect(page.locator('[data-testid^="familia-card-"]').first()).toBeVisible();
     expect(await page.locator('[data-testid^="familia-card-"]').count()).toBe(5);
     await expect(page.getByTestId('cbo-option-0')).toHaveAttribute('data-option-label', 'Ver exemplos');

--- a/e2e/cougar-orchestrator-nbs-tabs.spec.ts
+++ b/e2e/cougar-orchestrator-nbs-tabs.spec.ts
@@ -73,7 +73,7 @@ test.describe('COUGAR — orchestrator NBS tabs', () => {
     // from "real photos"; clicking enlarges the pair in the lightbox.
     expect(await page.locator('[data-testid^="familia-croqui-panel-"]').count()).toBe(5);
     const panel = page.getByTestId('familia-croqui-panel-encostas-e-solo');
-    await expect(panel.getByText(/Croqui da família|Família croqui/)).toBeVisible();
+    await expect(panel.getByText(/Croqui do grupo|Grupo croqui/)).toBeVisible();
     await expect(panel.getByText(/ANTES|BEFORE/)).toBeVisible();
     await expect(panel.getByText(/DEPOIS|AFTER/)).toBeVisible();
     await expect(

--- a/server/services/askUserGuards.ts
+++ b/server/services/askUserGuards.ts
@@ -22,7 +22,6 @@ import {
 import {
   QUESTIONNAIRES,
   filterRuledOptions,
-  askCopyForField,
   type FieldReader,
 } from '@shared/cbo-questionnaire';
 
@@ -128,19 +127,19 @@ export function prepareAskUser(questions: AskQuestion[], ctx: AskGuardContext): 
       }
     }
 
-    // Canonical wording, where the manifest declares it. The model still
-    // decides WHICH field to ask and when; it no longer decides the words,
-    // because the words are where the branch bug lived.
-    let question = q.question;
-    if (targetFields.length === 1) {
-      const canonical = askCopyForField(targetFields[0], ctx.read, ctx.lang);
-      if (canonical && canonical !== question) {
-        copyNotes.push(`${targetFields[0]} asked with its canonical wording`);
-        question = canonical;
-      }
-    }
-
-    items.push({ kind: 'render', question, options, source: q });
+    // NOTE: no canonical-wording substitution here, deliberately.
+    //
+    // It was tried and removed. Chip labels cannot identify a field reliably
+    // enough to rewrite its question: "Sim / Ainda não" belongs to has_cnpj AND
+    // nbs_experience, so the two fields whose wording actually broke can never
+    // be disambiguated from their chips — the substitution was inert exactly
+    // where it was needed. Where it DID fire, it silently rewrote questions
+    // nobody had complained about, which is how it landed three red specs.
+    //
+    // The wording fix lives in the close gate instead (score_maturity), which
+    // is where the broken question actually was: nbs_experience_detail is asked
+    // as prose and never reaches this tool at all.
+    items.push({ kind: 'render', question: q.question, options, source: q });
   }
 
   return { items, filteredNotes, copyNotes };

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -882,7 +882,6 @@ Include showMap: true on a question only when the user genuinely needs the map t
           : () => undefined,
       });
       const filteredNotes = guarded.filteredNotes;
-      const copyNotes = guarded.copyNotes;
       const blockedNotes: string[] = [];
       let converted = 0;
       let shown = 0;
@@ -914,9 +913,8 @@ Include showMap: true on a question only when the user genuinely needs the map t
       }
       const note = converted > 0 ? ` (${converted} single-option question(s) delivered as plain text instead — a one-option list is a free-text question; next time ask it as prose with no tool call)` : '';
       const filterNote = filteredNotes.length > 0 ? ` (${filteredNotes.join('; ')} — the user only saw the valid chips)` : '';
-      const copyNote = copyNotes.length > 0 ? ` (${copyNotes.join('; ')} — the manifest owns that wording; use it verbatim next time)` : '';
       const blockedNote = blockedNotes.length > 0 ? ` (${blockedNotes.length} duplicate question(s) NOT shown: ${blockedNotes.join('; ')} — never re-ask answered fields)` : '';
-      return { content: [{ type: "text" as const, text: `${shown + converted} question(s) shown.${note}${filterNote}${copyNote}${blockedNote} STOP and wait.` }] };
+      return { content: [{ type: "text" as const, text: `${shown + converted} question(s) shown.${note}${filterNote}${blockedNote} STOP and wait.` }] };
     },
     { annotations: { readOnlyHint: true } }
   );

--- a/shared/cbo-questionnaire.ts
+++ b/shared/cbo-questionnaire.ts
@@ -100,9 +100,14 @@ export const E1_QUESTIONNAIRE: QuestionnaireManifest = {
   // skill and the manifest cannot drift — the skill remains the place the flow
   // is explained; this is the place the wording is enforced.
   //
-  // Only the fields whose wording actually went wrong in W2, plus the two the
-  // duplicate-batch bug hit. The rest are unlisted on purpose: an unlisted
-  // field behaves exactly as it does today.
+  // ONLY the fields whose wording actually went wrong in W2. Everything else
+  // is unlisted on purpose and keeps the model's own phrasing.
+  //
+  // I first listed five, including paid_vs_volunteer and legal_form — fields
+  // nobody had complained about. That silently rewrote questions three existing
+  // specs assert on ("Como é a estrutura da equipe?"), which is the tell: if
+  // taking a field over changes what an org is asked without a report behind it,
+  // the manifest is being used to standardise rather than to fix.
   ask: {
     nbs_experience: {
       pt: 'Vocês já trabalharam com alguma solução baseada na natureza?',
@@ -129,18 +134,6 @@ export const E1_QUESTIONNAIRE: QuestionnaireManifest = {
           },
         },
       },
-    },
-    legal_form: {
-      pt: 'Qual é a forma jurídica de vocês?',
-      en: 'What is your legal form?',
-    },
-    groups_served: {
-      pt: 'Quem vocês atendem?',
-      en: 'Who do you serve?',
-    },
-    paid_vs_volunteer: {
-      pt: 'A equipe é paga ou voluntária?',
-      en: 'Is the team paid or voluntary?',
     },
   },
   requiredToClose: [


### PR DESCRIPTION
Merging #472–#480 left `main` with **six red specs**. Each PR was green on its own branch; the failures only existed in the combination, and nobody ran the full suite before merging — my process failure.

A control run on pre-merge `main` (6dab51d4) separated mine from pre-existing.

## 1. The manifest owned too much

#478 gave canonical copy to five fields. **Only two had wording that actually went wrong in W2.** `legal_form` and `paid_vs_volunteer` were never reported by anyone, and templating them silently rewrote questions three specs assert on (`"Como é a estrutura da equipe?"`).

Narrowed to `nbs_experience` and `nbs_experience_detail`.

The tell is worth keeping: **if taking a field over changes what an org is asked without a report behind it, the manifest is being used to standardise rather than to fix.**

## 2. Removed the `ask_user` copy substitution entirely

It could not work where it was needed, and did harm where it fired.

Chip labels cannot identify a field reliably — `"Sim"`/`"Ainda não"` belong to `has_cnpj` **and** `nbs_experience` — so the two fields whose wording broke can never be disambiguated from their chips. The substitution was inert exactly where it mattered.

The wording fix lives in the **close gate**, which is where the broken question actually is: `nbs_experience_detail` is asked as *prose* and never reaches `ask_user`. That path is unchanged and still tested across all three branches.

## 3. Followed #472’s rename into two more specs

`cougar-e2-instant-entry` and `cougar-orchestrator-nbs-tabs` assert the renamed copy. My grep in #472 searched for literal strings and missed both — exactly as it missed `cougar-e2-linear-journey`, caught during the #473 merge. **Three specs, three separate misses, one cause.**

## 4. A spec was asserting a state production cannot produce

`cbo-sse-heartbeat` scripted a **one-option** `ask_user` and expected a question card. The real tool has always converted a one-option list to prose; the fake model did not, because it was a hand-written mirror. Now that both share `askUserGuards`, that divergence is gone — so the spec was testing a fiction.

Given two options instead. **The fix is the spec, not a second divergence.**

## Result

**214 passed, 1 failed.** That one (`w2-scenarios` › *org 1 · Raízes do Sarandi*) also fails on pre-merge `main`, so it is pre-existing and untouched here. `tsc` unchanged at 5.