### PR TITLE
fix(w3): ten defects six simulations found

### DIFF
--- a/docs/w3-flow.md
+++ b/docs/w3-flow.md
@@ -158,3 +158,27 @@ the comment at the top of the cost section for what and why.
 - `e2e/w3-questionnaire-cross-section.spec.ts` — the manifest rules across
   sections.
 - `docs/w3-test-kit/` — four hand-run scenarios, one per verdict state.
+
+## What six simulations found
+
+`scripts/w3-sim-run.ts` drives six organisations through the real engine — no
+browser, no model, no database. Every one of these was invisible to a passing
+test suite, because a test asserts what you thought to assert and a transcript
+shows you what you actually said.
+
+| | what broke |
+|---|---|
+| **The manifest rule was a chip filter, not a rule.** | "Parceria com a prefeitura" is correctly absent on land the organisation owns — but the answer does not only arrive by tapping a chip. Typed, or relayed by the model, it reached the write path with the label intact and was stored. The org would have left W3 with a maintenance agreement the city cannot sign. |
+| **One site could only carry one solution.** | The entire four-state verdict is argued from an org that wants a garden it can fund now beside a swale that needs a study — and the flow had no beat for adding the second. |
+| **Beats read state from before their own writes.** | `chosen` and `areaM2` are snapshotted when the turn starts. `confirmSolution` appends and closes in the same turn, so the closing dossier showed the *previous* solution list. The same bug had already sent per-unit solutions to trace a footprint. |
+| **An org with no pin was told it had marked a place.** | *"No Encontro 2 vocês marcaram Rubem Berta"* — to an organisation that marked nothing, and the one least able to argue with us about its own record. It was then offered "Desenhar no mapa", which bailed with an apology and handed the turn to the model: a dead end in exactly the scenario the workshop most needs to handle. |
+| **A machine id was printed to the organisation.** | *"Confirmar no lugar se o problema é mesmo landslide"* — an English id, mid-Portuguese-sentence, describing their own hillside back to them. |
+| **Three contact rows for one door.** | Every ficha that names SMAMUS or DMAE uses the word *prefeitura* in the same breath, so all three matched. One of the three named nobody, and a coordinator had to work out which was real. |
+| **Every price printed twice.** | Once under "Quanto custa" and again, word for word, under "Documentar". |
+| **The board and the dossier disagreed about who finds a técnico.** | The `needs_study` pile exists because a cohort commissioning several studies at once is a procurement and a single org hiring one is not. The dossier assigned the study to the *org*. |
+| **`capacity` had collapsed into one signal.** | `established` required "a named person", read from `contact_name` — which E1 captures from everybody. So the grade was just `site_knowledge_depth` wearing a second name. It now reads `community_anchoring_lead` or a funding history: a name on a form is evidence that a form was filled in. |
+| **A site-less org learned nothing about its own choice.** | It spent the session choosing a solution and got a dossier that never mentioned it. |
+
+Two of these — the rule bypass and the stale reads — are the same shape, and it
+is the shape to watch for in this file: **a guard that only covers the path you
+were looking at**, and **a value read before the write that changes it**.

--- a/e2e/cougar-e3-linear-journey.spec.ts
+++ b/e2e/cougar-e3-linear-journey.spec.ts
@@ -54,6 +54,7 @@ const LANGS = [
     freq: 'A cada três meses',
     moneyText: 'dinheiro que volta todo ano',
     money: 'Ainda não sabemos', // E3_SUSTAINABILITY.indefinido
+    onlyThis: 'Só essa por enquanto',
     closingText: 'Pronto',
   },
   {
@@ -79,6 +80,7 @@ const LANGS = [
     freq: 'Quarterly',
     moneyText: 'money that comes back every year',
     money: 'Not decided yet', // E3_SUSTAINABILITY.indefinido
+    onlyThis: 'Just this one for now',
     closingText: 'Done',
   },
 ] as const;
@@ -148,6 +150,12 @@ for (const L of LANGS) {
       //     close — it is the gap the portfolio carries to the municipality.
       await expect(page.getByText(L.moneyText, { exact: false }).last()).toBeVisible({ timeout: 10_000 });
       await chip(L.money).click();
+
+      // 7b · One site can carry more than one solution, and that is offered
+      //      once, after the first is fully scoped — the case the four-state
+      //      verdict was argued from could not otherwise be expressed at all.
+      await expect(chip(L.onlyThis)).toBeVisible({ timeout: 10_000 });
+      await chip(L.onlyThis).click();
 
       // 8 · The dossier. Public-informal tenure with no technical marker on
       //     this solution… except the rain garden ficha DOES name a soil

--- a/e2e/cougar-e3-paths.spec.ts
+++ b/e2e/cougar-e3-paths.spec.ts
@@ -99,7 +99,7 @@ test.describe('COUGAR — E3 paths', () => {
   });
 
   test('a city partnership is not offered on land the organisation owns', async ({ page, request }) => {
-    await start(page, request, [
+    const cboId = await start(page, request, [
       ...SITED,
       { sectionId: 'intervention_site', field: 'land_tenure', value: 'private-owned' },
     ]);
@@ -125,14 +125,28 @@ test.describe('COUGAR — E3 paths', () => {
     await expect(chip('A gente mesmo')).toBeVisible();
     await expect(chip('Empresa contratada')).toBeVisible();
     await expect(chip('Parceria com a prefeitura')).toHaveCount(0);
+    // ⚠️ And the rule is not only a chip filter. Typed (or relayed by the
+    // model), the same answer reached the write path with the label intact and
+    // was stored — so the org would have left W3 with a maintenance agreement
+    // the city cannot sign. The engine now refuses the value itself.
+    await page.getByTestId('cbo-chat-input').fill('Parceria com a prefeitura');
+    await page.getByTestId('cbo-chat-input').press('Enter');
+    await page.waitForTimeout(2500);
+    const body = await (await request.get(`/api/cbo/${cboId}`)).json();
+    expect(body.state?.sections?.operations_sustain?.fields?.who_maintains?.value).not.toBe('parceria-prefeitura');
   });
 
   test('no place marked means no project — and W3 says exactly that', async ({ page, request }) => {
     await start(page, request, BASE);
     const chip = chipFor(page);
 
-    await expect(chip('É isso ✓')).toBeVisible({ timeout: 15_000 });
-    await chip('É isso ✓').click();
+    // ⚠️ An org with no pin is NOT asked to confirm a place it never marked.
+    // The opening used to say "no Encontro 2 vocês marcaram Rubem Berta" to an
+    // organisation that had marked nothing — claiming something that did not
+    // happen, to the org least able to argue with us about its own record.
+    await expect(chip('Marcar o lugar agora')).toBeVisible({ timeout: 15_000 });
+    await expect(chip('É isso ✓')).toHaveCount(0);
+    await chip('Seguir sem o lugar').click();
     await expect(page.getByTestId('cbo-solution-options')).toBeVisible({ timeout: 10_000 });
     // Nothing is filtered even here: the full catalogue is still reachable.
     await chip('Ver todas as soluções').click();
@@ -158,6 +172,8 @@ test.describe('COUGAR — E3 paths', () => {
     await chip('Todo mês').click();
     await expect(chip('Ainda não sabemos')).toBeVisible({ timeout: 10_000 });
     await chip('Ainda não sabemos').click();
+    await expect(chip('Só essa por enquanto')).toBeVisible({ timeout: 10_000 });
+    await chip('Só essa por enquanto').click();
 
     // The dossier is short, and honest about why: it does not manufacture a
     // scoped project over a place nobody has chosen.

--- a/e2e/w3-dossier.spec.ts
+++ b/e2e/w3-dossier.spec.ts
@@ -90,8 +90,20 @@ test.describe('W3 dossier — four records, four verdicts', () => {
     const d = buildDossier(ENCOSTA_VIVA);
     expect(d.capacity.grade).toBe('exploratory');
     expect(d.verdicts[0].state).toBe('needs_site');
-    // The disagreement is the reason to visit, not a missing field.
-    expect(d.items.some(i => i.list === 'investigate' && /enxurrada/.test(i.text))).toBe(true);
+    // The disagreement is the reason to visit, not a missing field — and it is
+    // named in THEIR words. This line used to print the stored id back at them
+    // ("se o problema é mesmo enxurrada"), and for a legacy record it printed
+    // an English one ("é mesmo landslide") in the middle of a Portuguese
+    // sentence, describing their own hillside.
+    expect(d.items.some(i => i.list === 'investigate' && /água que desce com força/.test(i.text))).toBe(true);
+    expect(d.items.every(i => !/\b(enxurrada|landslide|alagamento)\b/.test(i.text))).toBe(true);
+    // Even with no place, once they HAVE chosen something the ficha already
+    // knows what that choice will demand. The first version returned a dossier
+    // that never mentioned the solution they had just spent the session
+    // choosing — technically correct, and useless to take home.
+    const chosen = buildDossier({ ...ENCOSTA_VIVA, solutions: ['grade-viva'] });
+    expect(chosen.items.some(i => i.blockedBy && /marcar o lugar/.test(i.blockedBy))).toBe(true);
+    expect(chosen.items.some(i => /ART/.test(i.text))).toBe(true);
     // And it names what it could not produce.
     expect(d.gaps.join(' ')).toMatch(/área|area/i);
   });

--- a/knowledge/_skills/encontro-3.md
+++ b/knowledge/_skills/encontro-3.md
@@ -54,7 +54,11 @@ até a frase da ficha de onde ela veio.
    base). Ambas aceitam "Prefiro pular".
 5. **Depois do mutirão** — quem cuida → com que frequência → de onde vem o
    dinheiro recorrente.
-6. **O dossiê** — `show_dossier`: veredito por solução, as quatro listas
+6. **Mais uma solução?** — um lugar às vezes pede duas coisas (uma horta e uma
+   vala), cada uma com o seu caminho e o seu custo. Oferecido UMA vez, depois da
+   primeira estar fechada. A segunda reaproveita tudo o que já foi respondido
+   sobre o lugar — só o preço, que é por solução, é dito de novo.
+7. **O dossiê** — `show_dossier`: veredito por solução, as quatro listas
    (investigar / falar com / registrar / documentar) com dono proposto, a faixa
    de preço, e as pendências.
 
@@ -129,10 +133,22 @@ gente, não de documento.
 
 ### 5 · Uma organização que chega sem lugar marcado
 
-Acontece, e não é fracasso. O dossiê já trata isso: o veredito vira
-**"falta marcar o lugar"** e a única pendência é marcar um. Não force um projeto
-por cima de um vazio — diga com todas as letras que o resto fecha rápido assim
-que houver um ponto no mapa, e ofereça o mapa.
+Acontece, e não é fracasso. O platform já trata isso: a abertura NÃO finge que
+existe um ponto — ela diz que falta um e oferece `[Marcar o lugar agora]` /
+`[Seguir sem o lugar]`. Se a pessoa seguir sem, o veredito no fim vira
+**"falta marcar o lugar"**, e o dossiê já diz o que a solução escolhida vai
+exigir quando houver um ponto.
+
+Se a conversa cair em você aqui: nunca force um projeto por cima de um vazio, e
+nunca diga que elas "marcaram" alguma coisa que não marcaram. Diga com todas as
+letras que o resto fecha rápido assim que houver um ponto no mapa.
+
+### 6 · "Parceria com a prefeitura" em terreno próprio
+
+O servidor **recusa** esse valor em terreno próprio — não só tira o chip, recusa
+a escrita, venha ela de onde vier. Se a pessoa insistir, explique por quê (seria
+combinar um acordo que ninguém pode assinar) e ofereça as opções que sobram.
+Nunca contorne a recusa gravando outro campo no lugar.
 
 ## Don't re-ask — anything, ever
 

--- a/scripts/w3-sim-run.ts
+++ b/scripts/w3-sim-run.ts
@@ -1,0 +1,138 @@
+import { run, mkState } from './w3-sim';
+
+const E = 'Vamos começar o Encontro 3.';
+
+async function main() {
+// ── 1 · Sarandi: the richest W2 record. Public land + rain garden.
+await run('1 · HORTA RAÍZES DO SARANDI — W2 completo, terreno público, jardim de chuva',
+  mkState({
+    org_profile: { org_name: 'Horta Raízes do Sarandi', contact_name: 'Marlene Duarte', prior_project_scale: 'funded' },
+    intervention_site: {
+      bairro: 'Sarandi', site_name: 'Terreno ao lado da horta', _site_lat: '-30.0906', _site_lng: '-51.1726',
+      current_use: 'abandoned', land_tenure: 'public-informal', site_worry: 'alagamento',
+      site_story: 'Quando chove forte a água entra pelo fundo e fica dias parada.',
+      site_knowledge_depth: 'strong', nbs_interest: 'aguas-pluviais',
+    },
+  }), [
+    { msg: E },
+    { msg: 'É isso ✓', kind: 'chip' },
+    { msg: 'Jardins de chuva', kind: 'chip' },
+    { msg: 'Desenhar no mapa', kind: 'chip' },
+    { msg: 'Map selection (composite mode):\n- [zone] Sarandi: FLOOD risk, flood: 80%, heat: 40%, landslide: 5%\n- [custom] Área desenhada (5 vertices) (drawn area) at (-30.0906, -51.1726) · 500 m²\nTotal: 2 assets, 0 sampled points', kind: 'map' },
+    { msg: 'É o único terreno livre do quarteirão e é onde a água toda desce.' },
+    { msg: 'Terra batida com entulho, sem drenagem. Depois da chuva fica poça três dias.' },
+    { msg: 'Parceria com a prefeitura', kind: 'chip' },
+    { msg: 'A cada três meses', kind: 'chip' },
+    { msg: 'Ainda não sabemos', kind: 'chip' },
+    { msg: 'Só essa por enquanto', kind: 'chip' },
+  ]);
+
+// ── 2 · Encosta Viva: never marked a place.
+await run('2 · COLETIVO ENCOSTA VIVA — sem lugar marcado, encosta',
+  mkState({
+    org_profile: { org_name: 'Coletivo Encosta Viva', contact_name: 'Antônia Reis' },
+    intervention_site: { bairro: 'Glória', site_worry: 'landslide', site_knowledge_depth: 'thin' },
+  }), [
+    { msg: E },
+    { msg: 'Seguir sem o lugar', kind: 'chip' },
+    { msg: 'Ver todas as soluções', kind: 'chip' },
+    { msg: 'Grade viva', kind: 'chip' },
+    { msg: 'Ainda não sei o tamanho', kind: 'chip' },
+    { msg: 'Prefiro pular', kind: 'chip' },
+    { msg: 'O barranco fica logo atrás das casas e desce um pouco a cada chuva.' },
+    { msg: 'Voluntários da comunidade', kind: 'chip' },
+    { msg: 'Todo mês', kind: 'chip' },
+    { msg: 'Ainda não sabemos', kind: 'chip' },
+    { msg: 'Só essa por enquanto', kind: 'chip' },
+  ]);
+
+// ── 3 · Vila Nova: school yard, per-project pricing.
+await run('3 · ASSOCIAÇÃO CULTURAL VILA NOVA — pátio de escola, horta',
+  mkState({
+    org_profile: { org_name: 'Associação Cultural Vila Nova', contact_name: 'Jussara Lima' },
+    intervention_site: {
+      bairro: 'Vila Nova', site_name: 'Pátio da EMEF Nossa Senhora', _site_lat: '-30.13', _site_lng: '-51.22',
+      current_use: 'paved', land_tenure: 'public-informal', site_worry: 'heat',
+      site_story: 'O pátio é todo cimento, as crianças não têm sombra nenhuma no recreio.',
+      site_knowledge_depth: 'strong', nbs_interest: 'agricultura-urbana, verde-urbano',
+    },
+  }), [
+    { msg: E },
+    { msg: 'É isso ✓', kind: 'chip' },
+    { msg: 'Hortas urbanas', kind: 'chip' },
+    { msg: 'É o pátio da escola do bairro, onde as crianças já passam todo dia.' },
+    { msg: 'Metade cimento, metade terra pisada. Só tem uma árvore no canto.' },
+    { msg: 'Parceria com a prefeitura', kind: 'chip' },
+    { msg: 'Todo mês', kind: 'chip' },
+    { msg: 'Editais e projetos', kind: 'chip' },
+    { msg: 'Só essa por enquanto', kind: 'chip' },
+  ]);
+
+// ── 4 · Partenon: own land, legacy worry id, wants two solutions.
+await run('4 · REDE PARTENON — terreno próprio, worry legado "flood", duas soluções',
+  mkState({
+    org_profile: { org_name: 'Rede Partenon', contact_name: 'Cléber Assis', prior_project_scale: 'funded' },
+    intervention_site: {
+      bairro: 'Partenon', site_name: 'Terreno da sede', _site_lat: '-30.07', _site_lng: '-51.15',
+      current_use: 'vegetated', land_tenure: 'private-owned', site_worry: 'flood',
+      site_story: 'A água desce com força da rua de cima e leva a terra toda.',
+      site_knowledge_depth: 'strong', nbs_interest: 'aguas-pluviais, agricultura-urbana',
+    },
+  }), [
+    { msg: E },
+    { msg: 'É isso ✓', kind: 'chip' },
+    { msg: 'Hortas urbanas', kind: 'chip' },
+    { msg: 'É onde a gente já planta há seis anos e onde a água desce.' },
+    { msg: 'Terreno com mato alto e um barranco de dois metros no fundo.' },
+    // ⚠️ typed, not tapped: the chip is correctly absent on own land, and this
+    // is the path that used to write it anyway.
+    { msg: 'Parceria com a prefeitura', kind: 'chip' },
+    { msg: 'A gente mesmo', kind: 'chip' },
+    { msg: 'Todo mês', kind: 'chip' },
+    { msg: 'Recursos próprios', kind: 'chip' },
+    { msg: 'Levar mais uma solução', kind: 'chip' },
+    { msg: 'Biovaletas', kind: 'chip' },
+  ]);
+
+// ── 5 · A thin W2: bairro only, nothing else. The most common real state.
+await run('5 · GRUPO MISTURAÍ — W2 magro: só o bairro, sem relato, sem interesse marcado',
+  mkState({
+    org_profile: { org_name: 'Grupo Misturaí' },
+    intervention_site: { bairro: 'Rubem Berta' },
+  }), [
+    { msg: E },
+    { msg: 'Seguir sem o lugar', kind: 'chip' },
+    { msg: 'Jardins de chuva', kind: 'chip' },
+    { msg: 'Ainda não sei o tamanho', kind: 'chip' },
+    { msg: 'Prefiro pular', kind: 'chip' },
+    { msg: 'Prefiro pular', kind: 'chip' },
+    { msg: 'A gente mesmo', kind: 'chip' },
+    { msg: 'Uma vez por ano', kind: 'chip' },
+    { msg: 'Ainda não sabemos', kind: 'chip' },
+    { msg: 'Só essa por enquanto', kind: 'chip' },
+  ]);
+
+// ── 6 · A licenca slope solution, in English, on own land.
+await run('6 · SLOPE COLLECTIVE (en) — own land, retaining wall, licenca solution',
+  mkState({
+    org_profile: { org_name: 'Slope Collective', contact_name: 'Dora Neves' },
+    intervention_site: {
+      bairro: 'Lomba do Pinheiro', site_name: 'Barranco atrás da sede', _site_lat: '-30.11', _site_lng: '-51.10',
+      current_use: 'slope', land_tenure: 'private-owned', site_worry: 'landslide',
+      site_story: 'The slope behind the building sheds earth every heavy rain.',
+      site_knowledge_depth: 'strong', nbs_interest: 'encostas-e-solo',
+    },
+  }, 'en'), [
+    { msg: "Let's start Encontro 3." },
+    { msg: "That's it ✓", kind: 'chip' },
+    { msg: 'Green retaining wall', kind: 'chip' },
+    { msg: "I don't know the size yet", kind: 'chip' },
+    { msg: 'The houses above us are right on the edge of it.' },
+    { msg: 'Bare earth, two metres high, nothing planted.' },
+    { msg: 'Community volunteers', kind: 'chip' },
+    { msg: 'Quarterly', kind: 'chip' },
+    { msg: 'Not decided yet', kind: 'chip' },
+    { msg: 'Just this one for now', kind: 'chip' },
+  ], 'en');
+}
+main();

--- a/scripts/w3-sim.ts
+++ b/scripts/w3-sim.ts
@@ -1,0 +1,83 @@
+// Drives the REAL E3 checkpoint engine through six organisations, capturing
+// every word it says and every event it emits. No UI, no model, no DB — the
+// same function the server calls, so what comes out is what an org would see.
+import { serveE3Checkpoint } from '../server/services/cboE3Checkpoint';
+
+const normChip = (s: string) =>
+  s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, ' ').trim();
+
+type Field = { value: string };
+function mkState(fields: Record<string, Record<string, string>>, lang = 'pt') {
+  const sections: any = {};
+  for (const id of ['org_profile', 'intervention_site', 'intervention_type', 'impact_monitoring', 'operations_sustain', 'needs_support', 'results_evidence']) {
+    sections[id] = { fields: {} as Record<string, Field>, lastUpdatedBy: 'agent' };
+  }
+  for (const [sid, kv] of Object.entries(fields)) {
+    for (const [k, v] of Object.entries(kv)) sections[sid].fields[k] = { value: v, confidence: 'high', source: 'user' };
+  }
+  return { phase: 3, sections, editLog: [], gaps: [], maturityScores: [], priorityFlags: [], metadata: { language: lang } } as any;
+}
+
+interface Turn { msg: string; kind?: string }
+
+async function run(name: string, state: any, turns: Turn[], lang = 'pt') {
+  const log: string[] = [];
+  const events: any[] = [];
+  const deps = {
+    writeFields: (sectionId: string, fields: Record<string, string>) => {
+      for (const [k, v] of Object.entries(fields)) state.sections[sectionId].fields[k] = { value: v, confidence: 'high', source: 'user' };
+    },
+    recordCheckpoint: (step: string) => log.push(`      · [beat: ${step}]`),
+    normChip,
+  };
+  const push = (e: any) => {
+    events.push(e);
+    if (e.type === 'chat') log.push(`   🤖 ${String(e.content).replace(/\n+/g, '\n      ')}`);
+    else if (e.type === 'ask_user') log.push(`   ❓ ${e.question}\n      ${e.options.map((o: any) => `[${o.label}]${o.description ? ' — ' + o.description : ''}`).join('\n      ')}`);
+    else if (e.type === 'show_solution_options') log.push(`   📋 solution options (${e.items.length}${e.full ? ', FULL' : ''}):\n${e.items.slice(0, 5).map((i: any) => `      • ${i.solutionId}: ${i.reason}${i.caveat ? '\n        ⚠ ' + i.caveat : ''}`).join('\n')}`);
+    else if (e.type === 'show_dossier') log.push('   📄 DOSSIER');
+    else if (e.type === 'open_map') log.push(`   🗺  open_map preset=e3_footprint drawFootprint=${JSON.stringify(e.params.drawFootprint)}`);
+    else if (e.type === 'done') { /* quiet */ }
+    else if (e.type !== 'field_update') log.push(`   ⚙ ${e.type}`);
+  };
+
+  console.log(`\n${'═'.repeat(78)}\n${name}\n${'═'.repeat(78)}`);
+  for (const t of turns) {
+    console.log(`\n   👤 ${t.msg}${t.kind ? ` (${t.kind})` : ''}`);
+    log.length = 0;
+    const served = await serveE3Checkpoint('sim', t.msg, state, push, lang, t.kind ?? 'text', deps as any);
+    if (!served) console.log('   ⚠️  NOT SERVED — falls through to the model');
+    console.log(log.join('\n'));
+  }
+  const dossier = events.filter(e => e.type === 'show_dossier').pop()?.dossier;
+  if (dossier) {
+    console.log(`\n   ── DOSSIER ─────────────────────────────────────────────────`);
+    console.log(`   capacity: ${dossier.capacity.grade} — ${dossier.capacity.because.join('; ') || '(nothing)'}`);
+    for (const v of dossier.verdicts) console.log(`   verdict[${v.solutionId ?? '—'}] = ${v.state}\n      why: ${v.why}\n      unblocked by: ${v.unblockedBy}\n      source: ${v.source}`);
+    for (const b of dossier.budget) console.log(`   💰 ${b.solutionId} [${b.basis}] ${b.notePt}`);
+    for (const list of ['investigate', 'contact', 'gather', 'document']) {
+      const items = dossier.items.filter((i: any) => i.list === list);
+      if (items.length) console.log(`   ${list.toUpperCase()}:\n${items.map((i: any) => `      – (${i.owner}) ${i.text}${i.blockedBy ? `\n        blocked by: ${i.blockedBy}` : ''}\n        ← ${i.source}`).join('\n')}`);
+    }
+    if (dossier.gaps.length) console.log(`   GAPS:\n${dossier.gaps.map((g: string) => '      ! ' + g).join('\n')}`);
+  } else {
+    console.log('\n   ⚠️  NO DOSSIER PRODUCED');
+  }
+  return { state, dossier, events };
+}
+
+export { run, mkState };
+
+// ── How to use ──────────────────────────────────────────────────────────────
+// npx tsx scripts/w3-sim-run.ts
+//
+// Six organisations through the real E3 engine, no browser and no model. It is
+// how the eight defects listed in docs/w3-flow.md were found — every one of
+// them was invisible to a passing test suite, because a test asserts what you
+// thought to assert and a transcript shows you what you actually said.
+//
+// Add a scenario by adding a mkState + run() to w3-sim-run.ts. The value is in
+// READING the output, not in it exiting zero: watch for a beat that says
+// NOT SERVED (the turn fell through to the model), a dossier that names a
+// machine id, an item list with three rows for one door, and any sentence that
+// claims something the record does not support.

--- a/server/services/cboE3Checkpoint.ts
+++ b/server/services/cboE3Checkpoint.ts
@@ -34,7 +34,7 @@ import { topShortlist } from '@shared/w3-solutions';
 import { budgetLineFor, roundAreaM2 } from '@shared/w3-sizing';
 import { getSolution } from '@shared/nbs-catalog';
 import { getSolutionFicha } from '@shared/nbs-solution-fichas';
-import { E3_QUESTIONNAIRE, allowedOptionIds, askCopyFor, sectionsFieldReader } from '@shared/cbo-questionnaire';
+import { E3_QUESTIONNAIRE, allowedOptionIds, checkOptionRule, askCopyFor, sectionsFieldReader } from '@shared/cbo-questionnaire';
 import { cboFieldEnumOptions } from '@shared/cbo-field-catalog';
 import { resolveOpenMapParams } from '@shared/cbo-map-presets';
 
@@ -62,6 +62,13 @@ const E3C = {
   redesenhar: { pt: 'Quero desenhar de novo', en: 'I want to draw it again' },
   pular: { pt: 'Prefiro pular', en: "I'd rather skip" },
   verDossie: { pt: 'Ver o resumo do projeto', en: 'See the project summary' },
+  // An organisation with no pin used to be offered "Desenhar no mapa", which
+  // bailed with an apology and handed the turn to the model — a dead end in
+  // exactly the scenario the workshop most needs to handle well.
+  marcarAgora: { pt: 'Marcar o lugar agora', en: 'Mark the place now' },
+  seguirSemLugar: { pt: 'Seguir sem o lugar', en: 'Carry on without it' },
+  outraSolucao: { pt: 'Levar mais uma solução', en: 'Take one more solution' },
+  soEssa: { pt: 'Só essa por enquanto', en: 'Just this one for now' },
 } as const;
 
 /**
@@ -137,6 +144,21 @@ export async function serveE3Checkpoint(
     return true;
   };
 
+  /**
+   * The solutions and the area AS THEY STAND, not as they stood when the turn
+   * began.
+   *
+   * `chosen` and `areaM2` above are a snapshot taken at the top of this
+   * function, and several beats write before they read: confirmSolution appends
+   * a second solution and closes in the same turn. Reading the snapshot there
+   * built the dossier from the previous list — an organisation that added a
+   * bioswale beside its garden got a closing card showing only the garden,
+   * which is precisely the case the four-state verdict exists to handle.
+   */
+  const liveSolutions = () =>
+    read(TYPE)('chosen_solutions').split(',').map(v => v.trim()).filter(Boolean);
+  const liveArea = () => Number(read(SITE)('site_area_m2')) || 0;
+
   const w3Input = (): W3Input => ({
     site: Object.fromEntries(
       Object.entries(fieldsOf(SITE)).map(([k, v]) => [k, String(v?.value ?? '')]),
@@ -144,8 +166,8 @@ export async function serveE3Checkpoint(
     org: Object.fromEntries(
       Object.entries(fieldsOf('org_profile')).map(([k, v]) => [k, String(v?.value ?? '')]),
     ),
-    solutions: chosen,
-    ...(areaM2 ? { areaM2 } : {}),
+    solutions: liveSolutions(),
+    ...(liveArea() ? { areaM2: liveArea() } : {}),
     w3: {
       ...Object.fromEntries(Object.entries(fieldsOf(TYPE)).map(([k, v]) => [k, String(v?.value ?? '')])),
       ...Object.fromEntries(Object.entries(fieldsOf(IMPACT)).map(([k, v]) => [k, String(v?.value ?? '')])),
@@ -171,18 +193,52 @@ export async function serveE3Checkpoint(
     ask(copy ?? qPt, copy ?? qEn, opts.map(o => ({ pt: o.pt, en: o.en })));
     return finish(`ask-${field}`);
   };
-  /** Resolve a chip label back to the option id it came from. */
+  /**
+   * Resolve a chip label back to the option id it came from — and refuse an id
+   * the stored W2 answer excludes.
+   *
+   * ⚠️ Filtering the chips is not enough, and a simulation proved it: the
+   * "Parceria com a prefeitura" chip is correctly absent on land the
+   * organisation owns, but the answer does not only arrive by tapping a chip.
+   * A typed reply, or the model relaying one, reaches this function with the
+   * label intact — and the first version wrote it straight through, so the one
+   * guarantee the manifest layer exists to give was bypassed by the very flow
+   * that renders it. The organisation would have left W3 with a maintenance
+   * agreement the city cannot sign.
+   */
   const enumIdFromChip = (sectionId: string, field: string, chip: string): string | null => {
     const n = deps.normChip(chip);
     const hit = (cboFieldEnumOptions(sectionId, field) ?? []).find(
       o => deps.normChip(o.pt) === n || deps.normChip(o.en) === n,
     );
-    return hit ? hit.id : null;
+    if (!hit) return null;
+    if (sectionId === OPS && !checkOptionRule(E3_QUESTIONNAIRE, field, hit.id, manifestRead).ok) {
+      return null;
+    }
+    return hit.id;
   };
 
   // ── Beat 0 · pick up where W2 left off ────────────────────────────────────
   const openW3 = (): true => {
-    const place = siteName || bairro || (isPt ? 'o lugar de vocês' : 'your place');
+    // ⚠️ An organisation that never pinned a place has a BAIRRO, not a site.
+    // Telling it "no Encontro 2 vocês marcaram Rubem Berta" claims something
+    // that did not happen, and it is the org least able to argue with us about
+    // its own record. Name what actually exists, and say plainly what W3 will
+    // do about the gap rather than opening on a fiction.
+    if (!hasSitePin) {
+      const where = bairro.split(',')[0].trim();
+      say(
+        `Bem-vindas ao Encontro 3. Hoje a gente transforma o que vocês contaram num projeto: uma solução, um tamanho, uma faixa de preço, e quem precisa dizer sim.\n\nUma coisa só: ${where ? `vocês falaram do **${where}**, mas` : ''} ainda não tem um lugar marcado no mapa. Dá pra seguir mesmo assim — o que der pra fechar hoje fica fechado, e o resto espera o ponto.`,
+        `Welcome to Encontro 3. Today we turn what you told us into a project: one solution, a size, a price range, and who has to say yes.\n\nOne thing first: ${where ? `you told us about **${where}**, but ` : ''}there is still no place marked on the map. We can carry on anyway — whatever can be settled today gets settled, and the rest waits for the pin.`,
+      );
+      ask('Como prefere?', 'How would you like to do it?', [
+        { pt: E3C.marcarAgora.pt, en: E3C.marcarAgora.en, dPt: 'Abre o mapa', dEn: 'Opens the map' },
+        { pt: E3C.seguirSemLugar.pt, en: E3C.seguirSemLugar.en, dPt: 'A gente marca depois', dEn: 'We will mark it later' },
+      ]);
+      deps.writeFields(TYPE, { _e3_opened: 'yes' });
+      return finish('open-no-site');
+    }
+    const place = siteName || bairro;
     say(
       `Bem-vindas ao Encontro 3. No Encontro 2 vocês marcaram **${place}** e me contaram o que preocupa ali. Hoje a gente transforma isso num projeto: uma solução, um tamanho, uma faixa de preço, e quem precisa dizer sim.\n\nSó pra começar do lugar certo — ainda é **${place}**?`,
       `Welcome to Encontro 3. In Encontro 2 you marked **${place}** and told me what worries you there. Today we turn that into a project: one solution, a size, a price range, and who has to say yes.\n\nJust so we start in the right place — is it still **${place}**?`,
@@ -193,6 +249,18 @@ export async function serveE3Checkpoint(
     ]);
     deps.writeFields(TYPE, { _e3_opened: 'yes' });
     return finish('open');
+  };
+
+  /** Send them to E2's own site map. W3 does not reinvent that step. */
+  const openSiteMap = (detail: string): true => {
+    pushEvent({
+      type: 'open_map',
+      params: resolveOpenMapParams(
+        { preset: 'e2_site_focused', focusZone: bairro.split(',')[0].trim() },
+        isPt ? 'pt' : 'en',
+      ),
+    } as any);
+    return finish(detail);
   };
 
   // ── Beat 1 · the solution ─────────────────────────────────────────────────
@@ -227,15 +295,28 @@ export async function serveE3Checkpoint(
   };
 
   /** They picked one. Say what it will need, from its own ficha, before sizing. */
-  const confirmSolution = (solutionId: string): true => {
+  const confirmSolution = async (solutionId: string): Promise<true> => {
     const sol = getSolution(solutionId);
     const ficha = getSolutionFicha(solutionId);
-    deps.writeFields(TYPE, { chosen_solutions: solutionId });
+    const adding = type('_adding_solution') === 'yes';
+    deps.writeFields(TYPE, {
+      chosen_solutions: [...chosen, solutionId].join(','),
+      ...(adding ? { _adding_solution: '' } : {}),
+    });
     if (sol && ficha) {
       say(
         `**${sol.pt.label}** ✓\n\n${sol.pt.whatItIs}\n\n_Quem precisa dizer sim:_ ${ficha.pt.quemPrecisaDizerSim}`,
         `**${sol.en.label}** ✓\n\n${sol.en.whatItIs}\n\n_Who has to say yes:_ ${ficha.en.quemPrecisaDizerSim}`,
       );
+    }
+    // A second solution reuses everything already answered about the place —
+    // the footprint, why here, the baseline, who maintains it. Re-asking any of
+    // that would be the "you weren't listening" signal in its purest form. Only
+    // the price, which is per solution, is restated.
+    if (adding) {
+      const line = budgetLineFor(solutionId, areaM2 || undefined);
+      if (line) say(line.notePt, line.noteEn);
+      return await closeE3();
     }
     return askArea(solutionId);
   };
@@ -276,6 +357,23 @@ export async function serveE3Checkpoint(
       ]);
       deps.writeFields(SITE, { _area_asked: 'yes' });
       return finish('confirm-area');
+    }
+    // Offering "Desenhar no mapa" to an organisation with no pin is offering a
+    // step that cannot run: the draw session opens AT the site. It used to bail
+    // with an apology and hand the turn to the model. Offer the thing that would
+    // actually unblock it instead — marking the place — with the honest
+    // alternative beside it.
+    if (!hasSitePin) {
+      say(
+        `Sobre o tamanho: ${line ? line.notePt : 'a ficha cobra por m²'}, e pra fechar um total falta o lugar no mapa.`,
+        `On size: ${line ? line.noteEn : 'the ficha prices this per m²'}, and closing a total needs the place on the map.`,
+      );
+      ask('Quer marcar agora?', 'Want to mark it now?', [
+        { pt: E3C.marcarAgora.pt, en: E3C.marcarAgora.en, dPt: 'Abre o mapa', dEn: 'Opens the map' },
+        { pt: E3C.naoSeiTamanho.pt, en: E3C.naoSeiTamanho.en, dPt: 'Fica registrado como pendente', dEn: 'Recorded as still open' },
+      ]);
+      deps.writeFields(SITE, { _area_asked: 'yes' });
+      return finish('ask-area-no-site');
     }
     say(
       'Agora o tamanho. Contorne no mapa a área onde o projeto vai — não precisa ser exato, é pra ter uma ordem de grandeza e uma faixa de preço.',
@@ -343,6 +441,29 @@ export async function serveE3Checkpoint(
     askEnum(OPS, 'who_maintains', 'Depois que o mutirão vai embora, quem cuida disso no dia a dia?', 'After the mutirão goes home, who looks after this day to day?');
   const askFrequency = (): true =>
     askEnum(OPS, 'maintenance_frequency', 'Com que frequência isso precisa de cuidado?', 'How often does it need looking after?');
+  /**
+   * One site, more than one solution.
+   *
+   * The whole four-state verdict rests on this being possible: a community
+   * garden that can take money now, beside a stormwater intervention that
+   * cannot be sized without a study, is what broke the two-way split agreed on
+   * 27 August. Until this beat existed the flow could not express the case its
+   * own design was argued from — the first six simulations closed Partenon
+   * with a single solution.
+   */
+  const askAnotherSolution = (): true => {
+    say(
+      'Antes de fechar: às vezes um lugar pede mais de uma coisa — uma horta e uma vala, por exemplo. Cada uma tem o seu próprio caminho e o seu próprio custo, e a gente separa isso no resumo.',
+      'Before we close: sometimes a place needs more than one thing — a garden and a swale, say. Each has its own route and its own cost, and the summary keeps them separate.',
+    );
+    ask('Querem levar mais alguma solução nesse mesmo lugar?', 'Do you want to take another solution on this same place?', [
+      { pt: E3C.soEssa.pt, en: E3C.soEssa.en },
+      { pt: E3C.outraSolucao.pt, en: E3C.outraSolucao.en, dPt: 'Volta pra lista', dEn: 'Back to the list' },
+    ]);
+    deps.writeFields(TYPE, { _second_asked: 'yes' });
+    return finish('ask-second-solution');
+  };
+
   const askSustainability = (): true => {
     say(
       'E o dinheiro que volta todo ano — o da manutenção, não o da obra. **"Ainda não sabemos" é uma resposta válida aqui**: é justamente a conversa que a coordenação leva para a prefeitura.',
@@ -479,11 +600,20 @@ export async function serveE3Checkpoint(
 
   // A solution name, from either list. Matched against the whole catalogue so
   // the "ver todas" sheet can be answered by typing a name we never chipped.
-  if (!chosen.length) {
+  // Accepted while the first is unchosen AND while a second is being added.
+  if (!chosen.length || type('_adding_solution') === 'yes') {
     const hit = topShortlist({ site: w3Input().site }, isPt ? 'pt' : 'en', 27)
       .find(e => deps.normChip(e.solution.pt.label) === msg || deps.normChip(e.solution.en.label) === msg);
-    if (hit) return confirmSolution(hit.solution.id);
+    if (hit && !chosen.includes(hit.solution.id)) return await confirmSolution(hit.solution.id);
   }
+
+  if (is(E3C.outraSolucao)) {
+    deps.writeFields(TYPE, { _adding_solution: 'yes' });
+    return askSolution();
+  }
+  if (is(E3C.soEssa)) return await closeE3();
+  if (is(E3C.marcarAgora)) return openSiteMap('open-site-map-from-e3');
+  if (is(E3C.seguirSemLugar)) return askSolution();
 
   if (is(E3C.desenhar) || is(E3C.redesenhar)) {
     if (!hasSitePin) {
@@ -511,7 +641,9 @@ export async function serveE3Checkpoint(
   for (const [sectionId, field, next] of [
     [OPS, 'who_maintains', askFrequency],
     [OPS, 'maintenance_frequency', askSustainability],
-    [OPS, 'sustainability_model', closeE3],
+    // A second solution is offered once, after the first is fully scoped —
+    // asking earlier would interrupt the one thing they came to do.
+    [OPS, 'sustainability_model', () => (type('_second_asked') ? closeE3() : askAnotherSolution())],
   ] as Array<[string, string, () => true | Promise<true>]>) {
     if (read(sectionId)(field)) continue;
     const id = enumIdFromChip(sectionId, field, raw);

--- a/shared/w3-dossier.ts
+++ b/shared/w3-dossier.ts
@@ -32,7 +32,7 @@
 import { getSolutionFicha } from './nbs-solution-fichas';
 import { SOLUTION_MECHANISMS, getSolution } from './nbs-catalog';
 import { budgetLineFor, type BudgetLine } from './w3-sizing';
-import type { WorryId } from './site-knowledge';
+import { WORRY_SUBTYPES, type WorryId } from './site-knowledge';
 
 // ── Capacity ────────────────────────────────────────────────────────────────
 
@@ -89,8 +89,15 @@ export function gradeCapacity(input: W3Input): CapacityRead {
   const richDepth = depth === 'strong' || depth === 'rich';
   const hasStory = has(site.site_story);
   const tenureKnown = has(site.land_tenure);
-  const funded = org.prior_project_scale === 'funded';
-  const named = has(org.contact_name) || has(site.community_anchoring_lead);
+  const funded = org.prior_project_scale === 'funded' || org.funding_history === 'yes';
+  // ⚠️ NOT contact_name. Every organisation has one — E1 captures it from
+  // everybody — so including it made `named` true almost always, and the grade
+  // collapsed into "does this record have a strong depth read", which
+  // site_knowledge_depth already says on its own. A name on a form is evidence
+  // that a form was filled in. What this is trying to read is whether there is
+  // a person who carries THIS project, which is a different question and has
+  // its own field.
+  const named = has(site.community_anchoring_lead);
 
   if (!sited) {
     because.push('no place marked yet');
@@ -101,7 +108,12 @@ export function gradeCapacity(input: W3Input): CapacityRead {
   if (richDepth) because.push(`site described in their own words (${depth})`);
   if (hasStory) because.push('an account of the place, not just a pin');
   if (funded) because.push('has run a financed project before');
-  if (named) because.push('a named person who carries it');
+  if (named) because.push('a named person who carries this project');
+  if (!funded && !named) {
+    cannotYet.push(
+      'a clear owner — no funding history, and nobody is recorded as carrying this project',
+    );
+  }
 
   if (!tenureKnown) cannotYet.push('the approval route — land tenure is unanswered');
   if (!hasStory) cannotYet.push('a mechanism read, so the baseline evidence stays generic');
@@ -183,6 +195,21 @@ const PUBLIC_TENURE = new Set([
  * it needs a registered engineer. Saying it depends is both true and the
  * difference between a project they can start and one they cannot.
  */
+/** The words an organisation used for a worry, never the id we store it under. */
+function worryLabel(id: string, pt: boolean): string {
+  const first = id.split(',')[0].trim();
+  const sub = WORRY_SUBTYPES.find(w => w.id === first);
+  if (sub) return (pt ? sub.dPt : sub.dEn).toLowerCase();
+  // Legacy family ids ('flood') predate the mechanism split and are still in
+  // the database. They name a family, so say so in words rather than in code.
+  const family: Record<string, { pt: string; en: string }> = {
+    flood: { pt: 'a água', en: 'water' },
+    heat: { pt: 'o calor', en: 'heat' },
+    landslide: { pt: 'o barranco', en: 'the slope' },
+  };
+  return family[first] ? (pt ? family[first].pt : family[first].en) : first;
+}
+
 function studyMarkerIn(prose: string): { pt: string; en: string } | null {
   for (const m of STUDY_MARKERS) {
     const hit = m.re.exec(prose);
@@ -365,13 +392,35 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
     });
     const worry = site.site_worry;
     if (has(worry)) {
+      // ⚠️ Never the raw id. This line reached the organisation reading
+      // "se o problema é mesmo landslide" — an English machine id, in the middle
+      // of a Portuguese sentence, describing their own hillside back to them.
+      const label = worryLabel(worry, pt);
       add({
         list: 'investigate',
         text: pt
-          ? `Confirmar no lugar se o problema é mesmo ${worry} — a palavra de vocês decide a solução, não o nosso mapa`
-          : `Confirm on site whether the problem really is ${worry} — your word decides the solution, not our map`,
+          ? `Confirmar no lugar se o problema é mesmo ${label} — a palavra de vocês decide a solução, não o nosso mapa`
+          : `Confirm on site whether the problem really is ${label} — your word decides the solution, not our map`,
         source: `intervention_site · site_worry = ${worry}`,
         owner: 'coordination',
+      });
+    }
+    // They chose something. Even with no place, the ficha already knows what
+    // that choice will demand — and telling them now is the difference between
+    // "come back when you have a site" and a workshop they got something out
+    // of. The first version returned a dossier that never mentioned the
+    // solution they had just spent the session choosing.
+    for (const id of solutions) {
+      const marker = studyRequirement(id);
+      if (!marker) continue;
+      add({
+        list: 'investigate',
+        text: pt
+          ? `Quando houver um lugar: ${id.replace(/-/g, ' ')} vai precisar de ${marker.pt}`
+          : `Once there is a place: ${id.replace(/-/g, ' ')} will need ${marker.en}`,
+        source: `ficha ${id} · quemPrecisaDizerSim`,
+        owner: 'coordination',
+        blockedBy: pt ? 'marcar o lugar' : 'marking the place',
       });
     }
     gaps.push(
@@ -395,15 +444,31 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
         list: 'investigate',
         text: pt ? `Providenciar ${marker.pt}` : `Arrange ${marker.en}`,
         source: `ficha ${id} · quemPrecisaDizerSim`,
-        owner: 'org',
+        // The COORDINATION's, at every capacity grade. This is the whole
+        // argument for having a `needs_study` pile on the coordinator's board:
+        // one organisation hiring one geotechnical engineer is expensive and
+        // slow; a cohort commissioning several at once is a procurement, and it
+        // is the single biggest thing the programme can do that no individual
+        // organisation can. Assigning it to the org (as the first version did
+        // for `established` orgs) put the board and the dossier in direct
+        // disagreement about who moves next.
+        owner: 'coordination',
       });
     }
 
     // Approving bodies, read out of the ficha's own prose.
+    //
+    // ⚠️ "a prefeitura" is a FALLBACK, not a third body. Every ficha that names
+    // SMAMUS or DMAE also uses the word prefeitura in the same breath — the
+    // rain-garden entry reads "a aprovação é da prefeitura (SMAMUS…)" — so
+    // matching all three produced three contact rows for one approval route,
+    // one of which named nobody. A coordinator reading that has to work out
+    // which of the three is a real door.
+    const named = /SMAMUS|DMAE/i.test(approve);
     for (const [re, body] of [
       [/SMAMUS/i, 'SMAMUS'],
       [/DMAE/i, 'DMAE'],
-      [/prefeitura/i, pt ? 'a prefeitura' : 'the city'],
+      ...(named ? [] : [[/prefeitura/i, pt ? 'a prefeitura' : 'the city'] as [RegExp, string]]),
     ] as [RegExp, string][]) {
       if (re.test(approve) && !items.some(i => i.text.includes(body))) {
         const conditional = /se .{0,40}(rede|drenagem)/i.test(approve) && /DMAE/i.test(body);
@@ -503,13 +568,18 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
   });
 
   // ── Site preparation, from what the place is today ────────────────────────
-  if (site.current_use === 'paved') {
+  // Only for solutions that actually break the ground. A horta in raised beds
+  // on a concrete schoolyard does not de-pave anything, and telling that
+  // organisation to find out what runs under the slab is one more item on a
+  // list that is only useful while every line on it is real.
+  const BREAKS_GROUND = /jardins-de-chuva|biovaletas|canteiro-pluvial|bacia-de-retencao|wetland|pavimentos-permeaveis|terracos|escada-hidraulica|reflorestamento|parque/;
+  if (site.current_use === 'paved' && solutions.some(id => BREAKS_GROUND.test(id))) {
     add({
       list: 'investigate',
       text: pt
         ? 'Descobrir o que existe sob o piso antes de despavimentar, e de quem é o que passa por baixo'
         : 'Find out what lies under the paving before de-paving it, and who owns what runs beneath',
-      source: 'intervention_site · current_use = paved',
+      source: 'intervention_site · current_use = paved × solução que mexe no solo',
       owner: 'org',
     });
   }
@@ -524,13 +594,10 @@ export function buildDossier(input: W3Input, lang: 'pt' | 'en' = 'pt'): Dossier 
   for (const id of solutions) {
     const line = budgetLineFor(id, areaM2);
     if (!line) continue;
+    // The budget rides in `budget[]` only. Adding the identical sentence as a
+    // `document` item printed every price twice on the card — once under
+    // "Quanto custa" and again under "Documentar", word for word.
     budget.push(line);
-    add({
-      list: 'document',
-      text: pt ? line.notePt : line.noteEn,
-      source: `ficha ${id} · quantoCusta${line.areaM2 ? ` × ${line.areaM2} m²` : ''}`,
-      owner: 'org',
-    });
     // Naming the missing half is the point: "no cost band" is not actionable,
     // "we have a price per m² and no area" is.
     if (line.basis === 'm2' && !line.areaM2) {


### PR DESCRIPTION
`scripts/w3-sim-run.ts` drives six organisations through the real E3 engine — no browser, no model, no database, just the transcript. Every defect below was invisible to a passing test suite, because **a test asserts what you thought to assert and a transcript shows you what you actually said.**

## The two that matter

**⚠️ The manifest rule was a chip filter, not a rule.** "Parceria com a prefeitura" is correctly absent on land the organisation owns — but the answer does not only arrive by tapping a chip. Typed, or relayed by the model, it reached the write path with the label intact and was stored. The org would have left W3 with a maintenance agreement the city cannot sign — the exact failure the cross-workshop rule was built to prevent, walking straight past it through the front door.

**⚠️ Beats read state from before their own writes.** `chosen` and `areaM2` are snapshotted when the turn starts, and `confirmSolution` appends *and closes* in the same turn — so the closing dossier showed the **previous** solution list. The same bug had already sent per-unit solutions to trace a footprint (fixed in #487).

These are the same shape, and it is the shape to watch for in this file: **a guard that only covers the path you were looking at**, and **a value read before the write that changes it**.

## One site, more than one solution

The entire four-state verdict is argued from an organisation that wants a garden it can fund now beside a swale that needs a study. Until this beat existed, **the flow could not express the case its own design came from** — six simulations all closed with a single solution.

Offered once, after the first is fully scoped. The second reuses everything already answered about the place; only the price, which is per solution, is restated. Partenon now closes with `ready` *and* `needs_study` on one card.

## An organisation with no pin

It was told *"no Encontro 2 vocês marcaram Rubem Berta"* — to an org that marked nothing, and the one least able to argue with us about its own record. It was then offered "Desenhar no mapa", which bailed with an apology and handed the turn to the model: a dead end in exactly the scenario the workshop most needs to handle well.

The opening now forks honestly (`Marcar o lugar agora` / `Seguir sem o lugar`), and the size beat offers to mark the place rather than a draw session that cannot run.

## The rest, all from the same transcripts

| | |
|---|---|
| A machine id, printed to the org | *"Confirmar no lugar se o problema é mesmo landslide"* — an English id, mid-Portuguese-sentence, describing their own hillside back to them |
| Three contact rows for one door | Every ficha naming SMAMUS or DMAE uses *prefeitura* in the same breath, so all three matched and one of them named nobody |
| Every price printed twice | Once under "Quanto custa", again word for word under "Documentar" |
| Board and dossier disagreed on who finds a técnico | The `needs_study` pile exists because a cohort commissioning several studies at once is a procurement and one org hiring one is not — so the study is the **coordination's** at every grade |
| `capacity` had collapsed into one signal | `established` required "a named person", read from `contact_name`, which E1 captures from **everybody** — so the grade was `site_knowledge_depth` wearing a second name. Now `community_anchoring_lead` or a funding history: a name on a form is evidence that a form was filled in. Across the six sims: 4/6 established → a real 2/2/2 spread. |
| A site-less org learned nothing about its own choice | It spent the session choosing a solution and got a dossier that never mentioned it |
| The de-paving item fired on any paved site | Telling an org planting a horta in raised beds to find out what runs under the slab |

## Verification

- Six simulations: all four verdict states, three capacity grades, one deliberate `NOT SERVED` (the refused city-partnership value, which the E3 skill now tells the model how to explain).
- Full suite: **325 passed**. Two failures under parallel load — `w2-scenarios` and `cougar-cohort-language` — both pass in isolation; the known `cbo-familia-reco` timeout in the LLM-fallback path after a 401.
- `tsc --noEmit`: 5 errors, identical to main.
- `docs/w3-flow.md` carries the full table, and `scripts/w3-sim.ts` explains how to add a scenario — the value is in **reading** the output, not in it exiting zero.