### PR TITLE
feat(w3): a footprint has a size, and a size has a price

### DIFF
--- a/client/src/core/pages/cbo-profile.tsx
+++ b/client/src/core/pages/cbo-profile.tsx
@@ -71,6 +71,7 @@ function parseUploadFilename(content: string): string | null {
 import { LifeBuoy, ShieldCheck } from 'lucide-react';
 import { CboDataNoticeDialog } from '@/core/components/cbo/CboDataNoticeDialog';
 import { NBS_SHOWCASE_CARDS, getShowcaseCard } from '@shared/nbs-showcase-cards';
+import { polygonAreaM2, roundAreaM2 } from '@shared/w3-sizing';
 import type { WorkshopConfig } from '@shared/cohort-schema';
 import { localizedWorkshopName } from '@/lib/workshopHelpers';
 
@@ -91,7 +92,16 @@ function formatMapResult(result: MapSelectionResult): string {
         ? Object.entries(asset.rasterValues).map(([k, v]) => `${k}: ${v.toFixed(3)}`).join(', ')
         : '';
       const geomType = asset.geometry?.type === 'Polygon' ? ' (drawn area)' : '';
-      lines.push(`- [${asset.type}] ${asset.name}${geomType} at (${asset.coordinates[0].toFixed(4)}, ${asset.coordinates[1].toFixed(4)})${rasterInfo ? ` | ${rasterInfo}` : ''}`);
+      // The footprint's own size. Drawing a polygon has been possible since the
+      // map shipped, and the m² it implies was thrown away at exactly this
+      // line — so W3 could ask an organization to draw the area and still have
+      // nothing to multiply a per-m² price by. Appended AFTER the coordinates
+      // so the server's existing site parser matches unchanged.
+      const areaM2 = asset.geometry?.type === 'Polygon'
+        ? roundAreaM2(polygonAreaM2(asset.geometry as any))
+        : 0;
+      const areaInfo = areaM2 > 0 ? ` · ${areaM2} m²` : '';
+      lines.push(`- [${asset.type}] ${asset.name}${geomType} at (${asset.coordinates[0].toFixed(4)}, ${asset.coordinates[1].toFixed(4)})${areaInfo}${rasterInfo ? ` | ${rasterInfo}` : ''}`);
     }
   }
   for (const pt of result.sampledPoints) {

--- a/e2e/w3-questionnaire-cross-section.spec.ts
+++ b/e2e/w3-questionnaire-cross-section.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import {
+  E3_QUESTIONNAIRE,
+  E1_QUESTIONNAIRE,
+  allowedOptionIds,
+  checkOptionRule,
+  filterRuledOptions,
+  missingRequiredForClose,
+  sectionsFieldReader,
+} from '../shared/cbo-questionnaire';
+
+// ⚠️ MANIFEST-CROSS-SECTION.
+//
+// The manifest layer's header promises "E2–E6 opt in by adding a manifest — no
+// new code". Adding E3's manifest showed that was true only for org_profile,
+// in three separate places, and all three failed the same silent way: the rule
+// resolved nothing, so it reported "unconstrained" and let everything through.
+//
+//   1. the load-time validator looked every field up in ORG_PROFILE_ENUMS,
+//      so any manifest for another section threw at import;
+//   2. filterRuledOptions resolved chip labels through ORG_PROFILE_ENUMS, so
+//      fewer than two resolved and it returned null before filtering;
+//   3. FieldReader took only a field name, so a rule naming another section
+//      read from the wrong one.
+//
+// (3) is the one that matters for W3: `who_maintains` depends on `land_tenure`,
+// which is captured in W2 and lives in intervention_site. These tests fail if
+// any of the three regresses, and they are written against the real E3 manifest
+// rather than a fixture so they cannot pass on a stub.
+
+const sections = (site: Record<string, string>, ops: Record<string, string> = {}) => ({
+  intervention_site: { fields: Object.fromEntries(Object.entries(site).map(([k, v]) => [k, { value: v }])) },
+  operations_sustain: { fields: Object.fromEntries(Object.entries(ops).map(([k, v]) => [k, { value: v }])) },
+});
+
+const readFor = (site: Record<string, string>, ops: Record<string, string> = {}) =>
+  sectionsFieldReader(sections(site, ops) as any, 'operations_sustain');
+
+test.describe('manifest rules across sections', () => {
+  test('a city maintenance partnership is only offered on city land', () => {
+    // The rain-garden ficha: "quem cuida é a associação de moradores ou a
+    // prefeitura, dependendo de quem é o dono do terreno."
+    const onOwnLand = allowedOptionIds(E3_QUESTIONNAIRE, 'who_maintains', readFor({ land_tenure: 'private-owned' }));
+    expect(onOwnLand).not.toContain('parceria-prefeitura');
+    const onCityLand = allowedOptionIds(E3_QUESTIONNAIRE, 'who_maintains', readFor({ land_tenure: 'public-informal' }));
+    expect(onCityLand).toContain('parceria-prefeitura');
+  });
+
+  test('an unanswered dependency constrains nothing — it does not guess', () => {
+    expect(allowedOptionIds(E3_QUESTIONNAIRE, 'who_maintains', readFor({}))).toBeNull();
+  });
+
+  test('the write path rejects the excluded value, not just the chip', () => {
+    const read = readFor({ land_tenure: 'private-owned' });
+    expect(checkOptionRule(E3_QUESTIONNAIRE, 'who_maintains', 'parceria-prefeitura', read).ok).toBe(false);
+    expect(checkOptionRule(E3_QUESTIONNAIRE, 'who_maintains', 'voluntarios', read).ok).toBe(true);
+  });
+
+  test('the chip filter resolves labels through the manifest own section', () => {
+    // Labels, in Portuguese, exactly as a composer would render them — this is
+    // the path that was inert, because it resolved them against org_profile.
+    const options = [
+      { label: 'A gente mesmo' },
+      { label: 'Voluntários da comunidade' },
+      { label: 'Parceria com a prefeitura' },
+      { label: 'Ainda não sabemos' },
+    ];
+    const filtered = filterRuledOptions(E3_QUESTIONNAIRE, options, readFor({ land_tenure: 'private-owned' }));
+    expect(filtered).not.toBeNull();
+    expect(filtered!.field).toBe('who_maintains');
+    expect(filtered!.droppedLabels).toEqual(['Parceria com a prefeitura']);
+    expect(filtered!.kept.map(o => o.label)).not.toContain('Parceria com a prefeitura');
+  });
+
+  test('a single-section reader is what made this inert — it still is, visibly', () => {
+    // Documents the failure mode rather than asserting the bug is acceptable:
+    // a reader that ignores the section argument cannot see land_tenure, so
+    // the rule reports "unconstrained". Any future caller that builds one of
+    // these gets no protection, which is why sectionsFieldReader exists.
+    const blind = (field: string) => undefined;
+    expect(allowedOptionIds(E3_QUESTIONNAIRE, 'who_maintains', blind)).toBeNull();
+  });
+
+  test('E1 is unaffected — its dependency is inside its own section', () => {
+    const read = sectionsFieldReader(
+      { org_profile: { fields: { has_cnpj: { value: 'no' } } } } as any,
+      'org_profile',
+    );
+    expect(allowedOptionIds(E1_QUESTIONNAIRE, 'legal_form', read)).toEqual(['informal', 'other']);
+    expect(checkOptionRule(E1_QUESTIONNAIRE, 'legal_form', 'ONG', read).ok).toBe(false);
+  });
+
+  test('E3 will not close on the three answers that make a project defensible', () => {
+    const read = readFor({ land_tenure: 'private-owned' }, {});
+    expect(missingRequiredForClose(E3_QUESTIONNAIRE, read, null)).toEqual([
+      'justification_why_here',
+      'baseline_condition',
+      'who_maintains',
+    ]);
+    const answered = readFor({ land_tenure: 'private-owned' }, {
+      justification_why_here: 'É o único pátio do bairro que alaga.',
+      baseline_condition: 'Piso de cimento, sem sombra.',
+      who_maintains: 'voluntarios',
+    });
+    expect(missingRequiredForClose(E3_QUESTIONNAIRE, answered, null)).toEqual([]);
+  });
+
+  test('an open answer on money is allowed to close — it is the useful answer', () => {
+    // "Ainda não sabemos" about recurring money is the gap the portfolio carries
+    // to the municipality. Requiring it to close would turn it into a guess.
+    const read = readFor({ land_tenure: 'public-informal' }, {
+      justification_why_here: 'A encosta desce em cima das casas.',
+      baseline_condition: 'Barranco exposto, sem vegetação.',
+      who_maintains: 'indefinido',
+    });
+    expect(missingRequiredForClose(E3_QUESTIONNAIRE, read, null)).toEqual([]);
+  });
+});

--- a/e2e/w3-sizing.spec.ts
+++ b/e2e/w3-sizing.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+import {
+  SOLUTION_COSTS,
+  budgetLineFor,
+  polygonAreaM2,
+  ringAreaM2,
+  roundAreaM2,
+} from '../shared/w3-sizing';
+import { NBS_SOLUTION_FICHAS } from '../shared/nbs-solution-fichas';
+
+// W3 SIZING — the footprint, and the number that comes off it.
+//
+// These pin the three things that went wrong when this was a regex over the
+// ficha prose, because all three failed in the same direction: they produced a
+// confident number that was wrong, rather than no number.
+//
+//   • bacia-de-retenção is "R$ 700/m² de estrutura + R$ 300/m² de paisagismo".
+//     Taking the first figure understated a 300 m² basin by R$ 90.000.
+//   • escola-verde says the MMA cartilha does NOT close a number, then quotes
+//     R$ 250–500 per TREE. That got published as a per-m² rate.
+//   • "R$ 20.000" was truncated at the thousands separator to R$ 20.
+//
+// A budget line on a page an organisation shows a secretariat has to be
+// traceable. A wrong one is worse than a blank.
+
+test.describe('W3 sizing — area', () => {
+  test('a drawn ring measures what it covers', () => {
+    // ~100 m × ~100 m in Porto Alegre. One degree of latitude is ~111 km, so
+    // 0.0009° ≈ 100 m; longitude is that times cos(30°) ≈ 0.866.
+    const ring: Array<[number, number]> = [
+      [-51.2000, -30.0500],
+      [-51.19896, -30.0500],
+      [-51.19896, -30.0509],
+      [-51.2000, -30.0509],
+    ];
+    const m2 = ringAreaM2(ring);
+    expect(m2).toBeGreaterThan(9000);
+    expect(m2).toBeLessThan(11000);
+  });
+
+  test('a hole is subtracted, not added', () => {
+    const outer: Array<[number, number]> = [
+      [-51.2000, -30.0500], [-51.1980, -30.0500], [-51.1980, -30.0520], [-51.2000, -30.0520],
+    ];
+    const inner: Array<[number, number]> = [
+      [-51.1995, -30.0505], [-51.1990, -30.0505], [-51.1990, -30.0510], [-51.1995, -30.0510],
+    ];
+    const solid = polygonAreaM2({ type: 'Polygon', coordinates: [outer] });
+    const holed = polygonAreaM2({ type: 'Polygon', coordinates: [outer, inner] });
+    expect(holed).toBeLessThan(solid);
+    expect(holed).toBeGreaterThan(0);
+  });
+
+  test('a non-polygon measures zero rather than throwing', () => {
+    expect(polygonAreaM2({ type: 'Point', coordinates: [-51.2, -30.05] })).toBe(0);
+    expect(ringAreaM2([[-51.2, -30.05], [-51.1, -30.05]])).toBe(0);
+  });
+
+  test('the rounding admits what a finger-drawn polygon is worth', () => {
+    // 487 m² reads as a survey. It is four taps on a phone.
+    expect(roundAreaM2(487)).toBe(500);
+    expect(roundAreaM2(42)).toBe(40);
+    expect(roundAreaM2(3170)).toBe(3200);
+    expect(roundAreaM2(0)).toBe(0);
+  });
+});
+
+test.describe('W3 sizing — cost', () => {
+  test('every one of the 27 fichas is priced or explicitly unpriced', () => {
+    // The module throws at load if this is untrue, so reaching this line is
+    // most of the assertion. Restated here so the failure names itself.
+    for (const id of Object.keys(NBS_SOLUTION_FICHAS)) {
+      expect(SOLUTION_COSTS[id], `${id} has no cost entry`).toBeTruthy();
+    }
+    expect(Object.keys(SOLUTION_COSTS).length).toBe(Object.keys(NBS_SOLUTION_FICHAS).length);
+  });
+
+  test('a basin costs both of its lines, and shows the addition', () => {
+    const line = budgetLineFor('bacia-de-retencao', 300)!;
+    // 300 m² × (700 structure + 300 landscaping)
+    expect(line.lowBrl).toBe(300_000);
+    expect(line.notePt).toMatch(/R\$ 700\/m².*R\$ 300\/m²/);
+  });
+
+  test('a per-tree price is never published as a per-m² rate', () => {
+    const trees = budgetLineFor('corredores-verdes', 400)!;
+    expect(trees.basis).toBe('unit');
+    expect(trees.lowBrl).toBeNull();
+    expect(trees.notePt).toMatch(/por unidade|árvore/);
+    // escola-verde is the one that actually broke: its sentence opens by
+    // refusing to close a number and then quotes the per-tree figure.
+    const school = budgetLineFor('escola-verde', 400)!;
+    expect(school.basis).toBe('project');
+    expect(school.lowBrl).toBeNull();
+  });
+
+  test('thousands separators survive', () => {
+    expect(budgetLineFor('barraginha')!.notePt).toMatch(/R\$ 70/);
+    expect(budgetLineFor('captacao-agua-da-chuva')!.notePt).toMatch(/R\$ 4\.500/);
+    expect(budgetLineFor('captacao-agua-da-chuva')!.notePt).toMatch(/R\$ 10\.500/);
+  });
+
+  test('a ficha that closes no price says so instead of guessing', () => {
+    for (const id of ['parques-lineares', 'sistema-alimentar-local']) {
+      const line = budgetLineFor(id)!;
+      expect(line.basis).toBe('none');
+      expect(line.lowBrl).toBeNull();
+      expect(line.notePt).toMatch(/não fecha um preço/);
+    }
+  });
+
+  test('a per-m² price with no footprint reports the rate, not a total', () => {
+    const noArea = budgetLineFor('jardins-de-chuva')!;
+    expect(noArea.lowBrl).toBeNull();
+    expect(noArea.notePt).toMatch(/Falta desenhar a área/);
+    const withArea = budgetLineFor('jardins-de-chuva', 300)!;
+    expect(withArea.lowBrl).toBe(120_000);
+    expect(withArea.highBrl).toBe(210_000);
+  });
+
+  test('the range is never presented as a budget', () => {
+    for (const id of Object.keys(SOLUTION_COSTS)) {
+      const line = budgetLineFor(id, 250)!;
+      expect(line.notePt.length).toBeGreaterThan(20);
+      // Every line points at the next action — a quote, a count, a drawing.
+      expect(line.notePt).toMatch(/cotação|quantas|orça|Falta desenhar/i);
+      expect(line.noteEn).toMatch(/quote|how many|budgeted|footprint/i);
+    }
+  });
+
+  test('a derived figure always shows its arithmetic', () => {
+    for (const [id, cost] of Object.entries(SOLUTION_COSTS)) {
+      if (!cost.notaPt) continue;
+      const line = budgetLineFor(id, 100)!;
+      expect(line.notePt, `${id} hides its derivation`).toContain(cost.notaPt);
+      expect(line.noteEn).toContain(cost.notaEn!);
+    }
+  });
+
+  test('an unknown solution returns nothing rather than a zero', () => {
+    expect(budgetLineFor('no-such-solution', 300)).toBeNull();
+  });
+});

--- a/server/services/askUserGuards.ts
+++ b/server/services/askUserGuards.ts
@@ -47,7 +47,12 @@ export interface AskQuestion {
 export interface AskGuardContext {
   phase: number;
   lang: 'pt' | 'en';
-  /** Reads the org_profile section the manifest rules are written against. */
+  /**
+   * Reads whatever section a manifest rule names. Build it with
+   * `sectionsFieldReader(state.sections, <the phase's section>)` — a reader
+   * closed over ONE section makes every cross-workshop rule silently inert
+   * (see the FieldReader doc in shared/cbo-questionnaire.ts).
+   */
   read: FieldReader;
 }
 

--- a/server/services/cboAgent.ts
+++ b/server/services/cboAgent.ts
@@ -59,7 +59,7 @@ import { emitAssistantText } from "./agentOutput";
 // translation (JVP, 2026-08-06 — the Documento tab in English).
 import { isKnownOrgProfileField, canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, orgProfileOptionLabels, orgProfileLabelsForIds, ORG_PROFILE_FIELDS, enumFieldsMatchingOptions,
   E2_CURRENT_USE, E2_TENURE, E2_ROLES, canonicalizeCboFieldValue } from "@shared/cbo-field-catalog";
-import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredForClose, askCopyFor, type FieldReader, type QuestionnaireManifest } from "@shared/cbo-questionnaire";
+import { QUESTIONNAIRES, checkOptionRule, filterRuledOptions, missingRequiredForClose, askCopyFor, sectionsFieldReader, type FieldReader, type QuestionnaireManifest } from "@shared/cbo-questionnaire";
 import { prepareAskUser } from "./askUserGuards";
 import { commitConfirmedStagedFields, isAffirmativeReply } from "./e1ConfirmCommit";
 import { parseNbsInventory } from "@shared/nbs-inventory";
@@ -455,8 +455,12 @@ function createCboMcpTools(cboId: string) {
         // excludes (e.g. legal_form "ONG" after has_cnpj "Ainda não") is
         // rejected for every source — user chips included, since a wrong
         // stored combination is wrong no matter who produced it.
+        // Across ALL sections, not just this one: E3's who_maintains rule turns
+        // on land_tenure, which lives in intervention_site. A reader closed
+        // over the section being written finds nothing, and the rule passes
+        // every value — inert rather than failing, which is the worse mode.
         const ruleHit = manifests
-          .map(m => checkOptionRule(m, fieldName, finalValue, sectionFieldReader(section)))
+          .map(m => checkOptionRule(m, fieldName, finalValue, sectionsFieldReader(state.sections as any, args.sectionId)))
           .find(r => !r.ok) as { ok: false; dependsOn: string; allowedIds: string[] } | undefined;
         if (ruleHit) {
           ruleBlocked.push({ field: fieldName, dependsOn: ruleHit.dependsOn, allowedIds: ruleHit.allowedIds });
@@ -880,8 +884,13 @@ Include showMap: true on a question only when the user genuinely needs the map t
       const guarded = prepareAskUser(args.questions || [], {
         phase: qState0?.phase ?? 1,
         lang: (qState0 as any)?.metadata?.language === 'en' ? 'en' : 'pt',
-        read: qState0?.sections?.org_profile
-          ? sectionFieldReader(qState0.sections.org_profile)
+        // Section-aware, defaulting to the manifest section for this phase —
+        // an ask_user in E3 has to resolve land_tenure out of intervention_site.
+        read: qState0?.sections
+          ? sectionsFieldReader(
+              qState0.sections as any,
+              QUESTIONNAIRES[qState0.phase ?? 1]?.sectionId ?? 'org_profile',
+            )
           : () => undefined,
       });
       const filteredNotes = guarded.filteredNotes;
@@ -1066,6 +1075,7 @@ STOP and wait for the user's map selection after calling this tool.`,
         const gate = checkCloseGate({
           phase: state.phase,
           section: state.sections[closeManifest.sectionId as keyof typeof state.sections],
+          sections: state.sections as any,
           hasPath,
           lang: (state as any)?.metadata?.language === 'en' ? 'en' : 'pt',
         });
@@ -2221,8 +2231,11 @@ async function serveE2Checkpoint(
     if (raw.includes('- [site] DEFERRED')) return false; // legacy "bairro todo" flow → model
     const zones = Array.from(raw.matchAll(/^- \[zone\] (.+?): .*?flood: (\d+)%, heat: (\d+)%, landslide: (\d+)%/gm))
       .map(m => ({ name: m[1].trim(), flood: +m[2], heat: +m[3], landslide: +m[4] }));
-    const sites = Array.from(raw.matchAll(/^- \[(osm|custom)\] (.+?)(?: \(drawn area\))? at \((-?[\d.]+), (-?[\d.]+)\)/gm))
-      .map(m => ({ kind: m[1] as 'osm' | 'custom', name: m[2].trim(), lat: +m[3], lng: +m[4] }));
+    // The trailing "· 480 m²" is only present when they drew a polygon rather
+    // than dropping a pin. Optional by construction: a pin has no footprint,
+    // and W3 asks for one later rather than treating its absence as an error.
+    const sites = Array.from(raw.matchAll(/^- \[(osm|custom)\] (.+?)(?: \(drawn area\))? at \((-?[\d.]+), (-?[\d.]+)\)(?: · (\d+) m²)?/gm))
+      .map(m => ({ kind: m[1] as 'osm' | 'custom', name: m[2].trim(), lat: +m[3], lng: +m[4], areaM2: m[5] ? +m[5] : 0 }));
     if (zones.length === 0) return false;
 
     if (sites.length === 0) {
@@ -2291,6 +2304,9 @@ async function serveE2Checkpoint(
       site_name: s.name,
       _site_lat: String(s.lat),
       _site_lng: String(s.lng),
+      // Kept whenever it exists so W3 can open on "vocês já desenharam 480 m²
+      // — é isso?" instead of asking for the drawing a second time.
+      ...(s.areaM2 > 0 ? { site_area_m2: String(s.areaM2) } : {}),
     }, pushEvent);
     // A dropped pin is stored as "Ponto marcado (-30.0577, -51.1936)" — and the
     // next thing we do is ask the org to confirm it. Nobody can confirm a

--- a/server/services/cboCloseGate.ts
+++ b/server/services/cboCloseGate.ts
@@ -21,6 +21,7 @@ import {
   QUESTIONNAIRES,
   missingRequiredForClose,
   askCopyFor,
+  sectionsFieldReader,
   type FieldReader,
 } from '@shared/cbo-questionnaire';
 
@@ -35,6 +36,12 @@ export interface CloseGateResult {
 export function checkCloseGate(input: {
   phase: number;
   section: { fields: Record<string, { value: unknown } | undefined> } | undefined;
+  /**
+   * The whole state.sections map, when the caller has it. E3's requirements
+   * branch on W2 answers, so a gate that can only see its own section reads
+   * every cross-section dependency as unanswered and skips the rule.
+   */
+  sections?: Record<string, { fields?: Record<string, { value?: unknown } | undefined> } | undefined>;
   /** null = standalone session, path not persistable, so not gated on. */
   hasPath: boolean | null;
   lang: 'pt' | 'en';
@@ -42,10 +49,12 @@ export function checkCloseGate(input: {
   const manifest = QUESTIONNAIRES[input.phase];
   if (!manifest || !input.section) return { missing: [], message: null };
 
-  const read: FieldReader = (field: string) => {
-    const v = input.section!.fields[field]?.value;
-    return v == null ? undefined : String(v);
-  };
+  const read: FieldReader = input.sections
+    ? sectionsFieldReader(input.sections, manifest.sectionId)
+    : (field: string) => {
+        const v = input.section!.fields[field]?.value;
+        return v == null ? undefined : String(v);
+      };
 
   const missing = missingRequiredForClose(manifest, read, input.hasPath);
   if (missing.length === 0) return { missing: [], message: null };

--- a/server/services/fakeCboModel.ts
+++ b/server/services/fakeCboModel.ts
@@ -37,7 +37,7 @@ import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 import { emitAssistantText } from './agentOutput';
 import { isReplitDeployment } from './runtimeEnv';
 import { canonicalizeOrgProfileValue, isEnumOrgProfileField, isCanonicalOrgProfileValue, enumFieldsMatchingOptions } from '@shared/cbo-field-catalog';
-import { QUESTIONNAIRES, checkOptionRule } from '@shared/cbo-questionnaire';
+import { QUESTIONNAIRES, checkOptionRule, sectionsFieldReader } from '@shared/cbo-questionnaire';
 import { prepareAskUser } from './askUserGuards';
 import { checkCloseGate } from './cboCloseGate';
 import { commitConfirmedStagedFields } from './e1ConfirmCommit';
@@ -152,13 +152,14 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       ) break;
       // Same conditional-option rule as the real tool (manifest): a known
       // option excluded by the stored dependency answer is not stored.
-      if (op.sectionId === 'org_profile') {
+      // Every manifest section, not only org_profile — the real tool applies
+      // the rule wherever a manifest claims the section, and a fake that only
+      // checked E1's meant no spec could observe an E3 rule.
+      {
+        const read = sectionsFieldReader(state.sections as any, op.sectionId);
         const blocked = Object.values(QUESTIONNAIRES)
           .filter(m => m.sectionId === op.sectionId)
-          .some(m => !checkOptionRule(m, op.field, value, (f) => {
-            const v = section.fields[f]?.value;
-            return v == null ? undefined : String(v);
-          }).ok);
+          .some(m => !checkOptionRule(m, op.field, value, read).ok);
         if (blocked) break;
       }
       // Crawl-trust gate (mirror of the real tool): doc-sourced FREE-TEXT
@@ -253,6 +254,7 @@ function runOp(cboId: string, op: FakeOp, state: CboState, pushEvent: PushEvent,
       const gate = checkCloseGate({
         phase: state.phase,
         section: state.sections[(QUESTIONNAIRES[state.phase]?.sectionId ?? 'org_profile') as keyof typeof state.sections],
+        sections: state.sections as any,
         hasPath: null,
         lang: lang === 'en' ? 'en' : 'pt',
       });

--- a/shared/cbo-questionnaire.ts
+++ b/shared/cbo-questionnaire.ts
@@ -223,8 +223,31 @@ export const QUESTIONNAIRES: Record<number, QuestionnaireManifest> = {
   3: E3_QUESTIONNAIRE,
 };
 
-/** Raw stored value of a field, or undefined — the caller adapts its state shape. */
-export type FieldReader = (field: string) => string | undefined;
+/**
+ * Raw stored value of a field, or undefined — the caller adapts its state shape.
+ *
+ * `sectionId` is passed whenever a rule names a section other than the
+ * manifest's own. A reader that ignores it answers from a single section, which
+ * is right for E1 (every dependency it has is inside org_profile) and silently
+ * WRONG for E3, whose `who_maintains` rule turns on `land_tenure` over in
+ * intervention_site: a single-section reader returns undefined, `storedId`
+ * returns null, and `allowedOptionIds` reports "unconstrained" — the rule is
+ * inert rather than failing. Callers with the whole state should build their
+ * reader with `sectionsFieldReader` below.
+ */
+export type FieldReader = (field: string, sectionId?: string) => string | undefined;
+
+/** A section-aware reader over a CboState-shaped `sections` map. */
+export function sectionsFieldReader(
+  sections: Record<string, { fields?: Record<string, { value?: unknown } | undefined> } | undefined> | undefined,
+  defaultSectionId: string,
+): FieldReader {
+  return (field: string, sectionId?: string) => {
+    const sec = sections?.[sectionId ?? defaultSectionId];
+    const v = sec?.fields?.[field]?.value;
+    return v == null ? undefined : String(v);
+  };
+}
 
 /** Resolve a stored value (id, label or alias) to its option id, in any section. */
 function optionIdIn(sectionId: string, field: string, raw: string): string | null {
@@ -240,7 +263,7 @@ function optionIdIn(sectionId: string, field: string, raw: string): string | nul
 }
 
 function storedId(read: FieldReader, field: string, sectionId: string): string | null {
-  const raw = read(field);
+  const raw = read(field, sectionId);
   if (raw == null || String(raw).trim() === '') return null;
   return optionIdIn(sectionId, field, String(raw));
 }
@@ -286,7 +309,12 @@ export function filterRuledOptions(
   read: FieldReader,
 ): { field: string; kept: { label: string }[]; droppedLabels: string[] } | null {
   for (const field of Object.keys(manifest.optionRules)) {
-    const resolved = options.map(o => resolveOrgProfileOptionId(field, o.label));
+    // Through the manifest's OWN section, not org_profile. Resolving E3's
+    // who_maintains chips against ORG_PROFILE_ENUMS returned null for every
+    // one of them, so `resolved.filter(Boolean).length < 2` always continued
+    // and the guard was inert for every manifest but E1 — the same
+    // wrong-section bug the validator had, one function further down.
+    const resolved = options.map(o => optionIdIn(manifest.sectionId, field, o.label));
     if (resolved.filter(Boolean).length < 2) continue;
     const allowed = allowedOptionIds(manifest, field, read);
     if (!allowed) return null; // it IS the ruled question, but nothing to filter by

--- a/shared/w3-dossier.ts
+++ b/shared/w3-dossier.ts
@@ -31,6 +31,7 @@
 
 import { getSolutionFicha } from './nbs-solution-fichas';
 import { SOLUTION_MECHANISMS } from './nbs-catalog';
+import { budgetLineFor, type BudgetLine } from './w3-sizing';
 import type { WorryId } from './site-knowledge';
 
 // ── Capacity ────────────────────────────────────────────────────────────────
@@ -244,6 +245,8 @@ export interface Dossier {
   capacity: CapacityRead;
   verdicts: Verdict[];
   items: DossierItem[];
+  /** One line per chosen solution, traceable to its ficha's published price. */
+  budget: BudgetLine[];
   /** Items W3 could not generate, and the answer that would unlock each. */
   gaps: string[];
 }
@@ -311,7 +314,7 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
         ? 'Sem lugar marcado não há área, custo, aprovação nem manutenção a calcular'
         : 'With no place marked there is no area, cost, approval or maintenance to compute',
     );
-    return { capacity, verdicts, items, gaps };
+    return { capacity, verdicts, items, budget: [], gaps };
   }
 
   // ── Per solution, from its ficha ──────────────────────────────────────────
@@ -447,22 +450,49 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
   }
 
   // ── Money ─────────────────────────────────────────────────────────────────
-  if (input.areaM2) {
+  // A number, from the ficha's own published price, over the footprint they
+  // drew. Not a budget — a range to take to a supplier, which is the thing an
+  // organisation cannot produce on its own and the thing every funder asks for
+  // first.
+  const areaM2 = input.areaM2 ?? (Number(site.site_area_m2) || undefined);
+  const budget: BudgetLine[] = [];
+  for (const id of solutions) {
+    const line = budgetLineFor(id, areaM2);
+    if (!line) continue;
+    budget.push(line);
     add({
       list: 'document',
-      text: pt
-        ? `Orçamento para ${input.areaM2} m², para ser substituído por uma cotação real`
-        : `Budget for ${input.areaM2} m², to be replaced by a real quote`,
-      source: 'W3 stage 3 · intervention_area_m2 × ficha cost band',
+      text: pt ? line.notePt : line.noteEn,
+      source: `ficha ${id} · quantoCusta${line.areaM2 ? ` × ${line.areaM2} m²` : ''}`,
       owner: 'org',
     });
-  } else {
+    // Naming the missing half is the point: "no cost band" is not actionable,
+    // "we have a price per m² and no area" is.
+    if (line.basis === 'm2' && !line.areaM2) {
+      gaps.push(
+        pt
+          ? `${id.replace(/-/g, ' ')} tem preço por m² na ficha, mas ninguém desenhou a área — sem isso não sai um total`
+          : `${id.replace(/-/g, ' ')} has a per-m² price in its ficha, but no footprint was drawn — without one there is no total`,
+      );
+    }
+    if (line.basis === 'none') {
+      gaps.push(
+        pt
+          ? `A ficha de ${id.replace(/-/g, ' ')} não fecha preço — esta é uma cotação a pedir, não um campo a preencher`
+          : `The ${id.replace(/-/g, ' ')} ficha closes no price — this is a quote to request, not a field to fill`,
+      );
+    }
+  }
+  if (!areaM2 && solutions.length === 0) {
     gaps.push(pt ? 'Sem área desenhada não há faixa de custo' : 'Without a drawn footprint there is no cost band');
   }
 
   // An honest "not yet" is the most useful answer in the session: it is the gap
   // the portfolio carries to the municipality. Never treat it as incomplete.
-  if (w3.sustainability_model === 'indefinido' || w3.opex_estimate_year1 === 'unknown') {
+  // Both ids are from E3_SUSTAINABILITY / E3_MAINTAINS in the field catalog. An
+  // earlier version of this line also tested `opex_estimate_year1`, a field
+  // that exists nowhere — so half the condition could never fire.
+  if (w3.sustainability_model === 'indefinido' || w3.who_maintains === 'indefinido') {
     add({
       list: 'contact',
       text: pt
@@ -480,7 +510,7 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
   }
 
   for (const c of capacity.cannotYet) gaps.push(c);
-  return { capacity, verdicts, items, gaps };
+  return { capacity, verdicts, items, budget, gaps };
 }
 
 /** The list a portfolio sorts on: the worst verdict across a project's solutions. */

--- a/shared/w3-sizing.ts
+++ b/shared/w3-sizing.ts
@@ -1,0 +1,367 @@
+// ============================================================================
+// W3 SIZING — how big the thing is, and what that costs
+// ============================================================================
+// W2 ends with a pin. W3 has to turn that pin into a number an organisation can
+// take to a funder, and the shortest honest route is: they draw the footprint,
+// we measure it, and we multiply by a price the ficha already states.
+//
+// Everything here is deliberately dumb arithmetic over text the fichas already
+// carry, for the same reason shared/w3-dossier.ts calls no model: a budget line
+// an organisation shows a secretariat has to be traceable to a published
+// figure, not to a plausible-sounding number.
+//
+// ── What this refuses to do ─────────────────────────────────────────────────
+// 17 of the 27 fichas quote a price per m². The other 10 do not, and they do
+// not for real reasons: barraginhas are priced per lot of a hundred, corredores
+// verdes per planted tree, cisterns per unit, and parques lineares say outright
+// that no closed price exists because it depends on what the strip already has.
+// Inventing an R$/m² for those would produce exactly the confident wrong number
+// that makes the rest of the dossier untrustworthy. They return `kind: 'unit'`
+// or `kind: 'none'`, and W3 shows the ficha's own words instead.
+// ============================================================================
+
+import { getSolutionFicha } from './nbs-solution-fichas';
+
+// ── Area ────────────────────────────────────────────────────────────────────
+
+const EARTH_RADIUS_M = 6371008.8;
+const toRad = (d: number) => (d * Math.PI) / 180;
+
+/**
+ * Area of a lon/lat ring in m², by spherical excess — the same formula Turf's
+ * `area` uses, written out here so `shared/` stays importable from the server
+ * without pulling the whole of @turf/turf into it.
+ *
+ * Accurate to well under a percent at the scale W3 works on (a schoolyard, a
+ * praça), which is far finer than the precision a hand-drawn footprint carries
+ * in the first place — hence roundAreaM2 below.
+ */
+export function ringAreaM2(ring: Array<[number, number]>): number {
+  if (ring.length < 3) return 0;
+  let total = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const [lon1, lat1] = ring[i];
+    const [lon2, lat2] = ring[(i + 1) % ring.length];
+    total += (toRad(lon2) - toRad(lon1)) * (2 + Math.sin(toRad(lat1)) + Math.sin(toRad(lat2)));
+  }
+  return Math.abs((total * EARTH_RADIUS_M * EARTH_RADIUS_M) / 2);
+}
+
+/** Area of a GeoJSON Polygon, outer ring minus holes. */
+export function polygonAreaM2(geometry: { type: string; coordinates: unknown }): number {
+  if (geometry?.type !== 'Polygon' || !Array.isArray(geometry.coordinates)) return 0;
+  const rings = geometry.coordinates as Array<Array<[number, number]>>;
+  if (!rings.length) return 0;
+  return rings.reduce((acc, r, i) => acc + (i === 0 ? ringAreaM2(r) : -ringAreaM2(r)), 0);
+}
+
+/**
+ * Round to the precision a finger-drawn polygon actually carries.
+ *
+ * "487 m²" reads as a survey. It is four taps on a phone over a satellite tile,
+ * and the difference between 450 and 500 is where someone's finger landed. So
+ * the number is rounded to something that reads as the estimate it is, and the
+ * copy around it says "aproximadamente".
+ */
+export function roundAreaM2(m2: number): number {
+  if (m2 <= 0) return 0;
+  if (m2 < 100) return Math.round(m2 / 5) * 5;
+  if (m2 < 1000) return Math.round(m2 / 50) * 50;
+  if (m2 < 10000) return Math.round(m2 / 100) * 100;
+  return Math.round(m2 / 500) * 500;
+}
+
+// ── Cost ────────────────────────────────────────────────────────────────────
+//
+// The first version of this parsed `quantoCusta` with regexes, and it got three
+// of the 27 wrong in ways that all pointed the same direction — confidently:
+//
+//   • bacia-de-retenção reads "R$ 700/m² de estrutura + R$ 300/m² de
+//     paisagismo". The parse took the first figure and reported R$ 700/m²,
+//     understating a 300 m² basin by ninety thousand reais.
+//   • escola-verde opens by saying the MMA cartilha does NOT close a number,
+//     then quotes R$ 250–500 per planted TREE. The parse saw "m²" elsewhere in
+//     the sentence and published the per-tree figure as a per-m² rate.
+//   • barraginha and cisterna prices were truncated at the thousands separator
+//     — R$ 20.000 became R$ 20.
+//
+// So the numbers are authored, once, here. What stops them drifting from the
+// prose Robson reviewed is the invariant at the bottom of this file: both ends
+// of every band must appear literally in the ficha's own `quantoCusta`, and the
+// only exemption is a band that is explicitly derived — which must then carry a
+// `notaPt`/`notaEn` showing the arithmetic to the organisation. Edit the
+// sentence without editing the number and the module throws at load, in dev and
+// in every test run.
+
+export type CostBasis = 'm2' | 'unit' | 'project' | 'none';
+
+export interface SolutionCost {
+  basis: CostBasis;
+  /** R$, both ends. Absent for 'none'. */
+  low?: number;
+  high?: number;
+  /** 'unit': what one unit is. 'project': what that money buys. */
+  scalePt?: string;
+  scaleEn?: string;
+  /**
+   * Set when the figures are NOT literal in the ficha (a sum of two lines, a
+   * rate worked back from a total). Required in that case, and always shown —
+   * derived arithmetic an organisation cannot see is arithmetic it cannot
+   * defend in front of a secretariat.
+   */
+  notaPt?: string;
+  notaEn?: string;
+}
+
+/**
+ * Cost per solution, read off each ficha's `quantoCusta`.
+ *
+ * Ten of the 27 have no rate and say so — priced per lot, per tree, per unit,
+ * or genuinely open because it depends on what the site already has. Those get
+ * 'unit', 'project' or 'none' rather than a fabricated R$/m², and W3 shows the
+ * ficha's own sentence in their place. An honest "this one has no closed price"
+ * is a usable answer; a made-up rate on a budget sheet is not.
+ */
+export const SOLUTION_COSTS: Record<string, SolutionCost> = {
+  // ── Águas pluviais · infiltração ──────────────────────────────────────────
+  'jardins-de-chuva': { basis: 'm2', low: 400, high: 700 },
+  'canteiro-pluvial': { basis: 'm2', low: 400, high: 800 },
+  'biovaletas': { basis: 'm2', low: 200, high: 500 },
+  // The ficha lists the components and then its own closed-budget line.
+  'terracos-de-chuva': { basis: 'm2', low: 600, high: 1000 },
+  'escada-hidraulica-vegetada': { basis: 'm2', low: 600, high: 1200 },
+  'pavimentos-permeaveis': { basis: 'm2', low: 220, high: 480 },
+  'bacia-de-retencao': {
+    basis: 'm2',
+    low: 1000,
+    high: 1000,
+    notaPt: 'Soma das duas linhas da ficha: R$ 700/m² de estrutura mais R$ 300/m² de paisagismo e equipamentos.',
+    notaEn: "The ficha's two lines added: R$ 700/m² of structure plus R$ 300/m² of landscaping and equipment.",
+  },
+  'wetland-construido': { basis: 'm2', low: 1200, high: 2000 },
+  'ilhas-filtrantes-flutuantes': { basis: 'm2', low: 200, high: 700 },
+  'barraginha': {
+    basis: 'unit', low: 70, high: 200,
+    scalePt: 'barraginha', scaleEn: 'barraginha',
+  },
+  'captacao-agua-da-chuva': {
+    basis: 'unit', low: 4500, high: 10500,
+    scalePt: 'cisterna de 16 mil litros — o piso é em mutirão, o teto é contratada por edital',
+    scaleEn: 'a 16,000-litre cistern — the floor is mutirão-built, the ceiling is contracted through a public call',
+  },
+
+  // ── Áreas verdes ──────────────────────────────────────────────────────────
+  'parques-e-florestas-urbanas': { basis: 'm2', low: 100, high: 230 },
+  'teto-verde': {
+    basis: 'm2', low: 150, high: 350,
+    notaPt: 'Faixa do sistema comprado pronto. Feito pelo método bidim, em mutirão, cai para cerca de R$ 5 por m² — foi assim que o Teto Verde Favela cobriu mais de 20 lajes.',
+    notaEn: 'Range for a bought-in system. Built bidim-style in a mutirão it drops to about R$ 5 per m² — that is how Teto Verde Favela covered more than 20 roofs.',
+  },
+  'corredores-verdes': {
+    basis: 'unit', low: 250, high: 500,
+    scalePt: 'árvore plantada, com berço, tutor e protetor até o 3º ano',
+    scaleEn: 'planted tree, with pit, stake and guard through year 3',
+  },
+  'parques-lineares': { basis: 'none' },
+  'escola-verde': {
+    basis: 'project', low: 5000, high: 20000,
+    scalePt: 'um pátio pequeno com um jardim de chuva e algumas árvores',
+    scaleEn: 'a small schoolyard with a rain garden and a few trees',
+  },
+  'parque-naturalizado': { basis: 'm2', low: 100, high: 230 },
+
+  // ── Sistema alimentar ─────────────────────────────────────────────────────
+  'hortas-urbanas': {
+    basis: 'project', low: 300, high: 1200,
+    scalePt: 'uma horta pequena de 10 a 50 m², com material reaproveitado. Uma horta comunitária de porte médio, com cercamento e irrigação, soma perto de R$ 25.000',
+    scaleEn: 'a small garden of 10–50 m² using reclaimed materials. A mid-sized community garden with fencing and irrigation comes to around R$ 25,000',
+  },
+  'compostagem': {
+    basis: 'project', low: 300, high: 2000,
+    scalePt: 'de uma composteira doméstica pronta até uma estrutura comunitária com tambores reaproveitados',
+    scaleEn: 'from a ready-made household composter up to a community setup with reclaimed drums',
+  },
+  'cozinha-comunitaria-biodigestor': {
+    basis: 'project', low: 300, high: 8900,
+    scalePt: 'o biodigestor sozinho — caseiro com tambores no piso, kit comercial no teto. A cozinha completa é outra conta: hoje financiada pelo governo federal em até R$ 350 mil por unidade',
+    scaleEn: 'the biodigester alone — home-built from drums at the floor, a commercial kit at the ceiling. The full kitchen is a separate matter: currently federally financed up to R$ 350,000 per unit',
+  },
+  'sistema-alimentar-local': { basis: 'none' },
+
+  // ── Encostas ──────────────────────────────────────────────────────────────
+  'grade-viva': { basis: 'm2', low: 500, high: 600 },
+  'muro-de-arrimo-verde': {
+    basis: 'm2', low: 200, high: 300,
+    notaPt: 'Faixa da pedra ou gabião. A versão pré-fabricada tipo cribwall chega a R$ 1.000–2.000 por m².',
+    notaEn: 'Range for stone or gabion. The prefabricated cribwall version reaches R$ 1,000–2,000 per m².',
+  },
+  'solo-grampeado-verde': { basis: 'm2', low: 800, high: 1000 },
+  'contencoes-em-geocelulas': { basis: 'm2', low: 500, high: 700 },
+
+  // ── Restauração ───────────────────────────────────────────────────────────
+  'reflorestamento': { basis: 'm2', low: 100, high: 230 },
+  'restauracao-areas-umidas': {
+    basis: 'm2', low: 10, high: 60,
+    notaPt: 'Vem do total da ficha — R$ 20 mil a R$ 120 mil para recuperar 2.000 m² de banhado já existente. Construir um jardim filtrante novo é outra ordem de grandeza: R$ 540 a R$ 1.410 por m².',
+    notaEn: "Worked back from the ficha's total — R$ 20,000–120,000 to restore 2,000 m² of existing wetland. Building a new treatment wetland is a different order: R$ 540–1,410 per m².",
+  },
+};
+
+export interface BudgetLine {
+  solutionId: string;
+  basis: CostBasis;
+  /** Total for the drawn footprint. Null unless the basis is per-m² AND an area exists. */
+  lowBrl: number | null;
+  highBrl: number | null;
+  areaM2?: number;
+  /** The one line an organisation puts on a page. */
+  notePt: string;
+  noteEn: string;
+  /** The ficha sentence behind it — shown, never paraphrased away. */
+  sourcePt: string;
+  sourceEn: string;
+  /** The ficha marks its own figure as our inference rather than a cited value. */
+  estimado: boolean;
+}
+
+const brl = (v: number) => `R$ ${Math.round(v).toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
+const brlEn = (v: number) => `R$ ${Math.round(v).toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+
+/**
+ * The budget line for one solution over a drawn footprint.
+ *
+ * Always a range, never a point estimate, and the wording always says what it
+ * is for: getting a supplier to quote against. W3's job is to get an
+ * organisation into that conversation, not to stand in for it.
+ */
+export function budgetLineFor(solutionId: string, areaM2?: number): BudgetLine | null {
+  const ficha = getSolutionFicha(solutionId);
+  const cost = SOLUTION_COSTS[solutionId];
+  if (!ficha || !cost) return null;
+  const base = {
+    solutionId,
+    basis: cost.basis,
+    sourcePt: ficha.pt.quantoCusta,
+    sourceEn: ficha.en.quantoCusta,
+    estimado: !!ficha.custoEstimado,
+  };
+  const nota = (pt: boolean) => {
+    const n = pt ? cost.notaPt : cost.notaEn;
+    return n ? ` ${n}` : '';
+  };
+
+  if (cost.basis === 'm2' && cost.low != null && cost.high != null) {
+    const rate = cost.low === cost.high ? brl(cost.low) : `${brl(cost.low)}–${brl(cost.high)}`;
+    const rateEn = cost.low === cost.high ? brlEn(cost.low) : `${brlEn(cost.low)}–${brlEn(cost.high)}`;
+    if (!areaM2) {
+      return {
+        ...base,
+        lowBrl: null,
+        highBrl: null,
+        notePt: `${rate} por m². Falta desenhar a área para fechar um total.${nota(true)}`,
+        noteEn: `${rateEn} per m². The footprint is still undrawn, so there is no total.${nota(false)}`,
+      };
+    }
+    const lo = cost.low * areaM2;
+    const hi = cost.high * areaM2;
+    return {
+      ...base,
+      lowBrl: lo,
+      highBrl: hi,
+      areaM2,
+      notePt: `Cerca de ${lo === hi ? brl(lo) : `${brl(lo)}–${brl(hi)}`} para ${areaM2} m², à referência da ficha. É uma faixa para pedir cotação, não um orçamento fechado.${nota(true)}`,
+      noteEn: `About ${lo === hi ? brlEn(lo) : `${brlEn(lo)}–${brlEn(hi)}`} for ${areaM2} m², at the ficha's reference price. A range to request quotes against, not a closed budget.${nota(false)}`,
+    };
+  }
+
+  if ((cost.basis === 'unit' || cost.basis === 'project') && cost.low != null && cost.high != null) {
+    const per = cost.basis === 'unit' ? 'por' : 'para';
+    const perEn = cost.basis === 'unit' ? 'per' : 'for';
+    return {
+      ...base,
+      lowBrl: null,
+      highBrl: null,
+      ...(areaM2 ? { areaM2 } : {}),
+      notePt:
+        `${brl(cost.low)}–${brl(cost.high)} ${per} ${cost.scalePt}. ` +
+        (cost.basis === 'unit'
+          ? 'Esta solução se conta por unidade, não por metro quadrado — quantas vocês querem?'
+          : 'Esta solução se orça pelo conjunto, não por metro quadrado.') +
+        nota(true),
+      noteEn:
+        `${brlEn(cost.low)}–${brlEn(cost.high)} ${perEn} ${cost.scaleEn}. ` +
+        (cost.basis === 'unit'
+          ? 'This one is counted per unit, not per square metre — how many do you want?'
+          : 'This one is budgeted as a whole, not per square metre.') +
+        nota(false),
+    };
+  }
+
+  return {
+    ...base,
+    lowBrl: null,
+    highBrl: null,
+    ...(areaM2 ? { areaM2 } : {}),
+    notePt: `A ficha não fecha um preço para esta solução — o custo depende do que o lugar já tem. Vale pedir uma cotação cedo.${nota(true)}`,
+    noteEn: `The ficha does not close a price for this one — the cost depends on what the place already has. Worth asking for a quote early.${nota(false)}`,
+  };
+}
+
+// ── The invariant ───────────────────────────────────────────────────────────
+// Every band above must be findable in the ficha it claims to come from, unless
+// it declares itself derived and shows the working. Runs at module load, so a
+// content edit that orphans a number fails the test suite rather than shipping
+// a budget nobody can trace.
+
+/** Every currency amount stated in a sentence, with "R$ 20 mil" read as 20000. */
+function amountsIn(prose: string): Set<number> {
+  const found = new Set<number>();
+  const re = /R\$\s*([\d.,]+)(\s*mil)?/gi;
+  for (const m of Array.from(prose.matchAll(re))) {
+    const n = Number(m[1].replace(/\.(?=\d{3}\b)/g, '').replace(',', '.'));
+    if (!Number.isFinite(n)) continue;
+    found.add(m[2] ? n * 1000 : n);
+  }
+  // "R$ 400–700 por m²" and "entre R$ 70 e R$ 200" both leave the second figure
+  // without its own R$; take every bare number in the sentence too. This makes
+  // the check permissive on presence, which is the right direction: its job is
+  // to catch a number that has NO basis in the prose at all.
+  for (const m of Array.from(prose.matchAll(/(\d[\d.,]*)(\s*mil)?/g))) {
+    const n = Number(m[1].replace(/\.(?=\d{3}\b)/g, '').replace(',', '.'));
+    if (Number.isFinite(n)) found.add(m[2] ? n * 1000 : n);
+  }
+  return found;
+}
+
+for (const [id, cost] of Object.entries(SOLUTION_COSTS)) {
+  const ficha = getSolutionFicha(id);
+  if (!ficha) throw new Error(`w3-sizing: SOLUTION_COSTS has "${id}", which is not a ficha`);
+  if (cost.basis === 'none') continue;
+  if (cost.low == null || cost.high == null || cost.low > cost.high) {
+    throw new Error(`w3-sizing: ${id} declares basis "${cost.basis}" without a valid low/high band`);
+  }
+  if ((cost.basis === 'unit' || cost.basis === 'project') && !(cost.scalePt && cost.scaleEn)) {
+    throw new Error(`w3-sizing: ${id} is priced per ${cost.basis} but never says what one ${cost.basis} is`);
+  }
+  if (cost.notaPt || cost.notaEn) {
+    if (!(cost.notaPt && cost.notaEn)) throw new Error(`w3-sizing: ${id} has a derivation note in only one language`);
+    continue; // declared derived — the note carries the working
+  }
+  const amounts = amountsIn(ficha.pt.quantoCusta);
+  for (const v of [cost.low, cost.high]) {
+    if (!amounts.has(v)) {
+      throw new Error(
+        `w3-sizing: ${id} claims R$ ${v}, which no longer appears in its ficha's quantoCusta. ` +
+        `Either the sentence changed and the band must follow it, or the band is derived — in which case add notaPt/notaEn showing the arithmetic.`,
+      );
+    }
+  }
+}
+
+// Every ficha must be priced or explicitly declared unpriced. Adding a 28th
+// solution without a cost entry is then a load-time failure rather than a
+// silently blank budget line in someone's dossier.
+import { NBS_SOLUTION_FICHAS } from './nbs-solution-fichas';
+for (const id of Object.keys(NBS_SOLUTION_FICHAS)) {
+  if (!SOLUTION_COSTS[id]) throw new Error(`w3-sizing: ficha "${id}" has no SOLUTION_COSTS entry`);
+}


### PR DESCRIPTION
W3's job is a scoped project. That means a number an organisation can take to a funder, and three things were in the way.

## The area was being thrown away

The map has been able to draw polygons since it shipped. `formatMapResult` turned a drawn footprint into `- [custom] Custom area (5 vertices) (drawn area) at (lat, lng)` and dropped the geometry — so W3 could ask an org to draw the area and still have nothing to multiply a per-m² price by.

`shared/w3-sizing.ts` measures the ring by spherical excess (the formula Turf uses, written out so `shared/` stays importable from the server), rounds it to the precision a finger-drawn polygon actually carries — 487 m² reads as a survey; it is four taps on a phone — and the area travels with the selection as `· 480 m²`, appended after the coordinates so the server's existing site parser matches unchanged. Stored as `site_area_m2`.

## The price was parsed, and the parse was wrong three times

17 of the 27 fichas quote R$/m². My first pass read them with regexes, and every failure went the same direction — a confident wrong number rather than no number:

- **bacia-de-retenção** reads *"R$ 700/m² de estrutura + R$ 300/m² de paisagismo"*. The parse took the first figure and understated a 300 m² basin by R$ 90.000.
- **escola-verde** opens by saying the MMA cartilha does **not** close a number, then quotes R$ 250–500 per **tree**. That was published as a per-m² rate.
- **barraginha** and **cisterna** truncated at the thousands separator: R$ 20.000 → R$ 20.

The bands are now authored once in `SOLUTION_COSTS`, and an invariant at module load requires both ends of every band to appear literally in that ficha's own `quantoCusta`. The only exemption is a band that declares itself derived — which then *must* carry a note showing the arithmetic, because derived numbers an organisation cannot see are numbers it cannot defend in front of a secretariat. Edit the sentence without editing the number and the module throws, in dev and in every test run.

The 10 fichas with no rate get `unit`, `project` or `none` and show the ficha's own sentence. "A ficha não fecha um preço — o custo depende do que o lugar já tem" is a usable answer; a fabricated rate on a budget sheet is not.

Every line ends pointing at the next action — a quote to request, a count to give, a footprint to draw — and never presents itself as a budget.

## Two fixes to the manifest layer

Its header promises *"E2–E6 opt in by adding a manifest — no new code"*. Adding E3's manifest showed that held only for `org_profile`, in two more places beyond the validator fixed in #485, and both failed silently rather than loudly:

1. `filterRuledOptions` resolved chip labels through `ORG_PROFILE_ENUMS`, so fewer than two resolved and it returned `null` before filtering anything.
2. `FieldReader` took only a field name, so a rule naming another section read from the wrong one, found nothing, and reported "unconstrained".

(2) is exactly E3's `who_maintains`, which depends on `land_tenure` from W2 — straight out of the rain-garden ficha: *"quem cuida é a associação de moradores ou a prefeitura, dependendo de quem é o dono do terreno."* On land the organisation owns, a city maintenance partnership is not on the table, and offering it invites an agreement nobody can sign. The rule was inert in production while its unit test passed.

`sectionsFieldReader` is now used at all four call sites (update_section, ask_user, the close gate, and the fake model — which also only checked `org_profile`, so no spec could observe an E3 rule).

## Verification

- 31 new assertions across `w3-sizing.spec.ts` and `w3-questionnaire-cross-section.spec.ts`, including one that documents the single-section reader failure mode rather than asserting it away.
- Full suite: 317 passed. The 3 `w2-scenarios` failures under parallel load are the known `cbo-familia-reco` 20 s timeout in the LLM-fallback path after a 401; all 3 pass in isolation and on main.
- `tsc --noEmit`: 5 errors, identical to main.

**Next:** `serveE3Checkpoint`, the footprint drawing mode on the map, and the coordinator's portfolio view segregated by the four verdict states.