### PR TITLE
feat(w3): the dossier and the verdict, derived rather than authored

### DIFF
--- a/e2e/w3-dossier.spec.ts
+++ b/e2e/w3-dossier.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test';
+import {
+  buildDossier,
+  computeVerdict,
+  gradeCapacity,
+  portfolioState,
+  type W3Input,
+} from '../shared/w3-dossier';
+
+// W3 DOSSIER — pinned against four real Workshop 2 records.
+//
+// Each of these is a state the engine actually produced (docs/w2-test-kit and
+// the golden path), not a hand-written fixture. They are here because they
+// break the dossier in four different places, and because the 27 August
+// decision — a two-way known-feasible / requires-study split — cannot express
+// three of the four.
+//
+// If a future change makes every organisation land in the same verdict, or
+// makes a thin record look like a scoped project, these fail.
+
+const SARANDI: W3Input = {
+  org: { contact_name: 'Dona Marlene', prior_project_scale: 'funded' },
+  site: {
+    bairro: 'Sarandi',
+    site_lat: '-30.0906',
+    site_lng: '-51.1726',
+    site_name: 'Pátio da EMEI Solar',
+    site_story: 'Quando chove forte a água entra pelo fundo.',
+    site_worry: 'alagamento',
+    current_use: 'vacant_lot',
+    land_tenure: 'public_land',
+    site_knowledge_depth: 'rich',
+  },
+  solutions: ['jardins-de-chuva'],
+  areaM2: 120,
+};
+
+const ENCOSTA_VIVA: W3Input = {
+  site: { bairro: 'Lomba do Pinheiro', site_worry: 'enxurrada', site_knowledge_depth: 'thin' },
+};
+
+const VILA_NOVA: W3Input = {
+  org: { contact_name: 'Rita' },
+  site: {
+    bairro: 'Vila São José',
+    _site_lat: '-30.077',
+    _site_lng: '-51.1625',
+    site_name: 'Ponto marcado (-30.0770, -51.1625)',
+    site_story: '(remeteram ao arquivo que já enviaram)',
+    site_worry: 'heat',
+    current_use: 'paved',
+    land_tenure: 'public-informal',
+    site_knowledge_depth: 'strong',
+  },
+  solutions: ['parques-e-florestas-urbanas'],
+  areaM2: 300,
+};
+
+const PARTENON: W3Input = {
+  org: { contact_name: '' },
+  site: {
+    bairro: 'Partenon',
+    _site_lat: '-30.0626',
+    _site_lng: '-51.1768',
+    site_name: 'Avenida Bento Gonçalves, 3915',
+    site_story:
+      'Na enchente de 2024 a água do Guaíba subiu e tomou tudo aqui, o dique não segurou. ' +
+      'Mas o que atrapalha todo mês não é isso. Quando chove forte a água desce da rua de cima.',
+    site_worry: 'flood', // legacy family id — the story says enxurrada
+    current_use: 'abandoned',
+    land_tenure: 'public-informal',
+    site_knowledge_depth: 'strong',
+    community_anchoring_lead: 'a associação',
+  },
+  solutions: ['jardins-de-chuva', 'hortas-urbanas'],
+  areaM2: 200,
+};
+
+test.describe('W3 dossier — four records, four verdicts', () => {
+  test('a technical unknown outranks everything else', () => {
+    const d = buildDossier(SARANDI);
+    expect(d.verdicts).toHaveLength(1);
+    expect(d.verdicts[0].state).toBe('needs_study');
+    // Traceable to the ficha, not to a judgement call.
+    expect(d.verdicts[0].source).toContain('quemPrecisaDizerSim');
+    expect(d.verdicts[0].unblockedBy).toMatch(/infiltra/i);
+  });
+
+  test('no site means no project, and the dossier says so rather than going thin', () => {
+    const d = buildDossier(ENCOSTA_VIVA);
+    expect(d.capacity.grade).toBe('exploratory');
+    expect(d.verdicts[0].state).toBe('needs_site');
+    // The disagreement is the reason to visit, not a missing field.
+    expect(d.items.some(i => i.list === 'investigate' && /enxurrada/.test(i.text))).toBe(true);
+    // And it names what it could not produce.
+    expect(d.gaps.join(' ')).toMatch(/área|area/i);
+  });
+
+  test('engineering-trivial can still be blocked, by paperwork', () => {
+    const d = buildDossier(VILA_NOVA);
+    expect(d.verdicts[0].state).toBe('needs_permission');
+    expect(d.verdicts[0].source).toContain('land_tenure');
+    // Paved surfaces earn their own investigation.
+    expect(d.items.some(i => /sob o piso|under the paving/i.test(i.text))).toBe(true);
+    // Heat decides the evidence, not flooding.
+    expect(d.items.some(i => i.list === 'gather' && /meio-dia|midday/i.test(i.text))).toBe(true);
+  });
+
+  test('one site can be two projects with different verdicts', () => {
+    const d = buildDossier(PARTENON);
+    expect(d.verdicts).toHaveLength(2);
+    const states = d.verdicts.map(v => v.state);
+    expect(states).toContain('needs_study');       // the stormwater side
+    expect(states).toContain('needs_permission');  // the garden, on informal land
+    expect(new Set(states).size).toBeGreaterThan(1);
+  });
+
+  test('the four records do not collapse into one verdict', () => {
+    const states = [SARANDI, ENCOSTA_VIVA, VILA_NOVA, PARTENON].map(r =>
+      portfolioState(buildDossier(r).verdicts),
+    );
+    expect(new Set(states).size).toBeGreaterThanOrEqual(3);
+    expect(states).toContain('needs_site');
+  });
+
+  test('a legacy family id is flagged rather than guessed at', () => {
+    // Partenon stores `flood`, which names the family and not the mechanism —
+    // and the mechanism decides both the evidence and the solution.
+    const d = buildDossier(PARTENON);
+    expect(d.gaps.some(g => /mecanismo|mechanism/i.test(g))).toBe(true);
+    // A resolved mechanism produces evidence instead of a gap.
+    const resolved = buildDossier({ ...PARTENON, site: { ...PARTENON.site, site_worry: 'enxurrada' } });
+    expect(resolved.items.some(i => i.list === 'gather' && /força|force/i.test(i.text))).toBe(true);
+    expect(resolved.gaps.some(g => /mecanismo|mechanism/i.test(g))).toBe(false);
+  });
+
+  test('capacity changes who owns the work, never what is offered', () => {
+    expect(gradeCapacity(SARANDI).grade).toBe('established');
+    expect(gradeCapacity(ENCOSTA_VIVA).grade).toBe('exploratory');
+    // An emerging org is not sent to chase a secretariat alone.
+    const emerging = buildDossier({ ...VILA_NOVA, org: {} });
+    expect(gradeCapacity({ ...VILA_NOVA, org: {} }).grade).toBe('emerging');
+    expect(emerging.items.filter(i => i.list === 'contact').every(i => i.owner === 'coordination')).toBe(true);
+    // …but the same solutions still produce the same verdict.
+    expect(emerging.verdicts[0].state).toBe(buildDossier(VILA_NOVA).verdicts[0].state);
+  });
+
+  test('the ficha does not know it is a school; the site record does', () => {
+    const d = buildDossier(SARANDI);
+    expect(d.items.some(i => i.list === 'contact' && /EMEI/.test(i.text))).toBe(true);
+    // And that item is owned by the org — it is the one body they can reach.
+    expect(d.items.find(i => /EMEI/.test(i.text))!.owner).toBe('org');
+  });
+
+  test('every item is traceable — nothing is authored', () => {
+    for (const rec of [SARANDI, VILA_NOVA, PARTENON]) {
+      for (const item of buildDossier(rec).items) {
+        expect(item.source, `"${item.text}" must cite where it came from`).toBeTruthy();
+        expect(item.source).toMatch(/ficha|intervention_site|site-knowledge|W3 stage/);
+      }
+    }
+  });
+
+  test('both languages produce the same structure', () => {
+    const pt = buildDossier(PARTENON, 'pt');
+    const en = buildDossier(PARTENON, 'en');
+    expect(en.items).toHaveLength(pt.items.length);
+    expect(en.verdicts.map(v => v.state)).toEqual(pt.verdicts.map(v => v.state));
+  });
+});

--- a/shared/cbo-field-catalog.ts
+++ b/shared/cbo-field-catalog.ts
@@ -374,8 +374,79 @@ const E2_HAZARDS: CboEnumOption[] = [
   { id: 'other', pt: 'Outra coisa', en: 'Something else' },
 ];
 
+// ── Encontro 3 · scoping a project ──────────────────────────────────────────
+// Stored as machine ids, like intervention_site and for the same reason: the
+// W3 checkpoint machine and shared/w3-dossier.ts both compare against ids, so a
+// label in construction_model would silently stop matching.
+
+const E3_CONSTRUCTION: CboEnumOption[] = [
+  { id: 'mutirao', pt: 'Mutirão', en: 'Community work party', aliases: ['nós mesmos', 'a gente faz'] },
+  { id: 'contratada', pt: 'Empresa contratada', en: 'Hired contractor' },
+  { id: 'parceria', pt: 'Parceria com universidade ou ONG', en: 'University or NGO partnership' },
+  { id: 'mista', pt: 'Mutirão com apoio técnico', en: 'Mutirão with technical support' },
+  { id: 'indefinido', pt: 'Ainda não sabemos', en: 'Not decided yet' },
+];
+
+const E3_SCALE: CboEnumOption[] = [
+  { id: 'pequeno', pt: 'Pequeno', en: 'Small' },
+  { id: 'medio', pt: 'Médio', en: 'Medium' },
+  { id: 'grande', pt: 'Grande', en: 'Large' },
+];
+
+const E3_TIMEFRAME: CboEnumOption[] = [
+  { id: '6-meses', pt: '6 meses', en: '6 months' },
+  { id: '1-ano', pt: '1 ano', en: '1 year' },
+  { id: '2-anos', pt: '2 anos', en: '2 years' },
+  { id: 'faseado', pt: 'Por etapas', en: 'Phased' },
+];
+
+const E3_MONITORING: CboEnumOption[] = [
+  { id: 'nos', pt: 'A gente mesmo', en: 'Us' },
+  { id: 'parceiro', pt: 'Com uma universidade ou parceiro', en: 'With a university or partner' },
+  // Not a dead end. It is a request for a monitoring partner, and the dossier
+  // reads it as one.
+  { id: 'ninguem-ainda', pt: 'Ninguém ainda', en: 'Nobody yet' },
+];
+
+const E3_MAINTAINS: CboEnumOption[] = [
+  { id: 'nos', pt: 'A gente mesmo', en: 'Us' },
+  { id: 'voluntarios', pt: 'Voluntários da comunidade', en: 'Community volunteers' },
+  { id: 'parceria-prefeitura', pt: 'Parceria com a prefeitura', en: 'City partnership' },
+  { id: 'contratada', pt: 'Empresa contratada', en: 'Hired contractor' },
+  { id: 'indefinido', pt: 'Ainda não sabemos', en: 'Not decided yet' },
+];
+
+const E3_FREQUENCY: CboEnumOption[] = [
+  { id: 'mensal', pt: 'Todo mês', en: 'Monthly' },
+  { id: 'trimestral', pt: 'A cada três meses', en: 'Quarterly' },
+  { id: 'semestral', pt: 'Duas vezes por ano', en: 'Twice a year' },
+  { id: 'anual', pt: 'Uma vez por ano', en: 'Yearly' },
+  { id: 'indefinido', pt: 'Ainda não sabemos', en: 'Not decided yet' },
+];
+
+const E3_SUSTAINABILITY: CboEnumOption[] = [
+  { id: 'recursos-proprios', pt: 'Recursos próprios', en: 'Our own resources' },
+  { id: 'edital', pt: 'Editais e projetos', en: 'Grants and calls' },
+  { id: 'parceria-publica', pt: 'Parceria pública', en: 'Public partnership' },
+  { id: 'doacoes', pt: 'Doações e apoio local', en: 'Donations and local support' },
+  { id: 'indefinido', pt: 'Ainda não sabemos', en: 'Not decided yet' },
+];
+
 /** Enum tables per section+field, for every section past org_profile. */
 export const SECTION_ENUMS: Record<string, Record<string, CboEnumOption[]>> = {
+  intervention_type: {
+    construction_model: E3_CONSTRUCTION,
+    intervention_scale_band: E3_SCALE,
+  },
+  impact_monitoring: {
+    project_timeframe: E3_TIMEFRAME,
+    monitoring_capacity: E3_MONITORING,
+  },
+  operations_sustain: {
+    who_maintains: E3_MAINTAINS,
+    maintenance_frequency: E3_FREQUENCY,
+    sustainability_model: E3_SUSTAINABILITY,
+  },
   intervention_site: {
     current_use: E2_CURRENT_USE,
     land_tenure: E2_TENURE,

--- a/shared/cbo-questionnaire.ts
+++ b/shared/cbo-questionnaire.ts
@@ -25,12 +25,23 @@
 // values in rules are stable option IDS from ORG_PROFILE_ENUMS, never labels,
 // so label copy edits and language never break a rule.
 
-import { ORG_PROFILE_ENUMS, resolveOrgProfileOptionId } from './cbo-field-catalog';
+import { ORG_PROFILE_ENUMS, cboFieldEnumOptions, resolveOrgProfileOptionId } from './cbo-field-catalog';
 
 /** The option list for `field` is a function of an earlier answer:
  *  allow[<dependency option id>] = the option ids offerable for `field`. */
 export interface OptionRule {
   dependsOn: string;
+  /**
+   * Section the dependency lives in, when it is not this manifest's own.
+   *
+   * Real dependencies cross workshops: what an organisation may do in W3
+   * depends on what it answered in W2. `who_maintains` (operations_sustain)
+   * turns on `land_tenure` (intervention_site) — a city maintenance partnership
+   * is only on the table for land the city owns. Without this the validator
+   * looked the dependency up in the wrong section, found no ids, and threw at
+   * module load.
+   */
+  dependsOnSection?: string;
   allow: Record<string, string[]>;
 }
 
@@ -52,6 +63,8 @@ export interface AskCopy {
   /** Wording that depends on an earlier answer, keyed by that answer's id. */
   variants?: {
     dependsOn: string;
+    /** Section the dependency lives in, when it is not this manifest's own. */
+    dependsOnSection?: string;
     by: Record<string, { pt: string; en: string }>;
   };
 }
@@ -62,7 +75,8 @@ export interface AskCopy {
 export interface RequiredEntry {
   field: string;
   orField?: string;
-  requiredIf?: { field: string; isAnyOf?: string[]; isNoneOf?: string[] };
+  /** `section` names where the dependency lives when it is not this manifest's. */
+  requiredIf?: { field: string; section?: string; isAnyOf?: string[]; isNoneOf?: string[] };
 }
 
 export interface QuestionnaireManifest {
@@ -154,17 +168,81 @@ export const E1_QUESTIONNAIRE: QuestionnaireManifest = {
 
 /** Manifests by the phase they close. E2+ get entries as their skills gain
  *  enforceable structure. */
+
+/**
+ * Encontro 3 — scoping one solution onto one site.
+ *
+ * Deliberately short. W3's job is a defensible project, and three answers are
+ * what make a project defensible in words: why this solution here, what the
+ * place is like before anything is built, and who looks after it afterwards.
+ * Everything else W3 captures — the footprint, the cost band, the timeframe —
+ * either falls out of a drawing or is allowed to stay open.
+ *
+ * That is not laxity. `shared/w3-dossier.ts` reports every unanswered thing as
+ * a named gap rather than a blank, and an honest "ainda não sabemos" on money
+ * is the single most useful answer in the session: it is the gap the portfolio
+ * carries to the municipality. Requiring it to close would turn it into a
+ * guess.
+ */
+export const E3_QUESTIONNAIRE: QuestionnaireManifest = {
+  workshop: 'e3',
+  phase: 3,
+  sectionId: 'operations_sustain',
+  optionRules: {
+    // Straight out of the rain-garden ficha: "quem cuida é a associação de
+    // moradores ou a prefeitura, dependendo de quem é o dono do terreno." On
+    // land the organisation owns, a city maintenance partnership is not on the
+    // table — offering it invites an agreement nobody can sign.
+    who_maintains: {
+      dependsOn: 'land_tenure',
+      dependsOnSection: 'intervention_site',
+      allow: {
+        'private-owned': ['nos', 'voluntarios', 'contratada', 'indefinido'],
+        'formal-agreement': ['nos', 'voluntarios', 'contratada', 'indefinido'],
+        'public-informal': ['nos', 'voluntarios', 'parceria-prefeitura', 'indefinido'],
+        'public-no-access': ['nos', 'voluntarios', 'indefinido'],
+        'mixed': ['nos', 'voluntarios', 'parceria-prefeitura', 'contratada', 'indefinido'],
+      },
+    },
+  },
+  ask: {
+    who_maintains: {
+      pt: 'Depois que o mutirão vai embora, quem cuida disso no dia a dia?',
+      en: 'After the mutirão goes home, who looks after this day to day?',
+    },
+    baseline_condition: {
+      pt: 'Antes de qualquer obra: como é o lugar hoje? Isso é o que vai mostrar depois que mudou alguma coisa.',
+      en: 'Before any work: what is the place like today? This is what will show that anything changed.',
+    },
+  },
+  requiredToClose: ['justification_why_here', 'baseline_condition', 'who_maintains'],
+};
+
 export const QUESTIONNAIRES: Record<number, QuestionnaireManifest> = {
   1: E1_QUESTIONNAIRE,
+  3: E3_QUESTIONNAIRE,
 };
 
 /** Raw stored value of a field, or undefined — the caller adapts its state shape. */
 export type FieldReader = (field: string) => string | undefined;
 
-function storedId(read: FieldReader, field: string): string | null {
+/** Resolve a stored value (id, label or alias) to its option id, in any section. */
+function optionIdIn(sectionId: string, field: string, raw: string): string | null {
+  if (sectionId === 'org_profile') return resolveOrgProfileOptionId(field, raw);
+  const opts = cboFieldEnumOptions(sectionId, field);
+  if (!opts) return raw.trim() || null; // free text stands for itself
+  const norm = (v: string) => v.trim().toLowerCase();
+  const n = norm(raw);
+  const hit = opts.find(
+    o => norm(o.id) === n || norm(o.pt) === n || norm(o.en) === n || (o.aliases ?? []).some(a => norm(a) === n),
+  );
+  return hit ? hit.id : null;
+}
+
+function storedId(read: FieldReader, field: string, sectionId: string): string | null {
   const raw = read(field);
   if (raw == null || String(raw).trim() === '') return null;
-  return resolveOrgProfileOptionId(field, String(raw));
+  return optionIdIn(sectionId, field, String(raw));
 }
 
 /** The option ids currently offerable for `field`, or null when unconstrained
@@ -176,7 +254,7 @@ export function allowedOptionIds(
 ): string[] | null {
   const rule = manifest.optionRules[field];
   if (!rule) return null;
-  const dep = storedId(read, rule.dependsOn);
+  const dep = storedId(read, rule.dependsOn, rule.dependsOnSection ?? manifest.sectionId);
   if (!dep) return null;
   return rule.allow[dep] ?? null;
 }
@@ -191,7 +269,7 @@ export function checkOptionRule(
 ): { ok: true } | { ok: false; dependsOn: string; allowedIds: string[] } {
   const allowed = allowedOptionIds(manifest, field, read);
   if (!allowed) return { ok: true };
-  const id = resolveOrgProfileOptionId(field, value);
+  const id = optionIdIn(manifest.sectionId, field, value);
   // Unresolvable values are someone else's problem (the canonicalization /
   // off-list rules) — this rule only rejects a KNOWN option that the
   // dependency answer excludes.
@@ -242,7 +320,7 @@ export function missingRequiredForClose(
   for (const entry of manifest.requiredToClose) {
     const req: RequiredEntry = typeof entry === 'string' ? { field: entry } : entry;
     if (req.requiredIf) {
-      const dep = storedId(read, req.requiredIf.field);
+      const dep = storedId(read, req.requiredIf.field, req.requiredIf.section ?? manifest.sectionId);
       if (!dep) continue; // dependency itself unanswered → reported on its own line
       if (req.requiredIf.isAnyOf && !req.requiredIf.isAnyOf.includes(dep)) continue;
       if (req.requiredIf.isNoneOf && req.requiredIf.isNoneOf.includes(dep)) continue;
@@ -256,10 +334,15 @@ export function missingRequiredForClose(
 
 // Sanity: every id referenced by a rule must exist in the catalog — a typo'd
 // id would silently never match. Fails fast at module load in dev/tests.
+// Resolve through the section the manifest actually gates. The first version
+// of this read ORG_PROFILE_ENUMS directly, which made the header's promise —
+// "E2–E6 opt in by adding a manifest, no new code" — untrue in practice: any
+// manifest for another section found zero ids and threw at module load.
 for (const m of Object.values(QUESTIONNAIRES)) {
   for (const [field, rule] of Object.entries(m.optionRules)) {
-    const ids = new Set((ORG_PROFILE_ENUMS[field] ?? []).map(o => o.id));
-    const depIds = new Set((ORG_PROFILE_ENUMS[rule.dependsOn] ?? []).map(o => o.id));
+    const ids = new Set((cboFieldEnumOptions(m.sectionId, field) ?? []).map(o => o.id));
+    const depSection = rule.dependsOnSection ?? m.sectionId;
+    const depIds = new Set((cboFieldEnumOptions(depSection, rule.dependsOn) ?? []).map(o => o.id));
     for (const [dep, allowed] of Object.entries(rule.allow)) {
       if (!depIds.has(dep)) throw new Error(`cbo-questionnaire: ${m.workshop}.${field} rule keys unknown ${rule.dependsOn} id "${dep}"`);
       for (const id of allowed) {
@@ -285,7 +368,7 @@ export function askCopyFor(
   if (!entry) return null;
   const v = entry.variants;
   if (v) {
-    const dep = storedId(read, v.dependsOn);
+    const dep = storedId(read, v.dependsOn, v.dependsOnSection ?? manifest.sectionId);
     if (dep && v.by[dep]) return v.by[dep][lang];
   }
   return entry[lang];

--- a/shared/w3-dossier.ts
+++ b/shared/w3-dossier.ts
@@ -1,0 +1,491 @@
+// ============================================================================
+// W3 DOSSIER — the four lists and the verdict, derived rather than authored
+// ============================================================================
+// Encontro 3 turns a chosen site into a scoped project. Everything it hands
+// back is computed here, from answers the organisation already gave and from
+// facts the repo already holds — the 55 solution fichas name who must approve
+// each solution, what it needs before it can be designed, how it is maintained
+// and how it fails.
+//
+// Nothing in this file calls a model. That is the point: a coordinator can
+// audit "why is this project marked as needing a study" all the way back to a
+// line in a ficha, and the same input always produces the same dossier. It also
+// means the whole of W3's judgement is unit-testable against real W2 records,
+// which is how the four scenarios in the 10 September review were produced.
+//
+// ── The verdict is a property of a SOLUTION ON A SITE ────────────────────────
+// The 27 August meeting agreed a two-way split: known-feasible vs
+// requires-expert-study. Running four real W2 records through it broke that in
+// two places.
+//
+// Only one of the four was blocked by a technical unknown. One had never chosen
+// a place; one was engineering-trivial and blocked entirely by the fact that
+// nobody had ever written down that the organisation may use the land; and one
+// was two projects wearing a single name — a community garden that could take
+// money now, beside a stormwater intervention that cannot be sized without a
+// study. A single verdict per organisation has to round that to one or the
+// other, and both roundings are wrong.
+//
+// So: four states, computed per solution.
+// ============================================================================
+
+import { getSolutionFicha } from './nbs-solution-fichas';
+import { SOLUTION_MECHANISMS } from './nbs-catalog';
+import type { WorryId } from './site-knowledge';
+
+// ── Capacity ────────────────────────────────────────────────────────────────
+
+/**
+ * How much project an organisation can carry out of W3.
+ *
+ * This is NOT a ranking of organisations, and it never gates what they are
+ * offered — every solution stays reachable for everyone ("nada fica
+ * descartado"). It decides two narrower things: who the dossier proposes as the
+ * owner of each item, and what W3 can honestly claim to have produced.
+ *
+ * An `exploratory` organisation leaves with a site visit to arrange, not a
+ * project with a hole in it. Saying so is more use to them, and to the
+ * portfolio, than a thin dossier that looks like a scoped project.
+ */
+export type CapacityGrade = 'exploratory' | 'emerging' | 'established';
+
+export interface CapacityRead {
+  grade: CapacityGrade;
+  /** Plain reasons, for the coordinator drawer and the org's own document. */
+  because: string[];
+  /** What W3 cannot produce for them, named rather than left blank. */
+  cannotYet: string[];
+}
+
+export interface W3Input {
+  /** intervention_site fields, machine ids as stored. */
+  site: Record<string, string | undefined>;
+  /** org_profile fields. */
+  org?: Record<string, string | undefined>;
+  /** Solutions chosen in W3 (catalog ids). Empty before stage 2. */
+  solutions?: string[];
+  /** Footprint drawn in stage 3, if any. */
+  areaM2?: number;
+  /** Stage 3–5 answers, once given. */
+  w3?: Record<string, string | undefined>;
+}
+
+const has = (v: string | undefined | null): v is string =>
+  typeof v === 'string' && v.trim() !== '' && v.trim().toLowerCase() !== 'null';
+
+/** A site is only a site once we can put a footprint on it. */
+export function hasSite(site: Record<string, string | undefined>): boolean {
+  return has(site.site_lat ?? site._site_lat) && has(site.site_lng ?? site._site_lng);
+}
+
+export function gradeCapacity(input: W3Input): CapacityRead {
+  const { site, org = {} } = input;
+  const because: string[] = [];
+  const cannotYet: string[] = [];
+
+  const sited = hasSite(site);
+  const depth = site.site_knowledge_depth ?? 'thin';
+  const richDepth = depth === 'strong' || depth === 'rich';
+  const hasStory = has(site.site_story);
+  const tenureKnown = has(site.land_tenure);
+  const funded = org.prior_project_scale === 'funded';
+  const named = has(org.contact_name) || has(site.community_anchoring_lead);
+
+  if (!sited) {
+    because.push('no place marked yet');
+    cannotYet.push('a footprint, so no area, no cost band and no approval route');
+    return { grade: 'exploratory', because, cannotYet };
+  }
+
+  if (richDepth) because.push(`site described in their own words (${depth})`);
+  if (hasStory) because.push('an account of the place, not just a pin');
+  if (funded) because.push('has run a financed project before');
+  if (named) because.push('a named person who carries it');
+
+  if (!tenureKnown) cannotYet.push('the approval route — land tenure is unanswered');
+  if (!hasStory) cannotYet.push('a mechanism read, so the baseline evidence stays generic');
+
+  // Established needs both the site knowledge AND someone who has done this
+  // before or is clearly accountable — one alone is not enough to hand over a
+  // dossier and expect it worked through unaided.
+  const grade: CapacityGrade = richDepth && (funded || named) ? 'established' : 'emerging';
+  return { grade, because, cannotYet };
+}
+
+// ── Verdict ─────────────────────────────────────────────────────────────────
+
+export type VerdictState = 'ready' | 'needs_study' | 'needs_permission' | 'needs_site';
+
+export interface Verdict {
+  solutionId: string | null;
+  state: VerdictState;
+  /** One sentence, for the org. */
+  why: string;
+  /** The single thing that would move it on. */
+  unblockedBy: string;
+  /** Where the judgement came from, so a coordinator can check it. */
+  source: string;
+}
+
+/**
+ * Phrases in a ficha's `quemPrecisaDizerSim` that mean "this cannot be designed
+ * from community knowledge alone".
+ *
+ * Matched against the ficha prose rather than a separate flag because the
+ * fichas already say it, in the words Robson reviewed — a parallel boolean
+ * would be a second source of truth that drifts. The rain garden entry, for
+ * example, states that the layer design and the soil infiltration test need a
+ * técnico, "porque um jardim de chuva mal calculado não drena".
+ */
+const STUDY_MARKERS: { re: RegExp; pt: string; en: string }[] = [
+  { re: /teste de infiltraç/i, pt: 'um teste de infiltração do solo', en: 'a soil infiltration test' },
+  { re: /estudo geot[eé]cnic/i, pt: 'um estudo geotécnico', en: 'a geotechnical study' },
+  { re: /estudo hidrol[oó]gic/i, pt: 'um estudo hidrológico', en: 'a hydrological study' },
+  { re: /precisa de um t[eé]cnic|precisa de t[eé]cnic/i, pt: 'um técnico para o desenho', en: 'a technician for the design' },
+  { re: /projeto de engenharia|laudo/i, pt: 'um laudo técnico', en: 'a technical report' },
+];
+
+// Catalog ids are in shared/cbo-field-catalog.ts · E2_TENURE. The extra
+// spellings are legacy: sessions that predate the catalog stored `public_land`,
+// and those rows are still in the database — including the test-kit records
+// these rules are pinned against. Dropping them silently would make an
+// organisation on public land look like one with no tenure answer at all.
+/** Tenure where the right to build is not yet written down anywhere. */
+const INFORMAL_TENURE = new Set(['public-informal', 'public-no-access', 'informal', 'none', 'no-access']);
+/** Tenure where the approval is municipal rather than a landlord's. */
+const PUBLIC_TENURE = new Set([
+  'public-informal', 'public-no-access',
+  'public_land', 'public-land', 'public', // legacy
+]);
+
+function studyMarkerIn(prose: string): { pt: string; en: string } | null {
+  for (const m of STUDY_MARKERS) if (m.re.test(prose)) return { pt: m.pt, en: m.en };
+  return null;
+}
+
+export function computeVerdict(
+  solutionId: string | null,
+  input: W3Input,
+  lang: 'pt' | 'en' = 'pt',
+): Verdict {
+  const pt = lang === 'pt';
+  const { site } = input;
+
+  if (!hasSite(site)) {
+    return {
+      solutionId,
+      state: 'needs_site',
+      why: pt
+        ? 'Ainda não dá para dimensionar nem orçar: falta marcar o lugar.'
+        : 'Nothing can be sized or costed yet — no place has been marked.',
+      unblockedBy: pt ? 'marcar um lugar, mesmo que aproximado' : 'marking a place, even roughly',
+      source: 'intervention_site · no coordinates',
+    };
+  }
+
+  const ficha = solutionId ? getSolutionFicha(solutionId) : undefined;
+  const prose = ficha ? `${ficha.pt.quemPrecisaDizerSim} ${ficha.pt.comoFunciona}` : '';
+  const marker = prose ? studyMarkerIn(prose) : null;
+
+  // A technical unknown outranks a paperwork one: a permission for something
+  // that cannot yet be designed would be asking for the wrong thing.
+  if (marker) {
+    return {
+      solutionId,
+      state: 'needs_study',
+      why: pt
+        ? `Dá para construir, mas o desenho não se resolve só com o que a comunidade sabe — precisa de ${marker.pt}.`
+        : `It can be built, but the design cannot be settled from community knowledge alone — it needs ${marker.en}.`,
+      unblockedBy: pt ? marker.pt : marker.en,
+      source: `ficha ${solutionId} · quemPrecisaDizerSim`,
+    };
+  }
+
+  const tenure = site.land_tenure ?? '';
+  if (INFORMAL_TENURE.has(tenure)) {
+    return {
+      solutionId,
+      state: 'needs_permission',
+      why: pt
+        ? 'Tecnicamente dá para fazer. O que falta é alguém registrar por escrito que vocês podem usar o terreno.'
+        : 'Technically this can be done. What is missing is a written record that you may use the land.',
+      unblockedBy: pt ? 'uma autorização por escrito' : 'a written permission',
+      source: `intervention_site · land_tenure = ${tenure}`,
+    };
+  }
+
+  return {
+    solutionId,
+    state: 'ready',
+    why: pt
+      ? 'Nada trava daqui: o desenho cabe no que vocês já sabem e o terreno está resolvido.'
+      : 'Nothing blocks this: the design fits what you already know and the land is settled.',
+    unblockedBy: pt ? 'nada — pode ser orçado' : 'nothing — it can be quoted',
+    source: ficha ? `ficha ${solutionId}` : 'intervention_site',
+  };
+}
+
+// ── The four lists ──────────────────────────────────────────────────────────
+
+export type DossierList = 'investigate' | 'contact' | 'gather' | 'document';
+
+export interface DossierItem {
+  list: DossierList;
+  text: string;
+  /** Traceable origin — a ficha line, a stored field, a hazard rule. */
+  source: string;
+  /** Proposed owner. The organisation can always override it. */
+  owner: 'org' | 'coordination';
+  /** Set when this item cannot start until another is answered. */
+  blockedBy?: string;
+}
+
+export interface Dossier {
+  capacity: CapacityRead;
+  verdicts: Verdict[];
+  items: DossierItem[];
+  /** Items W3 could not generate, and the answer that would unlock each. */
+  gaps: string[];
+}
+
+/** The physical question each mechanism asks, for the baseline evidence. */
+const MECHANISM_EVIDENCE: Partial<Record<WorryId | string, { pt: string; en: string }>> = {
+  alagamento: {
+    pt: 'Fotografar onde a água junta e anotar quantos dias ela demora a ir embora',
+    en: 'Photograph where the water pools and record how many days it takes to drain',
+  },
+  inundacao: {
+    pt: 'Registrar até onde a água chegou — uma marca de nível, com data',
+    en: 'Record how high the water reached — a high-water mark, dated',
+  },
+  enxurrada: {
+    pt: 'Registrar por onde a água entra e com que força ela desce',
+    en: 'Record where the water enters and how fast it comes down',
+  },
+  heat: {
+    pt: 'Fotografar o espaço ao meio-dia, a sombra que existe e o piso',
+    en: 'Photograph the space at midday, whatever shade exists, and the surface',
+  },
+  landslide: {
+    pt: 'Fotografar a face do barranco, o que está acima e o que está abaixo',
+    en: 'Photograph the face of the slope, what is above it and what is below',
+  },
+};
+
+export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier {
+  const pt = lang === 'pt';
+  const { site, w3 = {} } = input;
+  const solutions = input.solutions ?? [];
+  const capacity = gradeCapacity(input);
+  const items: DossierItem[] = [];
+  const gaps: string[] = [];
+  const add = (i: DossierItem) => items.push(i);
+
+  const verdicts: Verdict[] = solutions.length
+    ? solutions.map(s => computeVerdict(s, input, lang))
+    : [computeVerdict(null, input, lang)];
+
+  // ── No site: the dossier is short on purpose, and says why ────────────────
+  if (!hasSite(site)) {
+    add({
+      list: 'gather',
+      text: pt
+        ? 'Marcar um lugar no mapa, mesmo que aproximado — tudo o mais depende disso'
+        : 'Mark a place on the map, even roughly — everything else depends on it',
+      source: 'intervention_site · no coordinates',
+      owner: 'org',
+    });
+    const worry = site.site_worry;
+    if (has(worry)) {
+      add({
+        list: 'investigate',
+        text: pt
+          ? `Confirmar no lugar se o problema é mesmo ${worry} — a palavra de vocês decide a solução, não o nosso mapa`
+          : `Confirm on site whether the problem really is ${worry} — your word decides the solution, not our map`,
+        source: `intervention_site · site_worry = ${worry}`,
+        owner: 'coordination',
+      });
+    }
+    gaps.push(
+      pt
+        ? 'Sem lugar marcado não há área, custo, aprovação nem manutenção a calcular'
+        : 'With no place marked there is no area, cost, approval or maintenance to compute',
+    );
+    return { capacity, verdicts, items, gaps };
+  }
+
+  // ── Per solution, from its ficha ──────────────────────────────────────────
+  for (const id of solutions) {
+    const ficha = getSolutionFicha(id);
+    if (!ficha) continue;
+    const approve = ficha.pt.quemPrecisaDizerSim;
+    const upkeep = ficha.pt.quemCuidaDepois;
+
+    const marker = studyMarkerIn(`${approve} ${ficha.pt.comoFunciona}`);
+    if (marker) {
+      add({
+        list: 'investigate',
+        text: pt ? `Providenciar ${marker.pt}` : `Arrange ${marker.en}`,
+        source: `ficha ${id} · quemPrecisaDizerSim`,
+        owner: 'org',
+      });
+    }
+
+    // Approving bodies, read out of the ficha's own prose.
+    for (const [re, body] of [
+      [/SMAMUS/i, 'SMAMUS'],
+      [/DMAE/i, 'DMAE'],
+      [/prefeitura/i, pt ? 'a prefeitura' : 'the city'],
+    ] as [RegExp, string][]) {
+      if (re.test(approve) && !items.some(i => i.text.includes(body))) {
+        const conditional = /se .{0,40}(rede|drenagem)/i.test(approve) && /DMAE/i.test(body);
+        add({
+          list: 'contact',
+          text: pt ? `Falar com ${body}` : `Approach ${body}`,
+          source: `ficha ${id} · quemPrecisaDizerSim`,
+          owner: 'coordination',
+          ...(conditional
+            ? {
+                blockedBy: pt
+                  ? 'confirmar antes se a solução se liga à rede pública de drenagem'
+                  : 'first confirming whether it connects to the public drainage network',
+              }
+            : {}),
+        });
+      }
+    }
+
+    if (/entope|colmata|troca(r)? as camadas|filtrant/i.test(upkeep)) {
+      add({
+        list: 'investigate',
+        text: pt
+          ? 'Definir quem paga a limpeza ou troca das camadas filtrantes quando elas entopem'
+          : 'Settle who pays to clean or replace the filter layers when they clog',
+        source: `ficha ${id} · quemCuidaDepois`,
+        owner: 'org',
+      });
+    }
+
+    add({
+      list: 'document',
+      text: pt
+        ? `Acordo de manutenção — quem cuida de ${id.replace(/-/g, ' ')} depois do mutirão`
+        : `Maintenance agreement — who looks after ${id.replace(/-/g, ' ')} after the mutirão`,
+      source: `ficha ${id} · quemCuidaDepois × land_tenure`,
+      owner: PUBLIC_TENURE.has(site.land_tenure ?? '') ? 'coordination' : 'org',
+    });
+  }
+
+  if (!solutions.length) {
+    gaps.push(
+      pt
+        ? 'Nenhuma solução escolhida ainda — as aprovações e os estudos saem da ficha da solução'
+        : 'No solution chosen yet — approvals and studies come from the solution ficha',
+    );
+  }
+
+  // ── Land, and who has to say yes to it ────────────────────────────────────
+  const tenure = site.land_tenure ?? '';
+  if (INFORMAL_TENURE.has(tenure)) {
+    add({
+      list: 'contact',
+      text: pt
+        ? 'Encontrar quem pode transformar "sempre usamos" em uma autorização escrita'
+        : 'Find who can turn "we have always used it" into a written permission',
+      source: `intervention_site · land_tenure = ${tenure}`,
+      owner: 'coordination',
+    });
+  }
+  // The ficha routes by land type; it does not know an institution sits on it.
+  if (PUBLIC_TENURE.has(tenure) && /escola|emei|emef|creche|posto|ubs/i.test(site.site_name ?? '')) {
+    add({
+      list: 'contact',
+      text: pt
+        ? `Falar com a direção de ${site.site_name} e a secretaria responsável — é terreno público com uma instituição em cima`
+        : `Approach the ${site.site_name} management and its secretariat — public land with an institution on it`,
+      source: 'intervention_site · site_name × land_tenure',
+      owner: 'org',
+    });
+  }
+
+  // ── What to measure, decided by the mechanism ─────────────────────────────
+  const worry = site.site_worry ?? '';
+  const evidence = MECHANISM_EVIDENCE[worry];
+  if (evidence) {
+    add({ list: 'gather', text: pt ? evidence.pt : evidence.en, source: 'site-knowledge · WORRY_SUBTYPES', owner: 'org' });
+  } else if (has(worry)) {
+    // A legacy family id ('flood') names the family but not the mechanism, and
+    // the mechanism is what decides the evidence AND the solution. Resolve it
+    // rather than guessing — Partenon's story says enxurrada while the stored
+    // worry says flood.
+    gaps.push(
+      pt
+        ? `A preocupação está registrada como "${worry}", que é a família e não o mecanismo — perguntar se é alagamento, inundação ou enxurrada antes de escolher a evidência`
+        : `The worry is stored as "${worry}", the family rather than the mechanism — ask whether it is ponding, river flooding or flash flooding before choosing the evidence`,
+    );
+  }
+
+  add({
+    list: 'document',
+    text: pt
+      ? 'Registro de linha de base — uma página, com data e foto, antes de qualquer obra'
+      : 'Baseline record — one page, dated and photographed, before any work',
+    source: 'W3 stage 4 · baseline_condition',
+    owner: 'org',
+  });
+
+  // ── Site preparation, from what the place is today ────────────────────────
+  if (site.current_use === 'paved') {
+    add({
+      list: 'investigate',
+      text: pt
+        ? 'Descobrir o que existe sob o piso antes de despavimentar, e de quem é o que passa por baixo'
+        : 'Find out what lies under the paving before de-paving it, and who owns what runs beneath',
+      source: 'intervention_site · current_use = paved',
+      owner: 'org',
+    });
+  }
+
+  // ── Money ─────────────────────────────────────────────────────────────────
+  if (input.areaM2) {
+    add({
+      list: 'document',
+      text: pt
+        ? `Orçamento para ${input.areaM2} m², para ser substituído por uma cotação real`
+        : `Budget for ${input.areaM2} m², to be replaced by a real quote`,
+      source: 'W3 stage 3 · intervention_area_m2 × ficha cost band',
+      owner: 'org',
+    });
+  } else {
+    gaps.push(pt ? 'Sem área desenhada não há faixa de custo' : 'Without a drawn footprint there is no cost band');
+  }
+
+  // An honest "not yet" is the most useful answer in the session: it is the gap
+  // the portfolio carries to the municipality. Never treat it as incomplete.
+  if (w3.sustainability_model === 'indefinido' || w3.opex_estimate_year1 === 'unknown') {
+    add({
+      list: 'contact',
+      text: pt
+        ? 'Dinheiro recorrente ficou em aberto — isso é uma conversa que a coordenação precisa abrir, não um campo vazio'
+        : 'Recurring money is open — that is a conversation for the coordination team to open, not an empty field',
+      source: 'W3 stage 5 · sustainability_model',
+      owner: 'coordination',
+    });
+  }
+
+  // Exploratory and emerging organisations should not be handed a list that
+  // assumes they can chase a municipal secretariat alone.
+  if (capacity.grade === 'emerging') {
+    for (const i of items) if (i.list === 'contact' && i.owner === 'org') i.owner = 'coordination';
+  }
+
+  for (const c of capacity.cannotYet) gaps.push(c);
+  return { capacity, verdicts, items, gaps };
+}
+
+/** The list a portfolio sorts on: the worst verdict across a project's solutions. */
+export function portfolioState(verdicts: Verdict[]): VerdictState {
+  const order: VerdictState[] = ['needs_site', 'needs_study', 'needs_permission', 'ready'];
+  for (const s of order) if (verdicts.some(v => v.state === s)) return s;
+  return 'ready';
+}


### PR DESCRIPTION
First of the pieces that must be clickable by the **10 September alignment**. W3 turns a chosen site into a scoped project; this is the part that decides what the organisation leaves holding.

`shared/w3-dossier.ts` computes the four lists and the feasibility verdict from answers already given and from the **55 solution fichas** — which already name who must approve each solution, what it needs before it can be designed, how it is maintained and how it fails. **No model is in the path**, so a coordinator can trace "why does this need a study" back to a line in a ficha, and the same input always produces the same dossier.

## Four verdict states, per solution — not two, per organisation

The 27 August meeting agreed known-feasible vs requires-expert-study. Running four real W2 records through that split broke it, and `e2e/w3-dossier.spec.ts` pins all four:

| record | verdict | why |
|---|---|---|
| Sarandi | `needs_study` | the ficha names a soil infiltration test |
| Encosta Viva | `needs_site` | three fields; nothing to size or cost |
| Vila Nova | `needs_permission` | engineering-trivial, blocked by paperwork |
| **Partenon** | **both** | a garden that can take money now, beside stormwater that cannot be sized yet |

Only one of the four is blocked by a technical unknown. A single verdict per organisation has to round Partenon to one side or the other, and **both roundings are wrong**.

## Capacity grades change who owns the work, never what is offered

`gradeCapacity` reads *exploratory / emerging / established* off the record. It does **not** gate the catalogue — "nada fica descartado" still holds, and a test asserts the same solutions produce the same verdict regardless of grade. What it changes is the proposed owner: an emerging org isn't handed a list assuming it can chase a municipal secretariat alone, and an exploratory one leaves with a **site visit to arrange** rather than a project with a hole in it.

## What the dry run caught

- **The ficha doesn't know it's a school.** Sarandi's site is a municipal school patio. SMAMUS and DMAE come from the ficha; the EMEI direction comes from reading `site_name`. Now a rule, and owned by the org — it's the one body they can reach this week.
- **A stored `site_worry` can be the legacy family** (`flood`) while the story names the mechanism (*enxurrada* from the street above). The mechanism decides both the evidence and the solution, so the dossier reports it as a gap to resolve rather than guessing. Partenon is exactly this case.
- **An honest "ainda não sabemos" on money** becomes a contact item for the coordination team, never an incomplete field.

## Manifest + schemas

W3's fields are declared, not coded. `requiredToClose` is deliberately **three fields** — why this solution here, what the place is like today, who maintains it — because those are what make a project defensible in words. The rest may stay open and is reported as a named gap.

Two things had to be fixed for the manifest layer's own promise to hold:

1. Its header says *"E2–E6 opt in by adding a manifest — no new code"*, but the load-time validator resolved every field through `ORG_PROFILE_ENUMS`. Any manifest for another section found zero ids and **threw at module load**. Now section-aware.
2. **Real dependencies cross workshops.** `who_maintains` (operations_sustain) turns on `land_tenure` (intervention_site), because a city maintenance partnership is only on the table for land the city owns — which is what the rain-garden ficha says. `OptionRule` gained `dependsOnSection`, and value resolution is no longer org_profile-specific.

> ⚠️ The rule is keyed on the real `E2_TENURE` ids (`private-owned`, `formal-agreement`, `public-informal`, `public-no-access`, `mixed`). My first pass invented ids and threw at module load. The dossier separately tolerates the legacy `public_land` still in stored rows, including the test-kit records — dropping it would make an org on public land look like one with no tenure answer at all.

## Verification

- `tsc --noEmit`: **5 errors, same as main**
- Full e2e: **299 passed, 0 failed**
- 10 new tests over the four real records, including one asserting every dossier item cites a traceable source

Review page with all four walkthroughs: https://claude.ai/code/artifact/724fe4b4-3c3c-42b7-b5a4-41d9f0bfb59c

**Next:** `serveE3Checkpoint` on E2's pattern, then map sizing, then the coordinator's portfolio view segregated by these four states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWutNw34isJNf1eefXLDvU