### PR TITLE
fix(cbo): remove the last two fakeCboModel mirrors, and the specs they hid

### DIFF
--- a/e2e/cbo-guards-not-mirrored.spec.ts
+++ b/e2e/cbo-guards-not-mirrored.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { TestApi } from './helpers/testApi';
+
+// Mirror audit of fakeCboModel, after ask_user turned out to be a hand-written
+// copy of the real tool's guards (so specs passed against a duplicate).
+//
+// Two more were found, and both were WORSE than ask_user: the rule was absent
+// from the fake model entirely, so no spec could ever trip it.
+//
+//   1. score_maturity — the real tool refuses to score while requiredToClose
+//      fields are missing. Scoring IS the close for E1, so this is the rule
+//      that stops an encontro closing half-filled. The fake model wrote the
+//      score unconditionally.
+//
+//   2. confirm_doc_fields — the real tool refuses to commit values staged in
+//      the CURRENT turn, which is the whole point of staging: a recap and its
+//      confirmation can never be the same turn. The fake model committed
+//      everything, and stamped stagedAtUserTurns: 0 so the guard could not
+//      have bitten anyway.
+//
+// Both now run the shared implementation. These specs exist to prove the guards
+// are reachable from the suite at all.
+test.describe('CBO — guards are shared with the fake model, not mirrored', () => {
+  const boot = async (page: any) => {
+    await page.goto('/cbo-profile');
+    const marker = page.getByTestId('cbo-stream-status');
+    await expect(marker).toHaveAttribute('data-cbo-id', /.+/, { timeout: 30_000 });
+    await expect(marker).toHaveAttribute('data-streaming', 'false', { timeout: 30_000 });
+    return { cboId: (await marker.getAttribute('data-cbo-id'))!, marker };
+  };
+
+  test('E1 cannot be scored while required fields are missing', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId, marker } = await boot(page);
+
+    // A near-empty profile tries to close.
+    await api.scriptCbo(cboId, [[
+      { op: 'score_maturity', metric: 'org_delivery_capacity', score: 3, justification: 'closing early' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    const state = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(
+      (state.state?.maturityScores ?? []).length,
+      'the gate refuses the score — this is what stops E1 closing half-filled',
+    ).toBe(0);
+  });
+
+  test('a full profile CAN be scored — the gate opens', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId, marker } = await boot(page);
+
+    // Fill everything requiredToClose asks for, then score.
+    const fill = (field: string, value: string) =>
+      ({ op: 'update_section' as const, sectionId: 'org_profile', field, value });
+    await api.scriptCbo(cboId, [[
+      fill('org_name', 'Horta do Beco'),
+      fill('contact_name', 'Paula'),
+      fill('contact_role', 'Presidente'),
+      fill('mission_summary', 'Transformação social e ambiental na comunidade.'),
+      fill('main_activities', 'Hortas e segurança alimentar'),
+      fill('has_cnpj', 'Sim, temos CNPJ'),
+      fill('legal_form', 'ONG / Associação'),
+      fill('year_founded', '5 a 10 anos'),
+      fill('team_size', '6–15'),
+      fill('paid_vs_volunteer', 'Todas voluntárias'),
+      fill('nbs_experience', 'Ainda não'),
+      fill('groups_served', 'Mulheres, Jovens'),
+      fill('funding_history', 'Sim, já recebemos'),
+      fill('funded_project_count', '2 a 5 projetos'),
+      fill('biggest_project_budget', 'R$ 10 a 50 mil'),
+      { op: 'set_path', path: 'has-idea' },
+      { op: 'score_maturity', metric: 'org_delivery_capacity', score: 2, justification: 'ok' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('oi');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    const state = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(
+      (state.state?.maturityScores ?? []).length,
+      'with everything answered the gate opens',
+    ).toBeGreaterThan(0);
+  });
+
+  test('a doc value staged this turn cannot be confirmed in the same turn', async ({ page, request }) => {
+    const api = new TestApi(request);
+    test.skip(!(await api.ping()).fakeModel, 'needs the fake model');
+    const { cboId, marker } = await boot(page);
+
+    // Stage and confirm in one breath — the org has not seen the recap yet.
+    await api.scriptCbo(cboId, [[
+      {
+        op: 'update_section',
+        sectionId: 'org_profile',
+        field: 'mission_summary',
+        value: 'Missão lida do site da organização.',
+        source: 'document',
+      },
+      { op: 'confirm_doc_fields' },
+    ]]);
+    const input = page.getByTestId('cbo-chat-input');
+    await input.fill('https://exemplo.org/');
+    await input.press('Enter');
+    await expect(marker).toHaveAttribute('data-streaming', 'false');
+
+    const state = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(
+      String(state.state?.sections?.org_profile?.fields?.mission_summary?.value ?? ''),
+      'staging exists so a human sees the value first — same-turn confirm must not commit',
+    ).toBe('');
+  });
+});

--- a/e2e/cbo-phase1-walkthrough.spec.ts
+++ b/e2e/cbo-phase1-walkthrough.spec.ts
@@ -24,9 +24,9 @@ const PHASE1_SCRIPT = [
   ],
   // Turn 3 — record the mission, ask legal form (chips).
   [
-    { op: 'update_section', sectionId: 'org_profile', field: 'mission', value: 'Cultivar alimento e reduzir alagamentos no bairro Cascata.' },
+    { op: 'say', text: 'Anotado.' },
     { op: 'ask_user', question: 'Qual é a forma jurídica da organização?', options: [
-      { label: 'Associação comunitária' },
+      { label: 'ONG / Associação' },
       { label: 'Coletivo informal' },
       { label: 'Estúdio / empresa' },
       { label: 'Escola' },
@@ -34,19 +34,41 @@ const PHASE1_SCRIPT = [
   ],
   // Turn 4 — record legal form, ask team size (chips).
   [
-    { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'Associação comunitária' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'legal_form', value: 'ONG / Associação' },
     { op: 'ask_user', question: 'Quantas pessoas fazem parte da equipe?', options: [
-      { label: '1–5' }, { label: '6–20' }, { label: 'Mais de 20' },
+      { label: '1–5' }, { label: '6–15' }, { label: '16+' },
     ] },
   ],
   // Turn 5 — record team size, ask years active (free text).
   [
-    { op: 'update_section', sectionId: 'org_profile', field: 'team_size', value: '6–20' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'team_size', value: '6–15' },
     { op: 'say', text: 'Há quantos anos a organização existe?' },
   ],
-  // Turn 6 — record years, score the two Phase-1 metrics, advance to Phase 2.
+  // Turn 6 — the rest of what E1 actually requires, then score and advance.
+  //
+  // This spec used to fill five fields and call that "a full org profile". It
+  // passed only because the fake model wrote maturity scores unconditionally;
+  // the real tool has always refused to close while requiredToClose fields are
+  // missing. Now that both share cboCloseGate, the spec has to build a profile
+  // the product would genuinely accept — which is what its name claims.
+  //
+  // It also used field names that do not exist (`mission`, `years_active`) and
+  // an off-list legal_form. Those are corrected here; the canonical labels come
+  // from ORG_PROFILE_ENUMS.
   [
-    { op: 'update_section', sectionId: 'org_profile', field: 'years_active', value: '8 anos' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'year_founded', value: '5 a 10 anos' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'mission_summary', value: 'Cultivar alimento e reduzir alagamentos no bairro Cascata.' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'contact_name', value: 'Ana Souza' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'contact_role', value: 'Coordenação' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'main_activities', value: 'Hortas e segurança alimentar' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'has_cnpj', value: 'Sim, temos CNPJ' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'paid_vs_volunteer', value: 'Todas voluntárias' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'nbs_experience', value: 'Ainda não' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'groups_served', value: 'Mulheres, Jovens' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'funding_history', value: 'Sim, já recebemos' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'funded_project_count', value: '2 a 5 projetos' },
+    { op: 'update_section', sectionId: 'org_profile', field: 'biggest_project_budget', value: 'R$ 10 a 50 mil' },
+    { op: 'set_path', path: 'has-idea' },
     { op: 'say', text: 'Perfeito — já tenho um bom retrato de vocês. Vou registrar a maturidade da Fase 1.' },
     { op: 'score_maturity', metric: 'org_delivery_capacity', score: 2, justification: 'Equipe estabelecida, 8 anos de atuação.' },
     { op: 'score_maturity', metric: 'team_technical_experience', score: 2, justification: 'Experiência prática em horta comunitária.' },
@@ -85,8 +107,8 @@ test('Phase 1 walkthrough: a full org profile is built and advances to Phase 2',
   await sendText('Horta Comunitária Cascata', 2);                            // → name recorded, asks mission
   await expect(marker).toHaveAttribute('data-org-name', 'Horta Comunitária Cascata');
   await sendText('Cultivar alimento e reduzir alagamentos no bairro Cascata.', 3); // → mission, asks legal form
-  await clickChip('Associação comunitária', 4);                              // → legal form, asks team size
-  await clickChip('6–20', 5);                                                // → team size, asks years
+  await clickChip('ONG / Associação', 4);                              // → legal form, asks team size
+  await clickChip('6–15', 5);                                                // → team size, asks years
   await sendText('8 anos', 6);                                               // → years, scores, advances
 
   // The flow advanced to Phase 2 and the document panel shows the org name.
@@ -98,7 +120,11 @@ test('Phase 1 walkthrough: a full org profile is built and advances to Phase 2',
   // Phase-1 metrics scored + phase advanced.
   const state = await (await request.get(`/api/cbo/${cboId}`)).json();
   const fields = state.state.sections.org_profile.fields;
-  for (const f of ['org_name', 'mission', 'legal_form', 'team_size', 'years_active']) {
+  // The real field names. This list previously asserted `mission` and
+  // `years_active`, which the product does not have — so it was checking that
+  // two fields nobody writes were "filled", and passing because the fake model
+  // wrote whatever it was handed.
+  for (const f of ['org_name', 'mission_summary', 'legal_form', 'team_size', 'year_founded', 'has_cnpj', 'nbs_experience', 'groups_served']) {
     expect(fields[f]?.value, `org_profile.${f} should be filled`).toBeTruthy();
   }
   expect(state.state.maturityScores.length).toBe(2);

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -63,6 +63,7 @@ import { prepareAskUser } from "./askUserGuards";
 import { commitConfirmedStagedFields, isAffirmativeReply } from "./e1ConfirmCommit";
 import { parseNbsInventory } from "@shared/nbs-inventory";
 import { isImplementationNarration } from "./assistantNoise";
+import { checkCloseGate } from "./cboCloseGate";
 
 /** Manifests whose rules govern this section (today: E1 ↔ org_profile). */
 function manifestsForSection(sectionId: string): QuestionnaireManifest[] {
@@ -1048,38 +1049,27 @@ STOP and wait for the user's map selection after calling this tool.`,
       // what makes "edit an earlier answer near the end → the model jumps to
       // the closing and skips the project-status question" structurally
       // impossible (field report 2026-07).
+      // CLOSE GATE (manifest): scoring IS the closing signal for E1, so refuse
+      // it while required questionnaire fields (or the set_path triage) are
+      // missing. Shared with the fake model — see cboCloseGate.ts. It used to
+      // live only here, which meant no spec could trip it.
       const closeManifest = QUESTIONNAIRES[state.phase];
       if (closeManifest) {
-        const gateSection = state.sections[closeManifest.sectionId as keyof typeof state.sections];
-        let hasPath: boolean | null = null; // null = standalone session, path not persistable
+        let hasPath: boolean | null = null; // null = standalone session
         if (closeManifest.requiresPath) {
           try {
             const rows = await db.select({ path: cohortMembers.path }).from(cohortMembers).where(eq(cohortMembers.cboStateId, cboId)).limit(1);
             hasPath = rows.length === 0 ? null : rows[0].path != null;
           } catch { hasPath = null; }
         }
-        const missing = gateSection ? missingRequiredForClose(closeManifest, sectionFieldReader(gateSection), hasPath) : [];
-        if (missing.length > 0) {
-          // Hand back the WORDS, not just the field names. nbs_experience_detail
-          // is asked as prose, so it never passes through ask_user and never
-          // gets the canonical copy that way — and prose is exactly where the
-          // branch broke: an org that answered "Ainda não" was asked what kind
-          // of NbS they had already worked with. Where the manifest declares
-          // wording, the model is given the sentence rather than asked to
-          // remember which variant applies.
-          const gateRead = sectionFieldReader(gateSection!);
-          const gateLang = (state as any)?.metadata?.language === 'en' ? 'en' : 'pt';
-          const lines = missing.map(field => {
-            const copy = askCopyFor(closeManifest, field, gateRead, gateLang);
-            return copy ? `${field} — ask it EXACTLY like this: "${copy}"` : field;
-          });
-          return {
-            content: [{
-              type: "text" as const,
-              text: `NOT scored — Encontro ${state.phase} can't close yet, these are still missing:\n${lines.map(l => `- ${l}`).join('\n')}\nAsk the user for each of them (chips for enum fields, prose for free-text), store the answers, and only then re-run the closing calls.`,
-            }],
-            isError: true,
-          };
+        const gate = checkCloseGate({
+          phase: state.phase,
+          section: state.sections[closeManifest.sectionId as keyof typeof state.sections],
+          hasPath,
+          lang: (state as any)?.metadata?.language === 'en' ? 'en' : 'pt',
+        });
+        if (gate.message) {
+          return { content: [{ type: "text" as const, text: gate.message }], isError: true };
         }
       }
       state.maturityScores = state.maturityScores.filter(s => s.metric !== args.metric);
@@ -3245,7 +3235,7 @@ export async function streamCboChat(cboId: string, userMessage: string, res: Res
   // fake instead of the live SDK — fast, free, and reproducible. The real path
   // below is byte-for-byte untouched. See server/services/fakeCboModel.ts.
   if (isFakeModelEnabled()) {
-    await streamWithFakeModel(cboId, userMessage, state, pushEvent, lang, { setCboState });
+    await streamWithFakeModel(cboId, userMessage, state, pushEvent, lang, { setCboState, countUserContentTurns });
     res.end();
     return;
   }

--- a/server/services/cboCloseGate.ts
+++ b/server/services/cboCloseGate.ts
@@ -1,0 +1,69 @@
+// ============================================================================
+// THE CLOSE GATE — one implementation, real tool and fake model
+// ============================================================================
+//
+// Scoring maturity IS the closing signal for E1, so the gate refuses it while
+// required questionnaire fields (or the set_path triage) are missing. That is
+// what makes "edit an earlier answer near the end → the model jumps to the
+// closing and skips the project-status question" structurally impossible
+// (field report 2026-07).
+//
+// It lived only in the real tool. The fake model wrote the score
+// unconditionally, so NO spec could trip the gate — the rule that stops an
+// encontro closing half-filled had no test at all, and the wording hand-over
+// added for the "Ainda não" branch had none either.
+//
+// Same lesson as askUserGuards: a rule that exists twice is a rule the suite
+// cannot see. This is the second mirror found in fakeCboModel; the audit that
+// found it is worth repeating for anything else that file re-implements.
+
+import {
+  QUESTIONNAIRES,
+  missingRequiredForClose,
+  askCopyFor,
+  type FieldReader,
+} from '@shared/cbo-questionnaire';
+
+export interface CloseGateResult {
+  /** Field names still missing. Empty means the encontro may close. */
+  missing: string[];
+  /** The refusal to hand the model, already carrying the exact wording for any
+   *  field the manifest owns. Null when nothing is missing. */
+  message: string | null;
+}
+
+export function checkCloseGate(input: {
+  phase: number;
+  section: { fields: Record<string, { value: unknown } | undefined> } | undefined;
+  /** null = standalone session, path not persistable, so not gated on. */
+  hasPath: boolean | null;
+  lang: 'pt' | 'en';
+}): CloseGateResult {
+  const manifest = QUESTIONNAIRES[input.phase];
+  if (!manifest || !input.section) return { missing: [], message: null };
+
+  const read: FieldReader = (field: string) => {
+    const v = input.section!.fields[field]?.value;
+    return v == null ? undefined : String(v);
+  };
+
+  const missing = missingRequiredForClose(manifest, read, input.hasPath);
+  if (missing.length === 0) return { missing: [], message: null };
+
+  // Hand back the WORDS, not just the field names. nbs_experience_detail is
+  // asked as prose, so it never passes through ask_user — and prose is exactly
+  // where the branch broke: an org that answered "Ainda não" was asked what
+  // kind of NbS they had already worked with.
+  const lines = missing.map(field => {
+    const copy = askCopyFor(manifest, field, read, input.lang);
+    return copy ? `${field} — ask it EXACTLY like this: "${copy}"` : field;
+  });
+
+  return {
+    missing,
+    message:
+      `NOT scored — Encontro ${input.phase} can't close yet, these are still missing:\n` +
+      lines.map(l => `- ${l}`).join('\n') +
+      `\nAsk the user for each of them (chips for enum fields, prose for free-text), store the answers, and only then re-run the closing calls.`,
+  };
+}

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -39,6 +39,8 @@ import { isReplitDeployment } from './runtimeEnv';
 import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, enumFieldsMatchingOptions } from '@shared/cbo-field-catalog';
 import { QUESTIONNAIRES, checkOptionRule } from '@shared/cbo-questionnaire';
 import { prepareAskUser } from './askUserGuards';
+import { checkCloseGate } from './cboCloseGate';
+import { commitConfirmedStagedFields } from './e1ConfirmCommit';
 
 export function isFakeModelEnabled(): boolean {
   // Deployment backstop: Replit shares App secrets with Deployments by
@@ -92,6 +94,9 @@ interface FakeDeps {
   // Passed in from streamCboChat (same module that owns the real path) so this
   // module never has to import from cboAgent — avoids a circular import.
   setCboState: (id: string, state: CboState) => void;
+  /** The real user-turn count. The staging gate is defined in terms of it, and
+   *  hardcoding 0 here is what made that gate untestable. */
+  countUserContentTurns: (id: string) => number;
 }
 
 // ── Driver ──────────────────────────────────────────────────────────────────
@@ -162,7 +167,7 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
         state.stagedDocFields = state.stagedDocFields ?? {};
         state.stagedDocFields[`${op.sectionId}.${op.field}`] = {
           sectionId: op.sectionId as any, field: op.field, value: String(value),
-          confidence: (op.confidence ?? 'high') as Confidence, stagedAtUserTurns: 0,
+          confidence: (op.confidence ?? 'high') as Confidence, stagedAtUserTurns: deps.countUserContentTurns(cboId),
         };
         deps.setCboState(cboId, state);
         break;
@@ -182,15 +187,19 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       break;
     }
     case 'confirm_doc_fields': {
-      const stagedAll = Object.values(state.stagedDocFields ?? {});
-      const wanted = op.fields?.length ? stagedAll.filter(s => op.fields!.includes(s.field)) : stagedAll;
-      for (const s of wanted) {
-        const sec = state.sections[s.sectionId as keyof typeof state.sections];
-        if (!sec) continue;
-        sec.fields[s.field] = { value: s.value, confidence: s.confidence, source: 'document', userEdited: false };
-        sec.lastUpdatedBy = 'agent';
-        delete state.stagedDocFields![`${s.sectionId}.${s.field}`];
-        pushEvent({ type: 'field_update', sectionId: s.sectionId, field: s.field, value: s.value, confidence: s.confidence, source: 'document' });
+      // The crawl-trust gate, from the same module the server-side commit uses.
+      // This used to commit unconditionally, so the rule that a recap and its
+      // confirmation can never be the same turn had no test — the whole point
+      // of staging was unenforced in the suite.
+      const before = Object.keys(state.stagedDocFields ?? {});
+      const outcome = commitConfirmedStagedFields(state, deps.countUserContentTurns(cboId));
+      for (const field of outcome.committed) {
+        const sec = state.sections.org_profile;
+        const v = sec?.fields?.[field]?.value;
+        pushEvent({ type: 'field_update', sectionId: 'org_profile', field, value: String(v ?? ''), confidence: 'high', source: 'document' });
+      }
+      if (outcome.committed.length === 0 && before.length > 0) {
+        pushEvent({ type: 'chat', content: '[staging] nothing committed — the user has not replied since these were staged', role: 'assistant' } as any);
       }
       deps.setCboState(cboId, state);
       break;
@@ -236,7 +245,21 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
     case 'score_maturity': {
       if (!isValidMaturityMetric(op.metric)) break;
       const score = Math.max(0, Math.min(3, Math.round(Number(op.score) || 0))) as 0 | 1 | 2 | 3;
-      // Replace any existing score for this metric (mirror real upsert intent).
+      // The close gate, from the same module the real tool uses. This used to
+      // be absent here entirely: the fake model wrote the score unconditionally,
+      // so no spec could trip the rule that stops an encontro closing with
+      // required fields missing. hasPath is null — a scripted session has no
+      // cohort member row, which is exactly how the real tool treats it.
+      const gate = checkCloseGate({
+        phase: state.phase,
+        section: state.sections[(QUESTIONNAIRES[state.phase]?.sectionId ?? 'org_profile') as keyof typeof state.sections],
+        hasPath: null,
+        lang: lang === 'en' ? 'en' : 'pt',
+      });
+      if (gate.message) {
+        pushEvent({ type: 'chat', content: `[close gate] ${gate.missing.join(', ')}`, role: 'assistant' } as any);
+        break;
+      }
       state.maturityScores = state.maturityScores.filter(s => s.metric !== op.metric);
       state.maturityScores.push({ metric: op.metric, score, justification: op.justification ?? 'fake' });
       state.totalMaturityScore = state.maturityScores.reduce((sum, s) => sum + s.score, 0);


### PR DESCRIPTION
Audit of `fakeCboModel` after `ask_user` turned out to be a hand-written copy of the real tool’s guards (#478).

**Two more were found, and both were worse.** The rule was not mirrored inaccurately — it was **absent**, so no spec could ever trip it.

## 1. `score_maturity` had no close gate

Scoring **is** the closing signal for E1, so the real tool refuses it while `requiredToClose` fields (or the `set_path` triage) are missing. That is the rule that makes *"edit an answer near the end, then jump to the closing and skip the project-status question"* structurally impossible.

The fake model wrote the score unconditionally — so that rule had **no test at all**, and neither did the wording hand-over added in #478.

## 2. `confirm_doc_fields` committed everything

The real tool refuses values staged in the **current** turn, which is the entire point of staging: a recap and its confirmation can never be the same turn. The fake model also stamped `stagedAtUserTurns: 0`, so the guard could not have bitten even if it had been checked.

Both now run `commitConfirmedStagedFields`, with the real user-turn count threaded through `FakeDeps`.

The close gate moves to `server/services/cboCloseGate.ts`; both callers use it.

## What the audit found underneath

`cbo-phase1-walkthrough` — **"a full org profile is built and advances to Phase 2"** — filled **five** fields and closed. It stayed green only because the fake model did not gate; the real product would have refused.

It also wrote two fields that **do not exist** (`mission`, `years_active`) and an off-list `legal_form` — then asserted those non-existent fields were "filled".

So the headline assertion was false in both directions: the profile was not full, and two of the fields it checked are not fields. It now builds a profile E1 genuinely accepts, with real names and canonical labels, and the gate lets it close — which is what the test always claimed to prove.

## Tests

New spec proves both guards are reachable from the suite:

- E1 **cannot** be scored while required fields are missing
- a complete profile **can** be scored — so the gate is not simply always refusing
- a same-turn confirm does **not** commit

**218 passed, 2 failed** — both `w2-scenarios`, both failing on pre-merge `main` as well. `tsc` unchanged at 5.

## Status

`fakeCboModel` no longer re-implements any org-facing guard. `update_section`’s canonicalization and option-rule checks still exist in both places, but call the same shared helpers from `cbo-field-catalog` / `cbo-questionnaire` rather than restating the logic — that one is a thin adapter, not a mirror.