### PR TITLE
fix(cbo): stop narrating our implementation to the organization

### DIFF
--- a/e2e/cbo-implementation-narration.spec.ts
+++ b/e2e/cbo-implementation-narration.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// W2, four of seven transcripts. In Ksa Rosa's session the "vou persistir" line
+// appears FIVE times between questions — not an error state, the normal path:
+//
+//   Vou persistir as respostas do Batch A e continuar com o Batch B.
+//   Agora vou chamar as ferramentas corretas para finalizar:
+//
+// Ana logged it as internal assessment text appearing mid-flow. It is not a
+// missing translation — the app ships pt-BR only. It is the model narrating its
+// own implementation, and the skill has asked it not to for months.
+test.describe('CBO — implementation narration never reaches the org', () => {
+  const boot = async (page: any) => {
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 30_000 });
+    return { cboId: (await marker.getAttribute('data-cbo-id'))!, marker };
+  };
+
+  test('machinery lines are dropped; the real message still arrives', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId, marker } = await boot(page);
+
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Vou persistir as respostas do Batch A e continuar com o Batch B.' },
+      { op: 'say', text: 'Agora vou chamar as ferramentas corretas para finalizar:' },
+      { op: 'say', text: 'Que trabalho lindo o de vocês! Me conta: qual é a missão?' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    const body = await page.locator('body').innerText();
+    expect(body, 'the org never sees "persistir"').not.toContain('persistir');
+    expect(body, 'nor Batch A').not.toContain('Batch A');
+    expect(body, 'nor our tool-calling').not.toContain('chamar as ferramentas');
+    expect(body, 'and the real message still arrives').toContain('qual é a missão');
+  });
+
+  test('a friendly progress line is NOT dropped', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId, marker } = await boot(page);
+
+    // COOP20 got this one. It tells the org their answers are being saved —
+    // which they should hear — and contains none of our vocabulary.
+    await api.scriptCbo(cboId, [[
+      { op: 'say', text: 'Entendi! Vou atualizar tudo isso no perfil de vocês.' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    await expect(page.getByText('Vou atualizar tudo isso no perfil', { exact: false }))
+      .toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/server/services/assistantNoise.ts
+++ b/server/services/assistantNoise.ts
@@ -1,0 +1,55 @@
+// ============================================================================
+// IMPLEMENTATION NARRATION — our machinery, told to the organization
+// ============================================================================
+//
+// W2, in four of seven transcripts:
+//
+//   Vou persistir as respostas do Batch A e continuar com o Batch B.
+//   Vou persistir essa resposta e finalizar o diagnóstico da Ksa Rosa.
+//   Agora vou chamar as ferramentas corretas para finalizar:
+//   Vou executar corretamente chamando as ferramentas de API diretamente.
+//   Baseando-me no estado atual e no skill do Encontro 1, vou finalizar agora:
+//
+// In Ksa Rosa's session the "vou persistir" line appears five times between
+// questions. It is not an error state — it is the normal path. Ana logged it as
+// internal assessment text appearing mid-flow; it is not a missing translation
+// (the app ships pt-BR only), it is the model narrating its own implementation.
+//
+// The skill has told it not to do this for months. Prompt-level rules leak, so
+// this drops the lines at the output boundary instead — the same seam that
+// already drops near-duplicate chat blocks.
+//
+// Deliberately narrow. Every trigger is a word that belongs to US and would
+// never appear in a sentence written for a community organization: "persistir"
+// (a developer's verb, not natural pt), "Batch A", "ferramentas de API", "skill
+// do Encontro". Friendly progress lines an org SHOULD see — "Vou atualizar tudo
+// isso no perfil de vocês", "Anotado!" — contain none of them and are untouched.
+
+/** Above this, it is a real message that happens to mention machinery, and
+ *  dropping it would cost the org content. These lines are always one breath. */
+const MAX_NARRATION_CHARS = 180;
+
+const NARRATION = [
+  /\bpersistir\b/i,                      // "vou persistir as respostas"
+  /\bbatch\s+[ab]\b/i,                   // "Batch A" / "Batch B"
+  /ferramentas\s+(corretas|de\s+api)/i,  // "chamar as ferramentas corretas"
+  /chamando\s+as\s+ferramentas/i,
+  /\bskill\s+do\s+encontro\b/i,
+  /\bupdate_section\b|\bask_user\b|\bscore_maturity\b|\bset_phase\b/i, // tool names
+  // English equivalents, for the en flow.
+  /\bi'?ll\s+persist\b/i,
+  /\bcall(ing)?\s+the\s+(correct\s+)?tools\b/i,
+];
+
+/**
+ * True when this assistant chat block is us narrating our own machinery rather
+ * than talking to the organization.
+ *
+ * Length is part of the test: a long message that happens to contain one of
+ * these words is a real message, and silence would be worse than the leak.
+ */
+export function isImplementationNarration(content: string): boolean {
+  const text = (content ?? '').trim();
+  if (!text || text.length > MAX_NARRATION_CHARS) return false;
+  return NARRATION.some(re => re.test(text));
+}

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -62,6 +62,7 @@ import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredFor
 import { prepareAskUser } from "./askUserGuards";
 import { commitConfirmedStagedFields, isAffirmativeReply } from "./e1ConfirmCommit";
 import { parseNbsInventory } from "@shared/nbs-inventory";
+import { isImplementationNarration } from "./assistantNoise";
 
 /** Manifests whose rules govern this section (today: E1 ↔ org_profile). */
 function manifestsForSection(sectionId: string): QuestionnaireManifest[] {
@@ -2987,6 +2988,13 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
     if (event.type === 'chat') {
       if (isTurnDuplicate(event.content)) {
         console.log(`[cbo] dropped near-duplicate chat block for ${cboId} (${event.content.length} chars)`);
+        return;
+      }
+      // Our machinery, narrated to the org — "vou persistir as respostas do
+      // Batch A", five times in one W2 session. Dropped here rather than asked
+      // for in the prompt, because the skill has asked for months.
+      if (isImplementationNarration(event.content)) {
+        console.log(`[cbo] dropped implementation narration for ${cboId}: ${event.content.slice(0, 80)}`);
         return;
       }
       turnChatTexts.push(normChat(event.content));


### PR DESCRIPTION
Ana’s remaining W2 item, and the one with the widest reach — **four of seven transcripts**. In Ksa Rosa’s session the `"vou persistir"` line lands **five times** between questions. Not an error state; the normal path.

```
Vou persistir as respostas do Batch A e continuar com o Batch B.
Agora vou chamar as ferramentas corretas para finalizar:
Vou executar corretamente chamando as ferramentas de API diretamente.
Baseando-me no estado atual e no skill do Encontro 1, vou finalizar agora:
```

It is **not** a missing translation — the app ships pt-BR only. It is the model narrating its own machinery, and the skill has told it not to for months.

## Why a filter, not a prompt rule

Prompt-level rules leak; this one has leaked all year. The lines are dropped at the output boundary instead — the same `pushEvent` seam that already drops near-duplicate chat blocks.

## Why it is safe

Every trigger is a word that belongs to **us** and would never appear in a sentence written for a community organization: `persistir` (a developer’s verb, not natural Portuguese), `Batch A`, `ferramentas de API`, `skill do Encontro`, raw tool names.

**Length is part of the test.** Above 180 characters it is a real message that happens to mention machinery, and silence would be worse than the leak.

Verified against the actual transcript lines — all five drop, and six real messages are untouched, including:

> *"Entendi! Vou atualizar tudo isso no perfil de vocês."*

COOP20 received that one, and the org **should** see it: it tells them their answers are being saved, and contains none of our vocabulary.

## Tests

The machinery lines never reach the DOM while the real message in the same turn still arrives; a friendly progress line is not dropped.

**Full suite: 215 passed, 2 failed** — both `w2-scenarios`, both failing on pre-merge `main` as well. `tsc` unchanged at 5.