### PR TITLE
fix(cbo): an unreadable upload stranded the org mid-photos

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -49,6 +49,7 @@ import { getEncontroPreambleConfig, encontroForPhase } from '@/core/components/c
 import { E1Cards } from '@/core/components/cbo/E1Cards';
 import { RequestSupportDialog } from '@/core/components/cbo/RequestSupportDialog';
 import { NbsShowcaseCardStrip } from '@/core/components/cbo/NbsShowcaseCard';
+import { uploadNotice } from '@shared/cbo-upload-notices';
 import { NbsExamplesSheet } from '@/core/components/cbo/NbsExamplesSheet';
 import { familiesOfWorries } from '@shared/site-knowledge';
 import { NbsTypeStrip } from '@/core/components/cbo/NbsTypeStrip';
@@ -2664,9 +2665,7 @@ export default function CboProfilePage() {
                       // reported to the org as "could not parse", i.e. as if
                       // their document were corrupt.
                       if (!res.ok) {
-                        await sendMessage(
-                          `I tried to upload "${file.name}" and it was refused. ${data.reason ?? ''} ${data.fix ?? ''} Tell them this plainly and continue with the current question.`.replace(/\s+/g, ' ').trim(),
-                        );
+                        await sendMessage(uploadNotice.refused(file.name, data.reason, data.fix));
                         continue;
                       }
                       // Gap 4 — link a site photo to the chosen site (best-effort;
@@ -2685,15 +2684,13 @@ export default function CboProfilePage() {
                         // was not, and does not re-upload the same file hoping
                         // for a different result (Ksa Rosa did, twice, and then
                         // left the session).
-                        await sendMessage(
-                          `I uploaded "${file.name}". It is saved and the coordination team can open it, but the text could not be read automatically, so nothing was filled in from it. Acknowledge that it arrived and is on file, do NOT ask them to send it again, and continue with the current question.`,
-                        );
+                        await sendMessage(uploadNotice.storedUnread(file.name));
                       } else {
-                        await sendMessage(`I'm uploading: "${file.name}".\n\nParsed content:\n${(data.content || '').slice(0, 8000)}\n\nPlease extract info, auto-fill sections, and score maturity.`);
+                        await sendMessage(uploadNotice.parsed(file.name, (data.content || '').slice(0, 8000)));
                       }
                     } catch {
                       // Genuine transport failure — nothing reached the server.
-                      await sendMessage(`Uploaded "${file.name}" but it did not reach us. Ask them to try again.`);
+                      await sendMessage(uploadNotice.transport(file.name));
                     }
                   }
                   setUploadingName(null);

--- a/e2e/cbo-upload-notice-roundtrip.spec.ts
+++ b/e2e/cbo-upload-notice-roundtrip.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import {
+  uploadNotice,
+  classifyUploadNotice,
+  isUnreadableUploadNotice,
+  UPLOAD_NOTICE_SIGNATURE,
+} from '../shared/cbo-upload-notices';
+
+// ⚠️ UPLOAD-NOTICE-STRANDS-PHOTO-BEAT (JVP, 2026-08-21, w2-scenarios org 1).
+//
+// After a file is attached, the client posts a notice describing what happened
+// to it. The photo beat in cboAgent has to recognise the ones that carried no
+// readable text and answer them ITSELF — because any turn that reaches the model
+// replaces the pending composer, which takes the "Pronto, pode seguir" chip away.
+// The beat already documents that consequence for "Anexar mais".
+//
+// It happened for real: three unreadable photos, chip gone, `_photos_done` never
+// set, and Beat 4's read-back never ran. The conversation stopped moving and the
+// scenario timed out waiting for "média do bairro".
+//
+// The builders and the classifier now derive from the same constants, and these
+// tests pin that coupling — so rewording a notice cannot silently stop it being
+// recognised, which is the failure that is otherwise invisible until an org is
+// stuck mid-upload.
+
+test.describe('CBO upload notices — every notice the client sends is recognised', () => {
+  test('each builder round-trips to its own kind', () => {
+    expect(classifyUploadNotice(uploadNotice.refused('a.pdf', 'Too large.', 'Send under 10 MB.'))).toBe('refused');
+    expect(classifyUploadNotice(uploadNotice.storedUnread('foto.jpg'))).toBe('storedUnread');
+    expect(classifyUploadNotice(uploadNotice.transport('doc.docx'))).toBe('transport');
+    expect(classifyUploadNotice(uploadNotice.parsed('plano.pdf', 'conteúdo do documento'))).toBe('parsed');
+  });
+
+  test('the beat answers the unreadable ones and leaves parsed to the model', () => {
+    // These three must never reach the model — its turn eats the pending chip.
+    expect(isUnreadableUploadNotice(uploadNotice.refused('a.pdf'))).toBe(true);
+    expect(isUnreadableUploadNotice(uploadNotice.storedUnread('foto.jpg'))).toBe(true);
+    expect(isUnreadableUploadNotice(uploadNotice.transport('doc.docx'))).toBe(true);
+    // This one carries a document the model has to read and fill sections from.
+    expect(isUnreadableUploadNotice(uploadNotice.parsed('plano.pdf', 'texto'))).toBe(false);
+  });
+
+  test('an ordinary message is not mistaken for a notice', () => {
+    for (const text of [
+      'A gente trabalha na horta desde 2019.',
+      'Aqui é pior',
+      'Pronto, pode seguir',
+      '',
+    ]) {
+      expect(classifyUploadNotice(text), `"${text}" must not classify`).toBeNull();
+    }
+  });
+
+  test('a parsed document quoting another notice still classifies as parsed', () => {
+    // The document body is arbitrary text and could contain any wording; the
+    // parsed signature appears before it, which is why parsed is checked first.
+    const notice = uploadNotice.parsed(
+      'ata.pdf',
+      `A ata registra: ${UPLOAD_NOTICE_SIGNATURE.storedUnread}, segundo o relato.`,
+    );
+    expect(classifyUploadNotice(notice)).toBe('parsed');
+    expect(isUnreadableUploadNotice(notice)).toBe(false);
+  });
+
+  test('every signature really appears in the notice it identifies', () => {
+    // The coupling that makes the classifier trustworthy. If a builder is
+    // reworded without touching its signature, this is what catches it.
+    expect(uploadNotice.refused('x.pdf')).toContain(UPLOAD_NOTICE_SIGNATURE.refused);
+    expect(uploadNotice.storedUnread('x.jpg')).toContain(UPLOAD_NOTICE_SIGNATURE.storedUnread);
+    expect(uploadNotice.transport('x.docx')).toContain(UPLOAD_NOTICE_SIGNATURE.transport);
+    expect(uploadNotice.parsed('x.pdf', 'y')).toContain(UPLOAD_NOTICE_SIGNATURE.parsed);
+  });
+});

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -24,6 +24,7 @@ import {
 } from "./cboPersistence";
 import { db } from "../db";
 import { cohortMembers, type SupportRequest } from "@shared/cohort-schema";
+import { classifyUploadNotice, isUnreadableUploadNotice } from '@shared/cbo-upload-notices';
 import { resolveOpenMapParams } from "@shared/cbo-map-presets";
 import { rankFamiliasForSite, inferSiteTypeLabel } from "@shared/nbs-recommendation";
 import { rankFamiliasWithContext, rankerCanRun, type FamiliaRankingResult } from "./familiaRanker";
@@ -2438,6 +2439,42 @@ async function serveE2Checkpoint(
     }, pushEvent);
     say('Anotado — isso ajuda a montar as duplas no Encontro 3.', 'Noted — that helps shape the pairings in Encontro 3.');
     return await closeE2();
+  }
+
+  // ── An upload that produced no readable text ───────────────────────────────
+  // These arrive as FREE TEXT, so they must be handled before the chip-only
+  // guard below — which is exactly why they were falling through to the model.
+  //
+  // The photo beat already documents the consequence, for the "Anexar mais"
+  // case: "Left unhandled it would fall through to the model, whose turn
+  // replaces the pending composer — so the 'Pronto, pode seguir' chip would
+  // vanish and the org would be stranded mid-upload." Three unreadable photos
+  // did precisely that: the chip went away, `_photos_done` was never set, and
+  // Beat 4's read-back never ran (w2-scenarios org 1).
+  //
+  // `parsed` notices are deliberately NOT caught — those carry a document the
+  // model needs to read and fill sections from.
+  if (
+    val('_story_done') === 'yes' &&
+    val('_photos_done') !== 'yes' &&
+    isUnreadableUploadNotice(raw)
+  ) {
+    const kind = classifyUploadNotice(raw);
+    if (kind === 'transport') {
+      say('Esse arquivo não chegou aqui. Dá pra tentar de novo?',
+          "That file didn't reach us. Could you try again?");
+    } else if (kind === 'refused') {
+      say('Esse arquivo eu não consegui aceitar — mas segue, dá pra mandar outro.',
+          "I couldn't accept that file — but carry on, you can send another.");
+    } else {
+      say('Recebi. Não consegui ler o conteúdo automaticamente, mas o arquivo está guardado e a coordenação abre.',
+          "Got it. I couldn't read the contents automatically, but the file is stored and the coordination team can open it.");
+    }
+    ask('Quando terminar de anexar:', 'When you finish attaching:', [
+      { pt: E2C.prontoSeguir.pt, en: E2C.prontoSeguir.en },
+      { pt: 'Anexar mais', en: 'Attach more', dPt: 'Abre de novo', dEn: 'Opens it again', action: 'upload_then_answer' },
+    ]);
+    return finish('await-uploads');
   }
 
   // ── Chip taps ──────────────────────────────────────────────────────────────

--- a/shared/cbo-upload-notices.ts
+++ b/shared/cbo-upload-notices.ts
@@ -1,0 +1,87 @@
+// ============================================================================
+// UPLOAD NOTICES — the messages the client posts on the org's behalf after a file
+// ============================================================================
+// When someone attaches a file, the client posts a message into the conversation
+// describing what happened to it. Those strings used to live inline in
+// cbo-profile.tsx, and the agent had no way to recognise them.
+//
+// That mattered because of a rule the photo beat already documents for "Anexar
+// mais" (server/services/cboAgent.ts):
+//
+//     "Left unhandled it would fall through to the model, whose turn replaces
+//      the pending composer — so the 'Pronto, pode seguir' chip would vanish and
+//      the org would be stranded mid-upload."
+//
+// Exactly that happened to the upload notices themselves. An unreadable photo
+// produced a notice the beat did not know, the model answered instead, its turn
+// replaced the pending question, and the org lost the only chip that advances
+// the step. `_photos_done` was never set, so the read-back never came — three
+// photos in, the conversation simply stopped moving.
+//
+// So the wording lives here once, and the classifier is derived from the same
+// constants the builders use. A reworded notice cannot silently stop matching.
+// ============================================================================
+
+export type UploadNoticeKind = 'refused' | 'storedUnread' | 'transport' | 'parsed';
+
+/**
+ * Stable fragments used BOTH to build the notice and to recognise it. Keep each
+ * one inside its builder's output — the round-trip test in
+ * e2e/cbo-upload-notice-roundtrip.spec.ts fails if that stops being true.
+ */
+export const UPLOAD_NOTICE_SIGNATURE: Record<UploadNoticeKind, string> = {
+  refused: 'and it was refused',
+  storedUnread: 'It is saved and the coordination team can open it',
+  transport: 'but it did not reach us',
+  parsed: 'Parsed content:',
+};
+
+export const uploadNotice = {
+  /** Rejected before it was ever read — too large, or a type we do not take. */
+  refused: (filename: string, reason?: string, fix?: string): string =>
+    `I tried to upload "${filename}" ${UPLOAD_NOTICE_SIGNATURE.refused}. ${reason ?? ''} ${fix ?? ''} `
+      .replace(/\s+/g, ' ')
+      .trim() + ' Tell them this plainly and stay on the current question.',
+
+  /** Stored, retrievable by the coordination team, but not machine-readable. */
+  storedUnread: (filename: string): string =>
+    `I uploaded "${filename}". ${UPLOAD_NOTICE_SIGNATURE.storedUnread}, but the text could not be read ` +
+    `automatically, so nothing was filled in from it. Acknowledge that it arrived and is on file, ` +
+    `do NOT ask them to send it again, and stay on the current question.`,
+
+  /** Nothing reached the server at all. */
+  transport: (filename: string): string =>
+    `Uploaded "${filename}" ${UPLOAD_NOTICE_SIGNATURE.transport}. Ask them to try again.`,
+
+  /** The happy path: text came back and the model should extract from it. */
+  parsed: (filename: string, content: string): string =>
+    `I'm uploading: "${filename}".\n\n${UPLOAD_NOTICE_SIGNATURE.parsed}\n${content}\n\n` +
+    `Please extract info, auto-fill sections, and score maturity.`,
+};
+
+/**
+ * Which notice this is, or null if the text is an ordinary message.
+ *
+ * `parsed` is checked first: a successfully-read file can contain any text at
+ * all, including another notice's wording, and its own signature appears before
+ * the document body.
+ */
+export function classifyUploadNotice(text: string): UploadNoticeKind | null {
+  if (!text) return null;
+  if (text.includes(UPLOAD_NOTICE_SIGNATURE.parsed)) return 'parsed';
+  for (const kind of ['storedUnread', 'refused', 'transport'] as const) {
+    if (text.includes(UPLOAD_NOTICE_SIGNATURE[kind])) return kind;
+  }
+  return null;
+}
+
+/**
+ * True when the notice means "no text came out of this file".
+ *
+ * These are the ones the photo beat must answer itself. `parsed` is excluded on
+ * purpose — that one still goes to the model, which has a document to read.
+ */
+export function isUnreadableUploadNotice(text: string): boolean {
+  const kind = classifyUploadNotice(text);
+  return kind === 'storedUnread' || kind === 'refused' || kind === 'transport';
+}


### PR DESCRIPTION
`w2-scenarios` **org 1 (Raízes do Sarandi)** has been failing on `main` since `af0b1a4f` — *"an upload we cannot read is still an upload we keep"*. Bisected: all three scenarios pass at #471 and org 1 fails from that commit onward.

It's one of the three documented scenarios in `docs/w2-test-kit`, so it's also the rehearsal for a real session.

## What actually broke

That commit gave the client a new message to post when a file arrives but can't be read. The message is **free text** — and every free-text turn falls past the `turnKind !== 'chip'` guard in `serveE2Checkpoint`, straight to the model.

The photo beat already documents what that costs, in the branch immediately above:

> *"Left unhandled it would fall through to the model, whose turn replaces the pending composer — so the 'Pronto, pode seguir' chip would vanish and the org would be stranded mid-upload."*

Which is exactly what happened, three times over:

```
47 [user]      I uploaded "01-por-onde-a-agua-entra.jpg". It is saved …
48 [assistant] Entendi. Vamos continuar.
49 [composer]  {"kind":"ask_user","question":"Como deseja prosseguir?" …}
```

The generic model turn replaced the upload question. The chip was gone → `_photos_done` never set → Beat 4's read-back never ran. The spec times out waiting for `"média do bairro"`; **a real organisation would simply be stuck**, in a conversation that had quietly stopped moving.

This only bites when extraction fails. Locally that's every photo (dummy OpenAI key), which is why the suite caught it — and in production it's the exact case the original commit was written for.

## The fix

`shared/cbo-upload-notices.ts` gives the four notices one definition, with builders and a classifier derived from the same constants. The client posts them; the photo beat recognises them.

The beat now answers the three "no readable text came out" kinds itself, **before the chip-only guard**, and re-serves the same pending question — the treatment `"Anexar mais"` already gets. `parsed` is deliberately left alone: it carries a document the model needs to read and fill sections from.

**Why a shared module rather than a string match:** the strings were inline in `cbo-profile.tsx` and unknown to the server, so the two sides could drift with nothing to notice. Now a reworded notice that stops being recognised fails a test instead of stranding someone mid-upload.

## Verification

| | |
|---|---|
| org 1 alone | **17.0s pass** (was 48.7s fail) |
| all three scenarios | pass |
| full suite | **289 passed, 0 failed** |
| `tsc --noEmit` | 5 errors, same as main |

The transcript now runs: notice → *"Recebi. Não consegui ler o conteúdo automaticamente, mas o arquivo está guardado e a coordenação abre."* → the chip → "Pronto, pode seguir" → the read-back.

`e2e/cbo-upload-notice-roundtrip.spec.ts` pins the coupling: every builder round-trips to its own kind, ordinary messages don't classify, a parsed document quoting another notice still reads as parsed, and each signature genuinely appears in the notice it identifies.

Remaining intermittency is the known one — `cbo-familia-reco` times out at 20s under parallel load, in the LLM path that falls back to deterministic after a 401. Not this, and not new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWutNw34isJNf1eefXLDvU